### PR TITLE
Add metrics qualifiers for structs that inject metrics

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -14,7 +14,7 @@ type App struct {
 	IncomingRouter route.Router      `inject:"inline"`
 	PeerRouter     route.Router      `inject:"inline"`
 	Collector      collect.Collector `inject:""`
-	Metrics        metrics.Metrics   `inject:""`
+	Metrics        metrics.Metrics   `inject:"metrics"`
 
 	// Version is the build ID for Refinery so that the running process may answer
 	// requests for the version

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -185,7 +185,7 @@ func newStartedApp(
 		&inject.Object{Value: &transmit.DefaultTransmission{LibhClient: peerClient, Name: "peer_"}, Name: "peerTransmission"},
 		&inject.Object{Value: shrdr},
 		&inject.Object{Value: collector},
-		&inject.Object{Value: metricsr},
+		&inject.Object{Value: metricsr, Name: "metrics"},
 		&inject.Object{Value: "test", Name: "version"},
 		&inject.Object{Value: samplerFactory},
 		&inject.Object{Value: &a},

--- a/collect/collect.go
+++ b/collect/collect.go
@@ -51,7 +51,7 @@ type InMemCollector struct {
 	Config         config.Config          `inject:""`
 	Logger         logger.Logger          `inject:""`
 	Transmission   transmit.Transmission  `inject:"upstreamTransmission"`
-	Metrics        metrics.Metrics        `inject:""`
+	Metrics        metrics.Metrics        `inject:"metrics"`
 	SamplerFactory *sample.SamplerFactory `inject:""`
 
 	// For test use only

--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/facebookgo/inject"
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/stretchr/testify/assert"
 
@@ -568,4 +569,22 @@ func TestAddSpanNoBlock(t *testing.T) {
 	assert.Error(t, err)
 	err = coll.AddSpanFromPeer(span)
 	assert.Error(t, err)
+}
+
+func TestDependencyInjection(t *testing.T) {
+	var g inject.Graph
+	err := g.Provide(
+		&inject.Object{Value: &InMemCollector{}},
+		&inject.Object{Value: &config.MockConfig{}},
+		&inject.Object{Value: &logger.NullLogger{}},
+		&inject.Object{Value: &transmit.MockTransmission{}, Name: "upstreamTransmission"},
+		&inject.Object{Value: &metrics.NullMetrics{}, Name: "metrics"},
+		&inject.Object{Value: &sample.SamplerFactory{}},
+	)
+	if err != nil {
+		t.Error(err)
+	}
+	if err := g.Populate(); err != nil {
+		t.Error(err)
+	}
 }

--- a/route/route.go
+++ b/route/route.go
@@ -62,7 +62,7 @@ type Router struct {
 	PeerTransmission     transmit.Transmission `inject:"peerTransmission"`
 	Sharder              sharder.Sharder       `inject:""`
 	Collector            collect.Collector     `inject:""`
-	Metrics              metrics.Metrics       `inject:""`
+	Metrics              metrics.Metrics       `inject:"metrics"`
 
 	// version is set on startup so that the router may answer HTTP requests for
 	// the version

--- a/sample/sample.go
+++ b/sample/sample.go
@@ -17,7 +17,7 @@ type Sampler interface {
 type SamplerFactory struct {
 	Config  config.Config   `inject:""`
 	Logger  logger.Logger   `inject:""`
-	Metrics metrics.Metrics `inject:""`
+	Metrics metrics.Metrics `inject:"metrics"`
 }
 
 // GetSamplerImplementationForDataset returns the sampler implementation for the dataset,

--- a/sample/sample_test.go
+++ b/sample/sample_test.go
@@ -1,3 +1,29 @@
 // +build all race
 
 package sample
+
+import (
+	"testing"
+
+	"github.com/facebookgo/inject"
+	"github.com/honeycombio/refinery/config"
+	"github.com/honeycombio/refinery/logger"
+	"github.com/honeycombio/refinery/metrics"
+)
+
+func TestDependencyInjection(t *testing.T) {
+	var g inject.Graph
+	err := g.Provide(
+		&inject.Object{Value: &SamplerFactory{}},
+
+		&inject.Object{Value: &config.MockConfig{}},
+		&inject.Object{Value: &logger.NullLogger{}},
+		&inject.Object{Value: &metrics.NullMetrics{}, Name: "metrics"},
+	)
+	if err != nil {
+		t.Error(err)
+	}
+	if err := g.Populate(); err != nil {
+		t.Error(err)
+	}
+}

--- a/transmit/transmit.go
+++ b/transmit/transmit.go
@@ -31,7 +31,7 @@ const (
 type DefaultTransmission struct {
 	Config     config.Config   `inject:""`
 	Logger     logger.Logger   `inject:""`
-	Metrics    metrics.Metrics `inject:""`
+	Metrics    metrics.Metrics `inject:"metrics"`
 	Version    string          `inject:"version"`
 	LibhClient *libhoney.Client
 

--- a/transmit/transmit_test.go
+++ b/transmit/transmit_test.go
@@ -5,6 +5,7 @@ package transmit
 import (
 	"testing"
 
+	"github.com/facebookgo/inject"
 	"github.com/honeycombio/refinery/config"
 	"github.com/honeycombio/refinery/logger"
 	"github.com/honeycombio/refinery/metrics"
@@ -26,4 +27,22 @@ func TestDefaultTransmissionUpdatesUserAgentAdditionAfterStart(t *testing.T) {
 	err := transmission.Start()
 	assert.Nil(t, err)
 	assert.Equal(t, libhoney.UserAgentAddition, "refinery/test")
+}
+
+func TestDependencyInjection(t *testing.T) {
+	var g inject.Graph
+	err := g.Provide(
+		&inject.Object{Value: &DefaultTransmission{}},
+
+		&inject.Object{Value: &config.MockConfig{}},
+		&inject.Object{Value: &logger.NullLogger{}},
+		&inject.Object{Value: &metrics.NullMetrics{}, Name: "metrics"},
+		&inject.Object{Value: "test", Name: "version"},
+	)
+	if err != nil {
+		t.Error(err)
+	}
+	if err := g.Populate(); err != nil {
+		t.Error(err)
+	}
 }


### PR DESCRIPTION
When using dependency injection, all dependencies listed in structs must use the same name qualifier. The dependency builder does not auto inject based on property name match.

This PR sets the metrics inject qualifier for the main metrics config that is registered when executing main.go.

This was missed because tests manually create their dependencies and do not rely on dependency injection which I've now added for any struct that injects a metrics instance.