### PR TITLE
Build and publish multi-arch docker images on tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,9 +126,16 @@ jobs:
   publish_docker:
     executor: linuxgo
     steps:
+      - restore_cache:
+          keys:
+            googkleko
+      - run: go install github.com/google/ko@latest
+      - save_cache:
+          key: googkleko
+          paths:
+            - $GOPATH/bin/ko
       - checkout
       - setup_remote_docker
-      - run: go install github.com/google/ko@latest
       - run:
           name: "Publish multi-arch docker image"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,6 @@ version: 2.1
 
 orbs:
   aws-cli: circleci/aws-cli@1.3.0
-  docker: circleci/docker@1.3.0
 
 executors:
   linuxgo:
@@ -125,7 +124,7 @@ jobs:
             aws s3 sync ~/artifacts s3://honeycomb-builds/honeycombio/refinery/$version/
 
   publish_docker:
-    executor: cimg/go:1.16
+    executor: linuxgo
     steps:
       - checkout
       - run: go install github.com/google/ko@latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,10 +128,10 @@ jobs:
     steps:
       - restore_cache:
           keys:
-            googkleko
+            googleko
       - run: go install github.com/google/ko@latest
       - save_cache:
-          key: googkleko
+          key: googleko
           paths:
             - $GOPATH/bin/ko
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,6 +127,7 @@ jobs:
     executor: linuxgo
     steps:
       - checkout
+      - setup_remote_docker
       - run: go install github.com/google/ko@latest
       - run:
           name: "Publish multi-arch docker image"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,7 +140,7 @@ jobs:
           name: "Publish multi-arch docker image"
           command: |
             echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin;
-            VERSION=${CIRCLE_TAG} KO_DOCKER_REPO=honeycombio build/build_docker.sh
+            build/build_docker.sh
 
 workflows:
   build:
@@ -179,6 +179,5 @@ workflows:
             - build
           filters:
             tags:
-              only: /^v.*/
-            branches:
-              ignore: /.*/
+              only: /.*/
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,6 +124,17 @@ jobs:
             if [[ -z "$version" ]] ; then version=${CIRCLE_SHA1:0:7}; fi
             aws s3 sync ~/artifacts s3://honeycomb-builds/honeycombio/refinery/$version/
 
+  publish_docker:
+    executor: cimg/go:1.16
+    steps:
+      - checkout
+      - run: go install github.com/google/ko@latest
+      - run:
+          name: "Publish multi-arch docker image"
+          command: |
+            echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin;
+            VERSION=${CIRCLE_TAG} KO_DOCKER_REPO=honeycombio build/build_docker.sh
+
 workflows:
   build:
     jobs:
@@ -155,19 +166,8 @@ workflows:
               only: /^v.*/
             branches:
               ignore: /.*/
-      - docker/publish:
-          tag: latest
-          extra_build_args: --build-arg BUILD_ID=${CIRCLE_SHA1:0:7}
-          image: $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME
-          requires:
-            - build
-          filters:
-            branches:
-              only: main
-      - docker/publish:
-          tag: latest,${CIRCLE_TAG:1}
-          extra_build_args: --build-arg BUILD_ID=${CIRCLE_TAG:1}
-          image: $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME
+      - publish_docker:
+          context: Honeycomb Secrets for Public Repos
           requires:
             - build
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
   linuxgo:
     parameters:
     docker:
-      - image: cimg/go:1.15
+      - image: cimg/go:1.16
       - image: redis:6
 
 commands:

--- a/build/build_docker.sh
+++ b/build/build_docker.sh
@@ -1,0 +1,18 @@
+set -o nounset
+set -o pipefail
+
+VERSION=${VERSION:-dev}
+PLATFORM="${PLATFORM:-linux/amd64,linux/arm64,darwin/amd64}"
+
+unset GOOS
+unset GOARCH
+export KO_DOCKER_REPO=${KO_DOCKER_REPO:-ko.local}
+export GOFLAGS="-ldflags=-X=main.version=${VERSION}"
+export SOURCE_DATE_EPOCH=$(date +%s)
+# shellcheck disable=SC2086
+ko publish \
+  --tags "head,${VERSION}" \
+  --base-import-paths \
+  --platform "${PLATFORM}" \
+  ${PUBLISH_ARGS-} \
+  ./cmd/refinery

--- a/build/build_docker.sh
+++ b/build/build_docker.sh
@@ -16,5 +16,5 @@ export SOURCE_DATE_EPOCH=$(date +%s)
 ko publish \
   --tags "${TAGS}" \
   --base-import-paths \
-  --platform "linux/amd64,linux/arm64,darwin/amd64" \
+  --platform "linux/amd64,linux/arm64" \
   ./cmd/refinery

--- a/build/build_docker.sh
+++ b/build/build_docker.sh
@@ -2,15 +2,18 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
-VERSION="${VERSION:-dev}"
 TAGS="latest"
+VERSION=${CIRCLE_TAG:-dev}
+REPO=${KO_DOCKER_REPO:-ko.local}
 if [[ $VERSION != "dev" ]]; then
+    # set docker username and add version tag
+    REPO="honeycombio"
     TAGS+=",$VERSION"
 fi
 
 unset GOOS
 unset GOARCH
-export KO_DOCKER_REPO=${KO_DOCKER_REPO:-ko.local}
+export KO_DOCKER_REPO=$REPO
 export GOFLAGS="-ldflags=-X=main.BuildID=$VERSION"
 export SOURCE_DATE_EPOCH=$(date +%s)
 # shellcheck disable=SC2086

--- a/build/build_docker.sh
+++ b/build/build_docker.sh
@@ -1,5 +1,6 @@
 set -o nounset
 set -o pipefail
+set -o xtrace
 
 VERSION="${VERSION:-dev}"
 TAGS="latest"

--- a/build/build_docker.sh
+++ b/build/build_docker.sh
@@ -10,7 +10,7 @@ fi
 unset GOOS
 unset GOARCH
 export KO_DOCKER_REPO=${KO_DOCKER_REPO:-ko.local}
-export GOFLAGS="-ldflags=-X=main.version=$VERSION"
+export GOFLAGS="-ldflags=-X=main.BuildID=$VERSION"
 export SOURCE_DATE_EPOCH=$(date +%s)
 # shellcheck disable=SC2086
 ko publish \

--- a/build/build_docker.sh
+++ b/build/build_docker.sh
@@ -1,18 +1,20 @@
 set -o nounset
 set -o pipefail
 
-VERSION=${VERSION:-dev}
-PLATFORM="${PLATFORM:-linux/amd64,linux/arm64,darwin/amd64}"
+VERSION="${VERSION:-dev}"
+TAGS="latest"
+if [[ $VERSION != "dev" ]]; then
+    TAGS+=",$VERSION"
+fi
 
 unset GOOS
 unset GOARCH
 export KO_DOCKER_REPO=${KO_DOCKER_REPO:-ko.local}
-export GOFLAGS="-ldflags=-X=main.version=${VERSION}"
+export GOFLAGS="-ldflags=-X=main.version=$VERSION"
 export SOURCE_DATE_EPOCH=$(date +%s)
 # shellcheck disable=SC2086
 ko publish \
-  --tags "head,${VERSION}" \
+  --tags "${TAGS}" \
   --base-import-paths \
-  --platform "${PLATFORM}" \
-  ${PUBLISH_ARGS-} \
+  --platform "linux/amd64,linux/arm64,darwin/amd64" \
   ./cmd/refinery

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/honeycombio/refinery
 
-go 1.14
+go 1.16
 
 require (
 	github.com/davecgh/go-spew v1.1.1


### PR DESCRIPTION
## Which problem is this PR solving?
When publishing to docker, our images should be built and be runnable on multiple architectures. This PR updates our docker image build process to use [Google KO](https://github.com/google/ko) to build the image.
- Resolves #318 
- Resolves #270 

## Short description of the changes
- update go.mod to use v.1.16
- replace docker orb with new `publish_docker` job
- use ko to build multi-arch docker image
- add build/build_docker.sh to manage executing ko command