### PR TITLE
Optionally record why a sample decision was made

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,10 @@ The `/query` endpoints are protected and can be enabled by specifying `QueryAuth
 - `$FORMAT` can be one of `json`, `yaml`, or `toml`.
 - `$DATASET` is the name of the dataset you want to check.
 
+### Sampling
+
+Refinery can send telemetry that includes information that can help debug the sampling decisions that are made. To enable it, in the config file, set `AddRuleReasonToTrace` to `true`. This will cause traces that are sent to Honeycomb to include a field `meta.refinery.reason`, which will contain text indicating which rule was evaluated that caused the trace to be included.
+
 ## Restarts
 
 Refinery does not yet buffer traces or sampling decisions to disk. When you restart the process all in-flight traces will be flushed (sent upstream to Honeycomb), but you will lose the record of past trace decisions. When started back up, it will start with a clean slate.

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -1,5 +1,3 @@
-// +build all race
-
 package app
 
 import (
@@ -262,8 +260,8 @@ func TestAppIntegrationWithNonLegacyKey(t *testing.T) {
 
 	var out bytes.Buffer
 	a, graph := newStartedApp(t, &transmission.WriterSender{W: &out}, 10500, nil, false)
-	a.IncomingRouter.SetEnvironmentCache(time.Second, func(s string) (string, error) {return "test", nil})
-	a.PeerRouter.SetEnvironmentCache(time.Second, func(s string) (string, error) {return "test", nil})
+	a.IncomingRouter.SetEnvironmentCache(time.Second, func(s string) (string, error) { return "test", nil })
+	a.PeerRouter.SetEnvironmentCache(time.Second, func(s string) (string, error) { return "test", nil })
 
 	// Send a root span, it should be sent in short order.
 	req := httptest.NewRequest(
@@ -561,8 +559,8 @@ func TestEventsEndpointWithNonLegacyKey(t *testing.T) {
 		basePort := 15000 + (i * 2)
 		senders[i] = &transmission.MockSender{}
 		app, graph := newStartedApp(t, senders[i], basePort, peers, false)
-		app.IncomingRouter.SetEnvironmentCache(time.Second, func(s string) (string, error) { return "test", nil})
-		app.PeerRouter.SetEnvironmentCache(time.Second, func(s string) (string, error) { return "test", nil})
+		app.IncomingRouter.SetEnvironmentCache(time.Second, func(s string) (string, error) { return "test", nil })
+		app.PeerRouter.SetEnvironmentCache(time.Second, func(s string) (string, error) { return "test", nil })
 		apps[i] = app
 		defer startstop.Stop(graph.Objects(), nil)
 

--- a/collect/cache/cache_test.go
+++ b/collect/cache/cache_test.go
@@ -1,5 +1,3 @@
-// +build all race
-
 package cache
 
 import (

--- a/collect/collect.go
+++ b/collect/collect.go
@@ -343,12 +343,13 @@ func (i *InMemCollector) processSpan(sp *types.Span) {
 		}
 
 		trace = &types.Trace{
-			APIHost:   sp.APIHost,
-			APIKey:    sp.APIKey,
-			Dataset:   sp.Dataset,
-			TraceID:   sp.TraceID,
-			StartTime: time.Now(),
-			SendBy:    time.Now().Add(timeout),
+			APIHost:    sp.APIHost,
+			APIKey:     sp.APIKey,
+			Dataset:    sp.Dataset,
+			TraceID:    sp.TraceID,
+			StartTime:  time.Now(),
+			SendBy:     time.Now().Add(timeout),
+			SampleRate: sp.SampleRate, // if it had a sample rate, we want to keep it
 		}
 		// push this into the cache and if we eject an unsent trace, send it ASAP
 		ejectedTrace := i.cache.Set(trace)
@@ -459,9 +460,10 @@ func (i *InMemCollector) send(trace *types.Trace) {
 	}
 
 	// make sampling decision and update the trace
-	rate, shouldSend, why := sampler.GetSampleRate(trace)
+	rate, shouldSend, reason := sampler.GetSampleRate(trace)
 	trace.SampleRate = rate
 	trace.KeepSample = shouldSend
+	logFields["reason"] = reason
 
 	// record this decision in the sent record LRU for future spans
 	sentRecord := traceSentRecord{
@@ -485,7 +487,7 @@ func (i *InMemCollector) send(trace *types.Trace) {
 	i.Logger.Info().WithFields(logFields).Logf("Sending trace")
 	for _, sp := range trace.GetSpans() {
 		if i.Config.GetAddRuleReasonToTrace() {
-			sp.Data["meta.refinery.reason"] = why
+			sp.Data["meta.refinery.reason"] = reason
 		}
 		if sp.SampleRate < 1 {
 			sp.SampleRate = 1

--- a/collect/collect.go
+++ b/collect/collect.go
@@ -459,7 +459,7 @@ func (i *InMemCollector) send(trace *types.Trace) {
 	}
 
 	// make sampling decision and update the trace
-	rate, shouldSend := sampler.GetSampleRate(trace)
+	rate, shouldSend, why := sampler.GetSampleRate(trace)
 	trace.SampleRate = rate
 	trace.KeepSample = shouldSend
 
@@ -484,6 +484,9 @@ func (i *InMemCollector) send(trace *types.Trace) {
 	}
 	i.Logger.Info().WithFields(logFields).Logf("Sending trace")
 	for _, sp := range trace.GetSpans() {
+		if i.Config.GetAddRuleReasonToTrace() {
+			sp.Data["meta.refinery.reason"] = why
+		}
 		if sp.SampleRate < 1 {
 			sp.SampleRate = 1
 		}

--- a/collect/collect_benchmark_test.go
+++ b/collect/collect_benchmark_test.go
@@ -1,5 +1,3 @@
-// +build all race
-
 package collect
 
 import (

--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -1,5 +1,3 @@
-// +build all race
-
 package collect
 
 import (
@@ -210,12 +208,12 @@ func TestDryRunMode(t *testing.T) {
 	var traceID2 = "def456"
 	var traceID3 = "ghi789"
 	// sampling decisions based on trace ID
-	_, keepTraceID1 := sampler.GetSampleRate(&types.Trace{TraceID: traceID1})
+	_, keepTraceID1, _ := sampler.GetSampleRate(&types.Trace{TraceID: traceID1})
 	// would be dropped if dry run mode was not enabled
 	assert.False(t, keepTraceID1)
-	_, keepTraceID2 := sampler.GetSampleRate(&types.Trace{TraceID: traceID2})
+	_, keepTraceID2, _ := sampler.GetSampleRate(&types.Trace{TraceID: traceID2})
 	assert.True(t, keepTraceID2)
-	_, keepTraceID3 := sampler.GetSampleRate(&types.Trace{TraceID: traceID3})
+	_, keepTraceID3, _ := sampler.GetSampleRate(&types.Trace{TraceID: traceID3})
 	// would be dropped if dry run mode was not enabled
 	assert.False(t, keepTraceID3)
 

--- a/config/config.go
+++ b/config/config.go
@@ -141,6 +141,8 @@ type Config interface {
 
 	GetAddHostMetadataToTrace() bool
 
+	GetAddRuleReasonToTrace() bool
+
 	GetEnvironmentCacheTTL() time.Duration
 
 	GetDatasetPrefix() string

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,6 +1,3 @@
-//go:build all || race
-// +build all race
-
 package config
 
 import (

--- a/config/config_test_reload_error_test.go
+++ b/config/config_test_reload_error_test.go
@@ -1,5 +1,4 @@
 //go:build all || !race
-// +build all !race
 
 package config
 

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -48,6 +48,7 @@ type configContents struct {
 	PeerManagement            PeerManagementConfig           `validate:"required"`
 	InMemCollector            InMemoryCollectorCacheCapacity `validate:"required"`
 	AddHostMetadataToTrace    bool
+	AddRuleReasonToTrace      bool
 	EnvironmentCacheTTL       time.Duration
 	DatasetPrefix             string
 	QueryAuthToken            string
@@ -141,6 +142,7 @@ func NewConfig(config, rules string, errorCallback func(error)) (Config, error) 
 	c.SetDefault("HoneycombLogger.LoggerSamplerEnabled", false)
 	c.SetDefault("HoneycombLogger.LoggerSamplerThroughput", 5)
 	c.SetDefault("AddHostMetadataToTrace", false)
+	c.SetDefault("AddRuleReasonToTrace", false)
 	c.SetDefault("EnvironmentCacheTTL", time.Hour)
 	c.SetDefault("GRPCServerParameters.MaxConnectionIdle", 1*time.Minute)
 	c.SetDefault("GRPCServerParameters.MaxConnectionAge", time.Duration(0))
@@ -786,6 +788,13 @@ func (f *fileConfig) GetAddHostMetadataToTrace() bool {
 	defer f.mux.RUnlock()
 
 	return f.conf.AddHostMetadataToTrace
+}
+
+func (f *fileConfig) GetAddRuleReasonToTrace() bool {
+	f.mux.RLock()
+	defer f.mux.RUnlock()
+
+	return f.conf.AddRuleReasonToTrace
 }
 
 func (f *fileConfig) GetEnvironmentCacheTTL() time.Duration {

--- a/config/mock.go
+++ b/config/mock.go
@@ -71,6 +71,7 @@ type MockConfig struct {
 	DryRun                        bool
 	DryRunFieldName               string
 	AddHostMetadataToTrace        bool
+	AddRuleReasonToTrace          bool
 	EnvironmentCacheTTL           time.Duration
 	DatasetPrefix                 string
 	QueryAuthToken                string
@@ -362,6 +363,13 @@ func (m *MockConfig) GetAddHostMetadataToTrace() bool {
 	defer m.Mux.RUnlock()
 
 	return m.AddHostMetadataToTrace
+}
+
+func (m *MockConfig) GetAddRuleReasonToTrace() bool {
+	m.Mux.RLock()
+	defer m.Mux.RUnlock()
+
+	return m.AddRuleReasonToTrace
 }
 
 func (f *MockConfig) GetEnvironmentCacheTTL() time.Duration {

--- a/config_complete.toml
+++ b/config_complete.toml
@@ -113,6 +113,10 @@ EnvironmentCacheTTL = "1h"
 # If left unspecified, the /query endpoints are inaccessible.
 # QueryAuthToken = "some-random-value"
 
+# AddRuleReasonToTrace causes traces that are sent to Honeycomb to include a field `meta.refinery.reason`,
+# which will contain text indicating which rule was evaluated that caused the trace to be included.
+# AddRuleReasonToTrace = true
+
 ############################
 ## Implementation Choices ##
 ############################

--- a/config_complete.toml
+++ b/config_complete.toml
@@ -113,8 +113,8 @@ EnvironmentCacheTTL = "1h"
 # If left unspecified, the /query endpoints are inaccessible.
 # QueryAuthToken = "some-random-value"
 
-# AddRuleReasonToTrace causes traces that are sent to Honeycomb to include a field `meta.refinery.reason`,
-# which will contain text indicating which rule was evaluated that caused the trace to be included.
+# AddRuleReasonToTrace causes traces that are sent to Honeycomb to include the field `meta.refinery.reason`.
+# This field contains text indicating which rule was evaluated that caused the trace to be included.
 # AddRuleReasonToTrace = true
 
 ############################

--- a/internal/peer/file_test.go
+++ b/internal/peer/file_test.go
@@ -1,5 +1,3 @@
-// +build all race
-
 package peer
 
 import (

--- a/internal/peer/peers_test.go
+++ b/internal/peer/peers_test.go
@@ -1,6 +1,3 @@
-//go:build all || race
-// +build all race
-
 package peer
 
 import (

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -1,5 +1,3 @@
-// +build all race
-
 package logger
 
 import (

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -1,3 +1,1 @@
-// +build all race
-
 package metrics

--- a/metrics/prometheus_test.go
+++ b/metrics/prometheus_test.go
@@ -1,5 +1,3 @@
-// +build all race
-
 package metrics
 
 import (

--- a/route/errors_test.go
+++ b/route/errors_test.go
@@ -1,5 +1,3 @@
-// +build all race
-
 package route
 
 import (

--- a/sample/deterministic.go
+++ b/sample/deterministic.go
@@ -35,11 +35,11 @@ func (d *DeterministicSampler) Start() error {
 	return nil
 }
 
-func (d *DeterministicSampler) GetSampleRate(trace *types.Trace) (rate uint, keep bool) {
+func (d *DeterministicSampler) GetSampleRate(trace *types.Trace) (rate uint, keep bool, why string) {
 	if d.sampleRate <= 1 {
-		return 1, true
+		return 1, true, "deterministic always"
 	}
 	sum := sha1.Sum([]byte(trace.TraceID + shardingSalt))
 	v := binary.BigEndian.Uint32(sum[:4])
-	return uint(d.sampleRate), v <= d.upperBound
+	return uint(d.sampleRate), v <= d.upperBound, "deterministic chance"
 }

--- a/sample/deterministic.go
+++ b/sample/deterministic.go
@@ -35,11 +35,11 @@ func (d *DeterministicSampler) Start() error {
 	return nil
 }
 
-func (d *DeterministicSampler) GetSampleRate(trace *types.Trace) (rate uint, keep bool, why string) {
+func (d *DeterministicSampler) GetSampleRate(trace *types.Trace) (rate uint, keep bool, reason string) {
 	if d.sampleRate <= 1 {
-		return 1, true, "deterministic always"
+		return 1, true, "deterministic/always"
 	}
 	sum := sha1.Sum([]byte(trace.TraceID + shardingSalt))
 	v := binary.BigEndian.Uint32(sum[:4])
-	return uint(d.sampleRate), v <= d.upperBound, "deterministic chance"
+	return uint(d.sampleRate), v <= d.upperBound, "deterministic/chance"
 }

--- a/sample/deterministic_test.go
+++ b/sample/deterministic_test.go
@@ -1,5 +1,3 @@
-// +build all race
-
 package sample
 
 import (
@@ -52,9 +50,10 @@ func TestGetSampleRate(t *testing.T) {
 	ds.Start()
 
 	for i, tst := range tsts {
-		rate, keep := ds.GetSampleRate(tst.trace)
+		rate, keep, why := ds.GetSampleRate(tst.trace)
 		assert.Equal(t, uint(10), rate, "sample rate should be fixed")
 		assert.Equal(t, tst.sampled, keep, "%d: trace ID %s should be %v", i, tst.trace.TraceID, tst.sampled)
+		assert.Equal(t, "deterministic chance", why)
 	}
 
 }

--- a/sample/deterministic_test.go
+++ b/sample/deterministic_test.go
@@ -50,10 +50,10 @@ func TestGetSampleRate(t *testing.T) {
 	ds.Start()
 
 	for i, tst := range tsts {
-		rate, keep, why := ds.GetSampleRate(tst.trace)
+		rate, keep, reason := ds.GetSampleRate(tst.trace)
 		assert.Equal(t, uint(10), rate, "sample rate should be fixed")
 		assert.Equal(t, tst.sampled, keep, "%d: trace ID %s should be %v", i, tst.trace.TraceID, tst.sampled)
-		assert.Equal(t, "deterministic chance", why)
+		assert.Equal(t, "deterministic/chance", reason)
 	}
 
 }

--- a/sample/dynamic.go
+++ b/sample/dynamic.go
@@ -50,7 +50,7 @@ func (d *DynamicSampler) Start() error {
 	return nil
 }
 
-func (d *DynamicSampler) GetSampleRate(trace *types.Trace) (uint, bool) {
+func (d *DynamicSampler) GetSampleRate(trace *types.Trace) (uint, bool, string) {
 	key := d.key.buildAndAdd(trace)
 	rate := d.dynsampler.GetSampleRate(key)
 	if rate < 1 { // protect against dynsampler being broken even though it shouldn't be
@@ -69,5 +69,5 @@ func (d *DynamicSampler) GetSampleRate(trace *types.Trace) (uint, bool) {
 		d.Metrics.Increment("dynsampler_num_dropped")
 	}
 	d.Metrics.Histogram("dynsampler_sample_rate", float64(rate))
-	return uint(rate), shouldKeep
+	return uint(rate), shouldKeep, "dynsampler for " + key
 }

--- a/sample/dynamic.go
+++ b/sample/dynamic.go
@@ -69,5 +69,5 @@ func (d *DynamicSampler) GetSampleRate(trace *types.Trace) (uint, bool, string) 
 		d.Metrics.Increment("dynsampler_num_dropped")
 	}
 	d.Metrics.Histogram("dynsampler_sample_rate", float64(rate))
-	return uint(rate), shouldKeep, "dynsampler for " + key
+	return uint(rate), shouldKeep, "dynamic/" + key
 }

--- a/sample/dynamic_ema.go
+++ b/sample/dynamic_ema.go
@@ -81,5 +81,5 @@ func (d *EMADynamicSampler) GetSampleRate(trace *types.Trace) (uint, bool, strin
 		d.Metrics.Increment("dynsampler_num_dropped")
 	}
 	d.Metrics.Histogram("dynsampler_sample_rate", float64(rate))
-	return uint(rate), shouldKeep, "ema for " + key
+	return uint(rate), shouldKeep, "emadynamic/" + key
 }

--- a/sample/dynamic_ema.go
+++ b/sample/dynamic_ema.go
@@ -62,7 +62,7 @@ func (d *EMADynamicSampler) Start() error {
 	return nil
 }
 
-func (d *EMADynamicSampler) GetSampleRate(trace *types.Trace) (uint, bool) {
+func (d *EMADynamicSampler) GetSampleRate(trace *types.Trace) (uint, bool, string) {
 	key := d.key.buildAndAdd(trace)
 	rate := d.dynsampler.GetSampleRate(key)
 	if rate < 1 { // protect against dynsampler being broken even though it shouldn't be
@@ -81,5 +81,5 @@ func (d *EMADynamicSampler) GetSampleRate(trace *types.Trace) (uint, bool) {
 		d.Metrics.Increment("dynsampler_num_dropped")
 	}
 	d.Metrics.Histogram("dynsampler_sample_rate", float64(rate))
-	return uint(rate), shouldKeep
+	return uint(rate), shouldKeep, "ema for " + key
 }

--- a/sample/dynamic_ema_test.go
+++ b/sample/dynamic_ema_test.go
@@ -1,5 +1,3 @@
-// +build all race
-
 package sample
 
 import (

--- a/sample/dynamic_test.go
+++ b/sample/dynamic_test.go
@@ -1,5 +1,3 @@
-// +build all race
-
 package sample
 
 import (

--- a/sample/rules.go
+++ b/sample/rules.go
@@ -59,30 +59,35 @@ func (s *RulesBasedSampler) Start() error {
 	return nil
 }
 
-func (s *RulesBasedSampler) GetSampleRate(trace *types.Trace) (rate uint, keep bool) {
+func (s *RulesBasedSampler) GetSampleRate(trace *types.Trace) (rate uint, keep bool, why string) {
 	logger := s.Logger.Debug().WithFields(map[string]interface{}{
 		"trace_id": trace.TraceID,
 	})
 
 	for _, rule := range s.Config.Rule {
 		var matched bool
+		var why string
 
 		switch rule.Scope {
 		case "span":
 			matched = ruleMatchesSpanInTrace(trace, rule, s.Config.CheckNestedFields)
+			why = "matched span - "
 		case "trace", "":
 			matched = ruleMatchesTrace(trace, rule, s.Config.CheckNestedFields)
+			why = "matched trace - "
 		default:
 			logger.WithFields(map[string]interface{}{
 				"rule_name": rule.Name,
 				"scope":     rule.Scope,
 			}).Logf("invalid scope %s given for rule: %s", rule.Scope, rule.Name)
 			matched = true
+			why = "matched due to invalid scope - "
 		}
 
 		if matched {
 			var rate uint
 			var keep bool
+			var samplerWhy string
 
 			if rule.Sampler != nil {
 				var sampler Sampler
@@ -91,12 +96,14 @@ func (s *RulesBasedSampler) GetSampleRate(trace *types.Trace) (rate uint, keep b
 					logger.WithFields(map[string]interface{}{
 						"rule_name": rule.Name,
 					}).Logf("could not find downstream sampler for rule: %s", rule.Name)
-					return 1, true
+					return 1, true, why + "no downstream sampler for rule: " + rule.Name
 				}
-				rate, keep = sampler.GetSampleRate(trace)
+				rate, keep, samplerWhy = sampler.GetSampleRate(trace)
+				why += rule.Name + " - " + samplerWhy
 			} else {
 				rate = uint(rule.SampleRate)
 				keep = !rule.Drop && rule.SampleRate > 0 && rand.Intn(rule.SampleRate) == 0
+				why += "rule name: " + rule.Name
 			}
 
 			s.Metrics.Histogram("rulessampler_sample_rate", float64(rule.SampleRate))
@@ -110,11 +117,11 @@ func (s *RulesBasedSampler) GetSampleRate(trace *types.Trace) (rate uint, keep b
 				"keep":      keep,
 				"drop_rule": rule.Drop,
 			}).Logf("got sample rate and decision")
-			return rate, keep
+			return rate, keep, why
 		}
 	}
 
-	return 1, true
+	return 1, true, "no rule matched"
 }
 
 func ruleMatchesTrace(t *types.Trace, rule *config.RulesBasedSamplerRule, checkNestedFields bool) bool {

--- a/sample/rules_test.go
+++ b/sample/rules_test.go
@@ -511,14 +511,14 @@ func TestRules(t *testing.T) {
 			trace.AddSpan(span)
 		}
 
-		rate, keep, why := sampler.GetSampleRate(trace)
+		rate, keep, reason := sampler.GetSampleRate(trace)
 
 		assert.Equal(t, d.ExpectedRate, rate, d.Rules)
 		name := d.ExpectedName
 		if name == "" {
 			name = d.Rules.Rule[0].Name
 		}
-		assert.Contains(t, why, name)
+		assert.Contains(t, reason, name)
 
 		// we can only test when we don't expect to keep the trace
 		if !d.ExpectedKeep {
@@ -665,14 +665,14 @@ func TestRulesWithNestedFields(t *testing.T) {
 			trace.AddSpan(span)
 		}
 
-		rate, keep, why := sampler.GetSampleRate(trace)
+		rate, keep, reason := sampler.GetSampleRate(trace)
 
 		assert.Equal(t, d.ExpectedRate, rate, d.Rules)
 		name := d.ExpectedName
 		if name == "" {
 			name = d.Rules.Rule[0].Name
 		}
-		assert.Contains(t, why, name)
+		assert.Contains(t, reason, name)
 
 		// we can only test when we don't expect to keep the trace
 		if !d.ExpectedKeep {
@@ -743,14 +743,14 @@ func TestRulesWithDynamicSampler(t *testing.T) {
 		}
 
 		sampler.Start()
-		rate, keep, why := sampler.GetSampleRate(trace)
+		rate, keep, reason := sampler.GetSampleRate(trace)
 
 		assert.Equal(t, d.ExpectedRate, rate, d.Rules)
 		name := d.ExpectedName
 		if name == "" {
 			name = d.Rules.Rule[0].Name
 		}
-		assert.Contains(t, why, name)
+		assert.Contains(t, reason, name)
 
 		// we can only test when we don't expect to keep the trace
 		if !d.ExpectedKeep {
@@ -831,14 +831,14 @@ func TestRulesWithEMADynamicSampler(t *testing.T) {
 		}
 
 		sampler.Start()
-		rate, keep, why := sampler.GetSampleRate(trace)
+		rate, keep, reason := sampler.GetSampleRate(trace)
 
 		assert.Equal(t, d.ExpectedRate, rate, d.Rules)
 		name := d.ExpectedName
 		if name == "" {
 			name = d.Rules.Rule[0].Name
 		}
-		assert.Contains(t, why, name)
+		assert.Contains(t, reason, name)
 
 		// we can only test when we don't expect to keep the trace
 		if !d.ExpectedKeep {

--- a/sample/sample.go
+++ b/sample/sample.go
@@ -11,7 +11,7 @@ import (
 )
 
 type Sampler interface {
-	GetSampleRate(trace *types.Trace) (rate uint, keep bool, why string)
+	GetSampleRate(trace *types.Trace) (rate uint, keep bool, reason string)
 	Start() error
 }
 

--- a/sample/sample.go
+++ b/sample/sample.go
@@ -11,7 +11,7 @@ import (
 )
 
 type Sampler interface {
-	GetSampleRate(trace *types.Trace) (rate uint, keep bool)
+	GetSampleRate(trace *types.Trace) (rate uint, keep bool, why string)
 	Start() error
 }
 

--- a/sample/sample_test.go
+++ b/sample/sample_test.go
@@ -1,5 +1,3 @@
-// +build all race
-
 package sample
 
 import (

--- a/sample/totalthroughput.go
+++ b/sample/totalthroughput.go
@@ -45,7 +45,7 @@ func (d *TotalThroughputSampler) Start() error {
 	}
 	d.dynsampler.Start()
 
-	// Register stastics this package will produce
+	// Register statistics this package will produce
 	d.Metrics.Register("dynsampler_num_dropped", "counter")
 	d.Metrics.Register("dynsampler_num_kept", "counter")
 	d.Metrics.Register("dynsampler_sample_rate", "histogram")
@@ -53,7 +53,7 @@ func (d *TotalThroughputSampler) Start() error {
 	return nil
 }
 
-func (d *TotalThroughputSampler) GetSampleRate(trace *types.Trace) (uint, bool) {
+func (d *TotalThroughputSampler) GetSampleRate(trace *types.Trace) (uint, bool, string) {
 	key := d.key.buildAndAdd(trace)
 	rate := d.dynsampler.GetSampleRate(key)
 	if rate < 1 { // protect against dynsampler being broken even though it shouldn't be
@@ -72,5 +72,5 @@ func (d *TotalThroughputSampler) GetSampleRate(trace *types.Trace) (uint, bool) 
 		d.Metrics.Increment("dynsampler_num_dropped")
 	}
 	d.Metrics.Histogram("dynsampler_sample_rate", float64(rate))
-	return uint(rate), shouldKeep
+	return uint(rate), shouldKeep, "totalthroughput for " + key
 }

--- a/sample/totalthroughput.go
+++ b/sample/totalthroughput.go
@@ -72,5 +72,5 @@ func (d *TotalThroughputSampler) GetSampleRate(trace *types.Trace) (uint, bool, 
 		d.Metrics.Increment("dynsampler_num_dropped")
 	}
 	d.Metrics.Histogram("dynsampler_sample_rate", float64(rate))
-	return uint(rate), shouldKeep, "totalthroughput for " + key
+	return uint(rate), shouldKeep, "totalthroughput/" + key
 }

--- a/sample/totalthroughput_test.go
+++ b/sample/totalthroughput_test.go
@@ -1,5 +1,3 @@
-// +build all race
-
 package sample
 
 import (

--- a/sample/trace_key_test.go
+++ b/sample/trace_key_test.go
@@ -1,5 +1,3 @@
-// +build all race
-
 package sample
 
 import (

--- a/sharder/deterministic_test.go
+++ b/sharder/deterministic_test.go
@@ -1,6 +1,3 @@
-//go:build all || race
-// +build all race
-
 package sharder
 
 import (

--- a/sharder/sharder_test.go
+++ b/sharder/sharder_test.go
@@ -1,3 +1,1 @@
-// +build all race
-
 package sharder

--- a/transmit/transmit_test.go
+++ b/transmit/transmit_test.go
@@ -1,5 +1,3 @@
-// +build all race
-
 package transmit
 
 import (


### PR DESCRIPTION
## Which problem is this PR solving?

- Fixes #473 

## Short description of the changes

- Adds a config flag, `AddRuleReasonToTrace` that adds a new field to traces called `meta.refinery.reason`, which is a string field that contains information about the sampler(s) that made a trace decision. If it was a rule-based sampler, it includes the rule name.
- Also removes unnecessary build flags that were causing tests not to run.
- Updates README and config file

