### PR TITLE
Revert "Use alpine as base image (#343)"

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,1 +1,0 @@
-defaultBaseImage: alpine:3.13


### PR DESCRIPTION
This reverts commit 7614a6e1691933a53182f6196be4fa40512f3632.

<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Fixes #350 

## Short description of the changes

- As mentioned in the linked issue, running with no command line arguments produced the command line parsing error. By removing this base image, there are no issues running sans command line args.

