### PR TITLE
rules-complete.toml: add some more example rules for RulesBasedSampler.

### DIFF
--- a/rules_complete.toml
+++ b/rules_complete.toml
@@ -220,12 +220,38 @@ SampleRate = 1
 		value = 1000.789
 
 	[[dataset4.rule]]
+		name = "retain traces with an exception, regardless of status code"
+		SampleRate = 1
+		[[dataset4.rule.condition]]
+		field = "exception"
+		operator = "exists"
+
+	[[dataset4.rule]]
 		name = "drop 200 responses"
 		drop = true
 		[[dataset4.rule.condition]]
 		field = "status_code"
 		operator = "="
 		value = 200
+
+	[[dataset4.rule]]
+		name = "keep more requests from address endpoints"
+		SampleRate = 10
+		[[dataset4.rule.condition]]
+		field = "request.path"
+		operator = "starts-with"
+		value = "/api/v1/address"
+
+	[[dataset4.rule]]
+		name = "retain mailer jobs more frequently"
+		SamplerRate = 5
+		[[dataset4.rule.condition]]
+		field = "job_name"
+		operator = "contains"
+		value = "MailerTask"
+		[[dataset4.rule.condition]]
+		field = "request.path"
+		operator = "not-exists"
 
 	[[dataset4.rule]]
 		SampleRate = 10 # default when no rules match, if missing defaults to 1


### PR DESCRIPTION
The example sampler rules in `rules_complete.toml` cover some of the basic boolean operators, but miss things like `contains`, `starts-with`, etc that are pretty useful and powerful. It's easy enough to look at the code and figure out which rules actually exist (so I would totally understand if you don't want to go down the path of enumerating every rule type in the example config), but I would have found it helpful to have a more complete set of examples to work off of so I made this PR.