### PR TITLE
Fix YAML config issues

### DIFF
--- a/sample/rules.go
+++ b/sample/rules.go
@@ -146,6 +146,11 @@ const (
 )
 
 func compare(a, b interface{}) (int, bool) {
+	// a is the tracing data field value. This can be: float64, int64, bool, or string
+	// b is the Rule condition value. This can be: float64, int64, int, bool, or string
+	// Note: in YAML config parsing, the Value may be returned as int
+	// When comparing numeric values, we need to check across the 3 types: float64, int64, and int
+
 	if a == nil {
 		if b == nil {
 			return equal, true
@@ -161,6 +166,16 @@ func compare(a, b interface{}) (int, bool) {
 	switch at := a.(type) {
 	case int64:
 		switch bt := b.(type) {
+		case int:
+			i := int(at)
+			switch {
+			case i < bt:
+				return less, true
+			case i > bt:
+				return more, true
+			default:
+				return equal, true
+			}
 		case int64:
 			switch {
 			case at < bt:
@@ -183,6 +198,16 @@ func compare(a, b interface{}) (int, bool) {
 		}
 	case float64:
 		switch bt := b.(type) {
+		case int:
+			f := float64(bt)
+			switch {
+			case at < f:
+				return less, true
+			case at > f:
+				return more, true
+			default:
+				return equal, true
+			}
 		case int64:
 			f := float64(bt)
 			switch {

--- a/sample/rules_test.go
+++ b/sample/rules_test.go
@@ -439,6 +439,34 @@ func TestRules(t *testing.T) {
 			ExpectedKeep: true,
 			ExpectedRate: 4,
 		},
+		{
+			Rules: &config.RulesBasedSamplerConfig{
+				Rule: []*config.RulesBasedSamplerRule{
+					{
+						Name:       "YAMLintgeaterthan",
+						SampleRate: 10,
+						Condition: []*config.RulesBasedSamplerCondition{
+							{
+								Field:    "test",
+								Operator: ">",
+								Value:    int(1),
+							},
+						},
+					},
+				},
+			},
+			Spans: []*types.Span{
+				{
+					Event: types.Event{
+						Data: map[string]interface{}{
+							"test": int64(2),
+						},
+					},
+				},
+			},
+			ExpectedKeep: true,
+			ExpectedRate: 10,
+		},
 	}
 
 	for _, d := range data {


### PR DESCRIPTION
When using YAML to specify config rules, the values can be interpreted as `int` instead of `int64`, leading to rule conditions not getting evaluated.  This fixes the compare function for RulesBasedSampler to check for the `int` type as well when doing a compare.