### PR TITLE
Handle all the datatypes in the EMA sampler

### DIFF
--- a/sample/dynamic.go
+++ b/sample/dynamic.go
@@ -2,8 +2,6 @@ package sample
 
 import (
 	"math/rand"
-	"sort"
-	"strconv"
 
 	dynsampler "github.com/honeycombio/dynsampler-go"
 
@@ -20,11 +18,9 @@ type DynamicSampler struct {
 
 	sampleRate        int64
 	clearFrequencySec int64
-	fieldList         []string
-	useTraceLength    bool
-	addDynsampleKey   bool
-	addDynsampleField string
 	configName        string
+
+	key *traceKey
 
 	dynsampler dynsampler.Sampler
 }
@@ -37,18 +33,7 @@ func (d *DynamicSampler) Start() error {
 		d.Config.ClearFrequencySec = 30
 	}
 	d.clearFrequencySec = d.Config.ClearFrequencySec
-
-	// get list of fields to use when constructing the dynsampler key
-	fieldList := d.Config.FieldList
-
-	// always put the field list in sorted order for easier comparison
-	sort.Strings(fieldList)
-	d.fieldList = fieldList
-
-	d.useTraceLength = d.Config.UseTraceLength
-
-	d.addDynsampleKey = d.Config.AddSampleRateKeyToTrace
-	d.addDynsampleField = d.Config.AddSampleRateKeyToTraceField
+	d.key = newTraceKey(d.Config.FieldList, d.Config.UseTraceLength, d.Config.AddSampleRateKeyToTrace, d.Config.AddSampleRateKeyToTraceField)
 
 	// spin up the actual dynamic sampler
 	d.dynsampler = &dynsampler.AvgSampleRate{
@@ -66,7 +51,7 @@ func (d *DynamicSampler) Start() error {
 }
 
 func (d *DynamicSampler) GetSampleRate(trace *types.Trace) (uint, bool) {
-	key := d.buildKey(trace)
+	key := d.key.buildAndAdd(trace)
 	rate := d.dynsampler.GetSampleRate(key)
 	if rate < 1 { // protect against dynsampler being broken even though it shouldn't be
 		rate = 1
@@ -85,57 +70,4 @@ func (d *DynamicSampler) GetSampleRate(trace *types.Trace) (uint, bool) {
 	}
 	d.Metrics.Histogram("dynsampler_sample_rate", float64(rate))
 	return uint(rate), shouldKeep
-}
-
-// buildKey takes a trace and returns the key to use for the dynsampler.
-func (d *DynamicSampler) buildKey(trace *types.Trace) string {
-	// fieldCollector gets all values from the fields listed in the config, even
-	// if they happen multiple times.
-	fieldCollector := map[string][]string{}
-
-	// for each field, for each span, get the value of that field
-	spans := trace.GetSpans()
-	for _, field := range d.fieldList {
-		for _, span := range spans {
-			if val, ok := span.Data[field]; ok {
-				switch val := val.(type) {
-				case string:
-					fieldCollector[field] = append(fieldCollector[field], val)
-				case float64:
-					valStr := strconv.FormatFloat(val, 'f', -1, 64)
-					fieldCollector[field] = append(fieldCollector[field], valStr)
-				case bool:
-					valStr := strconv.FormatBool(val)
-					fieldCollector[field] = append(fieldCollector[field], valStr)
-				}
-			}
-		}
-	}
-	// ok, now we have a map of fields to a list of all values for that field.
-
-	var key string
-	for _, field := range d.fieldList {
-		// sort and collapse list
-		sort.Strings(fieldCollector[field])
-		var prevStr string
-		for _, str := range fieldCollector[field] {
-			if str != prevStr {
-				key += str + "•"
-			}
-			prevStr = str
-		}
-		// get ready for the next element
-		key += ","
-	}
-	if d.useTraceLength {
-		key += strconv.FormatInt(int64(len(spans)), 10)
-	}
-
-	if d.addDynsampleKey {
-		for _, span := range trace.GetSpans() {
-			span.Data[d.addDynsampleField] = key
-		}
-	}
-
-	return key
 }

--- a/sample/dynamic_ema.go
+++ b/sample/dynamic_ema.go
@@ -1,6 +1,7 @@
 package sample
 
 import (
+	"fmt"
 	"math/rand"
 	"sort"
 	"strconv"
@@ -110,16 +111,7 @@ func (d *EMADynamicSampler) buildKey(trace *types.Trace) string {
 	for _, field := range d.fieldList {
 		for _, span := range spans {
 			if val, ok := span.Data[field]; ok {
-				switch val := val.(type) {
-				case string:
-					fieldCollector[field] = append(fieldCollector[field], val)
-				case float64:
-					valStr := strconv.FormatFloat(val, 'f', -1, 64)
-					fieldCollector[field] = append(fieldCollector[field], valStr)
-				case bool:
-					valStr := strconv.FormatBool(val)
-					fieldCollector[field] = append(fieldCollector[field], valStr)
-				}
+				fieldCollector[field] = append(fieldCollector[field], fmt.Sprintf("%v", val))
 			}
 		}
 	}

--- a/sample/dynamic_ema_test.go
+++ b/sample/dynamic_ema_test.go
@@ -21,7 +21,7 @@ func TestDynamicEMAAddSampleRateKeyToTrace(t *testing.T) {
 
 	sampler := &EMADynamicSampler{
 		Config: &config.EMADynamicSamplerConfig{
-			FieldList:                    []string{"http.status_code"},
+			FieldList:                    []string{"http.status_code", "request.path", "app.team.id", "important_field"},
 			AddSampleRateKeyToTrace:      true,
 			AddSampleRateKeyToTraceField: "meta.key",
 		},
@@ -34,7 +34,10 @@ func TestDynamicEMAAddSampleRateKeyToTrace(t *testing.T) {
 		trace.AddSpan(&types.Span{
 			Event: types.Event{
 				Data: map[string]interface{}{
-					"http.status_code": "200",
+					"http.status_code": 200,
+					"app.team.id":      float64(4),
+					"important_field":  true,
+					"request.path":     "/{slug}/fun",
 				},
 			},
 		})
@@ -43,11 +46,15 @@ func TestDynamicEMAAddSampleRateKeyToTrace(t *testing.T) {
 	sampler.GetSampleRate(trace)
 
 	spans := trace.GetSpans()
+
 	assert.Len(t, spans, spanCount, "should have the same number of spans as input")
 	for _, span := range spans {
 		assert.Equal(t, span.Event.Data, map[string]interface{}{
-			"http.status_code": "200",
-			"meta.key":         "200•,",
+			"http.status_code": 200,
+			"app.team.id":      float64(4),
+			"important_field":  true,
+			"request.path":     "/{slug}/fun",
+			"meta.key":         "4•,200•,true•,/{slug}/fun•,",
 		}, "should add the sampling key to all spans in the trace")
 	}
 }

--- a/sample/trace_key.go
+++ b/sample/trace_key.go
@@ -1,0 +1,80 @@
+package sample
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+
+	"github.com/honeycombio/refinery/types"
+)
+
+type traceKey struct {
+	fields            []string
+	useTraceLength    bool
+	addDynsampleKey   bool
+	addDynsampleField string
+}
+
+func newTraceKey(fields []string, useTraceLength, addDynsampleKey bool, addDynsampleField string) *traceKey {
+	// always put the field list in sorted order for easier comparison
+	sort.Strings(fields)
+	return &traceKey{
+		fields:            fields,
+		useTraceLength:    useTraceLength,
+		addDynsampleKey:   addDynsampleKey,
+		addDynsampleField: addDynsampleField,
+	}
+}
+
+// buildAndAdd, builds the trace key and adds it to the trace if configured to
+// do so
+func (d *traceKey) buildAndAdd(trace *types.Trace) string {
+	key := d.build(trace)
+
+	if d.addDynsampleKey {
+		for _, span := range trace.GetSpans() {
+			span.Data[d.addDynsampleField] = key
+		}
+	}
+
+	return key
+}
+
+// build, builds the trace key based on the configuration of the traceKeyGenerator
+func (d *traceKey) build(trace *types.Trace) string {
+	// fieldCollector gets all values from the fields listed in the config, even
+	// if they happen multiple times.
+	fieldCollector := map[string][]string{}
+
+	// for each field, for each span, get the value of that field
+	spans := trace.GetSpans()
+	for _, field := range d.fields {
+		for _, span := range spans {
+			if val, ok := span.Data[field]; ok {
+				fieldCollector[field] = append(fieldCollector[field], fmt.Sprintf("%v", val))
+			}
+		}
+	}
+	// ok, now we have a map of fields to a list of all values for that field.
+
+	var key string
+	for _, field := range d.fields {
+		// sort and collapse list
+		sort.Strings(fieldCollector[field])
+		var prevStr string
+		for _, str := range fieldCollector[field] {
+			if str != prevStr {
+				key += str + "•"
+			}
+			prevStr = str
+		}
+		// get ready for the next element
+		key += ","
+	}
+
+	if d.useTraceLength {
+		key += strconv.FormatInt(int64(len(spans)), 10)
+	}
+
+	return key
+}

--- a/sample/trace_key_test.go
+++ b/sample/trace_key_test.go
@@ -1,0 +1,36 @@
+// +build all race
+
+package sample
+
+import (
+	"testing"
+
+	"github.com/honeycombio/refinery/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKeyGeneration(t *testing.T) {
+	fields := []string{"http.status_code", "request.path", "app.team.id", "important_field"}
+	addKey := true
+	key := "meta.key"
+	useTraceLength := true
+
+	generator := newTraceKey(fields, useTraceLength, addKey, key)
+
+	trace := &types.Trace{}
+
+	trace.AddSpan(&types.Span{
+		Event: types.Event{
+			Data: map[string]interface{}{
+				"http.status_code": 200,
+				"request.path":     "/{slug}/home",
+				"app.team.id":      float64(2),
+				"important_field":  true,
+			},
+		},
+	})
+
+	expected := "2•,200•,true•,/{slug}/home•,1"
+
+	assert.Equal(t, expected, generator.build(trace))
+}

--- a/sample/trace_key_test.go
+++ b/sample/trace_key_test.go
@@ -78,4 +78,96 @@ func TestKeyGeneration(t *testing.T) {
 	expected = "2•,200•,true•,/{slug}/home•,4"
 
 	assert.Equal(t, expected, generator.build(trace))
+
+	// now test that multiple values across spans are condensed correctly
+	fields = []string{"http.status_code"}
+	addKey = true
+	key = "meta.key"
+	useTraceLength = true
+
+	generator = newTraceKey(fields, useTraceLength, addKey, key)
+
+	trace = &types.Trace{}
+
+	trace.AddSpan(&types.Span{
+		Event: types.Event{
+			Data: map[string]interface{}{
+				"http.status_code": 200,
+			},
+		},
+	})
+
+	trace.AddSpan(&types.Span{
+		Event: types.Event{
+			Data: map[string]interface{}{
+				"http.status_code": 200,
+			},
+		},
+	})
+
+	trace.AddSpan(&types.Span{
+		Event: types.Event{
+			Data: map[string]interface{}{
+				"http.status_code": 404,
+			},
+		},
+	})
+
+	trace.AddSpan(&types.Span{
+		Event: types.Event{
+			Data: map[string]interface{}{
+				"http.status_code": 404,
+			},
+		},
+	})
+
+	expected = "200•404•,4"
+
+	assert.Equal(t, expected, generator.build(trace))
+
+	// now test that multiple values across spans in a different order are condensed the same
+	fields = []string{"http.status_code"}
+	addKey = true
+	key = "meta.key"
+	useTraceLength = true
+
+	generator = newTraceKey(fields, useTraceLength, addKey, key)
+
+	trace = &types.Trace{}
+
+	trace.AddSpan(&types.Span{
+		Event: types.Event{
+			Data: map[string]interface{}{
+				"http.status_code": 404,
+			},
+		},
+	})
+
+	trace.AddSpan(&types.Span{
+		Event: types.Event{
+			Data: map[string]interface{}{
+				"http.status_code": 404,
+			},
+		},
+	})
+
+	trace.AddSpan(&types.Span{
+		Event: types.Event{
+			Data: map[string]interface{}{
+				"http.status_code": 200,
+			},
+		},
+	})
+
+	trace.AddSpan(&types.Span{
+		Event: types.Event{
+			Data: map[string]interface{}{
+				"http.status_code": 200,
+			},
+		},
+	})
+
+	expected = "200•404•,4"
+
+	assert.Equal(t, expected, generator.build(trace))
 }

--- a/sample/trace_key_test.go
+++ b/sample/trace_key_test.go
@@ -33,4 +33,49 @@ func TestKeyGeneration(t *testing.T) {
 	expected := "2•,200•,true•,/{slug}/home•,1"
 
 	assert.Equal(t, expected, generator.build(trace))
+
+	fields = []string{"http.status_code", "request.path", "app.team.id", "important_field"}
+	addKey = true
+	key = "meta.key"
+	useTraceLength = true
+
+	generator = newTraceKey(fields, useTraceLength, addKey, key)
+
+	trace = &types.Trace{}
+
+	trace.AddSpan(&types.Span{
+		Event: types.Event{
+			Data: map[string]interface{}{
+				"http.status_code": 200,
+			},
+		},
+	})
+
+	trace.AddSpan(&types.Span{
+		Event: types.Event{
+			Data: map[string]interface{}{
+				"request.path": "/{slug}/home",
+			},
+		},
+	})
+
+	trace.AddSpan(&types.Span{
+		Event: types.Event{
+			Data: map[string]interface{}{
+				"app.team.id": float64(2),
+			},
+		},
+	})
+
+	trace.AddSpan(&types.Span{
+		Event: types.Event{
+			Data: map[string]interface{}{
+				"important_field": true,
+			},
+		},
+	})
+
+	expected = "2•,200•,true•,/{slug}/home•,4"
+
+	assert.Equal(t, expected, generator.build(trace))
 }


### PR DESCRIPTION
Now that we support msgpack the types that might be in the data hash are more varied than they used to be. 

Adds the ability to format any type as a string in order to handle this