### PR TITLE
fix: error log event metadata

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -363,6 +363,11 @@ func TestPeerRouting(t *testing.T) {
 			"long":            "this is a test of the emergency broadcast system",
 			"foo":             "bar",
 		},
+		Metadata: map[string]string{
+			"api_host":    "http://api.honeycomb.io",
+			"dataset":     "dataset",
+			"environment": "",
+		},
 	}
 	assert.Equal(t, expectedEvent, senders[0].Events()[0])
 
@@ -482,6 +487,11 @@ func TestEventsEndpoint(t *testing.T) {
 				"trace.trace_id": "1",
 				"foo":            "bar",
 			},
+			Metadata: map[string]string{
+				"api_host":    "http://api.honeycomb.io",
+				"dataset":     "dataset",
+				"environment": "",
+			},
 		},
 		senders[0].Events()[0],
 	)
@@ -523,6 +533,11 @@ func TestEventsEndpoint(t *testing.T) {
 			Data: map[string]interface{}{
 				"trace.trace_id": "1",
 				"foo":            "bar",
+			},
+			Metadata: map[string]string{
+				"api_host":    "http://api.honeycomb.io",
+				"dataset":     "dataset",
+				"environment": "",
 			},
 		},
 		senders[1].Events()[0],
@@ -586,6 +601,11 @@ func TestEventsEndpointWithNonLegacyKey(t *testing.T) {
 				"trace.trace_id": "1",
 				"foo":            "bar",
 			},
+			Metadata: map[string]string{
+				"api_host":    "http://api.honeycomb.io",
+				"dataset":     "dataset",
+				"environment": "test",
+			},
 		},
 		senders[0].Events()[0],
 	)
@@ -627,6 +647,11 @@ func TestEventsEndpointWithNonLegacyKey(t *testing.T) {
 			Data: map[string]interface{}{
 				"trace.trace_id": "1",
 				"foo":            "bar",
+			},
+			Metadata: map[string]string{
+				"api_host":    "http://api.honeycomb.io",
+				"dataset":     "dataset",
+				"environment": "test",
 			},
 		},
 		senders[1].Events()[0],


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Refinery logs errors that it receives from libhoney (e.g. events are too large), but does not log any useful identifying information, making it very hard to find the source of the error
- [internal slack thread](https://houndsh.slack.com/archives/CDE86Q55X/p1648054731769209)

## Short description of the changes

- aligned metadata attached to events with what we attach to error logs
- `event_type` and `target` used to be properties on libhoney events, but are now gone, so 🤷 

how errors look before this change:
```
ERRO[0149] error when sending event                      api_host= dataset= error="got unexpected HTTP status 401: Unauthorized" event_type= status_code=401 target=
```

how error look after this change
```
ERRO[0219] error when sending event                      api_host="https://api-dogfood.honeycomb.io" dataset=year-java environment="huzzah env" error="got unexpected HTTP status 401: Unauthorized" status_code=401
```
