### PR TITLE
docs: update rules example

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -217,7 +217,7 @@ func TestReadRulesConfig(t *testing.T) {
 
 		rule = r.Rule[1]
 		assert.Equal(t, 1, rule.SampleRate)
-		assert.Equal(t, "500 errors or slow", rule.Name)
+		assert.Equal(t, "keep slow 500 errors", rule.Name)
 		assert.Len(t, rule.Condition, 2)
 
 	default:

--- a/rules_complete.toml
+++ b/rules_complete.toml
@@ -216,7 +216,7 @@ SampleRate = 1
 			value = "/health-check"
 
 	[[dataset4.rule]]
-		name = "500 errors or slow"
+		name = "keep slow 500 errors"
 		SampleRate = 1
 		[[dataset4.rule.condition]]
 			field = "status_code"
@@ -228,7 +228,7 @@ SampleRate = 1
 			value = 1000.789
 
 	[[dataset4.rule]]
-		name = "dynamic sample 200 responses"
+		name = "dynamically sample 200 responses"
 		[[dataset4.rule.condition]]
 			field = "status_code"
 			operator = "="


### PR DESCRIPTION
rule conditions are ANDed not ORed

<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- rule example is confusing because it implies that conditions are ORed

## Short description of the changes

- clarify with a better rule name

