### PR TITLE
Add rule Scope configuration option to rules-based sampler

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -246,7 +246,7 @@ func TestReadRulesConfig(t *testing.T) {
 	assert.NoError(t, err)
 	switch r := d.(type) {
 	case *RulesBasedSamplerConfig:
-		assert.Len(t, r.Rule, 4)
+		assert.Len(t, r.Rule, 5)
 
 		var rule *RulesBasedSamplerRule
 
@@ -259,6 +259,14 @@ func TestReadRulesConfig(t *testing.T) {
 		assert.Equal(t, 1, rule.SampleRate)
 		assert.Equal(t, "keep slow 500 errors", rule.Name)
 		assert.Len(t, rule.Condition, 2)
+
+		rule = r.Rule[3]
+		assert.Equal(t, 5, rule.SampleRate)
+		assert.Equal(t, "span", rule.Scope)
+
+		rule = r.Rule[4]
+		assert.Equal(t, 10, rule.SampleRate)
+		assert.Equal(t, "", rule.Scope)
 
 	default:
 		assert.Fail(t, "dataset4 should have a rules based sampler", d)

--- a/config/sampler_config.go
+++ b/config/sampler_config.go
@@ -62,6 +62,7 @@ type RulesBasedSamplerRule struct {
 	SampleRate int
 	Sampler    *RulesBasedDownstreamSampler
 	Drop       bool
+	MatchSpan  bool
 	Condition  []*RulesBasedSamplerCondition
 }
 

--- a/config/sampler_config.go
+++ b/config/sampler_config.go
@@ -62,7 +62,7 @@ type RulesBasedSamplerRule struct {
 	SampleRate int
 	Sampler    *RulesBasedDownstreamSampler
 	Drop       bool
-	MatchSpan  bool
+	Scope      string `validate:"oneof=span trace"`
 	Condition  []*RulesBasedSamplerCondition
 }
 

--- a/rules_complete.toml
+++ b/rules_complete.toml
@@ -250,7 +250,7 @@ SampleRate = 1
 		#
 		# this is especially helpful when sampling a dataset written to
 		# by multiple services that call one another in normal operation –
-		# you can set MatchSpan to true to attribute traces to an origin
+		# you can set Scope to 'span' to attribute traces to an origin
 		# service in a way that would be difficult without it.
 		Scope = "span"
 		[[dataset4.rule.condition]]

--- a/rules_complete.toml
+++ b/rules_complete.toml
@@ -243,6 +243,25 @@ SampleRate = 1
 			AddSampleRateKeyToTraceField = "meta.refinery.dynsampler_key"
 
 	[[dataset4.rule]]
+		name = "sample traces originating from a service"
+		# if true, a single span must match all of the conditions in this
+		# rule in order for the rule to match the trace.
+		#
+		# this is especially helpful when sampling a dataset written to
+		# by multiple services that call one another in normal operation –
+		# you can set MatchSpan to true to attribute traces to an origin
+		# service in a way that would be difficult without it.
+		MatchSpan = true
+		[[dataset4.rule.condition]]
+			field = "service name"
+			operator = "="
+			value = "users"
+		[[dataset4.rule.condition]]
+			field = "meta.span_type"
+			operator = "="
+			value = "root"
+
+	[[dataset4.rule]]
 		SampleRate = 10 # default when no rules match, if missing defaults to 10
 
 [dataset5]

--- a/rules_complete.toml
+++ b/rules_complete.toml
@@ -244,14 +244,15 @@ SampleRate = 1
 
 	[[dataset4.rule]]
 		name = "sample traces originating from a service"
-		# if true, a single span must match all of the conditions in this
-		# rule in order for the rule to match the trace.
+		# if scope is set to "span", a single span in the trace must match
+		# *all* of the conditions associated with this rule for the rule to
+		# apply to the trace.
 		#
 		# this is especially helpful when sampling a dataset written to
 		# by multiple services that call one another in normal operation –
 		# you can set MatchSpan to true to attribute traces to an origin
 		# service in a way that would be difficult without it.
-		MatchSpan = true
+		Scope = "span"
 		[[dataset4.rule.condition]]
 			field = "service name"
 			operator = "="

--- a/rules_complete.toml
+++ b/rules_complete.toml
@@ -253,6 +253,7 @@ SampleRate = 1
 		# you can set Scope to 'span' to attribute traces to an origin
 		# service in a way that would be difficult without it.
 		Scope = "span"
+		SampleRate = 5
 		[[dataset4.rule.condition]]
 			field = "service name"
 			operator = "="

--- a/rules_complete.toml
+++ b/rules_complete.toml
@@ -210,7 +210,7 @@ SampleRate = 1
 	CheckNestedFields = false
 
 	[[dataset4.rule]]
-		name = "drop healtchecks"
+		name = "drop healthchecks"
 		drop = true
 		[[dataset4.rule.condition]]
 			field = "http.route"

--- a/sample/rules.go
+++ b/sample/rules.go
@@ -67,10 +67,17 @@ func (s *RulesBasedSampler) GetSampleRate(trace *types.Trace) (rate uint, keep b
 	for _, rule := range s.Config.Rule {
 		var matched bool
 
-		if rule.MatchSpan {
+		switch rule.Scope {
+		case "span":
 			matched = ruleMatchesSpanInTrace(trace, rule, s.Config.CheckNestedFields)
-		} else {
+		case "trace", "":
 			matched = ruleMatchesTrace(trace, rule, s.Config.CheckNestedFields)
+		default:
+			logger.WithFields(map[string]interface{}{
+				"rule_name": rule.Name,
+				"scope":     rule.Scope,
+			}).Logf("invalid scope %s given for rule: %s", rule.Scope, rule.Name)
+			matched = false
 		}
 
 		if matched {

--- a/sample/rules.go
+++ b/sample/rules.go
@@ -77,7 +77,7 @@ func (s *RulesBasedSampler) GetSampleRate(trace *types.Trace) (rate uint, keep b
 				"rule_name": rule.Name,
 				"scope":     rule.Scope,
 			}).Logf("invalid scope %s given for rule: %s", rule.Scope, rule.Name)
-			matched = false
+			matched = true
 		}
 
 		if matched {

--- a/sample/rules_test.go
+++ b/sample/rules_test.go
@@ -843,7 +843,7 @@ func TestRuleMatchesSpanMatchingSpan(t *testing.T) {
 				Rule: []*config.RulesBasedSamplerRule{
 					{
 						Name:       "Rule to match span",
-						MatchSpan:  true,
+						Scope:      "span",
 						SampleRate: 10,
 						Condition: []*config.RulesBasedSamplerCondition{
 							{
@@ -886,8 +886,8 @@ func TestRuleMatchesSpanMatchingSpan(t *testing.T) {
 			Rules: &config.RulesBasedSamplerConfig{
 				Rule: []*config.RulesBasedSamplerRule{
 					{
-						Name:      "Rule to match span",
-						MatchSpan: true,
+						Name:  "Rule to match span",
+						Scope: "span",
 						Condition: []*config.RulesBasedSamplerCondition{
 							{
 								Field:    "rule_test",


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

We'd like to be able to apply all of the conditions in a rules-based sampler rule to a single span. In other words, we'd like a rule to be considered matched only if *all* of the conditions in that rule are satisfied by a single span in the trace. This allows us to more accurately make per-service sampling decisions in a dataset written to by multiple services.

- Closes see #420

## Short description of the changes

At a high level, we add a new `Scope` configuration option to the rule definition. By default (and if unspecified) it is "trace". If "span", all conditions in the rule must be satisfied together by some span in a trace. This is a subtle but important difference with the default behavior, effectively making a rule more strict than it would otherwise be.

`Scope` introduces some complexity to the rule based sampler. While many of the operations performed within the 
`GetSampleRate` method (extracting a value, checking for a match) are similar between the two approaches, the shape of the logic to compute a match is totally different when `Scope` is 'trace' than when it is 'span'. To avoid duplication, we refactor the common methods into private functions; this also makes the logic to loop through & compute a match a little easier to understand at a glance.

I added a basic spec to cover the new behavior.

