### PR TITLE
Add retries when connecting to redis during init

### DIFF
--- a/internal/peer/redis.go
+++ b/internal/peer/redis.go
@@ -59,7 +59,10 @@ func newRedisPeers(c config.Config) (Peers, error) {
 		IdleTimeout: 5 * time.Minute,
 		Wait:        true,
 		Dial: func() (redis.Conn, error) {
-			// keep trying to connect to redis
+			// if redis is started at the same time as refinery, connecting to redis can
+			// fail and cause refinery to error out.
+			// Instead, we will try to connect to redis for up to 10 seconds with
+			// a 1 second delay between attempts to allow the redis process to init
 			for timeout := time.After(10 * time.Second); ; {
 				select {
 				case <-timeout:
@@ -69,7 +72,6 @@ func newRedisPeers(c config.Config) (Peers, error) {
 					if err == nil {
 						return conn, nil
 					}
-					// delay before trying again
 					time.Sleep(time.Second)
 				}
 			}

--- a/internal/peer/redis.go
+++ b/internal/peer/redis.go
@@ -63,12 +63,16 @@ func newRedisPeers(c config.Config) (Peers, error) {
 			// fail and cause refinery to error out.
 			// Instead, we will try to connect to redis for up to 10 seconds with
 			// a 1 second delay between attempts to allow the redis process to init
+			var (
+				conn redis.Conn
+				err error
+			)
 			for timeout := time.After(10 * time.Second); ; {
 				select {
 				case <-timeout:
-					return nil, fmt.Errorf("failed to connect to redis at [%s]", redisHost)
+					return nil, err
 				default:
-					conn, err := redis.Dial("tcp", redisHost, options...)
+					conn, err = redis.Dial("tcp", redisHost, options...)
 					if err == nil {
 						return conn, nil
 					}


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
The refinery process only attempts to connect to redis ones during initialization. This can be challenging when redis is started at the same time and causes refinery to error out.

This change allows refinery to keep attempting to connect to redis for up to 10 seconds, with a one second delay between attempts.

## Short description of the changes
- Add timeout of 10 seconds when calling redis.dial with a 1 second delay between attempts

