### PR TITLE
Improves histogram buckets over the default set

### DIFF
--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -72,6 +72,9 @@ func (p *PromMetrics) Register(name string, metricType string) {
 			Name:      name,
 			Namespace: p.prefix,
 			Help:      name,
+			// This is an attempt at a usable set of buckets for a wide range of metrics
+			// 16 buckets, first upper bound of 1, each following upper bound is 4x the previous
+			Buckets: prometheus.ExponentialBuckets(1, 4, 16),
 		})
 	}
 


### PR DESCRIPTION
This is an attempt at a usable set of buckets for a wide range of metrics

## Which problem is this PR solving?

Fixes #115

As noted in the issue, the default buckets in the go client are as follows:

```
DefBuckets = []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10}
```

… and from the docs … 

> DefBuckets are the default Histogram buckets. The default buckets are tailored to broadly measure the response time (in seconds) of a network service. Most likely, however, you will be required to define buckets customized to your use case.

Additionally from the docs … 

> Buckets defines the buckets into which observations are counted. Each element in the slice is the upper inclusive bound of a bucket. The values must be sorted in strictly increasing order. There is no need to add a highest bucket with +Inf bound, it will be added implicitly. The default value is DefBuckets.

In the end, the `cache_entries` metric therefore always ends up in the implicit +inf bucket and makes the metric nearly useless. You just know your `cache_entries` are more than 10.

For example "your stuff is more than 10!":

![graphs that show that these only go to 10](https://user-images.githubusercontent.com/517302/143901822-21a001d8-6a8c-452a-a4ca-44345cd10b76.png)

