### PR TITLE
Add span.kind when ingesting OTLP

### DIFF
--- a/route/otlp_trace.go
+++ b/route/otlp_trace.go
@@ -102,10 +102,12 @@ func processTraceRequest(
 				spanID := hex.EncodeToString(span.SpanId)
 				timestamp := time.Unix(0, int64(span.StartTimeUnixNano)).UTC()
 
+				spanKind := getSpanKind(span.Kind)
 				eventAttrs := map[string]interface{}{
 					"trace.trace_id": traceID,
 					"trace.span_id":  spanID,
-					"type":           getSpanKind(span.Kind),
+					"type":           spanKind,
+					"span.kind":      spanKind,
 					"name":           span.Name,
 					"duration_ms":    float64(span.EndTimeUnixNano-span.StartTimeUnixNano) / float64(time.Millisecond),
 					"status_code":    int32(getSpanStatusCode(span.Status)),


### PR DESCRIPTION
Customers using OTEL are confused by the absence of `span.kind` attribute, because we map it to `type` on ingest. Adding `span.kind` in, with the plan to let customers know about `type` being deprecated and removing it in the future.

Updates https://github.com/honeycombio/telemetry-team/issues/14