### PR TITLE
Consolidate honeycomb metrics to use single lock & fix concurrent read/write

### DIFF
--- a/metrics/honeycomb.go
+++ b/metrics/honeycomb.go
@@ -295,7 +295,7 @@ func getOrAdd[T *counter | *gauge | *histogram](lock *sync.RWMutex, name string,
 	// attempt to get metric by name using read lock
 	lock.RLock()
 	metric, ok := metrics[name]
-	lock.Unlock()
+	lock.RUnlock()
 
 	// if found, return existing metric
 	if ok {

--- a/metrics/honeycomb.go
+++ b/metrics/honeycomb.go
@@ -280,7 +280,7 @@ func (h *HoneycombMetrics) Register(name string, metricType string) {
 	case "counter":
 		getOrAdd(&h.lock, name, h.counters, createCounter)
 	case "gauge":
-		getOrAdd(&h.lock, name, h.gauges, createGague)
+		getOrAdd(&h.lock, name, h.gauges, createGauge)
 	case "histogram":
 		getOrAdd(&h.lock, name, h.histograms, createHistogram)
 	default:
@@ -321,7 +321,7 @@ func createCounter(name string) *counter {
 	}
 }
 
-func createGague(name string) *gauge {
+func createGauge(name string) *gauge {
 	return &gauge{
 		name: name,
 	}
@@ -348,7 +348,7 @@ func (h *HoneycombMetrics) Increment(name string) {
 }
 
 func (h *HoneycombMetrics) Gauge(name string, val interface{}) {
-	gauge := getOrAdd(&h.lock, name, h.gauges, createGague)
+	gauge := getOrAdd(&h.lock, name, h.gauges, createGauge)
 
 	// update value, using gauge's lock
 	gauge.lock.Lock()

--- a/metrics/honeycomb.go
+++ b/metrics/honeycomb.go
@@ -289,8 +289,8 @@ func (h *HoneycombMetrics) Register(name string, metricType string) {
 }
 
 // getOrAdd attempts to retrieve a (generic) metric from the provided map by name, wrapping the read operation
-// with a read lock (RLock). If the metric is not present in the map, it aquire a write lock and executes
-// create function and add it's to the map.
+// with a read lock (RLock). If the metric is not present in the map, it acquires a write lock and executes
+// a create function to add it to the map.
 func getOrAdd[T *counter | *gauge | *histogram](lock *sync.RWMutex, name string, metrics map[string]T, createMetric func(name string) T) T {
 	// attempt to get metric by name using read lock
 	lock.RLock()
@@ -302,9 +302,9 @@ func getOrAdd[T *counter | *gauge | *histogram](lock *sync.RWMutex, name string,
 		return metric
 	}
 
-	// aquire write lock
+	// acquire write lock
 	lock.Lock()
-	// check again to see if it's been while waiting for write lock
+	// check again to see if it's been added while waiting for write lock
 	metric, ok = metrics[name]
 	if !ok {
 		// create new metric using create function and add to map

--- a/metrics/honeycomb.go
+++ b/metrics/honeycomb.go
@@ -228,8 +228,6 @@ func (h *HoneycombMetrics) reportToHoneycommb(ctx context.Context) {
 			}
 
 			h.lock.Lock()
-			defer h.lock.Unlock()
-
 			for _, count := range h.counters {
 				count.lock.Lock()
 				ev.AddField(PrefixMetricName(h.prefix, count.name), count.val)
@@ -262,6 +260,7 @@ func (h *HoneycombMetrics) reportToHoneycommb(ctx context.Context) {
 				}
 				histogram.lock.Unlock()
 			}
+			h.lock.Unlock()
 
 			ev.Send()
 		}


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
Honeycomb metrics currently utilises 3 locks, one for each map of counters, gauges and histograms and is unnecessary. In addition, the locks were only used when registering each metric and collecting metrics values - they were missing the lock to retrieve an entry for updating which risks a read / write error.

This PR updates honeycomb metrics to utilise a single lock that is used to control all three types of metrics and is also used when attempting to retrieve a metric from a map.

- Fixes #512 

## Short description of the changes
- Consolidate the 3 locks into a single lock
- Use lock when attempting to retrieve an existing metric from one of the maps to prevent concurrent read / write panics