### PR TITLE
Re-add missing docker login when publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,7 +145,7 @@ jobs:
           environment:
             KO_DOCKER_REPO: honeycombio
           command: |
-            echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+            echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin;
             ./build-docker.sh
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,7 +145,7 @@ jobs:
           environment:
             KO_DOCKER_REPO: honeycombio
           command: |
-            echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+            echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
             ./build-docker.sh
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,7 +144,9 @@ jobs:
           name: build docker images and publish to Docker Hub
           environment:
             KO_DOCKER_REPO: honeycombio
-          command: ./build-docker.sh
+          command: |
+            echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+            ./build-docker.sh
 
 workflows:
   build:


### PR DESCRIPTION
## Which problem is this PR solving?
We need to provide login credentials for publishing to DockerHub, these were accidentally removed while refactoring.

## Short description of the changes
- re-add docker login command when publishing

