### PR TITLE
Handle duplicate prometheus metrics registrations

### DIFF
--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -47,33 +47,30 @@ func (p *PromMetrics) Register(name string, metricType string) {
 
 	newmet, ok := p.metrics[name]
 
-	switch metricType {
-	case "counter":
-		if !ok {
-			newmet = promauto.NewCounter(prometheus.CounterOpts{
-				Name: name,
-				Help: name,
-			})
-		}
-	case "gauge":
-		if !ok {
-			newmet = promauto.NewGauge(prometheus.GaugeOpts{
-				Name: name,
-				Help: name,
-			})
-		}
-	case "histogram":
-		if !ok {
-			newmet = promauto.NewHistogram(prometheus.HistogramOpts{
-				Name: name,
-				Help: name,
-			})
-		}
+	// don't attempt to add the metric again as this will cause a panic
+	if !ok {
+		return
 	}
 
-	if newmet != nil {
-		p.metrics[name] = newmet
+	switch metricType {
+	case "counter":
+		newmet = promauto.NewCounter(prometheus.CounterOpts{
+			Name: name,
+			Help: name,
+		})
+	case "gauge":
+		newmet = promauto.NewGauge(prometheus.GaugeOpts{
+			Name: name,
+			Help: name,
+		})
+	case "histogram":
+		newmet = promauto.NewHistogram(prometheus.HistogramOpts{
+			Name: name,
+			Help: name,
+		})
 	}
+
+	p.metrics[name] = newmet
 }
 
 func (p *PromMetrics) IncrementCounter(name string) {

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -45,10 +45,10 @@ func (p *PromMetrics) Register(name string, metricType string) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
-	newmet, ok := p.metrics[name]
+	newmet, exists := p.metrics[name]
 
 	// don't attempt to add the metric again as this will cause a panic
-	if !ok {
+	if exists {
 		return
 	}
 

--- a/metrics/prometheus_test.go
+++ b/metrics/prometheus_test.go
@@ -1,0 +1,26 @@
+// +build all race
+
+package metrics
+
+import (
+	"testing"
+
+	"github.com/honeycombio/refinery/config"
+	"github.com/honeycombio/refinery/logger"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMultipleRegistrations(t *testing.T) {
+	p := &PromMetrics{
+		Logger: &logger.MockLogger{},
+		Config: &config.MockConfig{},
+	}
+
+	err := p.Start()
+
+	assert.NoError(t, err)
+
+	p.Register("test", "counter")
+
+	p.Register("test", "counter")
+}


### PR DESCRIPTION
Handle adding prometheus metrics in the same way that honeycomb metrics class works.

Surprised that no one else has run into this!

Another thing we could do here in addition to this: we could append the dataset that the sampler is for to the metrics so that they should all be unique
