### PR TITLE
Log sampler config and validation errors

### DIFF
--- a/config/file_config.go
+++ b/config/file_config.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-playground/validator"
 	libhoney "github.com/honeycombio/libhoney-go"
 	viper "github.com/spf13/viper"
+	"github.com/sirupsen/logrus"
 )
 
 type fileConfig struct {
@@ -287,6 +288,8 @@ func (f *fileConfig) validateConditionalConfigs() error {
 }
 
 func (f *fileConfig) validateSamplerConfigs() error {
+	logrus.Debugf("Sampler rules config - %v+", f.rules)
+
 	keys := f.rules.AllKeys()
 	for _, key := range keys {
 		parts := strings.Split(key, ".")
@@ -311,11 +314,13 @@ func (f *fileConfig) validateSamplerConfigs() error {
 			}
 			err := f.rules.Unmarshal(i)
 			if err != nil {
+				logrus.WithError(err).Warn("Failed to unmarshal sampler rule")
 				return err
 			}
 			v := validator.New()
 			err = v.Struct(i)
 			if err != nil {
+				logrus.WithError(err).Warn("Failed to validate sampler rule")
 				return err
 			}
 		}
@@ -342,11 +347,13 @@ func (f *fileConfig) validateSamplerConfigs() error {
 			if sub := f.rules.Sub(datasetName); sub != nil {
 				err := sub.Unmarshal(i)
 				if err != nil {
+					logrus.WithError(err).Warn("Failed to unmarshal dataset sampler rule")
 					return err
 				}
 				v := validator.New()
 				err = v.Struct(i)
 				if err != nil {
+					logrus.WithError(err).Warn("Failed to validate dataset sampler rule")
 					return err
 				}
 			}

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -11,8 +11,8 @@ import (
 	"github.com/fsnotify/fsnotify"
 	"github.com/go-playground/validator"
 	libhoney "github.com/honeycombio/libhoney-go"
-	viper "github.com/spf13/viper"
 	"github.com/sirupsen/logrus"
+	viper "github.com/spf13/viper"
 )
 
 type fileConfig struct {
@@ -310,18 +310,16 @@ func (f *fileConfig) validateSamplerConfigs() error {
 			case "TotalThroughputSampler":
 				i = &TotalThroughputSamplerConfig{}
 			default:
-				return errors.New("Invalid or missing default sampler type")
+				return fmt.Errorf("Invalid or missing default sampler type: %s", t)
 			}
 			err := f.rules.Unmarshal(i)
 			if err != nil {
-				logrus.WithError(err).Warn("Failed to unmarshal sampler rule")
-				return err
+				return fmt.Errorf("Failed to unmarshal sampler rule: %w", err)
 			}
 			v := validator.New()
 			err = v.Struct(i)
 			if err != nil {
-				logrus.WithError(err).Warn("Failed to validate sampler rule")
-				return err
+				return fmt.Errorf("Failed to validate sampler rule: %w", err)
 			}
 		}
 
@@ -341,20 +339,18 @@ func (f *fileConfig) validateSamplerConfigs() error {
 			case "TotalThroughputSampler":
 				i = &TotalThroughputSamplerConfig{}
 			default:
-				return errors.New("Invalid or missing dataset sampler type")
+				return fmt.Errorf("Invalid or missing dataset sampler type: %s", t)
 			}
 			datasetName := parts[0]
 			if sub := f.rules.Sub(datasetName); sub != nil {
 				err := sub.Unmarshal(i)
 				if err != nil {
-					logrus.WithError(err).Warn("Failed to unmarshal dataset sampler rule")
-					return err
+					return fmt.Errorf("Failed to unmarshal dataset sampler rule: %w", err)
 				}
 				v := validator.New()
 				err = v.Struct(i)
 				if err != nil {
-					logrus.WithError(err).Warn("Failed to validate dataset sampler rule")
-					return err
+					return fmt.Errorf("Failed to validate dataset sampler rule: %w", err)
 				}
 			}
 		}

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -288,7 +288,7 @@ func (f *fileConfig) validateConditionalConfigs() error {
 }
 
 func (f *fileConfig) validateSamplerConfigs() error {
-	logrus.Debugf("Sampler rules config - %v+", f.rules)
+	logrus.Debugf("Sampler rules config: %+v", f.rules)
 
 	keys := f.rules.AllKeys()
 	for _, key := range keys {


### PR DESCRIPTION
When loading sampler rules from file based config, it can be difficult to see what rules have been set or any validation errors.

This PR logs the sampler config in `Debug` level and also any unmarshalling / validation errors in `Warn` level.