### PR TITLE
allow BatchTimeout to be overriden on the libhoney Transmission

### DIFF
--- a/cmd/refinery/main.go
+++ b/cmd/refinery/main.go
@@ -138,7 +138,7 @@ func main() {
 	upstreamClient, err := libhoney.NewClient(libhoney.ClientConfig{
 		Transmission: &transmission.Honeycomb{
 			MaxBatchSize:          c.GetMaxBatchSize(),
-			BatchTimeout:          libhoney.DefaultBatchTimeout,
+			BatchTimeout:          c.GetBatchTimeout(),
 			MaxConcurrentBatches:  libhoney.DefaultMaxConcurrentBatches,
 			PendingWorkCapacity:   uint(c.GetUpstreamBufferSize()),
 			UserAgentAddition:     userAgentAddition,
@@ -156,7 +156,7 @@ func main() {
 	peerClient, err := libhoney.NewClient(libhoney.ClientConfig{
 		Transmission: &transmission.Honeycomb{
 			MaxBatchSize:          c.GetMaxBatchSize(),
-			BatchTimeout:          libhoney.DefaultBatchTimeout,
+			BatchTimeout:          c.GetBatchTimeout(),
 			MaxConcurrentBatches:  libhoney.DefaultMaxConcurrentBatches,
 			PendingWorkCapacity:   uint(c.GetPeerBufferSize()),
 			UserAgentAddition:     userAgentAddition,

--- a/config/config.go
+++ b/config/config.go
@@ -71,6 +71,9 @@ type Config interface {
 	// complete before sending it, to allow stragglers to arrive
 	GetSendDelay() (time.Duration, error)
 
+	// GetBatchTimeout returns how often to send off batches in seconds
+	GetBatchTimeout() time.Duration
+
 	// GetTraceTimeout is how long to wait before sending a trace even if it's
 	// not complete. This should be longer than the longest expected trace
 	// duration.

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -37,6 +37,7 @@ type configContents struct {
 	Sampler                   string        `validate:"required,oneof= DeterministicSampler DynamicSampler EMADynamicSampler RulesBasedSampler TotalThroughputSampler"`
 	Metrics                   string        `validate:"required,oneof= prometheus honeycomb"`
 	SendDelay                 time.Duration `validate:"required"`
+	BatchTimeout              time.Duration
 	TraceTimeout              time.Duration `validate:"required"`
 	MaxBatchSize              uint          `validate:"required"`
 	SendTicker                time.Duration `validate:"required"`
@@ -135,6 +136,7 @@ func NewConfig(config, rules string, errorCallback func(error)) (Config, error) 
 	c.SetDefault("Collector", "InMemCollector")
 	c.SetDefault("Metrics", "honeycomb")
 	c.SetDefault("SendDelay", 2*time.Second)
+	c.SetDefault("BatchTimeout", libhoney.DefaultBatchTimeout)
 	c.SetDefault("TraceTimeout", 60*time.Second)
 	c.SetDefault("MaxBatchSize", 500)
 	c.SetDefault("SendTicker", 100*time.Millisecond)
@@ -708,6 +710,13 @@ func (f *fileConfig) GetSendDelay() (time.Duration, error) {
 	defer f.mux.RUnlock()
 
 	return f.conf.SendDelay, nil
+}
+
+func (f *fileConfig) GetBatchTimeout() time.Duration {
+	f.mux.RLock()
+	defer f.mux.RUnlock()
+
+	return f.conf.BatchTimeout
 }
 
 func (f *fileConfig) GetTraceTimeout() (time.Duration, error) {

--- a/config/mock.go
+++ b/config/mock.go
@@ -57,6 +57,7 @@ type MockConfig struct {
 	GetPrometheusMetricsConfigVal PrometheusMetricsConfig
 	GetSendDelayErr               error
 	GetSendDelayVal               time.Duration
+	GetBatchTimeoutVal            time.Duration
 	GetTraceTimeoutErr            error
 	GetTraceTimeoutVal            time.Duration
 	GetMaxBatchSizeVal            uint
@@ -256,6 +257,13 @@ func (m *MockConfig) GetSendDelay() (time.Duration, error) {
 	defer m.Mux.RUnlock()
 
 	return m.GetSendDelayVal, m.GetSendDelayErr
+}
+
+func (m *MockConfig) GetBatchTimeout() time.Duration {
+	m.Mux.RLock()
+	defer m.Mux.RUnlock()
+
+	return m.GetBatchTimeoutVal
 }
 
 func (m *MockConfig) GetTraceTimeout() (time.Duration, error) {

--- a/config_complete.toml
+++ b/config_complete.toml
@@ -58,6 +58,11 @@ HoneycombAPI = "https://api.honeycomb.io"
 # Eligible for live reload.
 SendDelay = "2s"
 
+# BatchTimeout dictates how frequently to send unfulfilled batches. By default
+# this will use the DefaultBatchTimeout in libhoney as its value, which is 100ms.
+# Eligible for live reload.
+BatchTimeout = "1s"
+
 # TraceTimeout is a long timer; it represents the outside boundary of how long
 # to wait before sending an incomplete trace. Normally traces are sent when the
 # root span arrives. Sometimes the root span never arrives (due to crashes or


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

We have an issue where our ALB traffic has a `~5m` latency because of the cadence in which the CloudWatch logs are sent. Because the ALB represents our top-level traces, this means that _all_ web traffic is delayed by that same amount.

Decreasing the `TraceTimeout` value assists with this by spreading out the traffic, however this makes our rules a moot point as things we are intentionally trying to downsample do not get downsampled.

What we _really_ need is a manner to control how frequently events are sent upstream to Honeycomb so we can control how frequently we send things. https://github.com/honeycombio/libhoney-go/blob/8af08e456cfe1f786247ffdc755855999add2d76/libhoney.go#L136 indicates that `SendFrequency` can override how often batches are sent.

## Short description of the changes

This PR allows for the `BatchTimeout` to be configured for refinery rather than explicitly using `DefaultBatchTimeout`. I realize `SendFrequency` is what was mentioned above, but refinery calls `NewClient` rather than `Init` and you can see that all `SendFrequency` does is drive `BatchTimeout` on [the `Transmission` anyway](https://github.com/honeycombio/libhoney-go/blob/8af08e456cfe1f786247ffdc755855999add2d76/libhoney.go#L236).

