### PR TITLE
fix: deadlock when reloading configs

### DIFF
--- a/config/file_config.go
+++ b/config/file_config.go
@@ -206,9 +206,6 @@ func (f *fileConfig) onChange(in fsnotify.Event) {
 
 	f.unmarshal()
 
-	f.mux.RLock()
-	defer f.mux.RUnlock()
-
 	for _, c := range f.callbacks {
 		c()
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

This manifested in k8s because we get double notified about config changes.

Previously, onChange would acquire a read lock, and then each callback would also acquire a read lock
when reading whatever config value they care about. onChange also acquires a write lock when unmarshalling.
With additional goroutines calling onChange (e.g. in k8s), we were almost guaranteed to have a write lock in
between two recursive read locks.

From Go RLock docs:
```
// It should not be used for recursive read locking; a blocked Lock
// call excludes new readers from acquiring the lock. See the
// documentation on the RWMutex type.
```

A helpful answer from StackOverflow: https://stackoverflow.com/a/30549188

Fixes #380

## Short description of the changes

Removing the read lock around callbacks. Every config accessor function already has a read lock, and we don't care about locking config if a callback doesn't read config values.

