### PR TITLE
Update aws-client orb to latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  aws-cli: circleci/aws-cli@1.3.0
+  aws-cli: circleci/aws-cli@2.1.0
 
 commands:
   go-build:


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
Updates the AWS CLI orb used in the CircleCI workflows to deploy artefacts. This image based on a Ubuntu image that will longer be avaialble soon.

- Closes #404 

## Short description of the changes
- update awscli orb version to latest (2.1.0)

