### PR TITLE
Use alpine as base image

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,0 +1,1 @@
+defaultBaseImage: alpine:3.13

--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -320,14 +320,14 @@ func TestCacheSizeReload(t *testing.T) {
 	coll.AddSpan(&types.Span{TraceID: "2", Event: event})
 
 	expectedEvents := 1
-	wait := 2 * time.Millisecond
+	wait := 1 * time.Second
 	check := func() bool {
 		transmission.Mux.RLock()
 		defer transmission.Mux.RUnlock()
 
 		return len(transmission.Events) == expectedEvents
 	}
-	assert.Eventually(t, check, 10*wait, wait, "expected one trace evicted and sent")
+	assert.Eventually(t, check, 60*wait, wait, "expected one trace evicted and sent")
 
 	conf.Mux.Lock()
 	conf.GetInMemoryCollectorCacheCapacityVal.CacheCapacity = 2
@@ -339,7 +339,7 @@ func TestCacheSizeReload(t *testing.T) {
 		defer coll.mutex.RUnlock()
 
 		return coll.cache.(*cache.DefaultInMemCache).GetCacheSize() == 2
-	}, 10*wait, wait, "cache size to change")
+	}, 60*wait, wait, "cache size to change")
 
 	coll.AddSpan(&types.Span{TraceID: "3", Event: event})
 	time.Sleep(5 * conf.SendTickerVal)
@@ -351,7 +351,7 @@ func TestCacheSizeReload(t *testing.T) {
 	conf.ReloadConfig()
 
 	expectedEvents = 2
-	assert.Eventually(t, check, 10*wait, wait, "expected another trace evicted and sent")
+	assert.Eventually(t, check, 60*wait, wait, "expected another trace evicted and sent")
 }
 
 func TestSampleConfigReload(t *testing.T) {
@@ -361,7 +361,7 @@ func TestSampleConfigReload(t *testing.T) {
 
 	conf := &config.MockConfig{
 		GetSendDelayVal:                      0,
-		GetTraceTimeoutVal:                   10 * time.Millisecond,
+		GetTraceTimeoutVal:                   60 * time.Second,
 		GetSamplerTypeVal:                    &config.DeterministicSamplerConfig{SampleRate: 1},
 		SendTickerVal:                        2 * time.Millisecond,
 		GetInMemoryCollectorCacheCapacityVal: config.InMemoryCollectorCacheCapacity{CacheCapacity: 10},


### PR DESCRIPTION
Alpine is not _that_ much bigger than google's distroless image. and
having this OS layer underneath will make it easier to debug.

(Currently: do we have a problem with the network interface name in our
config?)