### PR TITLE
[dev/ci] test in dev and CI the same way

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,17 +31,7 @@ jobs:
       - image: redis:6
     steps:
       - checkout
-      - run:
-          name: install dockerize
-          command: wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && sudo tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
-          environment:
-            DOCKERIZE_VERSION: v0.3.0
-      - run:
-          name: Wait for redis
-          command: dockerize -wait tcp://localhost:6379 -timeout 1m
-      - run:
-          name: Tests
-          command: make test
+      - run: make test
 
   build_binaries:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,14 @@ jobs:
           key: v1-dockerize-{{ checksum "Makefile" }}
           paths:
             - dockerize.tar.gz
+      - restore_cache:
+          keys:
+            - v3-go-mod-{{ checksum "go.sum" }}
       - run: make test
+      - save_cache:
+          key: v3-go-mod-{{ checksum "go.sum" }}
+          paths:
+            - /home/circleci/go/pkg/mod
 
   build_binaries:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,11 +40,8 @@ jobs:
           name: Wait for redis
           command: dockerize -wait tcp://localhost:6379 -timeout 1m
       - run:
-          name: go_test with race
-          command: go test -tags race --race --timeout 60s -v ./...
-      - run:
-          name: go_test
-          command: go test -tags all --timeout 60s -v ./...
+          name: Tests
+          command: make test
 
   build_binaries:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,15 @@ jobs:
       - image: redis:6
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - v1-dockerize-{{ checksum "Makefile" }}
+            - v1-dockerize-
+      - run: make dockerize
+      - save_cache:
+          key: v1-dockerize-{{ checksum "Makefile" }}
+          paths:
+            - dockerize.tar.gz
       - run: make test
 
   build_binaries:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+.PHONY: test
+#: run all tests
+test: test_with_race test_all
+
+.PHONY: test_with_race
+#: run only tests tagged with potential race conditions
+test_with_race:
+	@echo
+	@echo "+++ testing - race conditions?"
+	@echo
+	go test -tags race --race --timeout 60s -v ./...
+
+.PHONY: test_all
+#: run all tests, but with no race condition detection
+test_all:
+	@echo
+	@echo "+++ testing - all the tests"
+	@echo
+	go test -tags all --timeout 60s -v ./...

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,14 @@
+MAKEFLAGS += --warn-undefined-variables
+MAKEFLAGS += --no-builtin-rules
+MAKEFLAGS += --no-builtin-variables
+
 .PHONY: test
 #: run all tests
 test: test_with_race test_all
 
 .PHONY: test_with_race
 #: run only tests tagged with potential race conditions
-test_with_race:
+test_with_race: wait_for_redis
 	@echo
 	@echo "+++ testing - race conditions?"
 	@echo
@@ -12,8 +16,40 @@ test_with_race:
 
 .PHONY: test_all
 #: run all tests, but with no race condition detection
-test_all:
+test_all: wait_for_redis
 	@echo
 	@echo "+++ testing - all the tests"
 	@echo
 	go test -tags all --timeout 60s -v ./...
+
+.PHONY: wait_for_redis
+# wait for Redis to become available for test suite
+wait_for_redis: dockerize
+	@echo
+	@echo "+++ We need a Redis running to run the tests."
+	@echo
+	@echo "Checking with dockerize $(shell ./dockerize --version)"
+	@./dockerize -wait tcp://localhost:6379 -timeout 30s
+
+# ensure the dockerize command is available
+dockerize: dockerize.tar.gz
+	tar xzvmf dockerize.tar.gz
+
+HOST_OS := $(shell uname -s | tr A-Z a-z)
+# You can override this version from an environment variable.
+DOCKERIZE_VERSION ?= v0.6.1
+DOCKERIZE_RELEASE_ASSET := dockerize-${HOST_OS}-amd64-${DOCKERIZE_VERSION}.tar.gz
+
+dockerize.tar.gz:
+	@echo
+	@echo "+++ Retrieving dockerize tool for Redis readiness check."
+	@echo
+	curl --location --silent --show-error \
+		--output dockerize.tar.gz \
+		https://github.com/jwilder/dockerize/releases/download/${DOCKERIZE_VERSION}/${DOCKERIZE_RELEASE_ASSET} \
+	&& file dockerize.tar.gz | grep --silent gzip
+
+.PHONY: clean
+clean:
+	rm -f dockerize.tar.gz
+	rm -f dockerize


### PR DESCRIPTION
## Which problem is this PR solving?

- "How We Test This" only lived in the Circle CI config.

## Short description of the changes

- Adds a Makefile
- Adds "test_with_race" and "test_all" make targets for the two test commands CI had been running
- Adds a "test" target to run both
- Adds targets for retrieving and running dockerize to verify Redis is available before running the test suite

- Caches the dockerize release asset
- Caches the go mod dependencies

I'll note that the caching didn't save any appreciable time on the test runs that took advantage of the caches. 