### PR TITLE
Skip S3 publish for forked builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,6 +153,9 @@ workflows:
           filters:
             tags:
               only: /.*/
+            branches:
+              # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
+              ignore: /pull\/[0-9]+/
       - docker/publish:
           tag: latest
           extra_build_args: --build-arg BUILD_ID=${CIRCLE_SHA1:0:7}


### PR DESCRIPTION
These builds don't have the required ENV variables to run this step. This can be seen in #185 