### PR TITLE
Make gRPC ServerParameters configurable

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -147,4 +147,14 @@ type Config interface {
 
 	// GetQueryAuthToken returns the token that must be used to access the /query endpoints
 	GetQueryAuthToken() string
+
+	GetGRPCMaxConnectionIdle() time.Duration
+
+	GetGRPCMaxConnectionAge() time.Duration
+
+	GetGRPCMaxConnectionAgeGrace() time.Duration
+
+	GetGRPCTime() time.Duration
+
+	GetGRPCTimeout() time.Duration
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -20,6 +20,7 @@ func TestGRPCListenAddrEnvVar(t *testing.T) {
 	defer os.Unsetenv(envVarName)
 
 	c, err := NewConfig("../config.toml", "../rules.toml", func(err error) {})
+
 	if err != nil {
 		t.Error(err)
 	}
@@ -36,6 +37,7 @@ func TestRedisHostEnvVar(t *testing.T) {
 	defer os.Unsetenv(envVarName)
 
 	c, err := NewConfig("../config.toml", "../rules.toml", func(err error) {})
+
 	if err != nil {
 		t.Error(err)
 	}
@@ -52,6 +54,7 @@ func TestRedisUsernameEnvVar(t *testing.T) {
 	defer os.Unsetenv(envVarName)
 
 	c, err := NewConfig("../config.toml", "../rules.toml", func(err error) {})
+
 	if err != nil {
 		t.Error(err)
 	}
@@ -68,6 +71,7 @@ func TestRedisPasswordEnvVar(t *testing.T) {
 	defer os.Unsetenv(envVarName)
 
 	c, err := NewConfig("../config.toml", "../rules.toml", func(err error) {})
+
 	if err != nil {
 		t.Error(err)
 	}
@@ -120,9 +124,7 @@ func TestReload(t *testing.T) {
 
 	c, err := NewConfig(config, rules, func(err error) {})
 	assert.NoError(t, err)
-	configFile.Close()
 
-	c, err := NewConfig(configFile.Name(), rulesFile.Name(), func(err error) {})
 	if err != nil {
 		t.Error(err)
 	}
@@ -175,10 +177,12 @@ func TestReload(t *testing.T) {
 	if d, _ := c.GetListenAddr(); d != "0.0.0.0:9000" {
 		t.Error("received", d, "expected", "0.0.0.0:9000")
 	}
+
 }
 
 func TestReadDefaults(t *testing.T) {
 	c, err := NewConfig("../config.toml", "../rules.toml", func(err error) {})
+
 	if err != nil {
 		t.Error(err)
 	}
@@ -241,6 +245,7 @@ func TestReadDefaults(t *testing.T) {
 
 func TestReadRulesConfig(t *testing.T) {
 	c, err := NewConfig("../config.toml", "../rules_complete.toml", func(err error) {})
+
 	if err != nil {
 		t.Error(err)
 	}
@@ -610,13 +615,16 @@ func TestDatasetPrefix(t *testing.T) {
 func TestQueryAuthToken(t *testing.T) {
 	config, rules := createTempConfigs(t, `
 	QueryAuthToken = "MySeekretToken"
+
 	[InMemCollector]
 		CacheCapacity=1000
+
 	[HoneycombMetrics]
 		MetricsHoneycombAPI="http://honeycomb.io"
 		MetricsAPIKey="1234"
 		MetricsDataset="testDatasetName"
 		MetricsReportingInterval=3
+
 	[HoneycombLogger]
 		LoggerHoneycombAPI="http://honeycomb.io"
 		LoggerAPIKey="1234"

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -150,6 +150,7 @@ func NewConfig(config, rules string, errorCallback func(error)) (Config, error) 
 
 	c.SetConfigFile(config)
 	err := c.ReadInConfig()
+
 	if err != nil {
 		return nil, err
 	}
@@ -238,6 +239,7 @@ func (f *fileConfig) unmarshal() error {
 	f.mux.Lock()
 	defer f.mux.Unlock()
 	err := f.config.Unmarshal(f.conf)
+
 	if err != nil {
 		return err
 	}

--- a/config/mock.go
+++ b/config/mock.go
@@ -74,6 +74,11 @@ type MockConfig struct {
 	EnvironmentCacheTTL           time.Duration
 	DatasetPrefix                 string
 	QueryAuthToken                string
+	GRPCMaxConnectionIdle         time.Duration
+	GRPCMaxConnectionAge          time.Duration
+	GRPCMaxConnectionAgeGrace     time.Duration
+	GRPCTime                      time.Duration
+	GRPCTimeout                   time.Duration
 
 	Mux sync.RWMutex
 }
@@ -86,77 +91,90 @@ func (m *MockConfig) ReloadConfig() {
 		callback()
 	}
 }
+
 func (m *MockConfig) RegisterReloadCallback(callback func()) {
 	m.Mux.Lock()
 	m.Callbacks = append(m.Callbacks, callback)
 	m.Mux.Unlock()
 }
+
 func (m *MockConfig) GetAPIKeys() ([]string, error) {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
 	return m.GetAPIKeysVal, m.GetAPIKeysErr
 }
+
 func (m *MockConfig) GetCollectorType() (string, error) {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
 	return m.GetCollectorTypeVal, m.GetCollectorTypeErr
 }
+
 func (m *MockConfig) GetInMemCollectorCacheCapacity() (InMemoryCollectorCacheCapacity, error) {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
 	return m.GetInMemoryCollectorCacheCapacityVal, m.GetInMemoryCollectorCacheCapacityErr
 }
+
 func (m *MockConfig) GetHoneycombAPI() (string, error) {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
 	return m.GetHoneycombAPIVal, m.GetHoneycombAPIErr
 }
+
 func (m *MockConfig) GetListenAddr() (string, error) {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
 	return m.GetListenAddrVal, m.GetListenAddrErr
 }
+
 func (m *MockConfig) GetPeerListenAddr() (string, error) {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
 	return m.GetPeerListenAddrVal, m.GetPeerListenAddrErr
 }
+
 func (m *MockConfig) GetCompressPeerCommunication() bool {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
 	return m.GetCompressPeerCommunicationsVal
 }
+
 func (m *MockConfig) GetGRPCListenAddr() (string, error) {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
 	return m.GetGRPCListenAddrVal, m.GetGRPCListenAddrErr
 }
+
 func (m *MockConfig) GetLoggerType() (string, error) {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
 	return m.GetLoggerTypeVal, m.GetLoggerTypeErr
 }
+
 func (m *MockConfig) GetHoneycombLoggerConfig() (HoneycombLoggerConfig, error) {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
 	return m.GetHoneycombLoggerConfigVal, m.GetHoneycombLoggerConfigErr
 }
+
 func (m *MockConfig) GetLoggingLevel() (string, error) {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
 	return m.GetLoggingLevelVal, m.GetLoggingLevelErr
 }
+
 func (m *MockConfig) GetOtherConfig(name string, iface interface{}) error {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
@@ -167,66 +185,77 @@ func (m *MockConfig) GetOtherConfig(name string, iface interface{}) error {
 	}
 	return m.GetOtherConfigErr
 }
+
 func (m *MockConfig) GetPeers() ([]string, error) {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
 	return m.GetPeersVal, m.GetPeersErr
 }
+
 func (m *MockConfig) GetRedisHost() (string, error) {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
 	return m.GetRedisHostVal, m.GetRedisHostErr
 }
+
 func (m *MockConfig) GetRedisUsername() (string, error) {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
 	return m.GetRedisUsernameVal, m.GetRedisUsernameErr
 }
+
 func (m *MockConfig) GetRedisPassword() (string, error) {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
 	return m.GetRedisPasswordVal, m.GetRedisPasswordErr
 }
+
 func (m *MockConfig) GetUseTLS() (bool, error) {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
 	return m.GetUseTLSVal, m.GetUseTLSErr
 }
+
 func (m *MockConfig) GetUseTLSInsecure() (bool, error) {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
 	return m.GetUseTLSInsecureVal, m.GetUseTLSInsecureErr
 }
+
 func (m *MockConfig) GetMetricsType() (string, error) {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
 	return m.GetMetricsTypeVal, m.GetMetricsTypeErr
 }
+
 func (m *MockConfig) GetHoneycombMetricsConfig() (HoneycombMetricsConfig, error) {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
 	return m.GetHoneycombMetricsConfigVal, m.GetHoneycombMetricsConfigErr
 }
+
 func (m *MockConfig) GetPrometheusMetricsConfig() (PrometheusMetricsConfig, error) {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
 	return m.GetPrometheusMetricsConfigVal, m.GetPrometheusMetricsConfigErr
 }
+
 func (m *MockConfig) GetSendDelay() (time.Duration, error) {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
 	return m.GetSendDelayVal, m.GetSendDelayErr
 }
+
 func (m *MockConfig) GetTraceTimeout() (time.Duration, error) {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
@@ -264,6 +293,7 @@ func (m *MockConfig) GetUpstreamBufferSize() int {
 
 	return m.GetUpstreamBufferSizeVal
 }
+
 func (m *MockConfig) GetPeerBufferSize() int {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
@@ -353,4 +383,39 @@ func (f *MockConfig) GetQueryAuthToken() string {
 	defer f.Mux.RUnlock()
 
 	return f.QueryAuthToken
+}
+
+func (f *MockConfig) GetGRPCMaxConnectionIdle() time.Duration {
+	f.Mux.RLock()
+	defer f.Mux.RUnlock()
+
+	return f.GRPCMaxConnectionIdle
+}
+
+func (f *MockConfig) GetGRPCMaxConnectionAge() time.Duration {
+	f.Mux.RLock()
+	defer f.Mux.RUnlock()
+
+	return f.GRPCMaxConnectionAge
+}
+
+func (f *MockConfig) GetGRPCMaxConnectionAgeGrace() time.Duration {
+	f.Mux.RLock()
+	defer f.Mux.RUnlock()
+
+	return f.GRPCMaxConnectionAgeGrace
+}
+
+func (f *MockConfig) GetGRPCTime() time.Duration {
+	f.Mux.RLock()
+	defer f.Mux.RUnlock()
+
+	return f.GRPCTime
+}
+
+func (f *MockConfig) GetGRPCTimeout() time.Duration {
+	f.Mux.RLock()
+	defer f.Mux.RUnlock()
+
+	return f.GRPCTimeout
 }

--- a/config_complete.toml
+++ b/config_complete.toml
@@ -323,3 +323,44 @@ MetricsReportingInterval = 3
 # listener.
 # Not eligible for live reload.
 # MetricsListenAddr = "localhost:2112"
+
+###########################
+## gRPC ServerParameters ##
+###########################
+
+# Reflects: https://pkg.go.dev/google.golang.org/grpc/keepalive#ServerParameters
+
+[GRPCServerParameters]
+
+# MaxConnectionIdle is a duration for the amount of time after which an
+# idle connection would be closed by sending a GoAway. Idleness duration is
+# defined since the most recent time the number of outstanding RPCs became
+# zero or the connection establishment.
+# Not eligible for live reload.
+# MaxConnectionIdle = "1m"
+
+# MaxConnectionAge is a duration for the maximum amount of time a
+# connection may exist before it will be closed by sending a GoAway. A
+# random jitter of +/-10% will be added to MaxConnectionAge to spread out
+# connection storms.
+# 0s sets duration to infinity which is the default.
+# Not eligible for live reload.
+# MaxConnectionAge = "0s"
+
+# MaxConnectionAgeGrace is an additive period after MaxConnectionAge after
+# which the connection will be forcibly closed.
+# 0s sets duration to infinity which is the default.
+# Not eligible for live reload.
+# MaxConnectionAgeGrace = "0s"
+
+# After a duration of this time if the server doesn't see any activity it
+# pings the client to see if the transport is still alive.
+# If set below 1s, a minimum value of 1s will be used instead.
+# Not eligible for live reload.
+# Time = "10s"
+
+# After having pinged for keepalive check, the server waits for a duration
+# of Timeout and if no activity is seen even after that the connection is
+# closed.
+# Not eligible for live reload.
+# Timeout = "2s"

--- a/config_complete.toml
+++ b/config_complete.toml
@@ -336,6 +336,8 @@ MetricsReportingInterval = 3
 # idle connection would be closed by sending a GoAway. Idleness duration is
 # defined since the most recent time the number of outstanding RPCs became
 # zero or the connection establishment.
+# 0s sets duration to infinity which is the default:
+# https://github.com/grpc/grpc-go/blob/60a3a7e969c401ca16dbcd0108ad544fb35aa61c/internal/transport/http2_server.go#L217-L219
 # Not eligible for live reload.
 # MaxConnectionIdle = "1m"
 
@@ -343,24 +345,30 @@ MetricsReportingInterval = 3
 # connection may exist before it will be closed by sending a GoAway. A
 # random jitter of +/-10% will be added to MaxConnectionAge to spread out
 # connection storms.
-# 0s sets duration to infinity which is the default.
+# 0s sets duration to infinity which is the default:
+# https://github.com/grpc/grpc-go/blob/60a3a7e969c401ca16dbcd0108ad544fb35aa61c/internal/transport/http2_server.go#L220-L222
 # Not eligible for live reload.
 # MaxConnectionAge = "0s"
 
 # MaxConnectionAgeGrace is an additive period after MaxConnectionAge after
 # which the connection will be forcibly closed.
-# 0s sets duration to infinity which is the default.
+# 0s sets duration to infinity which is the default:
+# https://github.com/grpc/grpc-go/blob/60a3a7e969c401ca16dbcd0108ad544fb35aa61c/internal/transport/http2_server.go#L225-L227
 # Not eligible for live reload.
 # MaxConnectionAgeGrace = "0s"
 
 # After a duration of this time if the server doesn't see any activity it
 # pings the client to see if the transport is still alive.
 # If set below 1s, a minimum value of 1s will be used instead.
+# 0s sets duration to 2 hours which is the default:
+# https://github.com/grpc/grpc-go/blob/60a3a7e969c401ca16dbcd0108ad544fb35aa61c/internal/transport/http2_server.go#L228-L230
 # Not eligible for live reload.
 # Time = "10s"
 
 # After having pinged for keepalive check, the server waits for a duration
 # of Timeout and if no activity is seen even after that the connection is
 # closed.
+# 0s sets duration to 20 seconds which is the default:
+# https://github.com/grpc/grpc-go/blob/60a3a7e969c401ca16dbcd0108ad544fb35aa61c/internal/transport/http2_server.go#L231-L233
 # Not eligible for live reload.
 # Timeout = "2s"

--- a/route/route.go
+++ b/route/route.go
@@ -220,9 +220,11 @@ func (r *Router) LnS(incomingOrPeer string) {
 			grpc.MaxSendMsgSize(GRPCMessageSizeMax), // default is math.MaxInt32
 			grpc.MaxRecvMsgSize(GRPCMessageSizeMax), // default is 4MB
 			grpc.KeepaliveParams(keepalive.ServerParameters{
-				Time:              10 * time.Second,
-				Timeout:           2 * time.Second,
-				MaxConnectionIdle: time.Minute,
+				MaxConnectionIdle:     r.Config.GetGRPCMaxConnectionIdle(),
+				MaxConnectionAge:      r.Config.GetGRPCMaxConnectionAge(),
+				MaxConnectionAgeGrace: r.Config.GetGRPCMaxConnectionAgeGrace(),
+				Time:                  r.Config.GetGRPCTime(),
+				Timeout:               r.Config.GetGRPCTimeout(),
 			}),
 		}
 		r.grpcServer = grpc.NewServer(serverOpts...)


### PR DESCRIPTION
Which problem is this PR solving
--------------------------------

At the moment, there is no way to override the ServerParameters used in
the `keepalive` configuration of the gRPC server. As to @bdarfler's
comments in #263, issues can arise where new hosts will never be
connected to because clients will reconnect to already existing hosts
and by the time replacement hosts are available, all clients will have
reconnected to existing hosts with a
`MaxConnectionAge`/`MaxConnectionAgeGrace` of
[infinity](https://github.com/grpc/grpc-go/blob/60a3a7e969c401ca16dbcd0108ad544fb35aa61c/internal/transport/defaults.go#L36-L37).

Short description of the changes
--------------------------------

The changes made are to plumb through the configuration of the GRPC
ServerParameters from the viper configuration and into the instantiation
of the actual gRPC server. These changes kept the previous default
configuration of refinery as the defaults of the configurable settings,
so anyone who doesn't explicitly override any of these configurations
should have exactly the same behavior.

Closes #263
