### PR TITLE
Fix reading of redis host env variable

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -12,6 +12,22 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestRedisEnvVar(t *testing.T) {
+	host := "redis.magic:1337"
+	os.Setenv("REFINERY_REDIS_HOST", host)
+	defer os.Unsetenv("REFINERY_REDIS_HOST")
+
+	c, err := NewConfig("../config.toml", "../rules.toml", func(err error) {})
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if d, _ := c.GetRedisHost(); d != host {
+		t.Error("received", d, "expected", host)
+	}
+}
+
 func TestReload(t *testing.T) {
 	tmpDir, err := ioutil.TempDir("", "")
 	assert.NoError(t, err)

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -113,7 +113,7 @@ type PeerManagementConfig struct {
 func NewConfig(config, rules string, errorCallback func(error)) (Config, error) {
 	c := viper.New()
 
-	c.BindEnv("redishost", "REFINERY_REDIS_HOST")
+	c.BindEnv("PeerManagement.RedisHost", "REFINERY_REDIS_HOST")
 	c.SetDefault("ListenAddr", "0.0.0.0:8080")
 	c.SetDefault("PeerListenAddr", "0.0.0.0:8081")
 	c.SetDefault("APIKeys", []string{"*"})


### PR DESCRIPTION
We moved the redis host to be under the `PeerManagement` key but did not update the path that it puts that ENV variable in. Updated it and added a test to check that we are using it.