### PR TITLE
Validate successful span scoped rules test

### DIFF
--- a/sample/rules_test.go
+++ b/sample/rules_test.go
@@ -844,7 +844,7 @@ func TestRuleMatchesSpanMatchingSpan(t *testing.T) {
 					{
 						Name:       "Rule to match span",
 						Scope:      "span",
-						SampleRate: 10,
+						SampleRate: 1,
 						Condition: []*config.RulesBasedSamplerCondition{
 							{
 								Field:    "rule_test",
@@ -880,7 +880,7 @@ func TestRuleMatchesSpanMatchingSpan(t *testing.T) {
 				},
 			},
 			ExpectedKeep: true,
-			ExpectedRate: 10,
+			ExpectedRate: 1,
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -948,10 +948,6 @@ func TestRuleMatchesSpanMatchingSpan(t *testing.T) {
 		rate, keep := sampler.GetSampleRate(trace)
 
 		assert.Equal(t, d.ExpectedRate, rate, d.Rules)
-
-		// we can only test when we don't expect to keep the trace
-		if !d.ExpectedKeep {
-			assert.Equal(t, d.ExpectedKeep, keep, d.Rules)
-		}
+		assert.Equal(t, d.ExpectedKeep, keep, d.Rules)
 	}
 }

--- a/sample/rules_test.go
+++ b/sample/rules_test.go
@@ -1,6 +1,3 @@
-//go:build all || race
-// +build all race
-
 package sample
 
 import (
@@ -837,39 +834,17 @@ func TestRulesWithEMADynamicSampler(t *testing.T) {
 }
 
 func TestRuleMatchesSpanMatchingSpan(t *testing.T) {
-	data := []TestRulesData{
+	testCases := []struct {
+		name           string
+		spans          []*types.Span
+		keepSpanScope  bool
+		keepTraceScope bool
+	}{
 		{
-			Rules: &config.RulesBasedSamplerConfig{
-				Rule: []*config.RulesBasedSamplerRule{
-					{
-						Name:       "Rule to match span",
-						Scope:      "span",
-						SampleRate: 1,
-						Condition: []*config.RulesBasedSamplerCondition{
-							{
-								Field:    "rule_test",
-								Operator: "=",
-								Value:    int64(1),
-							},
-							{
-								Field:    "rule_test_2",
-								Operator: "=",
-								Value:    int64(2),
-							},
-						},
-					},
-				},
-			},
-			Spans: []*types.Span{
-				{
-					Event: types.Event{
-						Data: map[string]interface{}{
-							"rule_test":        int64(1),
-							"http.status_code": "200",
-							"rule_test_2":      int64(2),
-						},
-					},
-				},
+			name:           "all conditions match single span",
+			keepSpanScope:  true,
+			keepTraceScope: true,
+			spans: []*types.Span{
 				{
 					Event: types.Event{
 						Data: map[string]interface{}{
@@ -878,76 +853,91 @@ func TestRuleMatchesSpanMatchingSpan(t *testing.T) {
 						},
 					},
 				},
+				{
+					Event: types.Event{
+						Data: map[string]interface{}{
+							"rule_test":        int64(5),
+							"http.status_code": "500",
+						},
+					},
+				},
 			},
-			ExpectedKeep: true,
-			ExpectedRate: 1,
 		},
 		{
-			Rules: &config.RulesBasedSamplerConfig{
-				Rule: []*config.RulesBasedSamplerRule{
-					{
-						Name:  "Rule to match span",
-						Scope: "span",
-						Condition: []*config.RulesBasedSamplerCondition{
-							{
-								Field:    "rule_test",
-								Operator: "=",
-								Value:    int64(1),
-							},
-							{
-								Field:    "rule_test_2",
-								Operator: "=",
-								Value:    int64(2),
-							},
-						},
-					},
-					{
-						Name:       "Default rule",
-						Drop:       true,
-						SampleRate: 1,
-					},
-				},
-			},
-			Spans: []*types.Span{
+			name:           "all conditions do not match single span",
+			keepSpanScope:  false,
+			keepTraceScope: true,
+			spans: []*types.Span{
 				{
 					Event: types.Event{
 						Data: map[string]interface{}{
 							"rule_test":        int64(1),
-							"http.status_code": "200",
+							"http.status_code": "500",
 						},
 					},
 				},
 				{
 					Event: types.Event{
 						Data: map[string]interface{}{
-							"rule_test_2":      int64(2),
+							"rule_test":        int64(5),
 							"http.status_code": "200",
 						},
 					},
 				},
 			},
-			ExpectedKeep: false,
-			ExpectedRate: 1,
 		},
 	}
 
-	for _, d := range data {
-		sampler := &RulesBasedSampler{
-			Config:  d.Rules,
-			Logger:  &logger.NullLogger{},
-			Metrics: &metrics.NullMetrics{},
-		}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, scope := range []string{"span", "trace"} {
+				sampler := &RulesBasedSampler{
+					Config: &config.RulesBasedSamplerConfig{
+						Rule: []*config.RulesBasedSamplerRule{
+							{
+								Name:       "Rule to match span",
+								Scope:      scope,
+								SampleRate: 1,
+								Condition: []*config.RulesBasedSamplerCondition{
+									{
+										Field:    "rule_test",
+										Operator: "=",
+										Value:    int64(1),
+									},
+									{
+										Field:    "http.status_code",
+										Operator: "=",
+										Value:    "200",
+									},
+								},
+							},
+							{
+								Name:       "Default rule",
+								Drop:       true,
+								SampleRate: 1,
+							},
+						},
+					},
+					Logger:  &logger.NullLogger{},
+					Metrics: &metrics.NullMetrics{},
+				}
 
-		trace := &types.Trace{}
+				trace := &types.Trace{}
 
-		for _, span := range d.Spans {
-			trace.AddSpan(span)
-		}
+				for _, span := range tc.spans {
+					trace.AddSpan(span)
+				}
 
-		sampler.Start()
-		rate, keep := sampler.GetSampleRate(trace)
+				sampler.Start()
+				rate, keep := sampler.GetSampleRate(trace)
 
-		assert.Equal(t, d.ExpectedRate, rate, d.Rules)
-		assert.Equal(t, d.ExpectedKeep, keep, d.Rules)
+				assert.Equal(t, uint(1), rate, rate)
+				if scope == "span" {
+					assert.Equal(t, tc.keepSpanScope, keep, keep)
+				} else {
+					assert.Equal(t, tc.keepTraceScope, keep, keep)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
The test to validate the new span scoped rule sets in #440 only validated the keep return property for unsuccessful sets of spans. This PR updates the test to verify that the keep property is correct by updating the sample rate on the rule set to 1.

## Short description of the changes
- Update sample rate in the test to 1, so we can validate the keep return property

