### PR TITLE
maint: change title on release workflow from (unset) var to hard-coded string

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           repo: github.com/honeycombio/helm-charts
-          title: ${{ steps.date.outputs.today }}
+          title: Bump Refinery to Latest Version
           body: |
             ## Bump Refinery
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,7 @@ name: Create helm chart issue on release
 on:
   release:
     types: [published]
+  workflow_dispatch:
 jobs:
   create_issue:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Error in previous workflow that attempted to create an issue states "Input required and not supplied: title".

## Short description of the changes

- While the title does match that of the [example](https://github.com/actions-ecosystem/action-create-issue#example) provided in the actions repo, it is based on a variable that is set in the example that we do not have set. I believe this is causing a blank title which is not allowed, as the title value is required. This PR changes the title from a variable that is unset (`{ steps.date.outputs.today }}`) to a hard-coded string (`Bump Refinery to Latest Version`).

