### PR TITLE
[logger] Properly format duration

### DIFF
--- a/logger/honeycomb.go
+++ b/logger/honeycomb.go
@@ -103,7 +103,7 @@ func (h *HoneycombLogger) Start() error {
 func (h *HoneycombLogger) readResponses() {
 	resps := h.libhClient.TxResponses()
 	for resp := range resps {
-		respString := fmt.Sprintf("Response: status: %d, duration: %dms", resp.StatusCode, resp.Duration)
+		respString := fmt.Sprintf("Response: status: %d, duration: %s", resp.StatusCode, resp.Duration)
 		// read response, log if there's an error
 		switch {
 		case resp.Err != nil:


### PR DESCRIPTION
`%d` prints ns, not ms. `%s` will format appropriately for all values.