### PR TITLE
Add dynamic sampler support to rules based samplers

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -217,7 +217,7 @@ func TestReadRulesConfig(t *testing.T) {
 
 		rule = r.Rule[1]
 		assert.Equal(t, 1, rule.SampleRate)
-		assert.Equal(t, "500 errors", rule.Name)
+		assert.Equal(t, "500 errors or slow", rule.Name)
 		assert.Len(t, rule.Condition, 2)
 
 	default:

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -206,19 +206,19 @@ func TestReadRulesConfig(t *testing.T) {
 	assert.NoError(t, err)
 	switch r := d.(type) {
 	case *RulesBasedSamplerConfig:
-		assert.Len(t, r.Rule, 3)
+		assert.Len(t, r.Rule, 4)
 
 		var rule *RulesBasedSamplerRule
 
 		rule = r.Rule[0]
-		assert.Equal(t, 1, rule.SampleRate)
-		assert.Equal(t, "500 errors", rule.Name)
-		assert.Len(t, rule.Condition, 2)
-
-		rule = r.Rule[1]
 		assert.True(t, rule.Drop)
 		assert.Equal(t, 0, rule.SampleRate)
 		assert.Len(t, rule.Condition, 1)
+
+		rule = r.Rule[1]
+		assert.Equal(t, 1, rule.SampleRate)
+		assert.Equal(t, "500 errors", rule.Name)
+		assert.Len(t, rule.Condition, 2)
 
 	default:
 		assert.Fail(t, "dataset4 should have a rules based sampler", d)

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -24,35 +24,6 @@ type fileConfig struct {
 	mux           sync.RWMutex
 }
 
-type RulesBasedSamplerCondition struct {
-	Field    string
-	Operator string
-	Value    interface{}
-}
-
-func (r *RulesBasedSamplerCondition) String() string {
-	return fmt.Sprintf("%+v", *r)
-}
-
-type RulesBasedSamplerRule struct {
-	Name       string
-	SampleRate int
-	Drop       bool
-	Condition  []*RulesBasedSamplerCondition
-}
-
-func (r *RulesBasedSamplerRule) String() string {
-	return fmt.Sprintf("%+v", *r)
-}
-
-type RulesBasedSamplerConfig struct {
-	Rule []*RulesBasedSamplerRule
-}
-
-func (r *RulesBasedSamplerConfig) String() string {
-	return fmt.Sprintf("%+v", *r)
-}
-
 type configContents struct {
 	ListenAddr                string `validate:"required"`
 	PeerListenAddr            string `validate:"required"`

--- a/config/sampler_config.go
+++ b/config/sampler_config.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"fmt"
-	"github.com/honeycombio/refinery/sample"
 )
 
 type DeterministicSamplerConfig struct {
@@ -58,12 +57,11 @@ type RulesBasedDownstreamSampler struct {
 }
 
 type RulesBasedSamplerRule struct {
-	Name              string
-	SampleRate        int
-	Downstream        *RulesBasedDownstreamSampler
-	DownstreamSampler sample.Sampler
-	Drop              bool
-	Condition         []*RulesBasedSamplerCondition
+	Name       string
+	SampleRate int
+	Downstream *RulesBasedDownstreamSampler
+	Drop       bool
+	Condition  []*RulesBasedSamplerCondition
 }
 
 func (r *RulesBasedSamplerRule) String() string {

--- a/config/sampler_config.go
+++ b/config/sampler_config.go
@@ -1,5 +1,10 @@
 package config
 
+import (
+	"fmt"
+	"github.com/honeycombio/refinery/sample"
+)
+
 type DeterministicSamplerConfig struct {
 	SampleRate int `validate:"required,gte=1"`
 }
@@ -35,4 +40,40 @@ type TotalThroughputSamplerConfig struct {
 	UseTraceLength               bool
 	AddSampleRateKeyToTrace      bool
 	AddSampleRateKeyToTraceField string `validate:"required_with=AddSampleRateKeyToTrace"`
+}
+
+type RulesBasedSamplerCondition struct {
+	Field    string
+	Operator string
+	Value    interface{}
+}
+
+func (r *RulesBasedSamplerCondition) String() string {
+	return fmt.Sprintf("%+v", *r)
+}
+
+type RulesBasedDownstreamSampler struct {
+	DynamicSampler    *DynamicSamplerConfig
+	EMADynamicSampler *EMADynamicSamplerConfig
+}
+
+type RulesBasedSamplerRule struct {
+	Name              string
+	SampleRate        int
+	Downstream        *RulesBasedDownstreamSampler
+	DownstreamSampler sample.Sampler
+	Drop              bool
+	Condition         []*RulesBasedSamplerCondition
+}
+
+func (r *RulesBasedSamplerRule) String() string {
+	return fmt.Sprintf("%+v", *r)
+}
+
+type RulesBasedSamplerConfig struct {
+	Rule []*RulesBasedSamplerRule
+}
+
+func (r *RulesBasedSamplerConfig) String() string {
+	return fmt.Sprintf("%+v", *r)
 }

--- a/config/sampler_config.go
+++ b/config/sampler_config.go
@@ -52,14 +52,15 @@ func (r *RulesBasedSamplerCondition) String() string {
 }
 
 type RulesBasedDownstreamSampler struct {
-	DynamicSampler    *DynamicSamplerConfig
-	EMADynamicSampler *EMADynamicSamplerConfig
+	DynamicSampler         *DynamicSamplerConfig
+	EMADynamicSampler      *EMADynamicSamplerConfig
+	TotalThroughputSampler *TotalThroughputSamplerConfig
 }
 
 type RulesBasedSamplerRule struct {
 	Name       string
 	SampleRate int
-	Downstream *RulesBasedDownstreamSampler
+	Sampler    *RulesBasedDownstreamSampler
 	Drop       bool
 	Condition  []*RulesBasedSamplerCondition
 }

--- a/rules_complete.toml
+++ b/rules_complete.toml
@@ -235,7 +235,7 @@ SampleRate = 1
 			value = 200
 		# define Dynamic Sampler used to determine sample rate
 		# Can be DyanmicSampler or EMADynamicSampler
-		[dataset4.downstream.DynamicSampler]
+		[dataset4.rule.downstream.DynamicSampler]
 			SampleRate = 5
 			FieldList = ["http.route", "http.method"]
 			AddSampleRateKeyToTrace = true

--- a/rules_complete.toml
+++ b/rules_complete.toml
@@ -203,11 +203,6 @@ SampleRate = 1
 	Sampler = "DeterministicSampler"
 	SampleRate = 10
 
-
-
-
-
-
 [dataset4]
 
 	Sampler = "RulesBasedSampler"
@@ -247,11 +242,6 @@ SampleRate = 1
 
 	[[dataset4.rule]]
 		SampleRate = 10 # default when no rules match, if missing defaults to 10
-
-
-
-
-
 
 [dataset5]
 

--- a/rules_complete.toml
+++ b/rules_complete.toml
@@ -203,6 +203,11 @@ SampleRate = 1
 	Sampler = "DeterministicSampler"
 	SampleRate = 10
 
+
+
+
+
+
 [dataset4]
 
 	Sampler = "RulesBasedSampler"
@@ -216,7 +221,7 @@ SampleRate = 1
 			value = "/health-check"
 
 	[[dataset4.rule]]
-		name = "500 errors"
+		name = "500 errors or slow"
 		SampleRate = 1
 		[[dataset4.rule.condition]]
 			field = "status_code"
@@ -233,16 +238,20 @@ SampleRate = 1
 			field = "status_code"
 			operator = "="
 			value = 200
-		# define Dynamic Sampler used to determine sample rate
-		# Can be DyanmicSampler or EMADynamicSampler
-		[dataset4.rule.downstream.DynamicSampler]
-			SampleRate = 5
-			FieldList = ["http.route", "http.method"]
+		[dataset4.rule.sampler.EMADynamicSampler]
+			Sampler = "EMADynamicSampler"
+			GoalSampleRate = 15
+			FieldList = ["request.method", "request.route"]
 			AddSampleRateKeyToTrace = true
 			AddSampleRateKeyToTraceField = "meta.refinery.dynsampler_key"
 
 	[[dataset4.rule]]
-		SampleRate = 10 # default when no rules match, if missing defaults to 1
+		SampleRate = 10 # default when no rules match, if missing defaults to 10
+
+
+
+
+
 
 [dataset5]
 

--- a/rules_complete.toml
+++ b/rules_complete.toml
@@ -208,24 +208,38 @@ SampleRate = 1
 	Sampler = "RulesBasedSampler"
 
 	[[dataset4.rule]]
+		name = "drop healtchecks"
+		drop = true
+		[[dataset4.rule.condition]]
+			field = "http.route"
+			operator = "="
+			value = "/health-check"
+
+	[[dataset4.rule]]
 		name = "500 errors"
 		SampleRate = 1
 		[[dataset4.rule.condition]]
-		field = "status_code"
-		operator = "="
-		value = 500
+			field = "status_code"
+			operator = "="
+			value = 500
 		[[dataset4.rule.condition]]
-		field = "duration_ms"
-		operator = ">="
-		value = 1000.789
+			field = "duration_ms"
+			operator = ">="
+			value = 1000.789
 
 	[[dataset4.rule]]
-		name = "drop 200 responses"
-		drop = true
+		name = "dynamic sample 200 responses"
 		[[dataset4.rule.condition]]
-		field = "status_code"
-		operator = "="
-		value = 200
+			field = "status_code"
+			operator = "="
+			value = 200
+		# define Dynamic Sampler used to determine sample rate
+		# Can be DyanmicSampler or EMADynamicSampler
+		[dataset4.downstream.DynamicSampler]
+			SampleRate = 5
+			FieldList = ["http.route", "http.method"]
+			AddSampleRateKeyToTrace = true
+			AddSampleRateKeyToTraceField = "meta.refinery.dynsampler_key"
 
 	[[dataset4.rule]]
 		SampleRate = 10 # default when no rules match, if missing defaults to 1

--- a/sample/rules.go
+++ b/sample/rules.go
@@ -1,12 +1,13 @@
 package sample
 
 import (
+	"math/rand"
+	"strings"
+
 	"github.com/honeycombio/refinery/config"
 	"github.com/honeycombio/refinery/logger"
 	"github.com/honeycombio/refinery/metrics"
 	"github.com/honeycombio/refinery/types"
-	"math/rand"
-	"strings"
 )
 
 type RulesBasedSampler struct {
@@ -36,7 +37,6 @@ func (s *RulesBasedSampler) Start() error {
 				sampler = &EMADynamicSampler{Config: rule.Sampler.EMADynamicSampler, Logger: s.Logger, Metrics: s.Metrics}
 			} else if rule.Sampler.TotalThroughputSampler != nil {
 				sampler = &TotalThroughputSampler{Config: rule.Sampler.TotalThroughputSampler, Logger: s.Logger, Metrics: s.Metrics}
-
 			} else {
 				s.Logger.Debug().WithFields(map[string]interface{}{
 					"rule_name": rule.Name,
@@ -52,10 +52,8 @@ func (s *RulesBasedSampler) Start() error {
 				continue
 			}
 			s.samplers[rule.String()] = sampler
-
 		}
 	}
-
 	return nil
 }
 
@@ -146,7 +144,6 @@ func (s *RulesBasedSampler) GetSampleRate(trace *types.Trace) (rate uint, keep b
 			var keep bool
 
 			if rule.Sampler != nil {
-
 				var sampler Sampler
 				var found bool
 				if sampler, found = s.samplers[rule.String()]; !found {
@@ -155,9 +152,7 @@ func (s *RulesBasedSampler) GetSampleRate(trace *types.Trace) (rate uint, keep b
 					}).Logf("could not find downstream sampler for rule: %s", rule.Name)
 					return 1, true
 				}
-
 				rate, keep = sampler.GetSampleRate(trace)
-
 			} else {
 				rate = uint(rule.SampleRate)
 				keep = !rule.Drop && rule.SampleRate > 0 && rand.Intn(rule.SampleRate) == 0

--- a/sample/rules_test.go
+++ b/sample/rules_test.go
@@ -535,7 +535,7 @@ func TestRulesWithDynamicSampler(t *testing.T) {
 								Value:    int64(1),
 							},
 						},
-						Downstream: &config.RulesBasedDownstreamSampler{
+						Sampler: &config.RulesBasedDownstreamSampler{
 							DynamicSampler: &config.DynamicSamplerConfig{
 								SampleRate:                   10,
 								FieldList:                    []string{"http.status_code"},
@@ -618,7 +618,7 @@ func TestRulesWithEMADynamicSampler(t *testing.T) {
 								Value:    int64(1),
 							},
 						},
-						Downstream: &config.RulesBasedDownstreamSampler{
+						Sampler: &config.RulesBasedDownstreamSampler{
 							EMADynamicSampler: &config.EMADynamicSamplerConfig{
 								GoalSampleRate:               10,
 								FieldList:                    []string{"http.status_code"},


### PR DESCRIPTION
## Which problem is this PR solving?
The RulesBased sample is exclusive to the other samplers. This PR allows you to use Dynamic and EMADynamic samplers to determine the sample rate of a RulesBased sampler rule.

## Short description of the changes

This adds a new `Downstream` option to a rule configuration. This option can be used to contain either a `DynamicSampler` or `EMADynamicSampler` option that is a complete configuration of their respective samplers.  When defined the downstream sampler will be used to determine the sample rate when all rule conditions are matched.

A popular use case is to use RulesBased sampling to keep all error and long duration traces while using a dynamic sampler for all other data, based on key fields.

Closes #283 


notes: 

- I'm not sure the word `Downstream` is the right one here. Naming things is hard.
- I would also prefer to have just the initial option contain the entire downstream sampler config, without having to wrap it into another config option.  However, because of Go's strong typing, this doesn't seem possible without significant re-architecture of how the config is parsed for all samplers.
