### PR TITLE
Update to YAML configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ For more detail on how this algorithm works, please refer to the `dynsampler` pa
 
 ## Dry Run Mode
 
-When getting started with Refinery or when updating sampling rules, it may be helpful to verify that the rules are working as expected before you start dropping traffic. By enabling dry run mode, all spans in each trace will be marked with the sampling decision in a field called `refinery_kept`. All traces will be sent to Honeycomb regardless of the sampling decision. You can then run queries in Honeycomb on this field to check your results and verify that the rules are working as intended. Enable dry run mode by adding `DryRun = true` in your configuration, as noted in `rules_complete.toml`.
+When getting started with Refinery or when updating sampling rules, it may be helpful to verify that the rules are working as expected before you start dropping traffic. By enabling dry run mode, all spans in each trace will be marked with the sampling decision in a field called `refinery_kept`. All traces will be sent to Honeycomb regardless of the sampling decision. You can then run queries in Honeycomb on this field to check your results and verify that the rules are working as intended. Enable dry run mode by adding `DryRun = true` in your configuration, as noted in `rules_complete.yaml`.
 
 When dry run mode is enabled, the metric `trace_send_kept` will increment for each trace, and the metric for `trace_send_dropped` will remain 0, reflecting that we are sending all traces to Honeycomb.
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ Additional RAM and CPU can be used by increasing configuration values to have a 
 
 Refinery is built by [CircleCI](https://circleci.com/gh/honeycombio/refinery). Released versions of Refinery are available via Github under the Releases tab.
 
+### Upgrading from v1.12.0
+The default setup for the refinery service will attempt to load configuration files in YAML format. 
+The prior TOML format configuration files can still be used, but will require a change to the service setup in `refinery.service` or `refinery.upstart`.
+The configuration properties between YAML and TOML formats are equivalent.
+
 ## Configuration
 
 Configuration is done in one of two ways, either entirely by the config file or a combination of the config file and a Redis service for managing the list of peers in the cluster.

--- a/build-pkg.sh
+++ b/build-pkg.sh
@@ -39,5 +39,5 @@ fpm -s dir -n refinery \
     $GOPATH/bin/refinery-linux-${arch}=/usr/bin/refinery \
     ./refinery.upstart=/etc/init/refinery.conf \
     ./refinery.service=/lib/systemd/system/refinery.service \
-    ./config.toml=/etc/refinery/refinery.toml \
-    ./rules.toml=/etc/refinery/rules.toml
+    ./config.yaml=/etc/refinery/refinery.yaml \
+    ./rules.yaml=/etc/refinery/rules.yaml

--- a/cmd/refinery/main.go
+++ b/cmd/refinery/main.go
@@ -33,8 +33,8 @@ var BuildID string
 var version string
 
 type Options struct {
-	ConfigFile     string `short:"c" long:"config" description:"Path to config file" default:"/etc/refinery/refinery.toml"`
-	RulesFile      string `short:"r" long:"rules_config" description:"Path to rules config file" default:"/etc/refinery/rules.toml"`
+	ConfigFile     string `short:"c" long:"config" description:"Path to config file" default:"/etc/refinery/refinery.yaml"`
+	RulesFile      string `short:"r" long:"rules_config" description:"Path to rules config file" default:"/etc/refinery/rules.yaml"`
 	Version        bool   `short:"v" long:"version" description:"Print version number and exit"`
 	Debug          bool   `short:"d" long:"debug" description:"If enabled, runs debug service (runs on the first open port between localhost:6060 and :6069 by default)"`
 	InterfaceNames bool   `long:"interface-names" description:"If set, print system's network interface names and exit."`

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,40 @@
+#######################
+## Quickstart Config ##
+#######################
+
+# InMemCollector brings together all the settings that are relevant to
+# collecting spans together to make traces.
+InMemCollector:
+
+  # The collection cache is used to collect all spans into a trace as well as
+  # remember the sampling decision for any spans that might come in after the
+  # trace has been marked "complete" (either by timing out or seeing the root
+  # span). The number of traces in the cache should be many multiples (100x to
+  # 1000x) of the total number of concurrently active traces (trace throughput *
+  # trace duration).
+  # Eligible for live reload. Growing the cache capacity with a live config reload
+  # is fine. Avoid shrinking it with a live reload (you can, but it may cause
+  # temporary odd sampling decisions).
+  CacheCapacity: 1000
+
+
+HoneycombMetrics:
+
+  # MetricsHoneycombAPI is the URL for the upstream Honeycomb API.
+  # Eligible for live reload.
+  MetricsHoneycombAPI: 'https://api.honeycomb.io'
+
+  # MetricsAPIKey is the API key to use to send log events to the Honeycomb logging
+  # dataset. This is separate from the APIKeys used to authenticate regular
+  # traffic.
+  # Eligible for live reload.
+  MetricsAPIKey: abcd1234
+
+  # MetricsDataset is the name of the dataset to which to send Refinery metrics
+  # Eligible for live reload.
+  MetricsDataset: Refinery Metrics
+
+  # MetricsReportingInterval is the frequency (in seconds) to send metric events
+  # to Honeycomb. Between 1 and 60 is recommended.
+  # Not eligible for live reload.
+  MetricsReportingInterval: 3

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,3 +1,4 @@
+//go:build all || race
 // +build all race
 
 package config
@@ -18,7 +19,7 @@ func TestGRPCListenAddrEnvVar(t *testing.T) {
 	os.Setenv(envVarName, address)
 	defer os.Unsetenv(envVarName)
 
-	c, err := NewConfig("../config.toml", "../rules.toml", func(err error) {})
+	c, err := NewConfig("../config.yaml", "../rules.yaml", func(err error) {})
 
 	if err != nil {
 		t.Error(err)
@@ -35,7 +36,7 @@ func TestRedisHostEnvVar(t *testing.T) {
 	os.Setenv(envVarName, host)
 	defer os.Unsetenv(envVarName)
 
-	c, err := NewConfig("../config.toml", "../rules.toml", func(err error) {})
+	c, err := NewConfig("../config.yaml", "../rules.yaml", func(err error) {})
 
 	if err != nil {
 		t.Error(err)
@@ -52,7 +53,7 @@ func TestRedisUsernameEnvVar(t *testing.T) {
 	os.Setenv(envVarName, username)
 	defer os.Unsetenv(envVarName)
 
-	c, err := NewConfig("../config.toml", "../rules.toml", func(err error) {})
+	c, err := NewConfig("../config.yaml", "../rules.yaml", func(err error) {})
 
 	if err != nil {
 		t.Error(err)
@@ -69,7 +70,7 @@ func TestRedisPasswordEnvVar(t *testing.T) {
 	os.Setenv(envVarName, password)
 	defer os.Unsetenv(envVarName)
 
-	c, err := NewConfig("../config.toml", "../rules.toml", func(err error) {})
+	c, err := NewConfig("../config.yaml", "../rules.yaml", func(err error) {})
 
 	if err != nil {
 		t.Error(err)
@@ -85,10 +86,10 @@ func TestReload(t *testing.T) {
 	assert.NoError(t, err)
 	defer os.RemoveAll(tmpDir)
 
-	rulesFile, err := ioutil.TempFile(tmpDir, "*.toml")
+	rulesFile, err := ioutil.TempFile(tmpDir, "*.yaml")
 	assert.NoError(t, err)
 
-	configFile, err := ioutil.TempFile(tmpDir, "*.toml")
+	configFile, err := ioutil.TempFile(tmpDir, "*.yaml")
 	assert.NoError(t, err)
 
 	dummy := []byte(`
@@ -166,7 +167,7 @@ func TestReload(t *testing.T) {
 }
 
 func TestReadDefaults(t *testing.T) {
-	c, err := NewConfig("../config.toml", "../rules.toml", func(err error) {})
+	c, err := NewConfig("../config.yaml", "../rules.yaml", func(err error) {})
 
 	if err != nil {
 		t.Error(err)
@@ -228,7 +229,7 @@ func TestReadDefaults(t *testing.T) {
 }
 
 func TestReadRulesConfig(t *testing.T) {
-	c, err := NewConfig("../config.toml", "../rules_complete.toml", func(err error) {})
+	c, err := NewConfig("../config.yaml", "../rules_complete.yaml", func(err error) {})
 
 	if err != nil {
 		t.Error(err)
@@ -270,10 +271,10 @@ func TestPeerManagementType(t *testing.T) {
 	assert.NoError(t, err)
 	defer os.RemoveAll(tmpDir)
 
-	configFile, err := ioutil.TempFile(tmpDir, "*.toml")
+	configFile, err := ioutil.TempFile(tmpDir, "*.yaml")
 	assert.NoError(t, err)
 
-	rulesFile, err := ioutil.TempFile(tmpDir, "*.toml")
+	rulesFile, err := ioutil.TempFile(tmpDir, "*.yaml")
 	assert.NoError(t, err)
 
 	_, err = configFile.Write([]byte(`
@@ -304,10 +305,10 @@ func TestAbsentTraceKeyField(t *testing.T) {
 	assert.NoError(t, err)
 	defer os.RemoveAll(tmpDir)
 
-	configFile, err := ioutil.TempFile(tmpDir, "*.toml")
+	configFile, err := ioutil.TempFile(tmpDir, "*.yaml")
 	assert.NoError(t, err)
 
-	rulesFile, err := ioutil.TempFile(tmpDir, "*.toml")
+	rulesFile, err := ioutil.TempFile(tmpDir, "*.yaml")
 	assert.NoError(t, err)
 
 	_, err = configFile.Write([]byte(`
@@ -344,10 +345,10 @@ func TestDebugServiceAddr(t *testing.T) {
 	assert.NoError(t, err)
 	defer os.RemoveAll(tmpDir)
 
-	configFile, err := ioutil.TempFile(tmpDir, "*.toml")
+	configFile, err := ioutil.TempFile(tmpDir, "*.yaml")
 	assert.NoError(t, err)
 
-	rulesFile, err := ioutil.TempFile(tmpDir, "*.toml")
+	rulesFile, err := ioutil.TempFile(tmpDir, "*.yaml")
 	assert.NoError(t, err)
 
 	_, err = configFile.Write([]byte(`
@@ -376,7 +377,7 @@ func TestDryRun(t *testing.T) {
 	assert.NoError(t, err)
 	defer os.RemoveAll(tmpDir)
 
-	configFile, err := ioutil.TempFile(tmpDir, "*.toml")
+	configFile, err := ioutil.TempFile(tmpDir, "*.yaml")
 	assert.NoError(t, err)
 
 	_, err = configFile.Write([]byte(`
@@ -390,7 +391,7 @@ func TestDryRun(t *testing.T) {
 		MetricsReportingInterval=3
 	`))
 
-	rulesFile, err := ioutil.TempFile(tmpDir, "*.toml")
+	rulesFile, err := ioutil.TempFile(tmpDir, "*.yaml")
 	assert.NoError(t, err)
 
 	_, err = rulesFile.Write([]byte(`
@@ -410,10 +411,10 @@ func TestMaxAlloc(t *testing.T) {
 	assert.NoError(t, err)
 	defer os.RemoveAll(tmpDir)
 
-	configFile, err := ioutil.TempFile(tmpDir, "*.toml")
+	configFile, err := ioutil.TempFile(tmpDir, "*.yaml")
 	assert.NoError(t, err)
 
-	rulesFile, err := ioutil.TempFile(tmpDir, "*.toml")
+	rulesFile, err := ioutil.TempFile(tmpDir, "*.yaml")
 	assert.NoError(t, err)
 
 	_, err = configFile.Write([]byte(`
@@ -442,7 +443,7 @@ func TestGetSamplerTypes(t *testing.T) {
 	assert.NoError(t, err)
 	defer os.RemoveAll(tmpDir)
 
-	configFile, err := ioutil.TempFile(tmpDir, "*.toml")
+	configFile, err := ioutil.TempFile(tmpDir, "*.yaml")
 	assert.NoError(t, err)
 
 	_, err = configFile.Write([]byte(`
@@ -456,7 +457,7 @@ func TestGetSamplerTypes(t *testing.T) {
 		MetricsReportingInterval=3
 	`))
 
-	rulesFile, err := ioutil.TempFile(tmpDir, "*.toml")
+	rulesFile, err := ioutil.TempFile(tmpDir, "*.yaml")
 	assert.NoError(t, err)
 
 	dummyConfig := []byte(`
@@ -530,10 +531,10 @@ func TestDefaultSampler(t *testing.T) {
 	assert.NoError(t, err)
 	defer os.RemoveAll(tmpDir)
 
-	rulesFile, err := ioutil.TempFile(tmpDir, "*.toml")
+	rulesFile, err := ioutil.TempFile(tmpDir, "*.yaml")
 	assert.NoError(t, err)
 
-	configFile, err := ioutil.TempFile(tmpDir, "*.toml")
+	configFile, err := ioutil.TempFile(tmpDir, "*.yaml")
 	assert.NoError(t, err)
 
 	dummy := []byte(`
@@ -567,10 +568,10 @@ func TestHoneycombLoggerConfig(t *testing.T) {
 	assert.NoError(t, err)
 	defer os.RemoveAll(tmpDir)
 
-	rulesFile, err := ioutil.TempFile(tmpDir, "*.toml")
+	rulesFile, err := ioutil.TempFile(tmpDir, "*.yaml")
 	assert.NoError(t, err)
 
-	configFile, err := ioutil.TempFile(tmpDir, "*.toml")
+	configFile, err := ioutil.TempFile(tmpDir, "*.yaml")
 	assert.NoError(t, err)
 
 	dummy := []byte(`
@@ -615,10 +616,10 @@ func TestHoneycombLoggerConfigDefaults(t *testing.T) {
 	assert.NoError(t, err)
 	defer os.RemoveAll(tmpDir)
 
-	rulesFile, err := ioutil.TempFile(tmpDir, "*.toml")
+	rulesFile, err := ioutil.TempFile(tmpDir, "*.yaml")
 	assert.NoError(t, err)
 
-	configFile, err := ioutil.TempFile(tmpDir, "*.toml")
+	configFile, err := ioutil.TempFile(tmpDir, "*.yaml")
 	assert.NoError(t, err)
 
 	dummy := []byte(`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -93,17 +93,17 @@ func TestReload(t *testing.T) {
 	assert.NoError(t, err)
 
 	dummy := []byte(`
-	ListenAddr="0.0.0.0:8080"
+ListenAddr: 0.0.0.0:8080
 
-	[InMemCollector]
-		CacheCapacity=1000
+InMemCollector:
+  CacheCapacity: 1000
 
-	[HoneycombMetrics]
-		MetricsHoneycombAPI="http://honeycomb.io"
-		MetricsAPIKey="1234"
-		MetricsDataset="testDatasetName"
-		MetricsReportingInterval=3
-	`)
+HoneycombMetrics:
+  MetricsHoneycombAPI: http://honeycomb.io
+  MetricsAPIKey: 1234
+  MetricsDataset: testDatasetName
+  MetricsReportingInterval: 3
+`)
 
 	_, err = configFile.Write(dummy)
 	assert.NoError(t, err)
@@ -154,7 +154,7 @@ func TestReload(t *testing.T) {
 	}()
 
 	if file, err := os.OpenFile(configFile.Name(), os.O_RDWR, 0644); err == nil {
-		file.WriteString(`ListenAddr = "0.0.0.0:9000"`)
+		file.WriteString(`ListenAddr: 0.0.0.0:9000 `)
 		file.Close()
 	}
 
@@ -278,19 +278,20 @@ func TestPeerManagementType(t *testing.T) {
 	assert.NoError(t, err)
 
 	_, err = configFile.Write([]byte(`
-	[InMemCollector]
-		CacheCapacity=1000
+InMemCollector:
+  CacheCapacity: 1000
 
-	[HoneycombMetrics]
-		MetricsHoneycombAPI="http://honeycomb.io"
-		MetricsAPIKey="1234"
-		MetricsDataset="testDatasetName"
-		MetricsReportingInterval=3
+HoneycombMetrics:
+  MetricsHoneycombAPI: http://honeycomb.io
+  MetricsAPIKey: 1234
+  MetricsDataset: testDatasetName
+  MetricsReportingInterval: 3
 
-	[PeerManagement]
-		Type = "redis"
-		Peers = ["http://refinery-1231:8080"]
-	`))
+PeerManagement:
+  Type: redis
+  Peers:
+    - "http://refinery-1231:8080"
+`))
 
 	c, err := NewConfig(configFile.Name(), rulesFile.Name(), func(err error) {})
 	assert.NoError(t, err)
@@ -312,26 +313,27 @@ func TestAbsentTraceKeyField(t *testing.T) {
 	assert.NoError(t, err)
 
 	_, err = configFile.Write([]byte(`
-		[InMemCollector]
-			CacheCapacity=1000
+InMemCollector:
+  CacheCapacity: 1000
 
-		[HoneycombMetrics]
-			MetricsHoneycombAPI="http://honeycomb.io"
-			MetricsAPIKey="1234"
-			MetricsDataset="testDatasetName"
-			MetricsReportingInterval=3
-	`))
+HoneycombMetrics:
+  MetricsHoneycombAPI: http://honeycomb.io
+  MetricsAPIKey: 1234
+  MetricsDataset: testDatasetName
+  MetricsReportingInterval: 3
+`))
 	assert.NoError(t, err)
 
 	_, err = rulesFile.Write([]byte(`
-		[dataset1]
-			Sampler = "EMADynamicSampler"
-			GoalSampleRate = 10
-			UseTraceLength = true
-			AddSampleRateKeyToTrace = true
-			FieldList = "[request.method]"
-			Weight = 0.4
-	`))
+dataset1:
+  Sampler: EMADynamicSampler
+  GoalSampleRate: 10
+  UseTraceLength: true
+  AddSampleRateKeyToTrace: true
+  FieldList:
+    - request.method
+  Weight: 0.4
+`))
 
 	rulesFile.Close()
 
@@ -352,17 +354,17 @@ func TestDebugServiceAddr(t *testing.T) {
 	assert.NoError(t, err)
 
 	_, err = configFile.Write([]byte(`
-	DebugServiceAddr = "localhost:8085"
+DebugServiceAddr: localhost:8085
 
-	[InMemCollector]
-		CacheCapacity=1000
+InMemCollector:
+  CacheCapacity: 1000
 
-	[HoneycombMetrics]
-		MetricsHoneycombAPI="http://honeycomb.io"
-		MetricsAPIKey="1234"
-		MetricsDataset="testDatasetName"
-		MetricsReportingInterval=3
-	`))
+HoneycombMetrics: 
+  MetricsHoneycombAPI: http://honeycomb.io
+  MetricsAPIKey: 1234
+  MetricsDataset: testDatasetName
+  MetricsReportingInterval: 3
+`))
 
 	c, err := NewConfig(configFile.Name(), rulesFile.Name(), func(err error) {})
 	assert.NoError(t, err)
@@ -381,22 +383,22 @@ func TestDryRun(t *testing.T) {
 	assert.NoError(t, err)
 
 	_, err = configFile.Write([]byte(`
-	[InMemCollector]
-		CacheCapacity=1000
+InMemCollector:
+  CacheCapacity: 1000
 
-	[HoneycombMetrics]
-		MetricsHoneycombAPI="http://honeycomb.io"
-		MetricsAPIKey="1234"
-		MetricsDataset="testDatasetName"
-		MetricsReportingInterval=3
-	`))
+HoneycombMetrics:
+  MetricsHoneycombAPI: http://honeycomb.io
+  MetricsAPIKey: 1234
+  MetricsDataset: testDatasetName
+  MetricsReportingInterval: 3
+`))
 
 	rulesFile, err := ioutil.TempFile(tmpDir, "*.yaml")
 	assert.NoError(t, err)
 
 	_, err = rulesFile.Write([]byte(`
-	DryRun=true
-	`))
+DryRun: true
+`))
 
 	c, err := NewConfig(configFile.Name(), rulesFile.Name(), func(err error) {})
 	assert.NoError(t, err)
@@ -418,16 +420,16 @@ func TestMaxAlloc(t *testing.T) {
 	assert.NoError(t, err)
 
 	_, err = configFile.Write([]byte(`
-	[InMemCollector]
-		CacheCapacity=1000
-		MaxAlloc=17179869184
+InMemCollector:
+  CacheCapacity: 1000
+  MaxAlloc: 17179869184
 
-	[HoneycombMetrics]
-		MetricsHoneycombAPI="http://honeycomb.io"
-		MetricsAPIKey="1234"
-		MetricsDataset="testDatasetName"
-		MetricsReportingInterval=3
-	`))
+HoneycombMetrics:
+  MetricsHoneycombAPI: http://honeycomb.io
+  MetricsAPIKey: 1234
+  MetricsDataset: testDatasetName
+  MetricsReportingInterval: 3
+`))
 
 	c, err := NewConfig(configFile.Name(), rulesFile.Name(), func(err error) {})
 	assert.NoError(t, err)
@@ -447,52 +449,51 @@ func TestGetSamplerTypes(t *testing.T) {
 	assert.NoError(t, err)
 
 	_, err = configFile.Write([]byte(`
-	[InMemCollector]
-		CacheCapacity=1000
+InMemCollector:
+  CacheCapacity: 1000
 
-	[HoneycombMetrics]
-		MetricsHoneycombAPI="http://honeycomb.io"
-		MetricsAPIKey="1234"
-		MetricsDataset="testDatasetName"
-		MetricsReportingInterval=3
-	`))
+HoneycombMetrics:
+  MetricsHoneycombAPI: http://honeycomb.io
+  MetricsAPIKey: 1234
+  MetricsDataset: testDatasetName
+  MetricsReportingInterval: 3
+`))
 
 	rulesFile, err := ioutil.TempFile(tmpDir, "*.yaml")
 	assert.NoError(t, err)
 
 	dummyConfig := []byte(`
-	Sampler = "DeterministicSampler"
-	SampleRate = 2
+Sampler: DeterministicSampler
+SampleRate: 2
 
-	['dataset 1']
-		Sampler = "DynamicSampler"
-		SampleRate = 2
-		FieldList = ["request.method","response.status_code"]
-		UseTraceLength = true
-		AddSampleRateKeyToTrace = true
-		AddSampleRateKeyToTraceField = "meta.refinery.dynsampler_key"
-		ClearFrequencySec = 60
+"dataset 1":
+  Sampler: DynamicSampler
+  SampleRate: 2
+  FieldList: [request.method,response.status_code]
+  UseTraceLength: true
+  AddSampleRateKeyToTrace: true
+  AddSampleRateKeyToTraceField: meta.refinery.dynsampler_key
+  ClearFrequencySec: 60
 
-	[dataset2]
+dataset2:
+  Sampler: DeterministicSampler
+  SampleRate: 10
 
-		Sampler = "DeterministicSampler"
-		SampleRate = 10
+dataset3:
+  Sampler: EMADynamicSampler
+  GoalSampleRate: 10
+  UseTraceLength: true
+  AddSampleRateKeyToTrace: true
+  AddSampleRateKeyToTraceField: meta.refinery.dynsampler_key
+  FieldList: 
+    - request.method
+  Weight: 0.3
 
-	[dataset3]
-
-		Sampler = "EMADynamicSampler"
-		GoalSampleRate = 10
-		UseTraceLength = true
-		AddSampleRateKeyToTrace = true
-		AddSampleRateKeyToTraceField = "meta.refinery.dynsampler_key"
-		FieldList = "[request.method]"
-		Weight = 0.3
-
-	[dataset4]
-
-		Sampler = "TotalThroughputSampler"
-		GoalThroughputPerSec = 100
-		FieldList = "[request.method]"
+dataset4:
+  Sampler: TotalThroughputSampler
+  GoalThroughputPerSec: 100
+  FieldList:
+    - request.method
 `)
 
 	_, err = rulesFile.Write(dummyConfig)
@@ -538,15 +539,15 @@ func TestDefaultSampler(t *testing.T) {
 	assert.NoError(t, err)
 
 	dummy := []byte(`
-	[InMemCollector]
-		CacheCapacity=1000
+InMemCollector:
+  CacheCapacity: 1000
 
-	[HoneycombMetrics]
-		MetricsHoneycombAPI="http://honeycomb.io"
-		MetricsAPIKey="1234"
-		MetricsDataset="testDatasetName"
-		MetricsReportingInterval=3
-	`)
+HoneycombMetrics:
+  MetricsHoneycombAPI: http://honeycomb.io
+  MetricsAPIKey: 1234
+  MetricsDataset: testDatasetName
+  MetricsReportingInterval: 3
+`)
 
 	_, err = configFile.Write(dummy)
 	assert.NoError(t, err)
@@ -575,22 +576,22 @@ func TestHoneycombLoggerConfig(t *testing.T) {
 	assert.NoError(t, err)
 
 	dummy := []byte(`
-	[InMemCollector]
-		CacheCapacity=1000
+InMemCollector:
+  CacheCapacity: 1000
 
-	[HoneycombMetrics]
-		MetricsHoneycombAPI="http://honeycomb.io"
-		MetricsAPIKey="1234"
-		MetricsDataset="testDatasetName"
-		MetricsReportingInterval=3
+HoneycombMetrics:
+  MetricsHoneycombAPI: http://honeycomb.io
+  MetricsAPIKey: 1234
+  MetricsDataset: testDatasetName
+  MetricsReportingInterval: 3
 
-	[HoneycombLogger]
-		LoggerHoneycombAPI="http://honeycomb.io"
-		LoggerAPIKey="1234"
-		LoggerDataset="loggerDataset"
-		LoggerSamplerEnabled=true
-		LoggerSamplerThroughput=10
-	`)
+HoneycombLogger:
+  LoggerHoneycombAPI: http://honeycomb.io
+  LoggerAPIKey: 1234
+  LoggerDataset: loggerDataset
+  LoggerSamplerEnabled: true
+  LoggerSamplerThroughput: 10
+`)
 
 	_, err = configFile.Write(dummy)
 	assert.NoError(t, err)
@@ -623,20 +624,20 @@ func TestHoneycombLoggerConfigDefaults(t *testing.T) {
 	assert.NoError(t, err)
 
 	dummy := []byte(`
-	[InMemCollector]
-		CacheCapacity=1000
+InMemCollector:
+  CacheCapacity: 1000
 
-	[HoneycombMetrics]
-		MetricsHoneycombAPI="http://honeycomb.io"
-		MetricsAPIKey="1234"
-		MetricsDataset="testDatasetName"
-		MetricsReportingInterval=3
+HoneycombMetrics:
+  MetricsHoneycombAPI: http://honeycomb.io
+  MetricsAPIKey: 1234
+  MetricsDataset: testDatasetName
+  MetricsReportingInterval: 3
 
-	[HoneycombLogger]
-		LoggerHoneycombAPI="http://honeycomb.io"
-		LoggerAPIKey="1234"
-		LoggerDataset="loggerDataset"
-	`)
+HoneycombLogger: 
+  LoggerHoneycombAPI: http://honeycomb.io
+  LoggerAPIKey: 1234
+  LoggerDataset: loggerDataset
+`)
 
 	_, err = configFile.Write(dummy)
 	assert.NoError(t, err)

--- a/config/config_test_reload_error_test.go
+++ b/config/config_test_reload_error_test.go
@@ -1,3 +1,4 @@
+//go:build all || !race
 // +build all !race
 
 package config
@@ -17,31 +18,31 @@ func TestErrorReloading(t *testing.T) {
 	assert.NoError(t, err)
 	defer os.RemoveAll(tmpDir)
 
-	rulesFile, err := ioutil.TempFile(tmpDir, "*.toml")
+	rulesFile, err := ioutil.TempFile(tmpDir, "*.yaml")
 	assert.NoError(t, err)
 
-	configFile, err := ioutil.TempFile(tmpDir, "*.toml")
+	configFile, err := ioutil.TempFile(tmpDir, "*.yaml")
 	assert.NoError(t, err)
 
 	dummy := []byte(`
-	[InMemCollector]
-		CacheCapacity=1000
+InMemCollector:
+  CacheCapacity: 1000
 
-	[HoneycombMetrics]
-		MetricsHoneycombAPI="http://honeycomb.io"
-		MetricsAPIKey="1234"
-		MetricsDataset="testDatasetName"
-		MetricsReportingInterval=3
-	`)
+HoneycombMetrics:
+  MetricsHoneycombAPI: http://honeycomb.io
+  MetricsAPIKey: 1234
+  MetricsDataset: testDatasetName
+  MetricsReportingInterval: 3
+`)
 
 	_, err = configFile.Write(dummy)
 	assert.NoError(t, err)
 	configFile.Close()
 
 	dummy = []byte(`
-	Sampler="DeterministicSampler"
-	SampleRate=1
-	`)
+Sampler: DeterministicSampler
+SampleRate: 1
+`)
 
 	_, err = rulesFile.Write(dummy)
 	assert.NoError(t, err)
@@ -73,7 +74,7 @@ func TestErrorReloading(t *testing.T) {
 		}
 	}()
 
-	err = ioutil.WriteFile(rulesFile.Name(), []byte(`Sampler="InvalidSampler"`), 0644)
+	err = ioutil.WriteFile(rulesFile.Name(), []byte(`Sampler: InvalidSampler`), 0644)
 
 	if err != nil {
 		t.Error(err)

--- a/config_complete.yaml
+++ b/config_complete.yaml
@@ -1,0 +1,312 @@
+#####################
+## Refinery Config ##
+#####################
+
+# ListenAddr is the IP and port on which to listen for incoming events. Incoming
+# traffic is expected to be HTTP, so if using SSL put something like nginx in
+# front to do the decryption.
+# Should be of the form 0.0.0.0:8080
+# Not eligible for live reload.
+ListenAddr: '0.0.0.0:8080'
+
+# GRPCListenAddr is the IP and port on which to listen for incoming events over
+# gRPC. Incoming traffic is expected to be unencrypted, so if using SSL put
+# something like nginx in front to do the decryption.
+# Should be of the form 0.0.0.0:9090
+# Not eligible for live reload.
+GRPCListenAddr: '0.0.0.0:9090'
+
+# PeerListenAddr is the IP and port on which to listen for traffic being
+# rerouted from a peer. Peer traffic is expected to be HTTP, so if using SSL
+# put something like nginx in front to do the decryption. Must be different from
+# ListenAddr
+# Should be of the form 0.0.0.0:8081
+# Not eligible for live reload.
+PeerListenAddr: '0.0.0.0:8081'
+
+# CompressPeerCommunication determines whether refinery will compress span data
+# it forwards to peers. If it costs money to transmit data between refinery
+# instances (e.g. they're spread across AWS availability zones), then you
+# almost certainly want compression enabled to reduce your bill. The option to
+# disable it is provided as an escape hatch for deployments that value lower CPU
+# utilization over data transfer costs.
+CompressPeerCommunication: true
+
+# APIKeys is a list of Honeycomb API keys that the proxy will accept. This list
+# only applies to events - other Honeycomb API actions will fall through to the
+# upstream API directly.
+# Adding keys here causes events arriving with API keys not in this list to be
+# rejected with an HTTP 401 error If an API key that is a literal '*' is in the
+# list, all API keys are accepted.
+# Eligible for live reload.
+APIKeys:
+  - '*' # wildcard accept all keys
+  # - replace-me
+  # - more-optional-keys
+
+# HoneycombAPI is the URL for the upstream Honeycomb API.
+# Eligible for live reload.
+HoneycombAPI: 'https://api.honeycomb.io'
+
+# SendDelay is a short timer that will be triggered when a trace is complete.
+# Refinery will wait this duration before actually sending the trace.  The
+# reason for this short delay is to allow for small network delays or clock
+# jitters to elapse and any final spans to arrive before actually sending the
+# trace.  This supports duration strings with supplied units. Set to 0 for
+# immediate sends.
+# Eligible for live reload.
+SendDelay: 2s
+
+# TraceTimeout is a long timer; it represents the outside boundary of how long
+# to wait before sending an incomplete trace. Normally traces are sent when the
+# root span arrives. Sometimes the root span never arrives (due to crashes or
+# whatever), and this timer will send a trace even without having received the
+# root span. If you have particularly long-lived traces you should increase this
+# timer. This supports duration strings with supplied units.
+# Eligible for live reload.
+TraceTimeout: 60s
+
+# MaxBatchSize is the number of events to be included in the batch for sending
+MaxBatchSize: 500
+
+# SendTicker is a short timer; it determines the duration to use to check for traces to send
+SendTicker: 100ms
+
+# LoggingLevel is the level above which we should log. Debug is very verbose,
+# and should only be used in pre-production environments. Info is the
+# recommended level. Valid options are "debug", "info", "error", and
+# "panic"
+# Not eligible for live reload.
+LoggingLevel: debug
+
+# UpstreamBufferSize and PeerBufferSize control how large of an event queue to use
+# when buffering events that will be forwarded to peers or the upstream API.
+UpstreamBufferSize: 10000
+PeerBufferSize: 10000
+
+# DebugServiceAddr sets the IP and port the debug service will run on
+# The debug service will only run if the command line flag -d is specified
+# The debug service runs on the first open port between localhost:6060 and :6069 by default
+#DebugServiceAddr: localhost:8085
+
+# AddHostMetadataToTrace determines whether or not to add information about
+# the host that Refinery is running on to the spans that it processes.
+# If enabled, information about the host will be added to each span with the
+# prefix `meta.refinery.`.
+# Currently, the only value added is 'meta.refinery.local_hostname'.
+# Not eligible for live reload
+AddHostMetadataToTrace: false
+
+# EnvironmentCacheTTL is the amount of time a cache entry will live that associates
+# an API key with an environment name.
+# Cache misses lookup the environment name using HoneycombAPI config value.
+# Default is 1 hour ("1h").
+# Not eligible for live reload.
+EnvironmentCacheTTL: 1h
+
+############################
+## Implementation Choices ##
+############################
+
+# Each of the config options below chooses an implementation of a Refinery
+# component to use. Depending on the choice there may be more configuration
+# required below in the section for that choice. Changing implementation choices
+# requires a process restart; these changes will not be picked up by a live
+# config reload. (Individual config options for a given implementation may be
+# eligible for live reload).
+
+# Collector describes which collector to use for collecting traces. The only
+# current valid option is "InMemCollector".. More can be added by adding
+# implementations of the Collector interface.
+Collector: InMemCollector
+
+# Logger describes which logger to use for Refinery logs. Valid options are
+# "logrus" and "honeycomb". The logrus option will write logs to STDOUT and the
+# honeycomb option will send them to a Honeycomb dataset.
+Logger: honeycomb
+
+# Metrics describes which service to use for Refinery metrics. Valid options are
+# "prometheus" and "honeycomb". The prometheus option starts a listener that
+# will reply to a request for /metrics. The honeycomb option will send summary
+# metrics to a Honeycomb dataset.
+Metrics: honeycomb
+
+#########################
+## Peer Management     ##
+#########################
+
+#PeerManagement:
+  #Type: file
+
+  # Peers is the list of all servers participating in this proxy cluster. Events
+  # will be sharded evenly across all peers based on the Trace ID. Values here
+  # should be the base URL used to access the peer, and should include scheme,
+  # hostname (or ip address) and port. All servers in the cluster should be in
+  # this list, including this host.
+  #Peers:
+  #  - "http://127.0.0.1:8081"
+  #  - "http://127.0.0.1:8081"
+  #  - "http://10.1.2.3.4:8080"
+  #  - "http://refinery-1231:8080"
+  #  - "http://peer-3.fqdn" // assumes port 80
+
+#PeerManagement:
+  #Type: redis
+
+  # RedisHost is is used to connect to redis for peer cluster membership management.
+  # Further, if the environment variable 'REFINERY_REDIS_HOST' is set it takes
+  # precedence and this value is ignored.
+  # Not eligible for live reload.
+  #RedisHost: localhost:6379
+
+  # RedisUsername is the username used to connect to redis for peer cluster membership management.
+  # If the environment variable 'REFINERY_REDIS_USERNAME' is set it takes
+  # precedence and this value is ignored.
+  # Not eligible for live reload.
+  #RedisUsername: ""
+
+  # RedisPassword is the password used to connect to redis for peer cluster membership management.
+  # If the environment variable 'REFINERY_REDIS_PASSWORD' is set it takes
+  # precedence and this value is ignored.
+  # Not eligible for live reload.
+  #RedisPassword: ""
+
+  # UseTLS enables TLS when connecting to redis for peer cluster membership management, and sets the MinVersion to 1.2.
+  # Not eligible for live reload.
+  #UseTLS: false
+
+  # UseTLSInsecure disables certificate checks
+  # Not eligible for live reload.
+  #UseTLSInsecure: false
+
+  # IdentifierInterfaceName is optional. By default, when using RedisHost, Refinery will use
+  # the local hostname to identify itself to other peers in Redis. If your environment
+  # requires that you use IPs as identifiers (for example, if peers can't resolve eachother
+  # by name), you can specify the network interface that Refinery is listening on here.
+  # Refinery will use the first unicast address that it finds on the specified network
+  # interface as its identifier.
+  # Not eligible for live reload.
+  #IdentifierInterfaceName: eth0
+
+  # UseIPV6Identifier is optional. If using IdentifierInterfaceName, Refinery will default to the first
+  # IPv4 unicast address it finds for the specified interface. If UseIPV6Identifier is used, will use
+  # the first IPV6 unicast address found.
+  #UseIPV6Identifier: false
+
+  # RedisIdentifier is optional. By default, when using RedisHost, Refinery will use
+  # the local hostname to identify itself to other peers in Redis. If your environment
+  # requires that you use IPs as identifiers (for example, if peers can't resolve eachother
+  # by name), you can specify the exact identifier (IP address, etc) to use here.
+  # Not eligible for live reload. Overrides IdentifierInterfaceName, if both are set.
+  #RedisIdentifier: 192.168.1.1
+
+#########################
+## In-Memory Collector ##
+#########################
+
+# InMemCollector brings together all the settings that are relevant to
+# collecting spans together to make traces.
+InMemCollector:
+
+  # The collection cache is used to collect all spans into a trace as well as
+  # remember the sampling decision for any spans that might come in after the
+  # trace has been marked "complete" (either by timing out or seeing the root
+  # span). The number of traces in the cache should be many multiples (100x to
+  # 1000x) of the total number of concurrently active traces (trace throughput *
+  # trace duration).
+  # Eligible for live reload. Growing the cache capacity with a live config reload
+  # is fine. Avoid shrinking it with a live reload (you can, but it may cause
+  # temporary odd sampling decisions).
+  CacheCapacity: 1000
+
+  # MaxAlloc is optional. If set, it must be an integer >= 0. 64-bit values are
+  # supported.
+  # If set to a non-zero value, once per tick (see SendTicker) the collector
+  # will compare total allocated bytes to this value. If allocation is too
+  # high, cache capacity will be reduced and an error will be logged.
+  # Useful values for this setting are generally in the range of 75%-90% of
+  # available system memory.
+  MaxAlloc: 0
+
+###################
+## Logrus Logger ##
+###################
+
+# LogrusLogger is a section of the config only used if you are using the
+# LogrusLogger to send all logs to STDOUT using the logrus package. If you are
+# using a different logger (eg honeycomb logger) you can leave all this
+# commented out.
+LogrusLogger: {}
+# logrus logger currently has no options!
+
+######################
+## Honeycomb Logger ##
+######################
+
+# HoneycombLogger is a section of the config only used if you are using the
+# HoneycombLogger to send all logs to a Honeycomb Dataset. If you are using a
+# different logger (eg file-based logger) you can leave all this commented out.
+HoneycombLogger:
+
+  # LoggerHoneycombAPI is the URL for the upstream Honeycomb API.
+  # Eligible for live reload.
+  LoggerHoneycombAPI: 'https://api.honeycomb.io'
+
+  # LoggerAPIKey is the API key to use to send log events to the Honeycomb logging
+  # dataset. This is separate from the APIKeys used to authenticate regular
+  # traffic.
+  # Eligible for live reload.
+  LoggerAPIKey: abcd1234
+
+  # LoggerDataset is the name of the dataset to which to send Refinery logs
+  # Eligible for live reload.
+  LoggerDataset: Refinery Logs
+
+  # LoggerSamplerEnabled enables a PerKeyThroughput dynamic sampler for log messages.
+  # This will sample log messages based on [log level:message] key on a per second throughput basis.
+  # Not eligible for live reload.
+  LoggerSamplerEnabled: true
+
+  # LoggerSamplerThroughput is the per key per second throughput for the log message dynamic sampler.
+  # Not eligible for live reload.
+  LoggerSamplerThroughput: 10
+
+#######################
+## Honeycomb Metrics ##
+#######################
+
+# HoneycombMetrics is a section of the config only used if you are using the
+# HoneycombMetrics to send all metrics to a Honeycomb Dataset. If you are using a
+# different metrics service (eg prometheus or metricsd) you can leave all this
+# commented out.
+HoneycombMetrics:
+
+  # MetricsHoneycombAPI is the URL for the upstream Honeycomb API.
+  # Eligible for live reload.
+  MetricsHoneycombAPI: 'https://api.honeycomb.io'
+
+  # MetricsAPIKey is the API key to use to send log events to the Honeycomb logging
+  # dataset. This is separate from the APIKeys used to authenticate regular
+  # traffic.
+  # Eligible for live reload.
+  MetricsAPIKey: abcd1234
+
+  # MetricsDataset is the name of the dataset to which to send Refinery metrics
+  # Eligible for live reload.
+  MetricsDataset: Refinery Metrics
+
+  # MetricsReportingInterval is the frequency (in seconds) to send metric events
+  # to Honeycomb. Between 1 and 60 is recommended.
+  # Not eligible for live reload.
+  MetricsReportingInterval: 3
+
+#####################@##
+## Prometheus Metrics ##
+#####################@##
+#PrometheusMetrics:
+
+  # MetricsListenAddr determines the interface and port on which Prometheus will
+  # listen for requests for /metrics. Must be different from the main Refinery
+  # listener.
+  # Not eligible for live reload.
+  #MetricsListenAddr: localhost:2112

--- a/refinery.service
+++ b/refinery.service
@@ -3,7 +3,7 @@ Description=Refinery Honeycomb Trace-Aware Sampling Proxy
 After=network.target
 
 [Service]
-ExecStart=/usr/bin/refinery -c /etc/refinery/refinery.toml -r /etc/refinery/rules.toml
+ExecStart=/usr/bin/refinery -c /etc/refinery/refinery.yaml -r /etc/refinery/rules.yaml
 KillMode=process
 Restart=on-failure
 User=honeycomb

--- a/refinery.upstart
+++ b/refinery.upstart
@@ -9,4 +9,4 @@ stop on runlevel [!2345]
 
 respawn
 
-exec su -s /bin/sh -c 'exec "$0" "$@"' honeycomb -- /usr/bin/refinery -c /etc/refinery/refinery.toml -r /etc/refinery/rules.toml
+exec su -s /bin/sh -c 'exec "$0" "$@"' honeycomb -- /usr/bin/refinery -c /etc/refinery/refinery.yaml -r /etc/refinery/rules.yaml

--- a/rules.yaml
+++ b/rules.yaml
@@ -1,0 +1,6 @@
+############################
+## Sampling Rules Config ##
+############################
+
+# Defaults for the rules configuration are set in file_config.go.
+# For an example file with various sampling methods and their configurations, see rules_complete.yaml.

--- a/rules_complete.yaml
+++ b/rules_complete.yaml
@@ -1,0 +1,256 @@
+############################
+## Sampling Rules Config ##
+############################
+
+# DryRun - If enabled, marks traces that would be dropped given current sampling rules,
+# and sends all traces regardless
+# DryRun = false
+
+# DryRunFieldName - the key to add to use to add to event data when using DryRun mode above, defaults to refinery_kept
+# DryRunFieldName = "refinery_kept"
+
+# DeterministicSampler is a section of the config for manipulating the
+# Deterministic Sampler implementation. This is the simplest sampling algorithm
+# - it is a static sample rate, choosing traces randomly to either keep or send
+# (at the appropriate rate). It is not influenced by the contents of the trace.
+Sampler: DeterministicSampler
+
+# SampleRate is the rate at which to sample. It indicates a ratio, where one
+# sample trace is kept for every n traces seen. For example, a SampleRate of 30
+# will keep 1 out of every 30 traces. The choice on whether to keep any specific
+# trace is random, so the rate is approximate.
+# Eligible for live reload.
+SampleRate: 1
+
+
+dataset1:
+
+  # Note: If your dataset name contains a space, you will have to escape the dataset name
+  # using single quotes, such as ['dataset 1']
+
+  # DynamicSampler is a section of the config for manipulating the simple Dynamic Sampler
+  # implementation. This sampler collects the values of a number of fields from a
+  # trace and uses them to form a key. This key is handed to the standard dynamic
+  # sampler algorithm which generates a sample rate based on the frequency with
+  # which that key has appeared in the previous ClearFrequencySec seconds. See
+  # https://github.com/honeycombio/dynsampler-go for more detail on the mechanics
+  # of the dynamic sampler.  This sampler uses the AvgSampleRate algorithm from
+  # that package.
+  Sampler: DynamicSampler
+
+  # SampleRate is the goal rate at which to sample. It indicates a ratio, where
+  # one sample trace is kept for every n traces seen. For example, a SampleRate of
+  # 30 will keep 1 out of every 30 traces. This rate is handed to the dynamic
+  # sampler, who assigns a sample rate for each trace based on the fields selected
+  # from that trace.
+  # Eligible for live reload.
+  SampleRate: 2
+
+  # FieldList is a list of all the field names to use to form the key that will be
+  # handed to the dynamic sampler. The cardinality of the combination of values
+  # from all of these keys should be reasonable in the face of the frequency of
+  # those keys. If the combination of fields in these keys essentially makes them
+  # unique, the dynamic sampler will do no sampling.  If the keys have too few
+  # values, you won't get samples of the most interesting traces. A good key
+  # selection will have consistent values for high frequency boring traffic and
+  # unique values for outliers and interesting traffic. Including an error field
+  # (or something like HTTP status code) is an excellent choice. As an example,
+  # assuming 30 or so endpoints, a combination of HTTP endpoint and status code
+  # would be a good set of keys in order to let you see accurately use of all
+  # endpoints and call out when there is failing traffic to any endpoint. Field
+  # names may come from any span in the trace.
+  # Eligible for live reload.
+  FieldList:
+    - request.method
+    - response.status_code
+
+  # UseTraceLength will add the number of spans in the trace in to the dynamic
+  # sampler as part of the key. The number of spans is exact, so if there are
+  # normally small variations in trace length you may want to leave this off. If
+  # traces are consistent lengths and changes in trace length is a useful
+  # indicator of traces you'd like to see in Honeycomb, set this to true.
+  # Eligible for live reload.
+  UseTraceLength: true
+
+  # AddSampleRateKeyToTrace when this is set to true, the sampler will add a field
+  # to the root span of the trace containing the key used by the sampler to decide
+  # the sample rate. This can be helpful in understanding why the sampler is
+  # making certain decisions about sample rate and help you understand how to
+  # better choose the sample rate key (aka the FieldList setting above) to use.
+  AddSampleRateKeyToTrace: true
+
+  # AddSampleRateKeyToTraceField is the name of the field the sampler will use
+  # when adding the sample rate key to the trace. This setting is only used when
+  # AddSampleRateKeyToTrace is true.
+  AddSampleRateKeyToTraceField: meta.refinery.dynsampler_key
+
+  # ClearFrequencySec is the name of the field the sampler will use to determine
+  # the period over which it will calculate the sample rate. This setting defaults
+  # to 30.
+  # Eligible for live reload.
+  ClearFrequencySec: 60
+
+
+dataset2:
+
+  # EMADynamicSampler is a section of the config for manipulating the Exponential
+  # Moving Average (EMA) Dynamic Sampler implementation. Like the simple DynamicSampler,
+  # it attempts to average a given sample rate, weighting rare traffic and frequent
+  # traffic differently so as to end up with the correct average.
+  #
+  # EMADynamicSampler is an improvement upon the simple DynamicSampler and is recommended
+  # for most use cases. Based on the DynamicSampler implementation, EMADynamicSampler differs
+  # in that rather than compute rate based on a periodic sample of traffic, it maintains an Exponential
+  # Moving Average of counts seen per key, and adjusts this average at regular intervals.
+  # The weight applied to more recent intervals is defined by `weight`, a number between
+  # (0, 1) - larger values weight the average more toward recent observations. In other words,
+  # a larger weight will cause sample rates more quickly adapt to traffic patterns,
+  # while a smaller weight will result in sample rates that are less sensitive to bursts or drops
+  # in traffic and thus more consistent over time.
+  #
+  # Keys that are not found in the EMA will always have a sample
+  # rate of 1. Keys that occur more frequently will be sampled on a logarithmic
+  # curve. In other words, every key will be represented at least once in any
+  # given window and more frequent keys will have their sample rate
+  # increased proportionally to wind up with the goal sample rate.
+  Sampler: EMADynamicSampler
+
+  # GoalSampleRate is the goal rate at which to sample. It indicates a ratio, where
+  # one sample trace is kept for every n traces seen. For example, a SampleRate of
+  # 30 will keep 1 out of every 30 traces. This rate is handed to the dynamic
+  # sampler, who assigns a sample rate for each trace based on the fields selected
+  # from that trace.
+  # Eligible for live reload.
+  GoalSampleRate: 2
+
+  # FieldList is a list of all the field names to use to form the key that will be
+  # handed to the dynamic sampler. The cardinality of the combination of values
+  # from all of these keys should be reasonable in the face of the frequency of
+  # those keys. If the combination of fields in these keys essentially makes them
+  # unique, the dynamic sampler will do no sampling.  If the keys have too few
+  # values, you won't get samples of the most interesting traces. A good key
+  # selection will have consistent values for high frequency boring traffic and
+  # unique values for outliers and interesting traffic. Including an error field
+  # (or something like HTTP status code) is an excellent choice. As an example,
+  # assuming 30 or so endpoints, a combination of HTTP endpoint and status code
+  # would be a good set of keys in order to let you see accurately use of all
+  # endpoints and call out when there is failing traffic to any endpoint. Field
+  # names may come from any span in the trace.
+  # Eligible for live reload.
+  FieldList:
+    - request.method
+    - response.status_code
+
+  # UseTraceLength will add the number of spans in the trace in to the dynamic
+  # sampler as part of the key. The number of spans is exact, so if there are
+  # normally small variations in trace length you may want to leave this off. If
+  # traces are consistent lengths and changes in trace length is a useful
+  # indicator of traces you'd like to see in Honeycomb, set this to true.
+  # Eligible for live reload.
+  UseTraceLength: true
+
+  # AddSampleRateKeyToTrace when this is set to true, the sampler will add a field
+  # to the root span of the trace containing the key used by the sampler to decide
+  # the sample rate. This can be helpful in understanding why the sampler is
+  # making certain decisions about sample rate and help you understand how to
+  # better choose the sample rate key (aka the FieldList setting above) to use.
+  AddSampleRateKeyToTrace: true
+
+  # AddSampleRateKeyToTraceField is the name of the field the sampler will use
+  # when adding the sample rate key to the trace. This setting is only used when
+  # AddSampleRateKeyToTrace is true.
+  AddSampleRateKeyToTraceField: meta.refinery.dynsampler_key
+
+  # AdjustmentInterval defines how often (in seconds) we adjust the moving average from
+  # recent observations. Default 15s
+  # Eligible for live reload.
+  AdjustmentInterval: 15
+
+  # Weight is a value between (0, 1) indicating the weighting factor used to adjust
+  # the EMA. With larger values, newer data will influence the average more, and older
+  # values will be factored out more quickly.  In mathematical literature concerning EMA,
+  # this is referred to as the `alpha` constant.
+  # Default is 0.5
+  # Eligible for live reload.
+  Weight: 0.5
+
+  # MaxKeys, if greater than 0, limits the number of distinct keys tracked in EMA.
+  # Once MaxKeys is reached, new keys will not be included in the sample rate map, but
+  # existing keys will continue to be be counted. You can use this to keep the sample rate
+  # map size under control.
+  # Eligible for live reload
+  MaxKeys: 0
+
+  # AgeOutValue indicates the threshold for removing keys from the EMA. The EMA of any key
+  # will approach 0 if it is not repeatedly observed, but will never truly reach it, so we have to
+  # decide what constitutes "zero". Keys with averages below this threshold will be removed
+  # from the EMA. Default is the same as Weight, as this prevents a key with the smallest
+  # integer value (1) from being aged out immediately. This value should generally be <= Weight,
+  # unless you have very specific reasons to set it higher.
+  # Eligible for live reload
+  AgeOutValue: 0.5
+
+  # BurstMultiple, if set, is multiplied by the sum of the running average of counts to define
+  # the burst detection threshold. If total counts observed for a given interval exceed the threshold
+  # EMA is updated immediately, rather than waiting on the AdjustmentInterval.
+  # Defaults to 2; negative value disables. With a default of 2, if your traffic suddenly doubles,
+  # burst detection will kick in.
+  # Eligible for live reload
+  BurstMultiple: 2
+
+  # BurstDetectionDelay indicates the number of intervals to run after Start is called before
+  # burst detection kicks in.
+  # Defaults to 3
+  # Eligible for live reload
+  BurstDetectionDelay: 3
+
+
+dataset3:
+  Sampler: DeterministicSampler
+  SampleRate: 10
+
+
+dataset4:
+  Sampler: RulesBasedSampler
+
+  rule:
+    - name: drop healtchecks
+      drop: true
+      condition:
+        - field: http.route
+          operator: '='
+          value: /health-check
+
+    - name: keep slow 500 errors
+      SampleRate: 1
+      condition:
+        - field: status_code
+          operator: '='
+          value: 500
+        - field: duration_ms
+          operator: '>='
+          value: 1000.789
+
+    - name: dynamically sample 200 responses
+      condition:
+        - field: status_code
+          operator: '='
+          value: 200
+      sampler:
+        EMADynamicSampler:
+          Sampler: EMADynamicSampler
+          GoalSampleRate: 15
+          FieldList:
+            - request.method
+            - request.route
+          AddSampleRateKeyToTrace: true
+          AddSampleRateKeyToTraceField: meta.refinery.dynsampler_key
+
+    - SampleRate: 10  # default when no rules match, if missing defaults to 10
+
+
+dataset5:
+
+  Sampler: TotalThroughputSampler
+  GoalThroughputPerSec: 100
+  FieldList: '[request.method]'

--- a/sample/trace_key.go
+++ b/sample/trace_key.go
@@ -51,7 +51,10 @@ func (d *traceKey) build(trace *types.Trace) string {
 	for _, field := range d.fields {
 		for _, span := range spans {
 			if val, ok := span.Data[field]; ok {
-				fieldCollector[field] = append(fieldCollector[field], fmt.Sprintf("%v", val))
+				sval := fmt.Sprintf("%v", val)
+				if len(sval) > 0 {
+					fieldCollector[field] = append(fieldCollector[field], sval)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
The popular deploy mechanism for refinery is in Kubernetes using Helm where all configuration is done in YAML format. The current configuration examples and docs on done in TOML format which leads to confusion with operators when deploying and configuring refinery.  

This PR is meant to align all configurations into the YAML format and avoid that confusion. After this PR is merged, we will also need to update docs to reflect YAML format for configuration.


- Creates YAML equivalent sample configurations based on existing TOML setup
- Migrates all tests to use a YAML format
- `refinery.service` and `refinery.upstart` reference a YAML based config
- Adds a note to readme about upgrading from prior versions. This note should only apply to those upgrading on non-Kubernetes environments, still using TOML format for config.

