### PR TITLE
Cache google ko deps between workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   aws-cli: circleci/aws-cli@2.1.0
+  go: circleci/go@1.7.1
 
 commands:
   go-build:
@@ -129,7 +130,9 @@ jobs:
     docker:
       - image: cimg/go:1.17
     steps:
+      - go/load-cache
       - run: go install github.com/google/ko@latest
+      - go/save-cache
       - checkout
       - setup_remote_docker
       - run:
@@ -140,7 +143,9 @@ jobs:
     docker:
       - image: cimg/go:1.17
     steps:
+      - go/load-cache
       - run: go install github.com/google/ko@latest
+      - go/save-cache
       - checkout
       - setup_remote_docker
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,6 @@ version: 2.1
 
 orbs:
   aws-cli: circleci/aws-cli@2.1.0
-  go: circleci/go@1.7.1
 
 commands:
   go-build:
@@ -24,6 +23,16 @@ commands:
           go build -ldflags "-X main.BuildID=${CIRCLE_TAG:-${CIRCLE_SHA1:0:7}}" \
           -o $GOPATH/bin/refinery-<< parameters.os >>-<< parameters.arch >> \
           ./cmd/refinery
+  setup_googleko:
+    steps:
+      - restore_cache:
+          keys:
+            - v1-googleko
+      - run: go install github.com/google/ko@latest
+      - save_cache:
+          key: v1-googleko
+          paths:
+            - /home/circleci/go/pkg/mod/
 
 jobs:
   test:
@@ -130,9 +139,7 @@ jobs:
     docker:
       - image: cimg/go:1.17
     steps:
-      - go/load-cache
-      - run: go install github.com/google/ko@latest
-      - go/save-cache
+      - setup_googleko
       - checkout
       - setup_remote_docker
       - run:
@@ -143,9 +150,7 @@ jobs:
     docker:
       - image: cimg/go:1.17
     steps:
-      - go/load-cache
-      - run: go install github.com/google/ko@latest
-      - go/save-cache
+      - setup_googleko
       - checkout
       - setup_remote_docker
       - run:


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
Caches Google KO binaries used to build docker images between workflow runs.

- Closes #332 

## Short description of the changes
- uses the CircleCI orb to cache and restore go dependencies

Restoring google ko from cache:
![image](https://user-images.githubusercontent.com/3481731/160409372-1eb64f4e-4274-4a1d-ab3c-14644cb2d069.png)
