### PR TITLE
build docker images during publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,26 +129,22 @@ jobs:
       - run: go install github.com/google/ko@latest
       - checkout
       - setup_remote_docker
-      - run: ./build-docker.sh
-      - run: mkdir -p ~/images
-      - run: docker save honeycombio/refinery | gzip > ~/images/refinery.tar.gz
-      - persist_to_workspace:
-          root: ~/
-          paths:
-            - images
-      - store_artifacts:
-          path: ~/images
+      - run:
+          name: build docker images and publish locally
+          command: ./build-docker.sh
 
   publish_docker:
     docker:
-      - image: cimg/base:stable
+      - image: cimg/go:1.16
     steps:
-      - attach_workspace:
-          at: ~/
+      - run: go install github.com/google/ko@latest
+      - checkout
       - setup_remote_docker
-      - run: docker load -i ~/images/refinery.tar.gz
-      - run: echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin;
-      - run: docker image push -a honeycombio/refinery
+      - run:
+          name: build docker images and publish to Docker Hub
+          environment:
+            KO_DOCKER_REPO: honeycombio
+          command: ./build-docker.sh
 
 workflows:
   build:

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -13,7 +13,7 @@ fi
 
 unset GOOS
 unset GOARCH
-export KO_DOCKER_REPO="ko.local"
+export KO_DOCKER_REPO=${KO_DOCKER_REPO:-ko.local}
 export GOFLAGS="-ldflags=-X=main.BuildID=$VERSION"
 export SOURCE_DATE_EPOCH=$(date +%s)
 # shellcheck disable=SC2086


### PR DESCRIPTION
## Which problem is this PR solving?
When building and publishing a docker image in multiple jobs, only the architecture of the CI runtime is persisted. We want to build and publish all architectures, so we've reverted to building the docker image as part publish step.

- Fixes #335 

## Short description of the changes
- update build-docker.sh to use the `KO_DOCKER_REPO` env var, defaulting to `ko.local` for local publishing
- update circle ci config to build the docker image both in `build_docker` and `publish_docker` jobs, with publish setting the `KO_DOCKER_REPO` env var so _ko_ publishes to Docker Hub.

