### PR TITLE
WIP: Add debug fields to error response metadata

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -139,4 +139,6 @@ type Config interface {
 	GetAddHostMetadataToTrace() bool
 
 	GetEnvironmentCacheTTL() time.Duration
+
+	GetDebugFieldsToLog() []string
 }

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -49,6 +49,7 @@ type configContents struct {
 	InMemCollector            InMemoryCollectorCacheCapacity `validate:"required"`
 	AddHostMetadataToTrace    bool
 	EnvironmentCacheTTL       time.Duration
+	DebugFieldsToLog          []string
 }
 
 type InMemoryCollectorCacheCapacity struct {
@@ -735,4 +736,11 @@ func (f *fileConfig) GetEnvironmentCacheTTL() time.Duration {
 	defer f.mux.RUnlock()
 
 	return f.conf.EnvironmentCacheTTL
+}
+
+func (f *fileConfig) GetDebugFieldsToLog() []string {
+	f.mux.RLock()
+	defer f.mux.RUnlock()
+
+	return f.conf.DebugFieldsToLog
 }

--- a/config/mock.go
+++ b/config/mock.go
@@ -71,6 +71,7 @@ type MockConfig struct {
 	DryRunFieldName               string
 	AddHostMetadataToTrace        bool
 	EnvironmentCacheTTL           time.Duration
+	DebugFieldsToLog              []string
 
 	Mux sync.RWMutex
 }
@@ -327,4 +328,11 @@ func (f *MockConfig) GetEnvironmentCacheTTL() time.Duration {
 	defer f.Mux.RUnlock()
 
 	return f.EnvironmentCacheTTL
+}
+
+func (f *MockConfig) GetDebugFieldsToLog() []string {
+	f.Mux.RLock()
+	defer f.Mux.RUnlock()
+
+	return f.DebugFieldsToLog
 }

--- a/transmit/transmit.go
+++ b/transmit/transmit.go
@@ -108,7 +108,7 @@ func (d *DefaultTransmission) EnqueueEvent(ev *types.Event) {
 		libhEv.AddField(k, v)
 
 		// if configured, add additional event fields to debug metadata
-		if d.Config.GetDebugFieldsToLog() != nil {
+		if len(d.Config.GetDebugFieldsToLog()) > 0 {
 			for _, k := range d.Config.GetDebugFieldsToLog() {
 				metadata[k] = v.(string)
 			}


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
When debugging error responses it would be useful to capture additional information from events. This PR adds support for an array of field names that will be copied from events into the debug metadata that is used to process failed event responses.

If no fields are specified, no additional data is logged.

Example config:
```toml
DebugFieldsToLog = [ "trace.trace_id", "service.name" ]
```

## Short description of the changes
- Introduce `DebugFieldsToLog` in Config interface, with implementations for both file and mock configs
- Check for the fields and use them to copy field data from events into debug messages when handling failed responses

