### PR TITLE
Add support for gzip compressed OTLP requests

### DIFF
--- a/route/route.go
+++ b/route/route.go
@@ -15,6 +15,7 @@ import (
 	"net"
 	"net/http"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -414,6 +415,11 @@ func (r *Router) Export(ctx context.Context, req *collectortrace.ExportTraceServ
 		return &collectortrace.ExportTraceServiceResponse{}, nil
 	}
 
+	var grpcRequestEncoding string
+	if val := md.Get("grpc-accept-encoding"); val != nil {
+		grpcRequestEncoding = strings.Join(val, ",")
+	}
+
 	for _, resourceSpan := range req.ResourceSpans {
 		resourceAttrs := make(map[string]interface{})
 
@@ -456,6 +462,9 @@ func (r *Router) Export(ctx context.Context, req *collectortrace.ExportTraceServ
 				}
 				if span.Attributes != nil {
 					addAttributesToMap(eventAttrs, span.Attributes)
+				}
+				if grpcRequestEncoding != "" {
+					eventAttrs["grpc_request_encoding"] = grpcRequestEncoding
 				}
 
 				sampleRate, err := getSampleRateFromAttributes(eventAttrs)

--- a/route/route.go
+++ b/route/route.go
@@ -26,6 +26,9 @@ import (
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
 
+	// grpc/gzip compressor, auto registers on import
+	_ "google.golang.org/grpc/encoding/gzip"
+
 	"github.com/honeycombio/refinery/collect"
 	"github.com/honeycombio/refinery/config"
 	"github.com/honeycombio/refinery/logger"


### PR DESCRIPTION
**Summary:**

Many different clients support compressing OTLP requests using gzip. Currently refinery does not support any form of compression and the request will fail.

This change adds support for gzip compressed OTLP requests by importing the [google.golang.org/grpc/encoding/gzip](https://pkg.go.dev/google.golang.org/grpc/encoding/gzip) package. The compressor is automatically registered with gRPC servers during import.

**Asana Fixes:**

https://app.asana.com/0/1199604629328245/1199952740433234

**Test Plan:**

I tested by creating a test branch of the [golang-otlp](https://github.com/honeycombio/examples/blob/mike/golang-otlp-gzip/golang-otlp/main.go) example that configured and uses gzip compression. Before applying this change to a local refinery instance, I would receive the following error when it tried to send the spans:
`2021/02/22 13:34:04 rpc error: code = Unimplemented desc = grpc: Decompressor is not installed for grpc-encoding "gzip"`

After the change was applied, the request was received and processed as expected.

**Observability Plan:**

A new field is added to the root span that handles incoming OTLP requests named `grpc_request_encoding` which takes the value from the "grpc-accept-encoding" metadata field. This new field can be used to query for requests that were **gzip** compressed.