### PR TITLE
Error response from libhoney does not always mean a non-20x response

### DIFF
--- a/transmit/transmit.go
+++ b/transmit/transmit.go
@@ -160,7 +160,7 @@ func (d *DefaultTransmission) processResponses(
 				if r.Err != nil {
 					log = log.WithField("error", r.Err.Error())
 				}
-				log.Logf("non-20x response when sending event")
+				log.Logf("error when sending event")
 				if honeycombAPI == apiHost {
 					// if the API host matches the configured honeycomb API,
 					// count it as an API error


### PR DESCRIPTION
* it could be a 200 API response that got an error on parsing the body