### PR TITLE
Add /debug/trace/{traceID} endpoint

### DIFF
--- a/route/route.go
+++ b/route/route.go
@@ -132,7 +132,7 @@ func (r *Router) LnS(incomingOrPeer string) {
 	muxxer.HandleFunc("/alive", r.alive).Name("local health")
 	muxxer.HandleFunc("/panic", r.panic).Name("intentional panic")
 	muxxer.HandleFunc("/version", r.version).Name("report version info")
-	muxxer.HandleFunc("/getNode/{traceID}", r.getNode).Name("get node address for given trace ID")
+	muxxer.HandleFunc("/debug/trace/{traceID}", r.debugTrace).Name("get debug information for given trace ID")
 
 	// require an auth header for events and batches
 	authedMuxxer := muxxer.PathPrefix("/1/").Methods("POST").Subrouter()
@@ -200,7 +200,7 @@ func (r *Router) version(w http.ResponseWriter, req *http.Request) {
 	w.Write([]byte(fmt.Sprintf(`{"source":"refinery","version":"%s"}`, r.versionStr)))
 }
 
-func (r *Router) getNode(w http.ResponseWriter, req *http.Request) {
+func (r *Router) debugTrace(w http.ResponseWriter, req *http.Request) {
 	traceID := mux.Vars(req)["traceID"]
 	shard := r.Sharder.WhichShard(traceID)
 	w.Write([]byte(fmt.Sprintf(`{"traceID":"%s","node":"%s"}`, traceID, shard.GetAddress())))

--- a/route/route.go
+++ b/route/route.go
@@ -132,6 +132,7 @@ func (r *Router) LnS(incomingOrPeer string) {
 	muxxer.HandleFunc("/alive", r.alive).Name("local health")
 	muxxer.HandleFunc("/panic", r.panic).Name("intentional panic")
 	muxxer.HandleFunc("/version", r.version).Name("report version info")
+	muxxer.HandleFunc("/getNode/{traceID}", r.getNode).Name("return host given trace ID")
 
 	// require an auth header for events and batches
 	authedMuxxer := muxxer.PathPrefix("/1/").Methods("POST").Subrouter()
@@ -197,6 +198,12 @@ func (r *Router) panic(w http.ResponseWriter, req *http.Request) {
 
 func (r *Router) version(w http.ResponseWriter, req *http.Request) {
 	w.Write([]byte(fmt.Sprintf(`{"source":"refinery","version":"%s"}`, r.versionStr)))
+}
+
+func (r *Router) getNode(w http.ResponseWriter, req *http.Request) {
+	traceID := mux.Vars(req)["traceID"]
+	shard := r.Sharder.WhichShard(traceID)
+	w.Write([]byte(fmt.Sprintf(`{"traceID":"%s","node":"%s"}`, traceID, shard.GetAddress())))
 }
 
 // event is handler for /1/event/

--- a/route/route.go
+++ b/route/route.go
@@ -132,7 +132,7 @@ func (r *Router) LnS(incomingOrPeer string) {
 	muxxer.HandleFunc("/alive", r.alive).Name("local health")
 	muxxer.HandleFunc("/panic", r.panic).Name("intentional panic")
 	muxxer.HandleFunc("/version", r.version).Name("report version info")
-	muxxer.HandleFunc("/getNode/{traceID}", r.getNode).Name("return host given trace ID")
+	muxxer.HandleFunc("/getNode/{traceID}", r.getNode).Name("get node address for given trace ID")
 
 	// require an auth header for events and batches
 	authedMuxxer := muxxer.PathPrefix("/1/").Methods("POST").Subrouter()

--- a/route/route_test.go
+++ b/route/route_test.go
@@ -237,7 +237,7 @@ func TestUnmarshal(t *testing.T) {
 	}
 }
 
-func TestGetNode(t *testing.T) {
+func TestDebugTrace(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/debug/trace/123abcdef", nil)
 	req = mux.SetURLVars(req, map[string]string{"traceID": "123abcdef"})
 

--- a/route/route_test.go
+++ b/route/route_test.go
@@ -14,6 +14,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gorilla/mux"
+	"github.com/honeycombio/refinery/sharder"
 	"github.com/klauspost/compress/zstd"
 	"github.com/vmihailenco/msgpack/v4"
 )
@@ -234,3 +236,35 @@ func TestUnmarshal(t *testing.T) {
 		t.Error("Expecting", now, "Received", b)
 	}
 }
+
+func TestGetNode(t *testing.T) {
+	req, _ := http.NewRequest("GET", "/getNode/123abcdef", nil)
+	req = mux.SetURLVars(req, map[string]string{"traceID": "123abcdef"})
+
+	rr := httptest.NewRecorder()
+	router := &Router{
+		Sharder: &TestSharder{},
+	}
+
+	router.getNode(rr, req)
+	if body := rr.Body.String(); body != `{"traceID":"123abcdef","node":"http://localhost:12345"}` {
+		t.Error(body)
+	}
+}
+
+type TestSharder struct{}
+
+func (s *TestSharder) MyShard() sharder.Shard { return nil }
+
+func (s *TestSharder) WhichShard(string) sharder.Shard {
+	return &TestShard{
+		addr: "http://localhost:12345",
+	}
+}
+
+type TestShard struct {
+	addr string
+}
+
+func (s *TestShard) Equals(other sharder.Shard) bool { return true }
+func (s *TestShard) GetAddress() string              { return s.addr }

--- a/route/route_test.go
+++ b/route/route_test.go
@@ -238,7 +238,7 @@ func TestUnmarshal(t *testing.T) {
 }
 
 func TestGetNode(t *testing.T) {
-	req, _ := http.NewRequest("GET", "/getNode/123abcdef", nil)
+	req, _ := http.NewRequest("GET", "/debug/trace/123abcdef", nil)
 	req = mux.SetURLVars(req, map[string]string{"traceID": "123abcdef"})
 
 	rr := httptest.NewRecorder()
@@ -246,7 +246,7 @@ func TestGetNode(t *testing.T) {
 		Sharder: &TestSharder{},
 	}
 
-	router.getNode(rr, req)
+	router.debugTrace(rr, req)
 	if body := rr.Body.String(); body != `{"traceID":"123abcdef","node":"http://localhost:12345"}` {
 		t.Error(body)
 	}


### PR DESCRIPTION
Add a diagnostics HTTP GET endpoint that returns the debug trace information, including the assigned node address using the configured sharding algorithm.

The endpoint can be called like this:
`http://localhost:9000/debug/trace/123abc`

The response is a JSON object two two properties and looks like the following:
`{"traceID":"123abc","node":"http://localhost:12345"}`