### PR TITLE
Add quotes for example DryRunFieldName value

### DIFF
--- a/rules.toml
+++ b/rules.toml
@@ -7,7 +7,7 @@
 # DryRun = false
 
 # DryRunFieldName - the key to add to use to add to event data when using DryRun mode above, defaults to refinery_kept
-# DryRunFieldName = refinery_kept
+# DryRunFieldName = "refinery_kept"
 
 # DeterministicSampler is a section of the config for manipulating the
 # Deterministic Sampler implementation. This is the simplest sampling algorithm


### PR DESCRIPTION
Fixes #194.

The example config includes the property `DryRunFieldName` that has a string value. However, the value is not wrapped in quotes which makes the config fail to load.