### PR TITLE
only publish to s3 when releasing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,10 +152,9 @@ workflows:
             - build
           filters:
             tags:
-              only: /.*/
+              only: /^v.*/
             branches:
-              # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
-              ignore: /pull\/[0-9]+/
+              ignore: /.*/
       - docker/publish:
           tag: latest
           extra_build_args: --build-arg BUILD_ID=${CIRCLE_SHA1:0:7}


### PR DESCRIPTION
We should only save artifacts to s3 when we've cut a release.