### PR TITLE
Verify that sample rate trace field key is specified, if needed.

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -399,6 +399,7 @@ func TestGetSamplerTypes(t *testing.T) {
 		GoalSampleRate = 10
 		UseTraceLength = true
 		AddSampleRateKeyToTrace = true
+		AddSampleRateKeyToTraceField = "meta.refinery.dynsampler_key"
 		FieldList = "[request.method]"
 		Weight = 0.3
 

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -197,11 +197,6 @@ func NewConfig(config, rules string, errorCallback func(error)) (Config, error) 
 		return nil, err
 	}
 
-	err = fc.validateSampleKeyConfigs()
-	if err != nil {
-		return nil, err
-	}
-
 	c.WatchConfig()
 	c.OnConfigChange(fc.onChange)
 
@@ -360,37 +355,6 @@ func (f *fileConfig) validateSamplerConfigs() error {
 			}
 		}
 	}
-	return nil
-}
-
-// verify that, if AddSampleRateKeyToTrace is set to true, AddSampleRateKeyToTraceField must be specified.
-func (f *fileConfig) validateSampleKeyConfigs() error {
-	sampleRateFieldRequired := false
-	sampleRateFieldProvided := false
-
-	keys := f.rules.AllKeys()
-
-	for _, key := range keys {
-		parts := strings.Split(key, ".")
-
-		if len(parts) > 1 && parts[1] == "addsampleratekeytotrace" {
-			val := f.rules.Get(key)
-			if val.(bool) {
-				sampleRateFieldRequired = true
-			}
-		}
-		if len(parts) > 1 && parts[1] == "addsampleratekeytotracefield" {
-			val := f.rules.Get(key)
-			if len(val.(string)) > 0 {
-				sampleRateFieldProvided = true
-			}
-		}
-	}
-
-	if sampleRateFieldRequired && !sampleRateFieldProvided {
-		return fmt.Errorf("AddSampleRateKeyToTrace is true, but no AddSampleRateKeyToTraceField is specified")
-	}
-
 	return nil
 }
 

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -380,7 +380,10 @@ func (f *fileConfig) validateSampleKeyConfigs() error {
 			}
 		}
 		if len(parts) > 1 && parts[1] == "addsampleratekeytotracefield" {
-			sampleRateFieldProvided = true
+			val := f.rules.Get(key)
+			if len(val.(string)) > 0 {
+				sampleRateFieldProvided = true
+			}
 		}
 	}
 

--- a/config/sampler_config.go
+++ b/config/sampler_config.go
@@ -10,7 +10,7 @@ type DynamicSamplerConfig struct {
 	FieldList                    []string `validate:"required"`
 	UseTraceLength               bool
 	AddSampleRateKeyToTrace      bool
-	AddSampleRateKeyToTraceField string
+	AddSampleRateKeyToTraceField string `validate:"required_with=AddSampleRateKeyToTrace"`
 }
 
 type EMADynamicSamplerConfig struct {
@@ -25,7 +25,7 @@ type EMADynamicSamplerConfig struct {
 	FieldList                    []string `validate:"required"`
 	UseTraceLength               bool
 	AddSampleRateKeyToTrace      bool
-	AddSampleRateKeyToTraceField string
+	AddSampleRateKeyToTraceField string `validate:"required_with=AddSampleRateKeyToTrace"`
 }
 
 type TotalThroughputSamplerConfig struct {
@@ -34,5 +34,5 @@ type TotalThroughputSamplerConfig struct {
 	FieldList                    []string `validate:"required"`
 	UseTraceLength               bool
 	AddSampleRateKeyToTrace      bool
-	AddSampleRateKeyToTraceField string
+	AddSampleRateKeyToTraceField string `validate:"required_with=AddSampleRateKeyToTrace"`
 }


### PR DESCRIPTION
Currently, if `AddSampleRateKeyToTrace` is set to true in a sampler config, and no `AddSampleRateKeyToTraceField` is specified, refinery will attempt to send the sample rate in a field with an empty key. This will result in hard to debug 400s being returned from the Honeycomb Events API. It's probably best to just prevent this configuration scenario. This change makes refinery fail fast if `AddSampleRateKeyToTrace` is true and `AddSampleRateKeyToTraceField` is not set, or is empty.