### PR TITLE
Properly set meta.refinery.local_hostname field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ refinery
 !/cmd/refinery
 test_redimem
 !/cmd/test_redimem
+
+dockerize*

--- a/collect/collect.go
+++ b/collect/collect.go
@@ -467,6 +467,12 @@ func (i *InMemCollector) send(trace *types.Trace) {
 			field := i.Config.GetDryRunFieldName()
 			sp.Data[field] = shouldSend
 		}
+		if i.Config.GetAddHostMetadataToTrace() {
+			if hostname, err := os.Hostname(); err == nil && hostname != "" {
+				// add hostname to span
+				sp.Data["meta.refinery.local_hostname"] = hostname
+			}
+		}
 		// if spans are already sampled, take that in to account when computing
 		// the final rate
 		sp.SampleRate *= trace.SampleRate

--- a/transmit/transmit.go
+++ b/transmit/transmit.go
@@ -2,7 +2,6 @@ package transmit
 
 import (
 	"context"
-	"os"
 	"sync"
 
 	libhoney "github.com/honeycombio/libhoney-go"
@@ -53,13 +52,6 @@ func (d *DefaultTransmission) Start() error {
 	upstreamAPI, err := d.Config.GetHoneycombAPI()
 	if err != nil {
 		return err
-	}
-
-	if d.Config.GetAddHostMetadataToTrace() {
-		if hostname, err := os.Hostname(); err == nil && hostname != "" {
-			// add hostname to spans
-			d.LibhClient.AddField("meta.refinery.local_hostname", hostname)
-		}
 	}
 
 	d.builder = d.LibhClient.NewBuilder()


### PR DESCRIPTION
Ensure the hostname is set before transmitting upstream to the current hostname.

## Which problem is this PR solving?

- Closes #385 

## Short description of the changes

- As suggested by @puckpuck in #385, the host metadata is now added just before the trace is sent upstream