### PR TITLE
Add 'meta.refinery.local_hostname' to all spans

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -125,4 +125,6 @@ type Config interface {
 	GetIsDryRun() bool
 
 	GetDryRunFieldName() string
+
+	GetAddHostMetadataToTrace() bool
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -168,6 +168,10 @@ func TestReadDefaults(t *testing.T) {
 		t.Error("received", d, "expected", "refinery_kept")
 	}
 
+	if d := c.GetAddHostMetadataToTrace(); d != true {
+		t.Error("received", d, "expected", true)
+	}
+
 	d, err := c.GetSamplerConfigForDataset("dataset-doesnt-exist")
 	assert.NoError(t, err)
 	assert.IsType(t, &DeterministicSamplerConfig{}, d)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -168,8 +168,8 @@ func TestReadDefaults(t *testing.T) {
 		t.Error("received", d, "expected", "refinery_kept")
 	}
 
-	if d := c.GetAddHostMetadataToTrace(); d != true {
-		t.Error("received", d, "expected", true)
+	if d := c.GetAddHostMetadataToTrace(); d != false {
+		t.Error("received", d, "expected", false)
 	}
 
 	d, err := c.GetSamplerConfigForDataset("dataset-doesnt-exist")

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -75,6 +75,7 @@ type configContents struct {
 	DryRunFieldName           string
 	PeerManagement            PeerManagementConfig           `validate:"required"`
 	InMemCollector            InMemoryCollectorCacheCapacity `validate:"required"`
+	AddHostMetadataToTrace    bool
 }
 
 type InMemoryCollectorCacheCapacity struct {
@@ -145,6 +146,7 @@ func NewConfig(config, rules string, errorCallback func(error)) (Config, error) 
 	c.SetDefault("MaxAlloc", uint64(0))
 	c.SetDefault("HoneycombLogger.LoggerSamplerEnabled", false)
 	c.SetDefault("HoneycombLogger.LoggerSamplerThroughput", 5)
+	c.SetDefault("AddHostMetadataToTrace", true)
 
 	c.SetConfigFile(config)
 	err := c.ReadInConfig()
@@ -721,4 +723,11 @@ func (f *fileConfig) GetDryRunFieldName() string {
 	defer f.mux.RUnlock()
 
 	return f.conf.DryRunFieldName
+}
+
+func (f *fileConfig) GetAddHostMetadataToTrace() bool {
+	f.mux.RLock()
+	defer f.mux.RUnlock()
+
+	return f.conf.AddHostMetadataToTrace
 }

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -146,7 +146,7 @@ func NewConfig(config, rules string, errorCallback func(error)) (Config, error) 
 	c.SetDefault("MaxAlloc", uint64(0))
 	c.SetDefault("HoneycombLogger.LoggerSamplerEnabled", false)
 	c.SetDefault("HoneycombLogger.LoggerSamplerThroughput", 5)
-	c.SetDefault("AddHostMetadataToTrace", true)
+	c.SetDefault("AddHostMetadataToTrace", false)
 
 	c.SetConfigFile(config)
 	err := c.ReadInConfig()

--- a/config/mock.go
+++ b/config/mock.go
@@ -64,6 +64,7 @@ type MockConfig struct {
 	DebugServiceAddr              string
 	DryRun                        bool
 	DryRunFieldName               string
+	AddHostMetadataToTrace        bool
 
 	Mux sync.RWMutex
 }
@@ -287,4 +288,11 @@ func (m *MockConfig) GetDryRunFieldName() string {
 	defer m.Mux.RUnlock()
 
 	return m.DryRunFieldName
+}
+
+func (m *MockConfig) GetAddHostMetadataToTrace() bool {
+	m.Mux.RLock()
+	defer m.Mux.RUnlock()
+
+	return m.AddHostMetadataToTrace
 }

--- a/config_complete.toml
+++ b/config_complete.toml
@@ -87,6 +87,14 @@ PeerBufferSize = 10000
 # The debug service runs on the first open port between localhost:6060 and :6069 by default
 # DebugServiceAddr = "localhost:8085"
 
+# AddHostMetadataToTrace determines whether or not to add information about
+# the host that Refinery is running on to the spans that it processes.
+# If enabled, information about the host will be added to each span with the
+# prefix `meta.refinery.`.
+# Currently the only value added is 'meta.refinery.local_hostname'.
+# Eligible for live reload
+AddHostMetadataToTrace = true
+
 ############################
 ## Implementation Choices ##
 ############################

--- a/config_complete.toml
+++ b/config_complete.toml
@@ -92,8 +92,8 @@ PeerBufferSize = 10000
 # If enabled, information about the host will be added to each span with the
 # prefix `meta.refinery.`.
 # Currently the only value added is 'meta.refinery.local_hostname'.
-# Eligible for live reload
-AddHostMetadataToTrace = true
+# Not eligible for live reload
+AddHostMetadataToTrace = false
 
 ############################
 ## Implementation Choices ##

--- a/transmit/transmit.go
+++ b/transmit/transmit.go
@@ -2,6 +2,7 @@ package transmit
 
 import (
 	"context"
+	"os"
 	"sync"
 
 	libhoney "github.com/honeycombio/libhoney-go"
@@ -54,6 +55,14 @@ func (d *DefaultTransmission) Start() error {
 	if err != nil {
 		return err
 	}
+
+	if d.Config.GetAddHostMetadataToTrace() {
+		if hostname, err := os.Hostname(); err == nil && hostname != "" {
+			// add hostname to spans
+			d.LibhClient.AddField("meta.refinery.local_hostname", hostname)
+		}
+	}
+
 	d.builder = d.LibhClient.NewBuilder()
 	d.builder.APIHost = upstreamAPI
 


### PR DESCRIPTION
The intention is to help determine issues with a single Refinery instance.