### PR TITLE
Add support for environment and dataset rules with same names

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ See the [Refinery documentation](https://docs.honeycomb.io/manage-data-volume/re
 
 With the change to support environemt and services in Honeycomb, some users will want to support both sending telemetry to a legacy dataset and a new environment called the same thing (eg `production`).
 
-This can be achomplihsed by leveraging the new `DataserPrefix` configuration property and then using that prefix in the rules definitions for the legacy datasets.
+This can be accomplished by leveraging the new `DatasetPrefix` configuration property and then using that prefix in the rules definitions for the legacy datasets.
 
 When Refinery receives telemetry using an API key associated to a legacy dataset, it will then use the prefix in the form `{prefix}.{dataset}` when trying to resolve the rules definition.
 
@@ -95,7 +95,7 @@ SampleRate = 1
     Sampler = "DeterministicSampler"
     SampleRate = 5
 
-    [legacy.production] # dataset called "prodiction"
+    [legacy.production] # dataset called "production"
     Sampler = "DeterministicSampler"
     SampleRate = 10
 ```

--- a/collect/collect.go
+++ b/collect/collect.go
@@ -449,7 +449,7 @@ func (i *InMemCollector) send(trace *types.Trace) {
 		logFields["environment"] = samplerKey
 	}
 
-	// use sampler key to find sampler, create and cache if not found
+	// use sampler key to find sampler; create and cache if not found
 	if sampler, found = i.datasetSamplers[samplerKey]; !found {
 		sampler = i.SamplerFactory.GetSamplerImplementationForKey(samplerKey, isLegacyKey)
 		i.datasetSamplers[samplerKey] = sampler

--- a/collect/collect.go
+++ b/collect/collect.go
@@ -449,9 +449,9 @@ func (i *InMemCollector) send(trace *types.Trace) {
 		logFields["environment"] = samplerKey
 	}
 
-	// use sampler key to find sampler, crete and cache if not found
+	// use sampler key to find sampler, create and cache if not found
 	if sampler, found = i.datasetSamplers[samplerKey]; !found {
-		sampler = i.SamplerFactory.GetSamplerImplementationForDataset(samplerKey)
+		sampler = i.SamplerFactory.GetSamplerImplementationForKey(samplerKey, isLegacyKey)
 		i.datasetSamplers[samplerKey] = sampler
 	}
 

--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -186,7 +186,7 @@ func TestDryRunMode(t *testing.T) {
 		Config: conf,
 		Logger: &logger.NullLogger{},
 	}
-	sampler := samplerFactory.GetSamplerImplementationForDataset("test")
+	sampler := samplerFactory.GetSamplerImplementationForKey("test", true)
 	coll := &InMemCollector{
 		Config:         conf,
 		Logger:         &logger.NullLogger{},

--- a/config/config.go
+++ b/config/config.go
@@ -139,4 +139,6 @@ type Config interface {
 	GetAddHostMetadataToTrace() bool
 
 	GetEnvironmentCacheTTL() time.Duration
+
+	GetDatasetPrefix() string
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -652,3 +652,40 @@ func TestHoneycombLoggerConfigDefaults(t *testing.T) {
 	assert.Equal(t, false, loggerConfig.LoggerSamplerEnabled)
 	assert.Equal(t, 5, loggerConfig.LoggerSamplerThroughput)
 }
+
+func TestDatasetPrefix(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	configFile, err := ioutil.TempFile(tmpDir, "*.toml")
+	assert.NoError(t, err)
+
+	_, err = configFile.Write([]byte(`
+	DatasetPrefix = "dataset"
+
+	[InMemCollector]
+		CacheCapacity=1000
+
+	[HoneycombMetrics]
+		MetricsHoneycombAPI="http://honeycomb.io"
+		MetricsAPIKey="1234"
+		MetricsDataset="testDatasetName"
+		MetricsReportingInterval=3
+
+	[HoneycombLogger]
+		LoggerHoneycombAPI="http://honeycomb.io"
+		LoggerAPIKey="1234"
+		LoggerDataset="loggerDataset"
+	`))
+	assert.NoError(t, err)
+	configFile.Close()
+
+	rulesFile, err := ioutil.TempFile(tmpDir, "*.toml")
+	assert.NoError(t, err)
+
+	c, err := NewConfig(configFile.Name(), rulesFile.Name(), func(err error) {})
+	assert.NoError(t, err)
+
+	assert.Equal(t, "dataset", c.GetDatasetPrefix())
+}

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -128,7 +128,6 @@ func NewConfig(config, rules string, errorCallback func(error)) (Config, error) 
 	c.SetDefault("HoneycombLogger.LoggerSamplerThroughput", 5)
 	c.SetDefault("AddHostMetadataToTrace", false)
 	c.SetDefault("EnvironmentCacheTTL", time.Hour)
-	c.SetDefault("DatasetPrefix", "")
 
 	c.SetConfigFile(config)
 	err := c.ReadInConfig()

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -49,6 +49,7 @@ type configContents struct {
 	InMemCollector            InMemoryCollectorCacheCapacity `validate:"required"`
 	AddHostMetadataToTrace    bool
 	EnvironmentCacheTTL       time.Duration
+	DatasetPrefix             string
 }
 
 type InMemoryCollectorCacheCapacity struct {
@@ -127,6 +128,7 @@ func NewConfig(config, rules string, errorCallback func(error)) (Config, error) 
 	c.SetDefault("HoneycombLogger.LoggerSamplerThroughput", 5)
 	c.SetDefault("AddHostMetadataToTrace", false)
 	c.SetDefault("EnvironmentCacheTTL", time.Hour)
+	c.SetDefault("DatasetPrefix", "")
 
 	c.SetConfigFile(config)
 	err := c.ReadInConfig()
@@ -735,4 +737,11 @@ func (f *fileConfig) GetEnvironmentCacheTTL() time.Duration {
 	defer f.mux.RUnlock()
 
 	return f.conf.EnvironmentCacheTTL
+}
+
+func (f *fileConfig) GetDatasetPrefix() string {
+	f.mux.RLock()
+	defer f.mux.RUnlock()
+
+	return f.conf.DatasetPrefix
 }

--- a/config/mock.go
+++ b/config/mock.go
@@ -71,6 +71,7 @@ type MockConfig struct {
 	DryRunFieldName               string
 	AddHostMetadataToTrace        bool
 	EnvironmentCacheTTL           time.Duration
+	DatasetPrefix                 string
 
 	Mux sync.RWMutex
 }
@@ -327,4 +328,11 @@ func (f *MockConfig) GetEnvironmentCacheTTL() time.Duration {
 	defer f.Mux.RUnlock()
 
 	return f.EnvironmentCacheTTL
+}
+
+func (f *MockConfig) GetDatasetPrefix() string {
+	f.Mux.RLock()
+	defer f.Mux.RUnlock()
+
+	return f.DatasetPrefix
 }

--- a/sample/sample.go
+++ b/sample/sample.go
@@ -1,6 +1,7 @@
 package sample
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/honeycombio/refinery/config"
@@ -21,10 +22,16 @@ type SamplerFactory struct {
 	Metrics metrics.Metrics `inject:"metrics"`
 }
 
-// GetSamplerImplementationForDataset returns the sampler implementation for the dataset,
-// or nil if it is not defined
-func (s *SamplerFactory) GetSamplerImplementationForDataset(dataset string) Sampler {
-	c, err := s.Config.GetSamplerConfigForDataset(dataset)
+// GetSamplerImplementationForKey returns the sampler implementation for the given
+// samplerKey (dataset or environment), or nil if it is not defined
+func (s *SamplerFactory) GetSamplerImplementationForKey(samplerKey string, isLegacyKey bool) Sampler {
+	if isLegacyKey {
+		if prefix := s.Config.GetDatasetPrefix(); prefix != "" {
+			samplerKey = fmt.Sprintf("%s.%s", prefix, samplerKey)
+		}
+	}
+
+	c, err := s.Config.GetSamplerConfigForDataset(samplerKey)
 	if err != nil {
 		return nil
 	}
@@ -49,11 +56,11 @@ func (s *SamplerFactory) GetSamplerImplementationForDataset(dataset string) Samp
 
 	err = sampler.Start()
 	if err != nil {
-		s.Logger.Debug().WithField("dataset", dataset).Logf("failed to start sampler")
+		s.Logger.Debug().WithField("dataset", samplerKey).Logf("failed to start sampler")
 		return nil
 	}
 
-	s.Logger.Debug().WithField("dataset", dataset).Logf("created implementation for sampler type %T", c)
+	s.Logger.Debug().WithField("dataset", samplerKey).Logf("created implementation for sampler type %T", c)
 
 	return sampler
 }

--- a/sample/sample.go
+++ b/sample/sample.go
@@ -23,7 +23,7 @@ type SamplerFactory struct {
 }
 
 // GetSamplerImplementationForKey returns the sampler implementation for the given
-// samplerKey (dataset or environment), or nil if it is not defined
+// samplerKey (dataset for legacy keys, environment otherwise), or nil if it is not defined
 func (s *SamplerFactory) GetSamplerImplementationForKey(samplerKey string, isLegacyKey bool) Sampler {
 	if isLegacyKey {
 		if prefix := s.Config.GetDatasetPrefix(); prefix != "" {

--- a/sample/sample_test.go
+++ b/sample/sample_test.go
@@ -3,12 +3,15 @@
 package sample
 
 import (
+	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/facebookgo/inject"
 	"github.com/honeycombio/refinery/config"
 	"github.com/honeycombio/refinery/logger"
 	"github.com/honeycombio/refinery/metrics"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDependencyInjection(t *testing.T) {
@@ -26,4 +29,81 @@ func TestDependencyInjection(t *testing.T) {
 	if err := g.Populate(); err != nil {
 		t.Error(err)
 	}
+}
+
+func TestDatasetPrefix(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	configFile, err := ioutil.TempFile(tmpDir, "*.toml")
+	assert.NoError(t, err)
+
+	_, err = configFile.Write([]byte(`
+	DatasetPrefix = "dataset"
+
+	[InMemCollector]
+		CacheCapacity=1000
+
+	[HoneycombMetrics]
+		MetricsHoneycombAPI="http://honeycomb.io"
+		MetricsAPIKey="1234"
+		MetricsDataset="testDatasetName"
+		MetricsReportingInterval=3
+
+	[HoneycombLogger]
+		LoggerHoneycombAPI="http://honeycomb.io"
+		LoggerAPIKey="1234"
+		LoggerDataset="loggerDataset"
+	`))
+	assert.NoError(t, err)
+	configFile.Close()
+
+	rulesFile, err := ioutil.TempFile(tmpDir, "*.toml")
+	assert.NoError(t, err)
+
+	_, err = rulesFile.Write([]byte(`
+	Sampler = "DeterministicSampler"
+	SampleRate = 1
+
+	[production]
+		Sampler = "DeterministicSampler"
+		SampleRate = 10
+
+	[dataset.production]
+		Sampler = "DeterministicSampler"
+		SampleRate = 20
+	`))
+	assert.NoError(t, err)
+	rulesFile.Close()
+
+	c, err := config.NewConfig(configFile.Name(), rulesFile.Name(), func(err error) {})
+	assert.NoError(t, err)
+
+	assert.Equal(t, "dataset", c.GetDatasetPrefix())
+
+	factory := SamplerFactory{Config: c, Logger: &logger.NullLogger{}, Metrics: &metrics.NullMetrics{}}
+
+	defaultSampler := &DeterministicSampler{
+		Config: &config.DeterministicSamplerConfig{SampleRate: 1},
+		Logger: &logger.NullLogger{},
+	}
+	defaultSampler.Start()
+
+	envSampler := &DeterministicSampler{
+		Config: &config.DeterministicSamplerConfig{SampleRate: 10},
+		Logger: &logger.NullLogger{},
+	}
+	envSampler.Start()
+
+	datasetSampler := &DeterministicSampler{
+		Config: &config.DeterministicSamplerConfig{SampleRate: 20},
+		Logger: &logger.NullLogger{},
+	}
+	datasetSampler.Start()
+
+	assert.Equal(t, defaultSampler, factory.GetSamplerImplementationForKey("unknown", false))
+	assert.Equal(t, defaultSampler, factory.GetSamplerImplementationForKey("unknown", true))
+	assert.Equal(t, envSampler, factory.GetSamplerImplementationForKey("production", false))
+	assert.Equal(t, datasetSampler, factory.GetSamplerImplementationForKey("production", true))
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
Adds support for config files to contain both a dataset and environment with the same name in the same rules config. This is achieved by adding a DatasetPrefix to the config and then using that prefix when setting up rule definitions.

config.toml
```
DatasetPrefix = "dataset"
```

rules.toml
```
Sampler = "DeterministicSampler"
SampleRate = 1

[production] # environment
  Sampler = "DeterministicSampler"
  SampleRate = 10

[dataset.production] # dataset
  Sampler = "DeterministicSampler"
  SampleRate = 20
```

- Closes #408 

## Short description of the changes
- Adds new config option DatasetPrefix, defaults to ""
- If a legacy is provided to the SamplerFactory, it uses the configured prefix along with the sample key to locate rules definitions
- Adds test to verify behaviour

