### PR TITLE
added username in config for redis auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ To enable the redis-based config:
 
 When launched in redis-config mode, Refinery needs a redis host to use for managing the list of peers in the Refinery cluster. This hostname and port can be specified in one of two ways:
 
-- set the `REFINERY_REDIS_HOST` environment variable (and optionally the `REFINERY_REDIS_PASSWORD` environment variable)
-- set the `RedisHost` field in the config file (and optionally the `RedisPassword` field in the config file)
+- set the `REFINERY_REDIS_HOST` environment variable (and optionally the `REFINERY_REDIS_USERNAME` and `REFINERY_REDIS_PASSWORD` environment variables)
+- set the `RedisHost` field in the config file (and optionally the `RedisUsername` and `RedisPassword` fields in the config file)
 
 The Redis host should be a hostname and a port, for example `redis.mydomain.com:6379`. The example config file has `localhost:6379` which obviously will not work with more than one host. When TLS is required to connect to the Redis instance, set the `UseTLS` config to `true`.
 

--- a/config/config.go
+++ b/config/config.go
@@ -45,6 +45,10 @@ type Config interface {
 	// management.
 	GetRedisHost() (string, error)
 
+	// GetRedisUsername returns the username of a Redis instance to use for peer
+	// management.
+	GetRedisUsername() (string, error)
+
 	// GetRedisPassword returns the password of a Redis instance to use for peer
 	// management.
 	GetRedisPassword() (string, error)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -46,6 +46,23 @@ func TestRedisHostEnvVar(t *testing.T) {
 	}
 }
 
+func TestRedisUsernameEnvVar(t *testing.T) {
+	const username = "admin"
+	const envVarName = "REFINERY_REDIS_USERNAME"
+	os.Setenv(envVarName, username)
+	defer os.Unsetenv(envVarName)
+
+	c, err := NewConfig("../config.toml", "../rules.toml", func(err error) {})
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if d, _ := c.GetRedisUsername(); d != username {
+		t.Error("received", d, "expected", username)
+	}
+}
+
 func TestRedisPasswordEnvVar(t *testing.T) {
 	const password = "admin1234"
 	const envVarName = "REFINERY_REDIS_PASSWORD"

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -82,6 +82,7 @@ type PeerManagementConfig struct {
 	Type                    string   `validate:"required,oneof= file redis"`
 	Peers                   []string `validate:"dive,url"`
 	RedisHost               string
+	RedisUsername           string
 	RedisPassword           string
 	UseTLS                  bool
 	UseTLSInsecure          bool
@@ -96,6 +97,7 @@ func NewConfig(config, rules string, errorCallback func(error)) (Config, error) 
 
 	c.BindEnv("GRPCListenAddr", "REFINERY_GRPC_LISTEN_ADDRESS")
 	c.BindEnv("PeerManagement.RedisHost", "REFINERY_REDIS_HOST")
+	c.BindEnv("PeerManagement.RedisUsername", "REFINERY_REDIS_USERNAME")
 	c.BindEnv("PeerManagement.RedisPassword", "REFINERY_REDIS_PASSWORD")
 	c.BindEnv("HoneycombLogger.LoggerAPIKey", "REFINERY_HONEYCOMB_API_KEY")
 	c.BindEnv("HoneycombMetrics.MetricsAPIKey", "REFINERY_HONEYCOMB_API_KEY")
@@ -412,6 +414,13 @@ func (f *fileConfig) GetRedisHost() (string, error) {
 	defer f.mux.RUnlock()
 
 	return f.config.GetString("PeerManagement.RedisHost"), nil
+}
+
+func (f *fileConfig) GetRedisUsername() (string, error) {
+	f.mux.RLock()
+	defer f.mux.RUnlock()
+
+	return f.config.GetString("PeerManagement.RedisUsername"), nil
 }
 
 func (f *fileConfig) GetRedisPassword() (string, error) {

--- a/config/mock.go
+++ b/config/mock.go
@@ -38,6 +38,8 @@ type MockConfig struct {
 	GetPeersVal                   []string
 	GetRedisHostErr               error
 	GetRedisHostVal               string
+	GetRedisUsernameErr           error
+	GetRedisUsernameVal           string
 	GetRedisPasswordErr           error
 	GetRedisPasswordVal           string
 	GetUseTLSErr                  error
@@ -172,6 +174,12 @@ func (m *MockConfig) GetRedisHost() (string, error) {
 	defer m.Mux.RUnlock()
 
 	return m.GetRedisHostVal, m.GetRedisHostErr
+}
+func (m *MockConfig) GetRedisUsername() (string, error) {
+	m.Mux.RLock()
+	defer m.Mux.RUnlock()
+
+	return m.GetRedisUsernameVal, m.GetRedisUsernameErr
 }
 func (m *MockConfig) GetRedisPassword() (string, error) {
 	m.Mux.RLock()

--- a/config_complete.toml
+++ b/config_complete.toml
@@ -152,6 +152,12 @@ Metrics = "honeycomb"
 # Not eligible for live reload.
 # RedisHost = "localhost:6379"
 
+# RedisUsername is the username used to connect to redis for peer cluster membership management.
+# If the environment variable 'REFINERY_REDIS_USERNAME' is set it takes
+# precedence and this value is ignored.
+# Not eligible for live reload.
+# RedisUsername = ""
+
 # RedisPassword is the password used to connect to redis for peer cluster membership management.
 # If the environment variable 'REFINERY_REDIS_PASSWORD' is set it takes
 # precedence and this value is ignored.

--- a/internal/peer/redis.go
+++ b/internal/peer/redis.go
@@ -65,7 +65,7 @@ func newRedisPeers(c config.Config) (Peers, error) {
 			// a 1 second delay between attempts to allow the redis process to init
 			var (
 				conn redis.Conn
-				err error
+				err  error
 			)
 			for timeout := time.After(10 * time.Second); ; {
 				select {
@@ -188,6 +188,11 @@ func buildOptions(c config.Config) []redis.DialOption {
 		redis.DialReadTimeout(1 * time.Second),
 		redis.DialConnectTimeout(1 * time.Second),
 		redis.DialDatabase(0), // TODO enable multiple databases for multiple samproxies
+	}
+
+	username, _ := c.GetRedisUsername()
+	if username != "" {
+		options = append(options, redis.DialUsername(username))
 	}
 
 	password, _ := c.GetRedisPassword()


### PR DESCRIPTION
## Which problem is this PR solving?

- Issue https://github.com/honeycombio/refinery/issues/396

## Short description of the changes

- Adds optional username field in the config file for authenticating with redis. I tested this on my refinery instance connected to aws' redis memorydb

