### PR TITLE
Add support to "does-not-contain" operator on RulesBasedSampler

### DIFF
--- a/sample/rules.go
+++ b/sample/rules.go
@@ -104,6 +104,14 @@ func (s *RulesBasedSampler) GetSampleRate(trace *types.Trace) (rate uint, keep b
 								match = strings.Contains(a, b)
 							}
 						}
+					case "does-not-contain":
+						switch a := value.(type) {
+						case string:
+							switch b := condition.Value.(type) {
+							case string:
+								match = !strings.Contains(a, b)
+							}
+						}
 					}
 				case false:
 					switch condition.Operator {

--- a/sample/rules_test.go
+++ b/sample/rules_test.go
@@ -443,6 +443,34 @@ func TestRules(t *testing.T) {
 			Rules: &config.RulesBasedSamplerConfig{
 				Rule: []*config.RulesBasedSamplerRule{
 					{
+						Name:       "does not contain test",
+						SampleRate: 4,
+						Condition: []*config.RulesBasedSamplerCondition{
+							{
+								Field:    "first",
+								Operator: "does-not-contain",
+								Value:    "noteyco",
+							},
+						},
+					},
+				},
+			},
+			Spans: []*types.Span{
+				{
+					Event: types.Event{
+						Data: map[string]interface{}{
+							"first": "honeycomb",
+						},
+					},
+				},
+			},
+			ExpectedKeep: true,
+			ExpectedRate: 4,
+		},
+		{
+			Rules: &config.RulesBasedSamplerConfig{
+				Rule: []*config.RulesBasedSamplerRule{
+					{
 						Name:       "YAMLintgeaterthan",
 						SampleRate: 10,
 						Condition: []*config.RulesBasedSamplerCondition{


### PR DESCRIPTION
Solves https://github.com/honeycombio/refinery/issues/265

Took must of the code from the "contains", including the test. 
Let me know what you think, and if it needs anything else. 

Docs and extra logging for unsupported operators to be added on 266 👍. 