### PR TITLE
Update rules-based sampler examples

### DIFF
--- a/rules_complete.toml
+++ b/rules_complete.toml
@@ -208,8 +208,9 @@ SampleRate = 1
 	Sampler = "RulesBasedSampler"
 
 	[[dataset4.rule]]
-		name = "500 errors"
+		name = "slow 500 errors"
 		SampleRate = 1
+		# all conditions must be met for this rule to trigger
 		[[dataset4.rule.condition]]
 		field = "status_code"
 		operator = "="
@@ -220,8 +221,8 @@ SampleRate = 1
 		value = 1000.789
 
 	[[dataset4.rule]]
-		name = "drop 200 responses"
-		drop = true
+		name = "downsample 200 responses"
+		SampleRate = 1000
 		[[dataset4.rule.condition]]
 		field = "status_code"
 		operator = "="


### PR DESCRIPTION
The name `500 errors` doesn't describe the rule completely, and it wasn't clear that [rule conditions use AND](https://github.com/honeycombio/refinery/blob/a861dee6a345f497ce9ae08f458e6064cbb322e4/sample/rules.go#L122) (am I understanding that correctly?).

I also changed the rule for 200 responses to downsample instead of dropping them. `drop` is a special case that should be used rarely on entire traces, and I think using it here makes the example less realistic. This is also an opportunity to give a large number for the `SampleRate` to help set expectations for users that sending 1/1000 "boring" events is safe and reasonable.