### PR TITLE
add support to look for peers on different ports from those at which they listen

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,6 +68,8 @@ jobs:
                 root: artifacts
                 paths:
                   - samproxies.tar
+            - store_artifacts:
+                path: artifacts/
 
   publish:
     docker:
@@ -109,9 +111,7 @@ workflows:
             - test
           filters:
             tags:
-              only: /^v\d+\.\d+\.\d+/
-            branches:
-              ignore: /.*/
+              only: /.*/
       - publish:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,27 @@ jobs:
             - buildevents/berun:
                 bename: go_build
                 becommand: go install -ldflags "-X main.BuildID=${CIRCLE_TAG:1:20}" ./...
+            - run: |
+                mkdir artifacts
+                cp $GOPATH/bin/samproxy* artifacts
+                tar -cvf artifacts/samproxies.tar artifacts/samproxy*
+                find artifacts -ls
+            - persist_to_workspace:
+                root: artifacts
+                paths:
+                  - *
+            - store_artifacts:
+                path: artifacts/
+
+
+  build_packages:
+    executor: linuxgo
+    steps:
+      - buildevents/with_job_span:
+          steps:
+            - checkout
+            - attach_workspace:
+                at: artifacts
             - buildevents/berun:
                 bename: apt_get_update
                 becommand: sudo apt-get -qq update
@@ -60,8 +81,6 @@ jobs:
                 bename: build_rpm
                 becommand: ./build-pkg.sh -v "${CIRCLE_TAG:1:20}" -t rpm
             - run: |
-                mkdir artifacts
-                cp $GOPATH/bin/samproxy* artifacts
                 tar -cvf artifacts/samproxies.tar artifacts/samproxy*
                 find artifacts -ls
             - persist_to_workspace:
@@ -112,9 +131,17 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - publish:
+      - build_artifacts:
           requires:
             - build
+          filters:
+            tags:
+              only: /^v\d+\.\d+\.\d+/
+            branches:
+              ignore: /.*/
+      - publish:
+          requires:
+            - build_artifacts
           filters:
             tags:
               only: /^v\d+\.\d+\.\d+/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,7 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - build_artifacts:
+      - build_packages:
           requires:
             - build
           filters:
@@ -141,7 +141,7 @@ workflows:
               ignore: /.*/
       - publish:
           requires:
-            - build_artifacts
+            - build_packages
           filters:
             tags:
               only: /^v\d+\.\d+\.\d+/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
             - persist_to_workspace:
                 root: artifacts
                 paths:
-                  - *
+                  - "*"
             - store_artifacts:
                 path: artifacts/
 

--- a/config.toml
+++ b/config.toml
@@ -5,7 +5,7 @@
 # ListenAddr is the IP and port on which to listen for incoming events. Incoming
 # traffic is expected to be HTTP, so if using SSL put something like nginx in
 # front to do the decryption.
-# Should be of the form 0.0.0.0:8080
+# Should be of the form "0.0.0.0:8080"
 # Not eligible for live reload.
 ListenAddr = "0.0.0.0:8080"
 
@@ -13,9 +13,20 @@ ListenAddr = "0.0.0.0:8080"
 # rerouted from a peer. Peer traffic is expected to be HTTP, so if using SSL
 # put something like nginx in front to do the decryption. Must be different from
 # ListenAddr
-# Should be of the form 0.0.0.0:8081
+# Should be of the form "0.0.0.0:8081"
 # Not eligible for live reload.
 PeerListenAddr = "0.0.0.0:8081"
+
+# PeerAdvertisePort is the port on which to advertise that this server is
+# available for peers. When running in a container with virtualized networking,
+# the port on which samproxy should listen can be different from the port by
+# which other servers can reach this machine. Use this setting to set the
+# advertised port when it is different from the the PeerListenAddr. Only valid
+# when used with Redis as the peer manager. Can be also be set with an
+# environment variable SAMPROXY_PEER_ADV_PORT.
+# Should be of the form "8081"
+# Not eligible for live reload
+PeerAdvertisePort = "8081"
 
 # APIKeys is a list of Honeycomb API keys that the proxy will accept. This list
 # only applies to events - other Honeycomb API actions will fall through to the

--- a/config/config.go
+++ b/config/config.go
@@ -29,6 +29,10 @@ type Config interface {
 	// peer traffic
 	GetPeerListenAddr() (string, error)
 
+	// GetPeerAdvertisePort returns the port to use when advertising our address to
+	// peers via redis
+	GetPeerAdvertisePort() (string, error)
+
 	// GetAPIKeys returns a list of Honeycomb API keys
 	GetAPIKeys() ([]string, error)
 

--- a/config/fileconfig.go
+++ b/config/fileconfig.go
@@ -17,6 +17,7 @@ type FileConfig struct {
 type confContents struct {
 	ListenAddr           string
 	PeerListenAddr       string
+	PeerAdvertisePort    string
 	APIKeys              []string
 	Peers                []string
 	RedisHost            string
@@ -85,6 +86,10 @@ func (f *FileConfig) GetListenAddr() (string, error) {
 
 func (f *FileConfig) GetPeerListenAddr() (string, error) {
 	return f.conf.PeerListenAddr, nil
+}
+
+func (f *FileConfig) GetPeerAdvertisePort() (string, error) {
+	return f.conf.PeerAdvertisePort, nil
 }
 
 func (f *FileConfig) GetAPIKeys() ([]string, error) {

--- a/config/mock.go
+++ b/config/mock.go
@@ -5,21 +5,23 @@ import "encoding/json"
 // MockConfig will respond with whatever config it's set to do during
 // initialization
 type MockConfig struct {
-	GetAPIKeysErr        error
-	GetAPIKeysVal        []string
-	GetCollectorTypeErr  error
-	GetCollectorTypeVal  string
-	GetHoneycombAPIErr   error
-	GetHoneycombAPIVal   string
-	GetListenAddrErr     error
-	GetListenAddrVal     string
-	GetPeerListenAddrErr error
-	GetPeerListenAddrVal string
-	GetLoggerTypeErr     error
-	GetLoggerTypeVal     string
-	GetLoggingLevelErr   error
-	GetLoggingLevelVal   string
-	GetOtherConfigErr    error
+	GetAPIKeysErr           error
+	GetAPIKeysVal           []string
+	GetCollectorTypeErr     error
+	GetCollectorTypeVal     string
+	GetHoneycombAPIErr      error
+	GetHoneycombAPIVal      string
+	GetListenAddrErr        error
+	GetListenAddrVal        string
+	GetPeerListenAddrErr    error
+	GetPeerListenAddrVal    string
+	GetPeerAdvertisePortErr error
+	GetPeerAdvertisePortVal string
+	GetLoggerTypeErr        error
+	GetLoggerTypeVal        string
+	GetLoggingLevelErr      error
+	GetLoggingLevelVal      string
+	GetOtherConfigErr       error
 	// GetOtherConfigVal must be a JSON representation of the config struct to be populated.
 	GetOtherConfigVal        string
 	GetPeersErr              error
@@ -52,6 +54,9 @@ func (m *MockConfig) GetHoneycombAPI() (string, error) {
 func (m *MockConfig) GetListenAddr() (string, error) { return m.GetListenAddrVal, m.GetListenAddrErr }
 func (m *MockConfig) GetPeerListenAddr() (string, error) {
 	return m.GetPeerListenAddrVal, m.GetPeerListenAddrErr
+}
+func (m *MockConfig) GetPeerAdvertisePort() (string, error) {
+	return m.GetPeerAdvertisePortVal, m.GetPeerAdvertisePortErr
 }
 func (m *MockConfig) GetLoggerType() (string, error) { return m.GetLoggerTypeVal, m.GetLoggerTypeErr }
 func (m *MockConfig) GetLoggingLevel() (string, error) {

--- a/sharder/deterministic.go
+++ b/sharder/deterministic.go
@@ -114,6 +114,12 @@ func (d *DeterministicSharder) Start() error {
 		}
 		d.Logger.Debugf("picked up local peer port of %s", localPort)
 
+		overridePeerPort, _ := d.Config.GetPeerAdvertisePort()
+		if overridePeerPort != "" {
+			localPort = overridePeerPort
+			d.Logger.Debugf("found peer advertise port override: will look for peer with port %s to identify as myself", localPort)
+		}
+
 		// get my local interfaces
 		localAddrs, err := net.InterfaceAddrs()
 		if err != nil {


### PR DESCRIPTION
In the containerized world, it is not uncommon to have the address at which a service is available be different from the address on which it listens. This change enables manually setting the external port and recognizing that it may be different from the port on which the service is actually listening. For example, in a marathon/mesos cluster, marathon provides this port as an environment variable.