### PR TITLE
Add tests for int64 sample rate values

### DIFF
--- a/route/route.go
+++ b/route/route.go
@@ -48,7 +48,6 @@ const (
 	traceIDLongLength      = 16
 	GRPCMessageSizeMax int = 5000000 // 5MB
 	defaultSampleRate      = 1
-	int32MaxValue          = 2147483647 // (2**31)-1
 )
 
 type Router struct {
@@ -823,16 +822,16 @@ func getSampleRateFromAttributes(attrs map[string]interface{}) (int, error) {
 		i, err = strconv.ParseInt(v, 10, 32)
 		sampleRate = int(i)
 	case int:
-		if v > int32MaxValue {
-			sampleRate = int32MaxValue
+		if v > math.MaxInt32 {
+			sampleRate = math.MaxInt32
 		} else {
 			sampleRate = v
 		}
 	case int32:
 		sampleRate = int(v)
 	case int64:
-		if v > int32MaxValue {
-			sampleRate = int32MaxValue
+		if v > math.MaxInt32 {
+			sampleRate = math.MaxInt32
 		} else {
 			sampleRate = int(v)
 		}

--- a/route/route_test.go
+++ b/route/route_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -325,6 +326,18 @@ func TestGetSampleRateFromAttributes(t *testing.T) {
 			attrKey:       "sampleRate",
 			attrValue:     "5",
 			expectedValue: 5,
+		},
+		{
+			name:          "can parse int64 value (less than int32 max)",
+			attrKey:       "sampleRate",
+			attrValue:     int64(100),
+			expectedValue: 100,
+		},
+		{
+			name:          "can parse int64 value (greater than int32 max)",
+			attrKey:       "sampleRate",
+			attrValue:     int64(math.MaxInt32 + 100),
+			expectedValue: math.MaxInt32,
 		},
 		{
 			name:          "does not parse float, gets default value",


### PR DESCRIPTION
Resolves #211.

Adds testing for parsing int64 sample rate values. Test cases include parsing a value that can be parsed into an int32 and a value greater than int32 max where the int32 max value is used instead.

Additionally, replace the custom max int32 value with the math package const `math.MaxInt32`.