### PR TITLE
fix: nil-check KeyValue.Value

### DIFF
--- a/route/otlp_trace.go
+++ b/route/otlp_trace.go
@@ -230,7 +230,7 @@ func processTraceRequest(
 
 func addAttributesToMap(attrs map[string]interface{}, attributes []*common.KeyValue) {
 	for _, attr := range attributes {
-		if attr.Key == "" {
+		if attr.Key == "" || attr.Value == nil {
 			continue
 		}
 		switch attr.Value.Value.(type) {

--- a/route/otlp_trace_test.go
+++ b/route/otlp_trace_test.go
@@ -91,6 +91,22 @@ func TestOTLPHandler(t *testing.T) {
 		mockTransmission.Flush()
 	})
 
+	t.Run("spans with invalid attributes", func(t *testing.T) {
+		req := &collectortrace.ExportTraceServiceRequest{
+			ResourceSpans: []*trace.ResourceSpans{{
+				InstrumentationLibrarySpans: []*trace.InstrumentationLibrarySpans{{
+					Spans: helperOTLPRequestSpansWithInvalidAttributes(),
+				}},
+			}},
+		}
+		_, err := router.Export(ctx, req)
+		if err != nil {
+			t.Errorf(`Unexpected error: %s`, err)
+		}
+		assert.Equal(t, 2, len(mockTransmission.Events))
+		mockTransmission.Flush()
+	})
+
 	// TODO: (MG) figuure out how we can test JSON created from OTLP requests
 	// Below is example, but requires significant usage of collector, sampler, conf, etc
 	t.Run("creates events for span events", func(t *testing.T) {
@@ -316,6 +332,42 @@ func helperOTLPRequestSpansWithoutStatus() []*trace.Span {
 							Value: &common.AnyValue{
 								Value: &common.AnyValue_StringValue{StringValue: "attribute_value"},
 							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func helperOTLPRequestSpansWithInvalidAttributes() []*trace.Span {
+	now := time.Now()
+	return []*trace.Span{
+		{
+			StartTimeUnixNano: uint64(now.UnixNano()),
+			Events: []*trace.Span_Event{
+				{
+					TimeUnixNano: uint64(now.UnixNano()),
+					Attributes: []*common.KeyValue{
+						{
+							Key: "",
+							Value: &common.AnyValue{
+								Value: &common.AnyValue_StringValue{StringValue: "attribute_value"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			StartTimeUnixNano: uint64(now.UnixNano()),
+			Events: []*trace.Span_Event{
+				{
+					TimeUnixNano: uint64(now.UnixNano()),
+					Attributes: []*common.KeyValue{
+						{
+							Key: "attribute_key",
+							Value: nil,
 						},
 					},
 				},

--- a/route/otlp_trace_test.go
+++ b/route/otlp_trace_test.go
@@ -103,7 +103,7 @@ func TestOTLPHandler(t *testing.T) {
 		if err != nil {
 			t.Errorf(`Unexpected error: %s`, err)
 		}
-		assert.Equal(t, 2, len(mockTransmission.Events))
+		assert.Equal(t, 4, len(mockTransmission.Events))
 		mockTransmission.Flush()
 	})
 


### PR DESCRIPTION
## Which problem is this PR solving?

- somehow we have a corrupt client that's sending a nil Value pointer, which is causing a crash.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0xc124e2]

goroutine 959 [running]:
github.com/honeycombio/refinery/route.addAttributesToMap(0xc06ad49c20, 0xc06a9e80c0, 0x7, 0x8)
	/app/route/otlp_trace.go:236 +0x62
github.com/honeycombio/refinery/route.processTraceRequest(0xf3a018, 0xc06a79b740, 0xc0000d2260, 0xc0694f6b80, 0xc048188f40, 0x20, 0xc04a920b28, 0x4, 0xc0695825a0, 0x0)
	/app/route/otlp_trace.go:125 +0x2292
github.com/honeycombio/refinery/route.(*Router).Export(0xc0000d2260, 0xf3a018, 0xc06a79b740, 0xc0694f6b80, 0xc0000d2260, 0xc06a79b740, 0xc04c063ba0)
	/app/route/otlp_trace.go:59 +0x178
github.com/honeycombio/refinery/internal/opentelemetry-proto-gen/collector/trace/v1._TraceService_Export_Handler(0xde9a00, 0xc0000d2260, 0xf3a018, 0xc06a79b740, 0xc06aae93e0, 0x0, 0xf3a018, 0xc06a79b740, 0xc06ac94000, 0x1c197)
	/app/internal/opentelemetry-proto-gen/collector/trace/v1/trace_service.pb.go:190 +0x214
google.golang.org/grpc.(*Server).processUnaryRPC(0xc00034a700, 0xf416f8, 0xc048262600, 0xc0695825a0, 0xc000407020, 0x1424ee0, 0x0, 0x0, 0x0)
	/go/pkg/mod/google.golang.org/grpc@v1.39.1/server.go:1293 +0x52b
google.golang.org/grpc.(*Server).handleStream(0xc00034a700, 0xf416f8, 0xc048262600, 0xc0695825a0, 0x0)
	/go/pkg/mod/google.golang.org/grpc@v1.39.1/server.go:1618 +0xd0c
google.golang.org/grpc.(*Server).serveStreams.func1.2(0xc04921a1a0, 0xc00034a700, 0xf416f8, 0xc048262600, 0xc0695825a0)
	/go/pkg/mod/google.golang.org/grpc@v1.39.1/server.go:941 +0xab
created by google.golang.org/grpc.(*Server).serveStreams.func1
	/go/pkg/mod/google.golang.org/grpc@v1.39.1/server.go:939 +0x1fd
```

## Short description of the changes

- Skips attributes with no key, or no value.

