### PR TITLE
feat: Make MaxBatchSize configurable

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -161,7 +161,7 @@ func newStartedApp(
 	sdPeer, _ := statsd.New(statsd.Prefix("refinery.peer"))
 	peerClient, err := libhoney.NewClient(libhoney.ClientConfig{
 		Transmission: &transmission.Honeycomb{
-			MaxBatchSize:         uint(c.GetMaxBatchSize()),
+			MaxBatchSize:         c.GetMaxBatchSize(),
 			BatchTimeout:         libhoney.DefaultBatchTimeout,
 			MaxConcurrentBatches: libhoney.DefaultMaxConcurrentBatches,
 			PendingWorkCapacity:  uint(c.GetPeerBufferSize()),

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -105,6 +105,7 @@ func newStartedApp(
 	c := &config.MockConfig{
 		GetSendDelayVal:                      0,
 		GetTraceTimeoutVal:                   10 * time.Millisecond,
+		GetMaxBatchSizeVal:                   500,
 		GetSamplerTypeVal:                    &config.DeterministicSamplerConfig{SampleRate: 1},
 		SendTickerVal:                        2 * time.Millisecond,
 		PeerManagementType:                   "file",
@@ -160,7 +161,7 @@ func newStartedApp(
 	sdPeer, _ := statsd.New(statsd.Prefix("refinery.peer"))
 	peerClient, err := libhoney.NewClient(libhoney.ClientConfig{
 		Transmission: &transmission.Honeycomb{
-			MaxBatchSize:         500,
+			MaxBatchSize:         uint(c.GetMaxBatchSize()),
 			BatchTimeout:         libhoney.DefaultBatchTimeout,
 			MaxConcurrentBatches: libhoney.DefaultMaxConcurrentBatches,
 			PendingWorkCapacity:  uint(c.GetPeerBufferSize()),

--- a/cmd/refinery/main.go
+++ b/cmd/refinery/main.go
@@ -134,7 +134,7 @@ func main() {
 	userAgentAddition := "refinery/" + version
 	upstreamClient, err := libhoney.NewClient(libhoney.ClientConfig{
 		Transmission: &transmission.Honeycomb{
-			MaxBatchSize:          uint(c.GetMaxBatchSize()),
+			MaxBatchSize:          c.GetMaxBatchSize(),
 			BatchTimeout:          libhoney.DefaultBatchTimeout,
 			MaxConcurrentBatches:  libhoney.DefaultMaxConcurrentBatches,
 			PendingWorkCapacity:   uint(c.GetUpstreamBufferSize()),
@@ -152,7 +152,7 @@ func main() {
 
 	peerClient, err := libhoney.NewClient(libhoney.ClientConfig{
 		Transmission: &transmission.Honeycomb{
-			MaxBatchSize:          uint(c.GetMaxBatchSize()),
+			MaxBatchSize:          c.GetMaxBatchSize(),
 			BatchTimeout:          libhoney.DefaultBatchTimeout,
 			MaxConcurrentBatches:  libhoney.DefaultMaxConcurrentBatches,
 			PendingWorkCapacity:   uint(c.GetPeerBufferSize()),

--- a/cmd/refinery/main.go
+++ b/cmd/refinery/main.go
@@ -134,7 +134,7 @@ func main() {
 	userAgentAddition := "refinery/" + version
 	upstreamClient, err := libhoney.NewClient(libhoney.ClientConfig{
 		Transmission: &transmission.Honeycomb{
-			MaxBatchSize:          500,
+			MaxBatchSize:          uint(c.GetMaxBatchSize()),
 			BatchTimeout:          libhoney.DefaultBatchTimeout,
 			MaxConcurrentBatches:  libhoney.DefaultMaxConcurrentBatches,
 			PendingWorkCapacity:   uint(c.GetUpstreamBufferSize()),
@@ -152,7 +152,7 @@ func main() {
 
 	peerClient, err := libhoney.NewClient(libhoney.ClientConfig{
 		Transmission: &transmission.Honeycomb{
-			MaxBatchSize:          500,
+			MaxBatchSize:          uint(c.GetMaxBatchSize()),
 			BatchTimeout:          libhoney.DefaultBatchTimeout,
 			MaxConcurrentBatches:  libhoney.DefaultMaxConcurrentBatches,
 			PendingWorkCapacity:   uint(c.GetPeerBufferSize()),

--- a/config/config.go
+++ b/config/config.go
@@ -73,7 +73,7 @@ type Config interface {
 	GetTraceTimeout() (time.Duration, error)
 
 	// GetMaxBatchSize is the number of events to be included in the batch for sending
-	GetMaxBatchSize() int
+	GetMaxBatchSize() uint
 
 	// GetOtherConfig attempts to fill the passed in struct with the contents of
 	// a subsection of the config.   This is used by optional configurations to

--- a/config/config.go
+++ b/config/config.go
@@ -72,6 +72,9 @@ type Config interface {
 	// duration.
 	GetTraceTimeout() (time.Duration, error)
 
+	// GetMaxBatchSize is the number of events to be included in the batch for sending
+	GetMaxBatchSize() int
+
 	// GetOtherConfig attempts to fill the passed in struct with the contents of
 	// a subsection of the config.   This is used by optional configurations to
 	// allow different implementations of necessary interfaces configure

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -646,7 +646,7 @@ func (f *fileConfig) GetTraceTimeout() (time.Duration, error) {
 	return f.conf.TraceTimeout, nil
 }
 
-func (f *fileConfig) GetMaxBatchSize() int {
+func (f *fileConfig) GetMaxBatchSize() uint {
 	f.mux.RLock()
 	defer f.mux.RUnlock()
 

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -38,6 +38,7 @@ type configContents struct {
 	Metrics                   string        `validate:"required,oneof= prometheus honeycomb"`
 	SendDelay                 time.Duration `validate:"required"`
 	TraceTimeout              time.Duration `validate:"required"`
+	MaxBatchSize							int						`validate:"required"`
 	SendTicker                time.Duration `validate:"required"`
 	UpstreamBufferSize        int           `validate:"required"`
 	PeerBufferSize            int           `validate:"required"`
@@ -113,6 +114,7 @@ func NewConfig(config, rules string, errorCallback func(error)) (Config, error) 
 	c.SetDefault("Metrics", "honeycomb")
 	c.SetDefault("SendDelay", 2*time.Second)
 	c.SetDefault("TraceTimeout", 60*time.Second)
+	c.SetDefault("MaxBatchSize", 500)
 	c.SetDefault("SendTicker", 100*time.Millisecond)
 	c.SetDefault("UpstreamBufferSize", libhoney.DefaultPendingWorkCapacity)
 	c.SetDefault("PeerBufferSize", libhoney.DefaultPendingWorkCapacity)
@@ -642,6 +644,13 @@ func (f *fileConfig) GetTraceTimeout() (time.Duration, error) {
 	defer f.mux.RUnlock()
 
 	return f.conf.TraceTimeout, nil
+}
+
+func (f *fileConfig) GetMaxBatchSize() int {
+	f.mux.RLock()
+	defer f.mux.RUnlock()
+
+	return f.conf.MaxBatchSize
 }
 
 func (f *fileConfig) GetOtherConfig(name string, iface interface{}) error {

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -38,7 +38,7 @@ type configContents struct {
 	Metrics                   string        `validate:"required,oneof= prometheus honeycomb"`
 	SendDelay                 time.Duration `validate:"required"`
 	TraceTimeout              time.Duration `validate:"required"`
-	MaxBatchSize              int           `validate:"required"`
+	MaxBatchSize              uint           `validate:"required"`
 	SendTicker                time.Duration `validate:"required"`
 	UpstreamBufferSize        int           `validate:"required"`
 	PeerBufferSize            int           `validate:"required"`

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -38,7 +38,7 @@ type configContents struct {
 	Metrics                   string        `validate:"required,oneof= prometheus honeycomb"`
 	SendDelay                 time.Duration `validate:"required"`
 	TraceTimeout              time.Duration `validate:"required"`
-	MaxBatchSize							int						`validate:"required"`
+	MaxBatchSize              int           `validate:"required"`
 	SendTicker                time.Duration `validate:"required"`
 	UpstreamBufferSize        int           `validate:"required"`
 	PeerBufferSize            int           `validate:"required"`

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -38,7 +38,7 @@ type configContents struct {
 	Metrics                   string        `validate:"required,oneof= prometheus honeycomb"`
 	SendDelay                 time.Duration `validate:"required"`
 	TraceTimeout              time.Duration `validate:"required"`
-	MaxBatchSize              uint           `validate:"required"`
+	MaxBatchSize              uint          `validate:"required"`
 	SendTicker                time.Duration `validate:"required"`
 	UpstreamBufferSize        int           `validate:"required"`
 	PeerBufferSize            int           `validate:"required"`

--- a/config/mock.go
+++ b/config/mock.go
@@ -56,6 +56,7 @@ type MockConfig struct {
 	GetSendDelayVal               time.Duration
 	GetTraceTimeoutErr            error
 	GetTraceTimeoutVal            time.Duration
+	GetMaxBatchSize			          int
 	GetUpstreamBufferSizeVal      int
 	GetPeerBufferSizeVal          int
 	SendTickerVal                 time.Duration
@@ -219,6 +220,13 @@ func (m *MockConfig) GetTraceTimeout() (time.Duration, error) {
 	defer m.Mux.RUnlock()
 
 	return m.GetTraceTimeoutVal, m.GetTraceTimeoutErr
+}
+
+func (m *MockConfig) GetMaxBatchSize() int {
+	m.Mux.RLock()
+	defer m.Mux.RUnlock()
+
+	return m.GetMaxBatchSizeVal
 }
 
 // TODO: allow per-dataset mock values

--- a/config/mock.go
+++ b/config/mock.go
@@ -56,7 +56,7 @@ type MockConfig struct {
 	GetSendDelayVal               time.Duration
 	GetTraceTimeoutErr            error
 	GetTraceTimeoutVal            time.Duration
-	GetMaxBatchSizeVal            int
+	GetMaxBatchSizeVal            uint
 	GetUpstreamBufferSizeVal      int
 	GetPeerBufferSizeVal          int
 	SendTickerVal                 time.Duration
@@ -222,7 +222,7 @@ func (m *MockConfig) GetTraceTimeout() (time.Duration, error) {
 	return m.GetTraceTimeoutVal, m.GetTraceTimeoutErr
 }
 
-func (m *MockConfig) GetMaxBatchSize() int {
+func (m *MockConfig) GetMaxBatchSize() uint {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 

--- a/config/mock.go
+++ b/config/mock.go
@@ -56,7 +56,7 @@ type MockConfig struct {
 	GetSendDelayVal               time.Duration
 	GetTraceTimeoutErr            error
 	GetTraceTimeoutVal            time.Duration
-	GetMaxBatchSize			          int
+	GetMaxBatchSizeVal	          int
 	GetUpstreamBufferSizeVal      int
 	GetPeerBufferSizeVal          int
 	SendTickerVal                 time.Duration

--- a/config/mock.go
+++ b/config/mock.go
@@ -56,7 +56,7 @@ type MockConfig struct {
 	GetSendDelayVal               time.Duration
 	GetTraceTimeoutErr            error
 	GetTraceTimeoutVal            time.Duration
-	GetMaxBatchSizeVal	          int
+	GetMaxBatchSizeVal            int
 	GetUpstreamBufferSizeVal      int
 	GetPeerBufferSizeVal          int
 	SendTickerVal                 time.Duration

--- a/config_complete.toml
+++ b/config_complete.toml
@@ -67,6 +67,9 @@ SendDelay = "2s"
 # Eligible for live reload.
 TraceTimeout = "60s"
 
+# MaxBatchSize is the number of events to be included in the batch for sending
+MaxBatchSize = 500
+
 # SendTicker is a short timer; it determines the duration to use to check for traces to send
 SendTicker = "100ms"
 


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- MaxBatchSize is currently hardcoded to 500 with no ability to override

## Short description of the changes

- Add config option for MaxBatchSize, with default of 500


