### PR TITLE
Fix crash bug related to sharding

### DIFF
--- a/sharder/deterministic.go
+++ b/sharder/deterministic.go
@@ -227,6 +227,12 @@ func (d *DeterministicSharder) WhichShard(traceID string) Shard {
 	portion := math.MaxUint32 / len(d.peers)
 	index := v / uint32(portion)
 
+	// #454 -- index can get out of range if v is close to 0xFFFFFFFF and portion would be non-integral.
+	// Consider revisiting this with a different sharding mechanism if we rework our scaling behavior.
+	if index > uint32(len(d.peers)) {
+		index = 0
+	}
+
 	return d.peers[index]
 }
 

--- a/sharder/deterministic.go
+++ b/sharder/deterministic.go
@@ -229,7 +229,7 @@ func (d *DeterministicSharder) WhichShard(traceID string) Shard {
 
 	// #454 -- index can get out of range if v is close to 0xFFFFFFFF and portion would be non-integral.
 	// Consider revisiting this with a different sharding mechanism if we rework our scaling behavior.
-	if index > uint32(len(d.peers)) {
+	if index >= uint32(len(d.peers)) {
 		index = 0
 	}
 

--- a/sharder/deterministic_test.go
+++ b/sharder/deterministic_test.go
@@ -1,3 +1,4 @@
+//go:build all || race
 // +build all race
 
 package sharder
@@ -21,6 +22,47 @@ func TestWhichShard(t *testing.T) {
 		"http://" + selfAddr,
 		"http://2.2.2.2:8081",
 		"http://3.3.3.3:8081",
+	}
+	config := &config.MockConfig{
+		GetPeerListenAddrVal: selfAddr,
+		GetPeersVal:          peers,
+		PeerManagementType:   "file",
+	}
+	filePeers, err := peer.NewPeers(config)
+	assert.Equal(t, nil, err)
+	sharder := DeterministicSharder{
+		Config: config,
+		Logger: &logger.NullLogger{},
+		Peers:  filePeers,
+	}
+
+	assert.NoError(t, sharder.Start(),
+		"starting deterministic sharder should not error")
+
+	shard := sharder.WhichShard(traceID)
+	assert.Contains(t, peers, shard.GetAddress(),
+		"should select a peer for a trace")
+
+	config.GetPeersVal = []string{}
+	config.ReloadConfig()
+	assert.Equal(t, shard.GetAddress(), sharder.WhichShard(traceID).GetAddress(),
+		"should select the same peer if peer list becomes empty")
+}
+
+func TestWhichShardAtEdge(t *testing.T) {
+	const (
+		selfAddr = "127.0.0.1:8081"
+		traceID  = "RCIVNUNA" // carefully chosen (by trying over a billion times) to hash in WhichShard to 0xFFFFFFFF
+	)
+
+	// The algorithm in WhichShard works correctly for divisors of 2^32-1. The prime factorization of that includes
+	// 1, 3, 5, 17, so we need something other than 3 to be sure that this test would fail.
+	// It was tested (and failed) without the additional conditional.
+	peers := []string{
+		"http://" + selfAddr,
+		"http://2.2.2.2:8081",
+		"http://3.3.3.3:8081",
+		"http://4.4.4.4:8081",
 	}
 	config := &config.MockConfig{
 		GetPeerListenAddrVal: selfAddr,


### PR DESCRIPTION
## Which problem is this PR solving?

- Fixes a bug where the shard index can get out of range if the last 4 bytes of the hash of the trace ID is close to 0xFFFFFFFF and the number of shards doesn't divide that value evenly. The algorithm in WhichShard works correctly for divisors of 2^32-1. The prime factorization of that includes 1, 3, 5, 17 (and products of those).

## Short description of the changes

- If shard would be out of range, assigns it to shard 0. This has the most minimal effect on existing behavior, especially when the number of shards changes.
- Adds a test that failed before the out of range check, but works with it in.

Fixes #454 