### PR TITLE
Ensure span links and events generate events and get resource attrs

### DIFF
--- a/route/middleware.go
+++ b/route/middleware.go
@@ -45,7 +45,7 @@ func (r *Router) apiKeyChecker(next http.Handler) http.Handler {
 				return
 			}
 		}
-		err = errors.New(fmt.Sprintf("api key %s not found in list of authed keys", apiKey))
+		err = fmt.Errorf("api key %s not found in list of authed keys", apiKey)
 		r.handlerReturnWithError(w, ErrAuthNeeded, err)
 	})
 }

--- a/route/route.go
+++ b/route/route.go
@@ -923,7 +923,7 @@ func getSampleRateFromAttributes(attrs map[string]interface{}) (int, error) {
 			sampleRate = int(v)
 		}
 	default:
-		err = fmt.Errorf("Unrecognised sampleRate datatype - %T", sampleRate)
+		err = fmt.Errorf("unrecognised sampleRate datatype - %T", sampleRate)
 		sampleRate = defaultSampleRate
 	}
 	// remove sampleRate from event fields

--- a/route/route.go
+++ b/route/route.go
@@ -478,7 +478,7 @@ func (r *Router) Export(ctx context.Context, req *collectortrace.ExportTraceServ
 				}
 
 				events := make([]*types.Event, 0, 1+len(span.Events)+len(span.Links))
-				events[0] = &types.Event{
+				events = append(events, &types.Event{
 					Context:    ctx,
 					APIHost:    apiHost,
 					APIKey:     apiKey,
@@ -486,7 +486,7 @@ func (r *Router) Export(ctx context.Context, req *collectortrace.ExportTraceServ
 					SampleRate: uint(sampleRate),
 					Timestamp:  timestamp,
 					Data:       eventAttrs,
-				}
+				})
 
 				for _, sevent := range span.Events {
 					timestamp := time.Unix(0, int64(sevent.TimeUnixNano)).UTC()

--- a/route/route.go
+++ b/route/route.go
@@ -523,7 +523,6 @@ func (r *Router) Export(ctx context.Context, req *collectortrace.ExportTraceServ
 				}
 
 				for _, slink := range span.Links {
-					var timestamp time.Time
 					attrs := map[string]interface{}{
 						"trace.trace_id":       traceID,
 						"trace.parent_id":      spanID,
@@ -552,7 +551,7 @@ func (r *Router) Export(ctx context.Context, req *collectortrace.ExportTraceServ
 						APIKey:     apiKey,
 						Dataset:    dataset,
 						SampleRate: uint(sampleRate),
-						Timestamp:  timestamp,
+						Timestamp:  time.Time{}, //links don't have timestamps, so use empty time
 						Data:       attrs,
 					})
 				}

--- a/route/route_test.go
+++ b/route/route_test.go
@@ -1,11 +1,10 @@
-// +build all race
-
 package route
 
 import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -418,6 +417,17 @@ func TestOTLPHandler(t *testing.T) {
 		},
 	}
 
+	conf := &config.MockConfig{
+		GetSendDelayVal:    0,
+		GetTraceTimeoutVal: 60 * time.Second,
+		GetSamplerTypeVal:  &config.DeterministicSamplerConfig{SampleRate: 1},
+		SendTickerVal:      2 * time.Millisecond,
+		GetInMemoryCollectorCacheCapacityVal: config.InMemoryCollectorCacheCapacity{
+			CacheCapacity: 100,
+			MaxAlloc:      100,
+		},
+	}
+
 	t.Run("span with status", func(t *testing.T) {
 		req := &collectortrace.ExportTraceServiceRequest{
 			ResourceSpans: []*trace.ResourceSpans{{
@@ -452,91 +462,95 @@ func TestOTLPHandler(t *testing.T) {
 
 	// TODO: (MG) figuure out how we can test JSON created from OTLP requests
 	// Below is example, but requires significant usage of collector, sampler, conf, etc
-	// t.Run("creates events for span events", func(t *testing.T) {
-	// 	traceID := []byte{0, 0, 0, 0, 1}
-	// 	spanID := []byte{1, 0, 0, 0, 0}
-	// 	req := &collectortrace.ExportTraceServiceRequest{
-	// 		ResourceSpans: []*trace.ResourceSpans{{
-	// 			InstrumentationLibrarySpans: []*trace.InstrumentationLibrarySpans{{
-	// 				Spans: []*trace.Span{{
-	// 					TraceId: traceID,
-	// 					SpanId:  spanID,
-	// 					Name:    "span_with_event",
-	// 					Events: []*trace.Span_Event{{
-	// 						TimeUnixNano: 12345,
-	// 						Name:         "span_link",
-	// 						Attributes: []*common.KeyValue{{
-	// 							Key: "event_attr_key", Value: &common.AnyValue{Value: &common.AnyValue_StringValue{StringValue: "event_attr_val"}},
-	// 						}},
-	// 					}},
-	// 				}},
-	// 			}},
-	// 		}},
-	// 	}
-	// 	_, err := router.Export(ctx, req)
-	// 	if err != nil {
-	// 		t.Errorf(`Unexpected error: %s`, err)
-	// 	}
+	t.Run("creates events for span events", func(t *testing.T) {
+		t.Skip("need additional work to support inspecting outbound JSON")
 
-	// 	time.Sleep(conf.SendTickerVal * 2)
+		traceID := []byte{0, 0, 0, 0, 1}
+		spanID := []byte{1, 0, 0, 0, 0}
+		req := &collectortrace.ExportTraceServiceRequest{
+			ResourceSpans: []*trace.ResourceSpans{{
+				InstrumentationLibrarySpans: []*trace.InstrumentationLibrarySpans{{
+					Spans: []*trace.Span{{
+						TraceId: traceID,
+						SpanId:  spanID,
+						Name:    "span_with_event",
+						Events: []*trace.Span_Event{{
+							TimeUnixNano: 12345,
+							Name:         "span_link",
+							Attributes: []*common.KeyValue{{
+								Key: "event_attr_key", Value: &common.AnyValue{Value: &common.AnyValue_StringValue{StringValue: "event_attr_val"}},
+							}},
+						}},
+					}},
+				}},
+			}},
+		}
+		_, err := router.Export(ctx, req)
+		if err != nil {
+			t.Errorf(`Unexpected error: %s`, err)
+		}
 
-	// 	mockTransmission.Mux.Lock()
-	// 	assert.Equal(t, 2, len(mockTransmission.Events))
+		time.Sleep(conf.SendTickerVal * 2)
 
-	// 	spanEvent := mockTransmission.Events[0]
-	// 	// assert.Equal(t, time.Unix(0, int64(12345)).UTC(), spanEvent.Timestamp)
-	// 	assert.Equal(t, bytesToTraceID(traceID), spanEvent.Data["trace.trace_id"])
-	// 	assert.Equal(t, hex.EncodeToString(spanID), spanEvent.Data["trace.span_id"])
-	// 	assert.Equal(t, "span_link", spanEvent.Data["span.name"])
-	// 	assert.Equal(t, "span_with_event", spanEvent.Data["parent.name"])
-	// 	assert.Equal(t, "span_event", spanEvent.Data["meta.annotation_type"])
-	// 	assert.Equal(t, "event_attr_key", spanEvent.Data["event_attr_val"])
-	// 	mockTransmission.Mux.Unlock()
-	// 	mockTransmission.Flush()
-	// })
+		mockTransmission.Mux.Lock()
+		assert.Equal(t, 2, len(mockTransmission.Events))
 
-	// t.Run("creates events for span links", func(t *testing.T) {
-	// 	traceID := []byte{0, 0, 0, 0, 1}
-	// 	spanID := []byte{1, 0, 0, 0, 0}
-	// 	linkTraceID := []byte{0, 0, 0, 0, 2}
-	// 	linkSpanID := []byte{2, 0, 0, 0, 0}
+		spanEvent := mockTransmission.Events[0]
+		// assert.Equal(t, time.Unix(0, int64(12345)).UTC(), spanEvent.Timestamp)
+		assert.Equal(t, bytesToTraceID(traceID), spanEvent.Data["trace.trace_id"])
+		assert.Equal(t, hex.EncodeToString(spanID), spanEvent.Data["trace.span_id"])
+		assert.Equal(t, "span_link", spanEvent.Data["span.name"])
+		assert.Equal(t, "span_with_event", spanEvent.Data["parent.name"])
+		assert.Equal(t, "span_event", spanEvent.Data["meta.annotation_type"])
+		assert.Equal(t, "event_attr_key", spanEvent.Data["event_attr_val"])
+		mockTransmission.Mux.Unlock()
+		mockTransmission.Flush()
+	})
 
-	// 	req := &collectortrace.ExportTraceServiceRequest{
-	// 		ResourceSpans: []*trace.ResourceSpans{{
-	// 			InstrumentationLibrarySpans: []*trace.InstrumentationLibrarySpans{{
-	// 				Spans: []*trace.Span{{
-	// 					Name:    "span_with_link",
-	// 					TraceId: traceID,
-	// 					SpanId:  spanID,
-	// 					Links: []*trace.Span_Link{{
-	// 						TraceId:    traceID,
-	// 						SpanId:     spanID,
-	// 						TraceState: "link_trace_state",
-	// 						Attributes: []*common.KeyValue{{
-	// 							Key: "link_attr_key", Value: &common.AnyValue{Value: &common.AnyValue_StringValue{StringValue: "link_attr_val"}},
-	// 						}},
-	// 					}},
-	// 				}},
-	// 			}},
-	// 		}},
-	// 	}
-	// 	_, err := router.Export(ctx, req)
-	// 	if err != nil {
-	// 		t.Errorf(`Unexpected error: %s`, err)
-	// 	}
+	t.Run("creates events for span links", func(t *testing.T) {
+		t.Skip("need additional work to support inspecting outbound JSON")
 
-	// 	time.Sleep(conf.SendTickerVal * 2)
-	// 	assert.Equal(t, 2, len(mockTransmission.Events))
+		traceID := []byte{0, 0, 0, 0, 1}
+		spanID := []byte{1, 0, 0, 0, 0}
+		linkTraceID := []byte{0, 0, 0, 0, 2}
+		linkSpanID := []byte{2, 0, 0, 0, 0}
 
-	// 	spanLink := mockTransmission.Events[1]
-	// 	assert.Equal(t, bytesToTraceID(traceID), spanLink.Data["trace.trace_id"])
-	// 	assert.Equal(t, hex.EncodeToString(spanID), spanLink.Data["trace.span_id"])
-	// 	assert.Equal(t, bytesToTraceID(linkTraceID), spanLink.Data["trace.link.trace_id"])
-	// 	assert.Equal(t, hex.EncodeToString(linkSpanID), spanLink.Data["trace.link.span_id"])
-	// 	assert.Equal(t, "link", spanLink.Data["meta.annotation_type"])
-	// 	assert.Equal(t, "link_attr_val", spanLink.Data["link_attr_key"])
-	// 	mockTransmission.Flush()
-	// })
+		req := &collectortrace.ExportTraceServiceRequest{
+			ResourceSpans: []*trace.ResourceSpans{{
+				InstrumentationLibrarySpans: []*trace.InstrumentationLibrarySpans{{
+					Spans: []*trace.Span{{
+						Name:    "span_with_link",
+						TraceId: traceID,
+						SpanId:  spanID,
+						Links: []*trace.Span_Link{{
+							TraceId:    traceID,
+							SpanId:     spanID,
+							TraceState: "link_trace_state",
+							Attributes: []*common.KeyValue{{
+								Key: "link_attr_key", Value: &common.AnyValue{Value: &common.AnyValue_StringValue{StringValue: "link_attr_val"}},
+							}},
+						}},
+					}},
+				}},
+			}},
+		}
+		_, err := router.Export(ctx, req)
+		if err != nil {
+			t.Errorf(`Unexpected error: %s`, err)
+		}
+
+		time.Sleep(conf.SendTickerVal * 2)
+		assert.Equal(t, 2, len(mockTransmission.Events))
+
+		spanLink := mockTransmission.Events[1]
+		assert.Equal(t, bytesToTraceID(traceID), spanLink.Data["trace.trace_id"])
+		assert.Equal(t, hex.EncodeToString(spanID), spanLink.Data["trace.span_id"])
+		assert.Equal(t, bytesToTraceID(linkTraceID), spanLink.Data["trace.link.trace_id"])
+		assert.Equal(t, hex.EncodeToString(linkSpanID), spanLink.Data["trace.link.span_id"])
+		assert.Equal(t, "link", spanLink.Data["meta.annotation_type"])
+		assert.Equal(t, "link_attr_val", spanLink.Data["link_attr_key"])
+		mockTransmission.Flush()
+	})
 }
 
 func TestDependencyInjection(t *testing.T) {


### PR DESCRIPTION
When generating events for OTLP span events and links, each sub-event should also get resource attributes added.

NOTE:
- Fixed a couple of linter warnings in https://github.com/honeycombio/refinery/pull/264/commits/258cf313cc3776733fdd56efbba25ec6aba56c86
- Testing event content is challenging because if the number of dependencies required, collector, metrics, sampler. I've tested the events are created as expected but fixing testing framework is larger task

cc @bdarfler 