### PR TITLE
Prep for 1.14.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,20 +4,19 @@
 
 ### Fixes
 
-3558a28 Fix crash bug related to sharding (#455) | [@kentquirk](https://github.com/kentquirk)
+- Fix crash bug related to sharding (#455) | [@kentquirk](https://github.com/kentquirk)
 
 ### Maintenance
 
-111b40d bump husky to 0.10.5 (#450) | [@MikeGoldsmith](https://github.com/MikeGoldsmith)
-744df42 Bump github.com/klauspost/compress from 1.15.2 to 1.15.4 (#451) | dependabot
-c5c91d6 Bump github.com/tidwall/gjson from 1.14.0 to 1.14.1 (#444) | dependabot
-3c8fb13 Bump github.com/fsnotify/fsnotify from 1.5.1 to 1.5.4 (#441) | dependabot
+- bump husky to 0.10.5 (#450) | [@MikeGoldsmith](https://github.com/MikeGoldsmith)
+- Bump github.com/klauspost/compress from 1.15.2 to 1.15.4 (#451) | dependabot
+- Bump github.com/tidwall/gjson from 1.14.0 to 1.14.1 (#444) | dependabot
+- Bump github.com/fsnotify/fsnotify from 1.5.1 to 1.5.4 (#441) | dependabot
 
 ### Documentation
 
-5e16407 add a note about reloading the configuration when running within docker (#448) | [@leviwilson](https://github.com/leviwilson)
-4d1d52c README: remove incorrect mention of sending SIGUSR1 to trigger a configuration reload (#447) | [@jharley](https://github.com/jharley)
-
+- add a note about reloading the configuration when running within docker (#448) | [@leviwilson](https://github.com/leviwilson)
+- README: remove incorrect mention of sending SIGUSR1 to trigger a configuration reload (#447) | [@jharley](https://github.com/jharley)
 
 ## 1.14.0 2022-05-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Refinery Changelog
 
+## 1.14.1 2022-05-16
+
+### Fixes
+
+3558a28 Fix crash bug related to sharding (#455) | [@kentquirk](https://github.com/kentquirk)
+
+### Maintenance
+
+111b40d bump husky to 0.10.5 (#450) | [@MikeGoldsmith](https://github.com/MikeGoldsmith)
+744df42 Bump github.com/klauspost/compress from 1.15.2 to 1.15.4 (#451) | dependabot
+c5c91d6 Bump github.com/tidwall/gjson from 1.14.0 to 1.14.1 (#444) | dependabot
+3c8fb13 Bump github.com/fsnotify/fsnotify from 1.5.1 to 1.5.4 (#441) | dependabot
+
+### Documentation
+
+5e16407 add a note about reloading the configuration when running within docker (#448) | [@leviwilson](https://github.com/leviwilson)
+4d1d52c README: remove incorrect mention of sending SIGUSR1 to trigger a configuration reload (#447) | [@jharley](https://github.com/jharley)
+
+
 ## 1.14.0 2022-05-03
 
 ### Enhancements


### PR DESCRIPTION
## 1.14.1 2022-05-16

### Fixes

3558a28 Fix crash bug related to sharding (#455) | [@kentquirk](https://github.com/kentquirk)

### Maintenance

111b40d bump husky to 0.10.5 (#450) | [@MikeGoldsmith](https://github.com/MikeGoldsmith)
744df42 Bump github.com/klauspost/compress from 1.15.2 to 1.15.4 (#451) | dependabot
c5c91d6 Bump github.com/tidwall/gjson from 1.14.0 to 1.14.1 (#444) | dependabot
3c8fb13 Bump github.com/fsnotify/fsnotify from 1.5.1 to 1.5.4 (#441) | dependabot

### Documentation

5e16407 add a note about reloading the configuration when running within docker (#448) | [@leviwilson](https://github.com/leviwilson)
4d1d52c README: remove incorrect mention of sending SIGUSR1 to trigger a configuration reload (#447) | [@jharley](https://github.com/jharley)
