### PR TITLE
sample: change dynsampler metric names to match rulessampler convention

### DIFF
--- a/sample/rules.go
+++ b/sample/rules.go
@@ -43,7 +43,7 @@ func (s *RulesBasedSampler) GetSampleRate(trace *types.Trace) (rate uint, keep b
 			if keep {
 				s.Metrics.Increment("rulessampler_num_kept")
 			} else {
-				s.Metrics.Increment("dynsampler_num_dropped")
+				s.Metrics.Increment("rulessampler_num_dropped")
 			}
 			logger.WithFields(map[string]interface{}{
 				"rate":      rate,
@@ -124,7 +124,7 @@ func (s *RulesBasedSampler) GetSampleRate(trace *types.Trace) (rate uint, keep b
 			if keep {
 				s.Metrics.Increment("rulessampler_num_kept")
 			} else {
-				s.Metrics.Increment("dynsampler_num_dropped")
+				s.Metrics.Increment("rulessampler_num_dropped")
 			}
 			logger.WithFields(map[string]interface{}{
 				"rate":      rate,


### PR DESCRIPTION
While reading the rules implementation and configuring our local Refinery, I noticed a couple of metrics that appeared to be misnamed. All of the other metrics are prefixed with `rulessampler`, but these two (for dropping events) are prefixed with `dynsampler`. This _seemed_ like an oversight, though I'm by no means an expert. This PR changes the "dropped" metrics to conform to the convention of the other metric names.

Note that this is a breaking change: any existing dashboards, SLOs, etc built around the rules sampler and using the old metric name may no longer work as intended after this rename. A backwards compatible approach would be to emit both metrics, and then deprecate the `dynsampler` version later one. I didn't do that here, but am happy to do so if people feel strongly about it.

I ran the sampler unit test suite locally & confirmed that it passed with this change.