### PR TITLE
Add endpoints to help debug refinery rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Because the normal configuration file formats (TOML and YAML) can sometimes be c
 
 `curl --include --get $REFINERY_HOST/debug/allrules/$FORMAT` will retrieve the entire rules configuration.
 
-`curl --include --get $REFINERY_HOST/debug/rules/$FORMAT/$DATASET` will retrieve the rule set that refinery will use for the specified dataset.
+`curl --include --get $REFINERY_HOST/debug/rules/$FORMAT/$DATASET` will retrieve the rule set that refinery will use for the specified dataset. It comes back as a map of the sampler type to its rule set.
 
 - `$REFINERY_HOST` should be the url of your refinery.
 - `$FORMAT` can be one of `json`, `yaml`, or `toml`.

--- a/README.md
+++ b/README.md
@@ -133,7 +133,22 @@ Refinery emits a number of metrics to give some indication about the health of t
 
 ## Troubleshooting
 
+### Logging
+
 The default logging level of `warn` is almost entirely silent. The `debug` level emits too much data to be used in production, but contains excellent information in a pre-production environment. Setting the logging level to `debug` during initial configuration will help understand what's working and what's not, but when traffic volumes increase it should be set to `warn`.
+
+### Configuration
+
+Because the normal configuration file formats (TOML and YAML) can sometimes be confusing to read and write, it may be valuable to check the loaded configuration by using one of the debug endpoints from the command line:
+
+`curl --include --get $REFINERY_HOST/debug/allrules/$FORMAT` will retrieve the entire rules configuration.
+
+`curl --include --get $REFINERY_HOST/debug/rules/$FORMAT/$DATASET` will retrieve the rule set that refinery will use for the specified dataset.
+
+- `$REFINERY_HOST` should be the url of your refinery.
+- `$FORMAT` can be one of `json`, `yaml`, or `toml`.
+- `$DATASET` is the name of the dataset you want to check.
+
 
 ## Restarts
 

--- a/config/config.go
+++ b/config/config.go
@@ -102,6 +102,9 @@ type Config interface {
 	// GetSamplerConfigForDataset returns the sampler type to use for the given dataset
 	GetSamplerConfigForDataset(string) (interface{}, error)
 
+	// GetAllSamplerConfigs returns all dataset configurations in a map, including the default
+	GetAllSamplerConfigs() (map[string]interface{}, error)
+
 	// GetMetricsType returns the type of metrics to use. Valid types are in the
 	// metrics package
 	GetMetricsType() (string, error)

--- a/config/config.go
+++ b/config/config.go
@@ -99,8 +99,8 @@ type Config interface {
 	// GetInMemCollectorCacheCapacity returns the config specific to the InMemCollector
 	GetInMemCollectorCacheCapacity() (InMemoryCollectorCacheCapacity, error)
 
-	// GetSamplerConfigForDataset returns the sampler type to use for the given dataset
-	GetSamplerConfigForDataset(string) (interface{}, error)
+	// GetSamplerConfigForDataset returns the sampler type and name to use for the given dataset
+	GetSamplerConfigForDataset(string) (interface{}, string, error)
 
 	// GetAllSamplerRules returns all dataset rules in a map, including the default
 	GetAllSamplerRules() (map[string]interface{}, error)

--- a/config/config.go
+++ b/config/config.go
@@ -102,8 +102,8 @@ type Config interface {
 	// GetSamplerConfigForDataset returns the sampler type to use for the given dataset
 	GetSamplerConfigForDataset(string) (interface{}, error)
 
-	// GetAllSamplerConfigs returns all dataset configurations in a map, including the default
-	GetAllSamplerConfigs() (map[string]interface{}, error)
+	// GetAllSamplerRules returns all dataset rules in a map, including the default
+	GetAllSamplerRules() (map[string]interface{}, error)
 
 	// GetMetricsType returns the type of metrics to use. Valid types are in the
 	// metrics package

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,3 +1,4 @@
+//go:build all || race
 // +build all race
 
 package config
@@ -212,9 +213,10 @@ func TestReadDefaults(t *testing.T) {
 		t.Error("received", d, "expected", time.Hour)
 	}
 
-	d, err := c.GetSamplerConfigForDataset("dataset-doesnt-exist")
+	d, name, err := c.GetSamplerConfigForDataset("dataset-doesnt-exist")
 	assert.NoError(t, err)
 	assert.IsType(t, &DeterministicSamplerConfig{}, d)
+	assert.Equal(t, "DeterministicSampler", name)
 
 	type imcConfig struct {
 		CacheCapacity int
@@ -234,15 +236,17 @@ func TestReadRulesConfig(t *testing.T) {
 		t.Error(err)
 	}
 
-	d, err := c.GetSamplerConfigForDataset("dataset-doesnt-exist")
+	d, name, err := c.GetSamplerConfigForDataset("dataset-doesnt-exist")
 	assert.NoError(t, err)
 	assert.IsType(t, &DeterministicSamplerConfig{}, d)
+	assert.Equal(t, "DeterministicSampler", name)
 
-	d, err = c.GetSamplerConfigForDataset("dataset1")
+	d, name, err = c.GetSamplerConfigForDataset("dataset1")
 	assert.NoError(t, err)
 	assert.IsType(t, &DynamicSamplerConfig{}, d)
+	assert.Equal(t, "DynamicSampler", name)
 
-	d, err = c.GetSamplerConfigForDataset("dataset4")
+	d, name, err = c.GetSamplerConfigForDataset("dataset4")
 	assert.NoError(t, err)
 	switch r := d.(type) {
 	case *RulesBasedSamplerConfig:
@@ -267,6 +271,8 @@ func TestReadRulesConfig(t *testing.T) {
 		rule = r.Rule[4]
 		assert.Equal(t, 10, rule.SampleRate)
 		assert.Equal(t, "", rule.Scope)
+
+		assert.Equal(t, "RulesBasedSampler", name)
 
 	default:
 		assert.Fail(t, "dataset4 should have a rules based sampler", d)
@@ -512,24 +518,29 @@ func TestGetSamplerTypes(t *testing.T) {
 		t.Error(err)
 	}
 
-	if d, err := c.GetSamplerConfigForDataset("dataset-doesnt-exist"); assert.Equal(t, nil, err) {
+	if d, name, err := c.GetSamplerConfigForDataset("dataset-doesnt-exist"); assert.Equal(t, nil, err) {
 		assert.IsType(t, &DeterministicSamplerConfig{}, d)
+		assert.Equal(t, "DeterministicSampler", name)
 	}
 
-	if d, err := c.GetSamplerConfigForDataset("dataset 1"); assert.Equal(t, nil, err) {
+	if d, name, err := c.GetSamplerConfigForDataset("dataset 1"); assert.Equal(t, nil, err) {
 		assert.IsType(t, &DynamicSamplerConfig{}, d)
+		assert.Equal(t, "DynamicSampler", name)
 	}
 
-	if d, err := c.GetSamplerConfigForDataset("dataset2"); assert.Equal(t, nil, err) {
+	if d, name, err := c.GetSamplerConfigForDataset("dataset2"); assert.Equal(t, nil, err) {
 		assert.IsType(t, &DeterministicSamplerConfig{}, d)
+		assert.Equal(t, "DeterministicSampler", name)
 	}
 
-	if d, err := c.GetSamplerConfigForDataset("dataset3"); assert.Equal(t, nil, err) {
+	if d, name, err := c.GetSamplerConfigForDataset("dataset3"); assert.Equal(t, nil, err) {
 		assert.IsType(t, &EMADynamicSamplerConfig{}, d)
+		assert.Equal(t, "EMADynamicSampler", name)
 	}
 
-	if d, err := c.GetSamplerConfigForDataset("dataset4"); assert.Equal(t, nil, err) {
+	if d, name, err := c.GetSamplerConfigForDataset("dataset4"); assert.Equal(t, nil, err) {
 		assert.IsType(t, &TotalThroughputSamplerConfig{}, d)
+		assert.Equal(t, "TotalThroughputSampler", name)
 	}
 }
 
@@ -563,9 +574,10 @@ func TestDefaultSampler(t *testing.T) {
 
 	assert.NoError(t, err)
 
-	s, err := c.GetSamplerConfigForDataset("nonexistent")
+	s, name, err := c.GetSamplerConfigForDataset("nonexistent")
 
 	assert.NoError(t, err)
+	assert.Equal(t, "DeterministicSampler", name)
 
 	assert.IsType(t, &DeterministicSamplerConfig{}, s)
 }

--- a/config/config_test_reload_error_test.go
+++ b/config/config_test_reload_error_test.go
@@ -1,3 +1,4 @@
+//go:build all || !race
 // +build all !race
 
 package config
@@ -55,9 +56,12 @@ func TestErrorReloading(t *testing.T) {
 		t.Error(err)
 	}
 
-	d, _ := c.GetSamplerConfigForDataset("dataset5")
+	d, name, _ := c.GetSamplerConfigForDataset("dataset5")
 	if _, ok := d.(DeterministicSamplerConfig); ok {
-		t.Error("received", d, "expected", "DeterministicSampler")
+		t.Error("type received", d, "expected", "DeterministicSampler")
+	}
+	if name != "DeterministicSampler" {
+		t.Error("name received", d, "expected", "DeterministicSampler")
 	}
 
 	wg := &sync.WaitGroup{}
@@ -82,7 +86,7 @@ func TestErrorReloading(t *testing.T) {
 	wg.Wait()
 
 	// config should error and not update sampler to invalid type
-	d, _ = c.GetSamplerConfigForDataset("dataset5")
+	d, _, _ = c.GetSamplerConfigForDataset("dataset5")
 	if _, ok := d.(DeterministicSamplerConfig); ok {
 		t.Error("received", d, "expected", "DeterministicSampler")
 	}

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -521,14 +521,14 @@ func (f *fileConfig) GetCollectorType() (string, error) {
 	return f.conf.Collector, nil
 }
 
-func (f *fileConfig) GetAllSamplerConfigs() (map[string]interface{}, error) {
+func (f *fileConfig) GetAllSamplerRules() (map[string]interface{}, error) {
 	samplers := make(map[string]interface{})
 
 	keys := f.rules.AllKeys()
 	for _, key := range keys {
 		parts := strings.Split(key, ".")
 
-		// extract default sampler config
+		// extract default sampler rules
 		if parts[0] == "sampler" {
 			err := f.rules.Unmarshal(&samplers)
 			if err != nil {
@@ -539,7 +539,7 @@ func (f *fileConfig) GetAllSamplerConfigs() (map[string]interface{}, error) {
 			continue
 		}
 
-		// extract dataset sampler configs
+		// extract all dataset sampler rules
 		if len(parts) > 1 && parts[1] == "sampler" {
 			t := f.rules.GetString(key)
 			m := make(map[string]interface{})

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -557,9 +557,11 @@ func (f *fileConfig) GetAllSamplerRules() (map[string]interface{}, error) {
 	return samplers, nil
 }
 
-func (f *fileConfig) GetSamplerConfigForDataset(dataset string) (interface{}, error) {
+func (f *fileConfig) GetSamplerConfigForDataset(dataset string) (interface{}, string, error) {
 	f.mux.RLock()
 	defer f.mux.RUnlock()
+
+	const notfound = "not found"
 
 	key := fmt.Sprintf("%s.Sampler", dataset)
 	if ok := f.rules.IsSet(key); ok {
@@ -578,11 +580,11 @@ func (f *fileConfig) GetSamplerConfigForDataset(dataset string) (interface{}, er
 		case "TotalThroughputSampler":
 			i = &TotalThroughputSamplerConfig{}
 		default:
-			return nil, errors.New("No Sampler found")
+			return nil, notfound, errors.New("No Sampler found")
 		}
 
 		if sub := f.rules.Sub(dataset); sub != nil {
-			return i, sub.Unmarshal(i)
+			return i, t, sub.Unmarshal(i)
 		}
 
 	} else if ok := f.rules.IsSet("Sampler"); ok {
@@ -601,13 +603,13 @@ func (f *fileConfig) GetSamplerConfigForDataset(dataset string) (interface{}, er
 		case "TotalThroughputSampler":
 			i = &TotalThroughputSamplerConfig{}
 		default:
-			return nil, errors.New("No Sampler found")
+			return nil, notfound, errors.New("No Sampler found")
 		}
 
-		return i, f.rules.Unmarshal(i)
+		return i, t, f.rules.Unmarshal(i)
 	}
 
-	return nil, errors.New("No Sampler found")
+	return nil, notfound, errors.New("No Sampler found")
 }
 
 func (f *fileConfig) GetInMemCollectorCacheCapacity() (InMemoryCollectorCacheCapacity, error) {

--- a/config/mock.go
+++ b/config/mock.go
@@ -247,8 +247,8 @@ func (m *MockConfig) GetSamplerConfigForDataset(dataset string) (interface{}, er
 	return m.GetSamplerTypeVal, m.GetSamplerTypeErr
 }
 
-// GetAllSamplerConfigs returns all dataset configurations, including the default
-func (m *MockConfig) GetAllSamplerConfigs() (map[string]interface{}, error) {
+// GetAllSamplerRules returns all dataset rules, including the default
+func (m *MockConfig) GetAllSamplerRules() (map[string]interface{}, error) {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 

--- a/config/mock.go
+++ b/config/mock.go
@@ -47,6 +47,7 @@ type MockConfig struct {
 	GetUseTLSInsecureErr          error
 	GetUseTLSInsecureVal          bool
 	GetSamplerTypeErr             error
+	GetSamplerTypeName            string
 	GetSamplerTypeVal             interface{}
 	GetMetricsTypeErr             error
 	GetMetricsTypeVal             string
@@ -240,11 +241,11 @@ func (m *MockConfig) GetMaxBatchSize() uint {
 }
 
 // TODO: allow per-dataset mock values
-func (m *MockConfig) GetSamplerConfigForDataset(dataset string) (interface{}, error) {
+func (m *MockConfig) GetSamplerConfigForDataset(dataset string) (interface{}, string, error) {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
-	return m.GetSamplerTypeVal, m.GetSamplerTypeErr
+	return m.GetSamplerTypeVal, m.GetSamplerTypeName, m.GetSamplerTypeErr
 }
 
 // GetAllSamplerRules returns all dataset rules, including the default

--- a/config/mock.go
+++ b/config/mock.go
@@ -247,6 +247,15 @@ func (m *MockConfig) GetSamplerConfigForDataset(dataset string) (interface{}, er
 	return m.GetSamplerTypeVal, m.GetSamplerTypeErr
 }
 
+// GetAllSamplerConfigs returns all dataset configurations, including the default
+func (m *MockConfig) GetAllSamplerConfigs() (map[string]interface{}, error) {
+	m.Mux.RLock()
+	defer m.Mux.RUnlock()
+
+	v := map[string]interface{}{"dataset1": m.GetSamplerTypeVal}
+	return v, m.GetSamplerTypeErr
+}
+
 func (m *MockConfig) GetUpstreamBufferSize() int {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/facebookgo/startstop v0.0.0-20161013234910-bc158412526d
 	github.com/fsnotify/fsnotify v1.5.4
 	github.com/go-playground/validator v9.31.0+incompatible
-	github.com/golang/protobuf v1.5.2
 	github.com/gomodule/redigo v1.8.9
 	github.com/gorilla/mux v1.8.0
 	github.com/hashicorp/golang-lru v0.5.4
@@ -29,6 +28,7 @@ require (
 	github.com/vmihailenco/msgpack/v4 v4.3.11
 	go.opentelemetry.io/proto/otlp v0.11.0
 	google.golang.org/grpc v1.48.0
+	google.golang.org/protobuf v1.28.0
 	gopkg.in/alexcesaro/statsd.v2 v2.0.0
 	gopkg.in/yaml.v2 v2.4.0
 )
@@ -42,6 +42,7 @@ require (
 	github.com/facebookgo/structtag v0.0.0-20150214074306-217e25fb9691 // indirect
 	github.com/go-playground/locales v0.13.0 // indirect
 	github.com/go-playground/universal-translator v0.17.0 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/leodido/go-urn v1.2.0 // indirect
@@ -70,7 +71,6 @@ require (
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20220519153652-3a47de7e79bd // indirect
-	google.golang.org/protobuf v1.28.0 // indirect
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
 	gopkg.in/ini.v1 v1.66.4 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/jessevdk/go-flags v1.5.0
 	github.com/json-iterator/go v1.1.12
 	github.com/klauspost/compress v1.15.7
+	github.com/pelletier/go-toml/v2 v2.0.1
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.2
 	github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0
@@ -27,9 +28,9 @@ require (
 	github.com/tidwall/gjson v1.14.1
 	github.com/vmihailenco/msgpack/v4 v4.3.11
 	go.opentelemetry.io/proto/otlp v0.11.0
-	golang.org/x/net v0.0.0-20220520000938-2e3eb7b945c2 // indirect
 	google.golang.org/grpc v1.48.0
 	gopkg.in/alexcesaro/statsd.v2 v2.0.0
+	gopkg.in/yaml.v2 v2.4.0
 )
 
 require (
@@ -50,7 +51,6 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
-	github.com/pelletier/go-toml/v2 v2.0.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect
@@ -65,6 +65,7 @@ require (
 	github.com/vmihailenco/msgpack/v5 v5.3.5 // indirect
 	github.com/vmihailenco/tagparser v0.1.1 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
+	golang.org/x/net v0.0.0-20220520000938-2e3eb7b945c2 // indirect
 	golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
@@ -72,6 +73,5 @@ require (
 	google.golang.org/protobuf v1.28.0 // indirect
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
 	gopkg.in/ini.v1 v1.66.4 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/internal/peer/peers_test.go
+++ b/internal/peer/peers_test.go
@@ -1,3 +1,4 @@
+//go:build all || race
 // +build all race
 
 package peer

--- a/route/otlp_trace_test.go
+++ b/route/otlp_trace_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/protobuf/proto"
 	huskyotlp "github.com/honeycombio/husky/otlp"
 	"github.com/honeycombio/refinery/config"
 	"github.com/honeycombio/refinery/logger"
@@ -24,6 +23,7 @@ import (
 	resource "go.opentelemetry.io/proto/otlp/resource/v1"
 	trace "go.opentelemetry.io/proto/otlp/trace/v1"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/proto"
 )
 
 const legacyAPIKey = "c9945edf5d245834089a1bd6cc9ad01e"

--- a/route/proxy.go
+++ b/route/proxy.go
@@ -3,7 +3,6 @@ package route
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 )
@@ -25,7 +24,7 @@ func (r *Router) proxy(w http.ResponseWriter, req *http.Request) {
 	// let's copy the request over to a new one and
 	// dispatch it upstream
 	defer req.Body.Close()
-	reqBod, _ := ioutil.ReadAll(req.Body)
+	reqBod, _ := io.ReadAll(req.Body)
 	buf := bytes.NewBuffer(reqBod)
 	upstreamReq, err := http.NewRequest(req.Method, upstreamTarget+req.URL.String(), buf)
 	if err != nil {

--- a/route/route.go
+++ b/route/route.go
@@ -276,6 +276,7 @@ func (r *Router) getSamplerRules(w http.ResponseWriter, req *http.Request) {
 	if err != nil {
 		w.Write([]byte(fmt.Sprintf("got error %v trying to fetch config for dataset %s\n", err, dataset)))
 		w.WriteHeader(http.StatusBadRequest)
+		return
 	}
 	r.marshalToFormat(w, map[string]interface{}{name: cfg}, format)
 }
@@ -286,6 +287,7 @@ func (r *Router) getAllSamplerRules(w http.ResponseWriter, req *http.Request) {
 	if err != nil {
 		w.Write([]byte(fmt.Sprintf("got error %v trying to fetch configs", err)))
 		w.WriteHeader(http.StatusBadRequest)
+		return
 	}
 	r.marshalToFormat(w, cfgs, format)
 }

--- a/route/route.go
+++ b/route/route.go
@@ -156,8 +156,8 @@ func (r *Router) LnS(incomingOrPeer string) {
 	muxxer.HandleFunc("/panic", r.panic).Name("intentional panic")
 	muxxer.HandleFunc("/version", r.version).Name("report version info")
 	muxxer.HandleFunc("/debug/trace/{traceID}", r.debugTrace).Name("get debug information for given trace ID")
-	muxxer.HandleFunc("/debug/config/{format}/{dataset}", r.getSamplerConfig).Name("get formatted sampler config for given dataset")
-	muxxer.HandleFunc("/debug/configs/{format}", r.getSamplerConfigs).Name("get formatted sampler config for all datasets")
+	muxxer.HandleFunc("/debug/rules/{format}/{dataset}", r.getSamplerRules).Name("get formatted sampler rules for given dataset")
+	muxxer.HandleFunc("/debug/allrules/{format}", r.getAllSamplerRules).Name("get formatted sampler rules for all datasets")
 
 	// require an auth header for events and batches
 	authedMuxxer := muxxer.PathPrefix("/1/").Methods("POST").Subrouter()
@@ -269,7 +269,7 @@ func (r *Router) debugTrace(w http.ResponseWriter, req *http.Request) {
 	w.Write([]byte(fmt.Sprintf(`{"traceID":"%s","node":"%s"}`, traceID, shard.GetAddress())))
 }
 
-func (r *Router) getSamplerConfig(w http.ResponseWriter, req *http.Request) {
+func (r *Router) getSamplerRules(w http.ResponseWriter, req *http.Request) {
 	format := strings.ToLower(mux.Vars(req)["format"])
 	dataset := mux.Vars(req)["dataset"]
 	cfg, err := r.Config.GetSamplerConfigForDataset(dataset)
@@ -280,9 +280,9 @@ func (r *Router) getSamplerConfig(w http.ResponseWriter, req *http.Request) {
 	r.marshalToFormat(w, cfg, format)
 }
 
-func (r *Router) getSamplerConfigs(w http.ResponseWriter, req *http.Request) {
+func (r *Router) getAllSamplerRules(w http.ResponseWriter, req *http.Request) {
 	format := strings.ToLower(mux.Vars(req)["format"])
-	cfgs, err := r.Config.GetAllSamplerConfigs()
+	cfgs, err := r.Config.GetAllSamplerRules()
 	if err != nil {
 		w.Write([]byte(fmt.Sprintf("got error %v trying to fetch configs", err)))
 		w.WriteHeader(http.StatusBadRequest)

--- a/route/route.go
+++ b/route/route.go
@@ -272,12 +272,12 @@ func (r *Router) debugTrace(w http.ResponseWriter, req *http.Request) {
 func (r *Router) getSamplerRules(w http.ResponseWriter, req *http.Request) {
 	format := strings.ToLower(mux.Vars(req)["format"])
 	dataset := mux.Vars(req)["dataset"]
-	cfg, err := r.Config.GetSamplerConfigForDataset(dataset)
+	cfg, name, err := r.Config.GetSamplerConfigForDataset(dataset)
 	if err != nil {
 		w.Write([]byte(fmt.Sprintf("got error %v trying to fetch config for dataset %s\n", err, dataset)))
 		w.WriteHeader(http.StatusBadRequest)
 	}
-	r.marshalToFormat(w, cfg, format)
+	r.marshalToFormat(w, map[string]interface{}{name: cfg}, format)
 }
 
 func (r *Router) getAllSamplerRules(w http.ResponseWriter, req *http.Request) {

--- a/route/route_test.go
+++ b/route/route_test.go
@@ -319,7 +319,7 @@ func TestDebugTrace(t *testing.T) {
 	}
 }
 
-func TestDebugConfigs(t *testing.T) {
+func TestDebugAllRules(t *testing.T) {
 	tests := []struct {
 		format string
 		expect string
@@ -345,7 +345,7 @@ func TestDebugConfigs(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.format, func(t *testing.T) {
 
-			req, _ := http.NewRequest("GET", "/debug/configs/"+tt.format, nil)
+			req, _ := http.NewRequest("GET", "/debug/allrules/"+tt.format, nil)
 			req = mux.SetURLVars(req, map[string]string{"format": tt.format})
 
 			rr := httptest.NewRecorder()
@@ -355,13 +355,13 @@ func TestDebugConfigs(t *testing.T) {
 				},
 			}
 
-			router.getSamplerConfigs(rr, req)
+			router.getAllSamplerRules(rr, req)
 			assert.Equal(t, tt.expect, rr.Body.String())
 		})
 	}
 }
 
-func TestDebugConfig(t *testing.T) {
+func TestDebugRules(t *testing.T) {
 	tests := []struct {
 		format  string
 		dataset string
@@ -392,7 +392,7 @@ func TestDebugConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.format, func(t *testing.T) {
 
-			req, _ := http.NewRequest("GET", "/debug/config/"+tt.format+"/"+tt.format, nil)
+			req, _ := http.NewRequest("GET", "/debug/rules/"+tt.format+"/"+tt.format, nil)
 			req = mux.SetURLVars(req, map[string]string{
 				"format":  tt.format,
 				"dataset": tt.dataset,
@@ -405,7 +405,7 @@ func TestDebugConfig(t *testing.T) {
 				},
 			}
 
-			router.getSamplerConfig(rr, req)
+			router.getSamplerRules(rr, req)
 			assert.Equal(t, tt.expect, rr.Body.String())
 		})
 	}

--- a/route/route_test.go
+++ b/route/route_test.go
@@ -370,17 +370,17 @@ func TestDebugRules(t *testing.T) {
 		{
 			format:  "json",
 			dataset: "dataset1",
-			expect:  `"FakeSamplerType"`,
+			expect:  `{"FakeSamplerName":"FakeSamplerType"}`,
 		},
 		{
 			format:  "toml",
 			dataset: "dataset1",
-			expect:  "'FakeSamplerType'",
+			expect:  "FakeSamplerName = 'FakeSamplerType'\n",
 		},
 		{
 			format:  "yaml",
 			dataset: "dataset1",
-			expect:  "FakeSamplerType\n",
+			expect:  "FakeSamplerName: FakeSamplerType\n",
 		},
 		{
 			format:  "bogus",
@@ -401,7 +401,8 @@ func TestDebugRules(t *testing.T) {
 			rr := httptest.NewRecorder()
 			router := &Router{
 				Config: &config.MockConfig{
-					GetSamplerTypeVal: "FakeSamplerType",
+					GetSamplerTypeVal:  "FakeSamplerType",
+					GetSamplerTypeName: "FakeSamplerName",
 				},
 			}
 

--- a/route/route_test.go
+++ b/route/route_test.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -19,6 +18,7 @@ import (
 	"github.com/honeycombio/refinery/logger"
 	"github.com/honeycombio/refinery/metrics"
 	"github.com/honeycombio/refinery/transmit"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/gorilla/mux"
 	"github.com/honeycombio/refinery/sharder"
@@ -38,7 +38,7 @@ func TestDecompression(t *testing.T) {
 
 	router := &Router{zstdDecoders: decoders}
 	req := &http.Request{
-		Body:   ioutil.NopCloser(pReader),
+		Body:   io.NopCloser(pReader),
 		Header: http.Header{},
 	}
 	reader, err := router.getMaybeCompressedBody(req)
@@ -46,7 +46,7 @@ func TestDecompression(t *testing.T) {
 		t.Errorf("unexpected err: %s", err.Error())
 	}
 
-	b, err := ioutil.ReadAll(reader)
+	b, err := io.ReadAll(reader)
 	if err != nil {
 		t.Errorf("unexpected err: %s", err.Error())
 	}
@@ -62,14 +62,14 @@ func TestDecompression(t *testing.T) {
 	}
 	w.Close()
 
-	req.Body = ioutil.NopCloser(buf)
+	req.Body = io.NopCloser(buf)
 	req.Header.Set("Content-Encoding", "gzip")
 	reader, err = router.getMaybeCompressedBody(req)
 	if err != nil {
 		t.Errorf("unexpected err: %s", err.Error())
 	}
 
-	b, err = ioutil.ReadAll(reader)
+	b, err = io.ReadAll(reader)
 	if err != nil {
 		t.Errorf("unexpected err: %s", err.Error())
 	}
@@ -88,14 +88,14 @@ func TestDecompression(t *testing.T) {
 	}
 	zstdW.Close()
 
-	req.Body = ioutil.NopCloser(buf)
+	req.Body = io.NopCloser(buf)
 	req.Header.Set("Content-Encoding", "zstd")
 	reader, err = router.getMaybeCompressedBody(req)
 	if err != nil {
 		t.Errorf("unexpected err: %s", err.Error())
 	}
 
-	b, err = ioutil.ReadAll(reader)
+	b, err = io.ReadAll(reader)
 	if err != nil {
 		t.Errorf("unexpected err: %s", err.Error())
 	}
@@ -123,7 +123,7 @@ func unmarshalRequest(w *httptest.ResponseRecorder, content string, body io.Read
 
 		w.Write([]byte(traceID))
 	}).ServeHTTP(w, &http.Request{
-		Body: ioutil.NopCloser(body),
+		Body: io.NopCloser(body),
 		Header: http.Header{
 			"Content-Type": []string{content},
 		},
@@ -143,7 +143,7 @@ func unmarshalBatchRequest(w *httptest.ResponseRecorder, content string, body io
 
 		w.Write([]byte(e.getEventTime().Format(time.RFC3339Nano)))
 	}).ServeHTTP(w, &http.Request{
-		Body: ioutil.NopCloser(body),
+		Body: io.NopCloser(body),
 		Header: http.Header{
 			"Content-Type": []string{content},
 		},
@@ -316,6 +316,98 @@ func TestDebugTrace(t *testing.T) {
 	router.debugTrace(rr, req)
 	if body := rr.Body.String(); body != `{"traceID":"123abcdef","node":"http://localhost:12345"}` {
 		t.Error(body)
+	}
+}
+
+func TestDebugConfigs(t *testing.T) {
+	tests := []struct {
+		format string
+		expect string
+	}{
+		{
+			format: "json",
+			expect: `{"dataset1":"FakeSamplerType"}`,
+		},
+		{
+			format: "toml",
+			expect: "dataset1 = 'FakeSamplerType'\n",
+		},
+		{
+			format: "yaml",
+			expect: "dataset1: FakeSamplerType\n",
+		},
+		{
+			format: "bogus",
+			expect: "invalid format 'bogus' when marshaling\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.format, func(t *testing.T) {
+
+			req, _ := http.NewRequest("GET", "/debug/configs/"+tt.format, nil)
+			req = mux.SetURLVars(req, map[string]string{"format": tt.format})
+
+			rr := httptest.NewRecorder()
+			router := &Router{
+				Config: &config.MockConfig{
+					GetSamplerTypeVal: "FakeSamplerType",
+				},
+			}
+
+			router.getSamplerConfigs(rr, req)
+			assert.Equal(t, tt.expect, rr.Body.String())
+		})
+	}
+}
+
+func TestDebugConfig(t *testing.T) {
+	tests := []struct {
+		format  string
+		dataset string
+		expect  string
+	}{
+		{
+			format:  "json",
+			dataset: "dataset1",
+			expect:  `"FakeSamplerType"`,
+		},
+		{
+			format:  "toml",
+			dataset: "dataset1",
+			expect:  "'FakeSamplerType'",
+		},
+		{
+			format:  "yaml",
+			dataset: "dataset1",
+			expect:  "FakeSamplerType\n",
+		},
+		{
+			format:  "bogus",
+			dataset: "dataset1",
+			expect:  "invalid format 'bogus' when marshaling\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.format, func(t *testing.T) {
+
+			req, _ := http.NewRequest("GET", "/debug/config/"+tt.format+"/"+tt.format, nil)
+			req = mux.SetURLVars(req, map[string]string{
+				"format":  tt.format,
+				"dataset": tt.dataset,
+			})
+
+			rr := httptest.NewRecorder()
+			router := &Router{
+				Config: &config.MockConfig{
+					GetSamplerTypeVal: "FakeSamplerType",
+				},
+			}
+
+			router.getSamplerConfig(rr, req)
+			assert.Equal(t, tt.expect, rr.Body.String())
+		})
 	}
 }
 

--- a/sample/sample.go
+++ b/sample/sample.go
@@ -31,7 +31,7 @@ func (s *SamplerFactory) GetSamplerImplementationForKey(samplerKey string, isLeg
 		}
 	}
 
-	c, err := s.Config.GetSamplerConfigForDataset(samplerKey)
+	c, _, err := s.Config.GetSamplerConfigForDataset(samplerKey)
 	if err != nil {
 		return nil
 	}


### PR DESCRIPTION
## Which problem is this PR solving?

There have been multiple reports of people not realizing their configs were not parsing the way they were intended. This adds two endpoints:
- `/debug/allrules/$FORMAT` will retrieve the entire rules configuration
- `/debug/rules/$FORMAT/$DATASET` will retrieve the rule set that refinery will use for the specified dataset. It comes back as a map of the sampler type to its rule set.

## Short description of the changes

- Add the endpoints
- Add a feature to config to return the full rule set
- Extend existing config feature to return the sampler name along with its rules struct
- Add/expand tests for it all
