### PR TITLE
More permissive JSON detection

### DIFF
--- a/route/route.go
+++ b/route/route.go
@@ -542,9 +542,7 @@ func unmarshal(r *http.Request, data io.Reader, v interface{}) error {
 		return msgpack.NewDecoder(data).
 			UseDecodeInterfaceLoose(true).
 			Decode(v)
-	case "application/json":
-		return jsoniter.NewDecoder(data).Decode(v)
 	default:
-		return errors.New("Bad Content-Type")
+		return jsoniter.NewDecoder(data).Decode(v)
 	}
 }

--- a/route/route_test.go
+++ b/route/route_test.go
@@ -164,7 +164,7 @@ func TestUnmarshal(t *testing.T) {
 
 	w = httptest.NewRecorder()
 	body = bytes.NewBufferString(`{"traceId": "test"}`)
-	unmarshalRequest(w, "application/json", body)
+	unmarshalRequest(w, "application/json; charset=utf-8", body)
 
 	if b := w.Body.String(); b != "test" {
 		t.Error("Expecting test")


### PR DESCRIPTION
Match the logic that the API server uses to detect content-type, assuming that everything is JSON unless told that it is msgpack