### PR TITLE
Add an --interface-names flag

### DIFF
--- a/cmd/refinery/main.go
+++ b/cmd/refinery/main.go
@@ -33,10 +33,11 @@ var BuildID string
 var version string
 
 type Options struct {
-	ConfigFile string `short:"c" long:"config" description:"Path to config file" default:"/etc/refinery/refinery.toml"`
-	RulesFile  string `short:"r" long:"rules_config" description:"Path to rules config file" default:"/etc/refinery/rules.toml"`
-	Version    bool   `short:"v" long:"version" description:"Print version number and exit"`
-	Debug      bool   `short:"d" long:"debug" description:"If enabled, runs debug service (runs on the first open port between localhost:6060 and :6069 by default)"`
+	ConfigFile     string `short:"c" long:"config" description:"Path to config file" default:"/etc/refinery/refinery.toml"`
+	RulesFile      string `short:"r" long:"rules_config" description:"Path to rules config file" default:"/etc/refinery/rules.toml"`
+	Version        bool   `short:"v" long:"version" description:"Print version number and exit"`
+	Debug          bool   `short:"d" long:"debug" description:"If enabled, runs debug service (runs on the first open port between localhost:6060 and :6069 by default)"`
+	InterfaceNames bool   `long:"interface-names" description:"If set, print system's network interface names and exit."`
 }
 
 func main() {
@@ -55,6 +56,18 @@ func main() {
 
 	if opts.Version {
 		fmt.Println("Version: " + version)
+		os.Exit(0)
+	}
+
+	if opts.InterfaceNames {
+		ifaces, err := net.Interfaces()
+		if err != nil {
+			fmt.Printf("Error: %s\n", err)
+			os.Exit(1)
+		}
+		for _, i := range ifaces {
+			fmt.Println(i.Name)
+		}
 		os.Exit(0)
 	}
 

--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -320,14 +320,14 @@ func TestCacheSizeReload(t *testing.T) {
 	coll.AddSpan(&types.Span{TraceID: "2", Event: event})
 
 	expectedEvents := 1
-	wait := 2 * time.Millisecond
+	wait := 1 * time.Second
 	check := func() bool {
 		transmission.Mux.RLock()
 		defer transmission.Mux.RUnlock()
 
 		return len(transmission.Events) == expectedEvents
 	}
-	assert.Eventually(t, check, 10*wait, wait, "expected one trace evicted and sent")
+	assert.Eventually(t, check, 60*wait, wait, "expected one trace evicted and sent")
 
 	conf.Mux.Lock()
 	conf.GetInMemoryCollectorCacheCapacityVal.CacheCapacity = 2
@@ -339,7 +339,7 @@ func TestCacheSizeReload(t *testing.T) {
 		defer coll.mutex.RUnlock()
 
 		return coll.cache.(*cache.DefaultInMemCache).GetCacheSize() == 2
-	}, 10*wait, wait, "cache size to change")
+	}, 60*wait, wait, "cache size to change")
 
 	coll.AddSpan(&types.Span{TraceID: "3", Event: event})
 	time.Sleep(5 * conf.SendTickerVal)
@@ -351,7 +351,7 @@ func TestCacheSizeReload(t *testing.T) {
 	conf.ReloadConfig()
 
 	expectedEvents = 2
-	assert.Eventually(t, check, 10*wait, wait, "expected another trace evicted and sent")
+	assert.Eventually(t, check, 60*wait, wait, "expected another trace evicted and sent")
 }
 
 func TestSampleConfigReload(t *testing.T) {
@@ -361,7 +361,7 @@ func TestSampleConfigReload(t *testing.T) {
 
 	conf := &config.MockConfig{
 		GetSendDelayVal:                      0,
-		GetTraceTimeoutVal:                   10 * time.Millisecond,
+		GetTraceTimeoutVal:                   60 * time.Second,
 		GetSamplerTypeVal:                    &config.DeterministicSamplerConfig{SampleRate: 1},
 		SendTickerVal:                        2 * time.Millisecond,
 		GetInMemoryCollectorCacheCapacityVal: config.InMemoryCollectorCacheCapacity{CacheCapacity: 10},


### PR DESCRIPTION
Our config lets you specify which network name to use for peers; this
flag makes it easier to discover what interfaces the binary has
available.

Example, on a locally-built image:
```
± docker run  -t ko.local/refinery:e2915c3075fd17b54c155f53b04acf0cff1a027a5610cc7bf25052d0725bd7ed --interface-names
lo
eth0
```