### PR TITLE
Create helm-chart issue on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,3 +19,4 @@ jobs:
 
           labels: |
             type: dependencies
+            status: oncall

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,21 @@
+name: Create helm chart issue on release
+on:
+  release:
+    types: [published]
+jobs:
+  create_issue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create an issue
+        uses: actions-ecosystem/action-create-issue@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repo: github.com/honeycombio/helm-charts
+          title: ${{ steps.date.outputs.today }}
+          body: |
+            ## Bump Refinery
+
+            Update Refinery to latest version
+
+          labels: |
+            type: dependencies


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
Adds a github action that creates a new issue on the helm-charts repo when a new refinery release is published.

- Closes #435 

## Short description of the changes
- Adds new github workflow that creates issue on refinery releases

