### PR TITLE
add a note about reloading the configuration when running within docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ There are a few components of Refinery with multiple implementations; the config
 
 When configuration changes, Refinery will automatically reload the configuration[^1].
 
-[^1]: When running within docker, be sure to mount the directory of the configuration rather than the file itself so the [reloading will work](https://github.com/spf13/viper/issues/920)
+[^1]: When running Refinery within docker, be sure to mount the directory containing configuration & rules files so that [reloading will work](https://github.com/spf13/viper/issues/920) as expected.
 
 ### Redis-based Peer Management
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ There are a few vital configuration options; read through this list and make sur
 
 There are a few components of Refinery with multiple implementations; the config file lets you choose which you'd like. As an example, there are two logging implementations - one that uses `logrus` and sends logs to STDOUT and a `honeycomb` implementation that sends the log messages to a Honeycomb dataset instead. Components with multiple implementations have one top level config item that lets you choose which implementation to use and then a section further down with additional config options for that choice (for example, the Honeycomb logger requires an API key).
 
-When configuration changes, Refinery will automatically reload the configuration.
+When configuration changes, Refinery will automatically reload the configuration[^1].
+
+[^1]: When running within docker, be sure to mount the directory of the configuration rather than the file itself so the [reloading will work](https://github.com/spf13/viper/issues/920)
 
 ### Redis-based Peer Management
 


### PR DESCRIPTION
This pull request modifies the documentation regarding the automatic configuration file reloading when running within a docker container, since you need to mount the directory in rather than the file itself in order for viper to see the configuration changes.