### PR TITLE
Replace legacy with classic in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,18 +73,18 @@ In environments where domain name resolution is slow or unreliable, override the
 See the [Refinery documentation](https://docs.honeycomb.io/manage-data-volume/refinery/) for more details on tuning a cluster.
 
 
-### Mixing Legacy and Environment & Services Rule Definitions
+### Mixing Classic and Environment & Services Rule Definitions
 
-With the change to support environemt and services in Honeycomb, some users will want to support both sending telemetry to a legacy dataset and a new environment called the same thing (eg `production`).
+With the change to support environemt and services in Honeycomb, some users will want to support both sending telemetry to a classic dataset and a new environment called the same thing (eg `production`).
 
-This can be accomplished by leveraging the new `DatasetPrefix` configuration property and then using that prefix in the rules definitions for the legacy datasets.
+This can be accomplished by leveraging the new `DatasetPrefix` configuration property and then using that prefix in the rules definitions for the classic datasets.
 
-When Refinery receives telemetry using an API key associated to a legacy dataset, it will then use the prefix in the form `{prefix}.{dataset}` when trying to resolve the rules definition.
+When Refinery receives telemetry using an API key associated to a classic dataset, it will then use the prefix in the form `{prefix}.{dataset}` when trying to resolve the rules definition.
 
 For example
 config.toml
 ```toml
-DatasetPrefix = "legacy"
+DatasetPrefix = "classic"
 ```
 
 rules.toml
@@ -97,7 +97,7 @@ SampleRate = 1
     Sampler = "DeterministicSampler"
     SampleRate = 5
 
-    [legacy.production] # dataset called "production"
+    [classic.production] # dataset called "production"
     Sampler = "DeterministicSampler"
     SampleRate = 10
 ```


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
Updates README to ensure the correct terminology is used (classic vs legacy).

## Short description of the changes
- Updates README to use classic instead of legacy

