### PR TITLE
Allow adding extra fields to error logs

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -362,7 +362,7 @@ func TestPeerRouting(t *testing.T) {
 			"long":            "this is a test of the emergency broadcast system",
 			"foo":             "bar",
 		},
-		Metadata: map[string]string{
+		Metadata: map[string]any{
 			"api_host":    "http://api.honeycomb.io",
 			"dataset":     "dataset",
 			"environment": "",
@@ -486,7 +486,7 @@ func TestEventsEndpoint(t *testing.T) {
 				"trace.trace_id": "1",
 				"foo":            "bar",
 			},
-			Metadata: map[string]string{
+			Metadata: map[string]any{
 				"api_host":    "http://api.honeycomb.io",
 				"dataset":     "dataset",
 				"environment": "",
@@ -533,7 +533,7 @@ func TestEventsEndpoint(t *testing.T) {
 				"trace.trace_id": "1",
 				"foo":            "bar",
 			},
-			Metadata: map[string]string{
+			Metadata: map[string]any{
 				"api_host":    "http://api.honeycomb.io",
 				"dataset":     "dataset",
 				"environment": "",
@@ -600,7 +600,7 @@ func TestEventsEndpointWithNonLegacyKey(t *testing.T) {
 				"trace.trace_id": "1",
 				"foo":            "bar",
 			},
-			Metadata: map[string]string{
+			Metadata: map[string]any{
 				"api_host":    "http://api.honeycomb.io",
 				"dataset":     "dataset",
 				"environment": "test",
@@ -647,7 +647,7 @@ func TestEventsEndpointWithNonLegacyKey(t *testing.T) {
 				"trace.trace_id": "1",
 				"foo":            "bar",
 			},
-			Metadata: map[string]string{
+			Metadata: map[string]any{
 				"api_host":    "http://api.honeycomb.io",
 				"dataset":     "dataset",
 				"environment": "test",

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -1,5 +1,4 @@
 //go:build all || race
-// +build all race
 
 package app
 
@@ -9,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -215,7 +213,7 @@ func post(t testing.TB, req *http.Request) {
 	resp, err := httpClient.Do(req)
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	io.Copy(ioutil.Discard, resp.Body)
+	io.Copy(io.Discard, resp.Body)
 	resp.Body.Close()
 }
 
@@ -333,7 +331,7 @@ func TestPeerRouting(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 
 	blob := `[` + string(spans[0]) + `]`
-	req.Body = ioutil.NopCloser(strings.NewReader(blob))
+	req.Body = io.NopCloser(strings.NewReader(blob))
 	post(t, req)
 	assert.Eventually(t, func() bool {
 		return len(senders[0].Events()) == 1
@@ -383,7 +381,7 @@ func TestPeerRouting(t *testing.T) {
 	req.Header.Set("X-Honeycomb-Team", legacyAPIKey)
 	req.Header.Set("Content-Type", "application/json")
 
-	req.Body = ioutil.NopCloser(strings.NewReader(blob))
+	req.Body = io.NopCloser(strings.NewReader(blob))
 	post(t, req)
 	assert.Eventually(t, func() bool {
 		return len(senders[1].Events()) == 1
@@ -716,7 +714,7 @@ func BenchmarkTraces(b *testing.B) {
 
 	sender := &countingWriterSender{
 		WriterSender: transmission.WriterSender{
-			W: ioutil.Discard,
+			W: io.Discard,
 		},
 	}
 	_, graph := newStartedApp(b, sender, 11000, nil, false)
@@ -734,7 +732,7 @@ func BenchmarkTraces(b *testing.B) {
 		sender.resetCount()
 		for n := 0; n < b.N; n++ {
 			blob := `[` + string(spans[n%len(spans)]) + `]`
-			req.Body = ioutil.NopCloser(strings.NewReader(blob))
+			req.Body = io.NopCloser(strings.NewReader(blob))
 			post(b, req)
 		}
 		sender.waitForCount(b, b.N)
@@ -752,7 +750,7 @@ func BenchmarkTraces(b *testing.B) {
 				blob = append(blob, ',')
 			}
 			blob[len(blob)-1] = ']'
-			req.Body = ioutil.NopCloser(bytes.NewReader(blob))
+			req.Body = io.NopCloser(bytes.NewReader(blob))
 
 			post(b, req)
 		}
@@ -776,13 +774,13 @@ func BenchmarkTraces(b *testing.B) {
 						blob = append(blob, ',')
 					}
 					blob[len(blob)-1] = ']'
-					req.Body = ioutil.NopCloser(bytes.NewReader(blob))
+					req.Body = io.NopCloser(bytes.NewReader(blob))
 
 					resp, err := httpClient.Do(req)
 					assert.NoError(b, err)
 					if resp != nil {
 						assert.Equal(b, http.StatusOK, resp.StatusCode)
-						io.Copy(ioutil.Discard, resp.Body)
+						io.Copy(io.Discard, resp.Body)
 						resp.Body.Close()
 					}
 				}
@@ -799,7 +797,7 @@ func BenchmarkTraces(b *testing.B) {
 func BenchmarkDistributedTraces(b *testing.B) {
 	sender := &countingWriterSender{
 		WriterSender: transmission.WriterSender{
-			W: ioutil.Discard,
+			W: io.Discard,
 		},
 	}
 
@@ -837,7 +835,7 @@ func BenchmarkDistributedTraces(b *testing.B) {
 		sender.resetCount()
 		for n := 0; n < b.N; n++ {
 			blob := `[` + string(spans[n%len(spans)]) + `]`
-			req.Body = ioutil.NopCloser(strings.NewReader(blob))
+			req.Body = io.NopCloser(strings.NewReader(blob))
 			req.URL.Host = addrs[n%len(addrs)]
 			post(b, req)
 		}
@@ -856,7 +854,7 @@ func BenchmarkDistributedTraces(b *testing.B) {
 				blob = append(blob, ',')
 			}
 			blob[len(blob)-1] = ']'
-			req.Body = ioutil.NopCloser(bytes.NewReader(blob))
+			req.Body = io.NopCloser(bytes.NewReader(blob))
 			req.URL.Host = addrs[n%len(addrs)]
 
 			post(b, req)

--- a/config/config.go
+++ b/config/config.go
@@ -161,4 +161,6 @@ type Config interface {
 	GetGRPCTimeout() time.Duration
 
 	GetPeerTimeout() time.Duration
+
+	GetAdditionalErrorFields() []string
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"io/ioutil"
 	"os"
 	"sync"
 	"testing"
@@ -79,10 +78,10 @@ func TestRedisPasswordEnvVar(t *testing.T) {
 }
 
 func createTempConfigs(t *testing.T, configBody string, rulesBody string) (string, string) {
-	tmpDir, err := ioutil.TempDir("", "")
+	tmpDir, err := os.MkdirTemp("", "")
 	assert.NoError(t, err)
 
-	configFile, err := ioutil.TempFile(tmpDir, "*.toml")
+	configFile, err := os.CreateTemp(tmpDir, "*.toml")
 	assert.NoError(t, err)
 
 	if configBody != "" {
@@ -91,7 +90,7 @@ func createTempConfigs(t *testing.T, configBody string, rulesBody string) (strin
 	}
 	configFile.Close()
 
-	rulesFile, err := ioutil.TempFile(tmpDir, "*.toml")
+	rulesFile, err := os.CreateTemp(tmpDir, "*.toml")
 	assert.NoError(t, err)
 
 	if rulesBody != "" {
@@ -636,11 +635,11 @@ func TestQueryAuthToken(t *testing.T) {
 }
 
 func TestGRPCServerParameters(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "")
+	tmpDir, err := os.MkdirTemp("", "")
 	assert.NoError(t, err)
 	defer os.RemoveAll(tmpDir)
 
-	configFile, err := ioutil.TempFile(tmpDir, "*.toml")
+	configFile, err := os.CreateTemp(tmpDir, "*.toml")
 	assert.NoError(t, err)
 
 	_, err = configFile.Write([]byte(`
@@ -668,7 +667,7 @@ func TestGRPCServerParameters(t *testing.T) {
 	assert.NoError(t, err)
 	configFile.Close()
 
-	rulesFile, err := ioutil.TempFile(tmpDir, "*.toml")
+	rulesFile, err := os.CreateTemp(tmpDir, "*.toml")
 	assert.NoError(t, err)
 
 	c, err := NewConfig(configFile.Name(), rulesFile.Name(), func(err error) {})

--- a/config/config_test_reload_error_test.go
+++ b/config/config_test_reload_error_test.go
@@ -3,7 +3,6 @@
 package config
 
 import (
-	"io/ioutil"
 	"os"
 	"sync"
 	"testing"
@@ -13,14 +12,14 @@ import (
 )
 
 func TestErrorReloading(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "")
+	tmpDir, err := os.MkdirTemp("", "")
 	assert.NoError(t, err)
 	defer os.RemoveAll(tmpDir)
 
-	rulesFile, err := ioutil.TempFile(tmpDir, "*.toml")
+	rulesFile, err := os.CreateTemp(tmpDir, "*.toml")
 	assert.NoError(t, err)
 
-	configFile, err := ioutil.TempFile(tmpDir, "*.toml")
+	configFile, err := os.CreateTemp(tmpDir, "*.toml")
 	assert.NoError(t, err)
 
 	dummy := []byte(`
@@ -76,7 +75,7 @@ func TestErrorReloading(t *testing.T) {
 		}
 	}()
 
-	err = ioutil.WriteFile(rulesFile.Name(), []byte(`Sampler="InvalidSampler"`), 0644)
+	err = os.WriteFile(rulesFile.Name(), []byte(`Sampler="InvalidSampler"`), 0644)
 
 	if err != nil {
 		t.Error(err)

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -53,6 +53,7 @@ type configContents struct {
 	DatasetPrefix             string
 	QueryAuthToken            string
 	GRPCServerParameters      GRPCServerParameters
+	AdditionalErrorFields     []string
 }
 
 type InMemoryCollectorCacheCapacity struct {
@@ -151,6 +152,7 @@ func NewConfig(config, rules string, errorCallback func(error)) (Config, error) 
 	c.SetDefault("GRPCServerParameters.MaxConnectionAgeGrace", time.Duration(0))
 	c.SetDefault("GRPCServerParameters.Time", 10*time.Second)
 	c.SetDefault("GRPCServerParameters.Timeout", 2*time.Second)
+	c.SetDefault("AdditionalErrorFields", []string{"trace.span_id"})
 
 	c.SetConfigFile(config)
 	err := c.ReadInConfig()
@@ -860,4 +862,11 @@ func (f *fileConfig) GetPeerTimeout() time.Duration {
 	defer f.mux.RUnlock()
 
 	return f.conf.PeerManagement.Timeout
+}
+
+func (f *fileConfig) GetAdditionalErrorFields() []string {
+	f.mux.RLock()
+	defer f.mux.RUnlock()
+
+	return f.conf.AdditionalErrorFields
 }

--- a/config/mock.go
+++ b/config/mock.go
@@ -81,6 +81,7 @@ type MockConfig struct {
 	GRPCTime                      time.Duration
 	GRPCTimeout                   time.Duration
 	PeerTimeout                   time.Duration
+	AdditionalErrorFields         []string
 
 	Mux sync.RWMutex
 }
@@ -434,4 +435,11 @@ func (f *MockConfig) GetPeerTimeout() time.Duration {
 	defer f.Mux.RUnlock()
 
 	return f.PeerTimeout
+}
+
+func (f *MockConfig) GetAdditionalErrorFields() []string {
+	f.Mux.RLock()
+	defer f.Mux.RUnlock()
+
+	return f.AdditionalErrorFields
 }

--- a/config_complete.toml
+++ b/config_complete.toml
@@ -111,11 +111,24 @@ EnvironmentCacheTTL = "1h"
 # are not typically needed in normal operation.
 # Can be specified in the environment as REFINERY_QUERY_AUTH_TOKEN.
 # If left unspecified, the /query endpoints are inaccessible.
+# Not eligible for live reload.
 # QueryAuthToken = "some-random-value"
 
 # AddRuleReasonToTrace causes traces that are sent to Honeycomb to include the field `meta.refinery.reason`.
 # This field contains text indicating which rule was evaluated that caused the trace to be included.
+# Eligible for live reload.
 # AddRuleReasonToTrace = true
+
+# AdditionalErrorFields should be a list of span fields that should be included when logging
+# errors that happen during ingestion of events (for example, the span too large error).
+# This is primarily useful in trying to track down misbehaving senders in a large installation.
+# The fields `dataset`, `apihost`, and `environment` are always included.
+# If a field is not present in the span, it will not be present in the error log.
+# Default is ["trace.span_id"].
+# Eligible for live reload.
+AdditionalErrorFields = [
+	"trace.span_id"
+]
 
 ############################
 ## Implementation Choices ##

--- a/internal/peer/peers_test.go
+++ b/internal/peer/peers_test.go
@@ -1,6 +1,3 @@
-//go:build all || race
-// +build all race
-
 package peer
 
 import (

--- a/logger/honeycomb.go
+++ b/logger/honeycomb.go
@@ -240,7 +240,7 @@ func (h *HoneycombEntry) Logf(f string, args ...interface{}) {
 	ev := h.builder.NewEvent()
 	msg := fmt.Sprintf(f, args...)
 	ev.AddField("msg", msg)
-	ev.Metadata = map[string]string{
+	ev.Metadata = map[string]any{
 		"api_host": ev.APIHost,
 		"dataset":  ev.Dataset,
 	}

--- a/metrics/honeycomb.go
+++ b/metrics/honeycomb.go
@@ -222,7 +222,7 @@ func (h *HoneycombMetrics) reportToHoneycommb(ctx context.Context) {
 			return
 		case <-tick.C:
 			ev := h.libhClient.NewEvent()
-			ev.Metadata = map[string]string{
+			ev.Metadata = map[string]any{
 				"api_host": ev.APIHost,
 				"dataset":  ev.Dataset,
 			}

--- a/route/route_test.go
+++ b/route/route_test.go
@@ -9,23 +9,22 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/facebookgo/inject"
-	"github.com/gorilla/mux"
 	"github.com/honeycombio/refinery/collect"
 	"github.com/honeycombio/refinery/config"
 	"github.com/honeycombio/refinery/logger"
 	"github.com/honeycombio/refinery/metrics"
-	"github.com/honeycombio/refinery/sharder"
 	"github.com/honeycombio/refinery/transmit"
-	"github.com/klauspost/compress/zstd"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/gorilla/mux"
+	"github.com/honeycombio/refinery/sharder"
+	"github.com/klauspost/compress/zstd"
 	"github.com/vmihailenco/msgpack/v4"
-	_ "google.golang.org/grpc/encoding/gzip"
 	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/metadata"
 )
@@ -557,22 +556,4 @@ func TestGRPCHealthProbeWatch(t *testing.T) {
 
 	sentMessage := mockServer.GetSentMessages()[0]
 	assert.Equal(t, grpc_health_v1.HealthCheckResponse_SERVING, sentMessage.Status)
-}
-
-func Test_getEventTime(t *testing.T) {
-	tests := []struct {
-		name string
-		time string
-		want time.Time
-	}{
-		{"check python", "2022-09-11T17:17:21.904Z", time.Time{}},
-		// TODO: Add test cases.
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := getEventTime(tt.time); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("getEventTime() = %v, want %v", got, tt.want)
-			}
-		})
-	}
 }

--- a/route/route_test.go
+++ b/route/route_test.go
@@ -9,22 +9,23 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/facebookgo/inject"
+	"github.com/gorilla/mux"
 	"github.com/honeycombio/refinery/collect"
 	"github.com/honeycombio/refinery/config"
 	"github.com/honeycombio/refinery/logger"
 	"github.com/honeycombio/refinery/metrics"
-	"github.com/honeycombio/refinery/transmit"
-	"github.com/stretchr/testify/assert"
-
-	"github.com/gorilla/mux"
 	"github.com/honeycombio/refinery/sharder"
+	"github.com/honeycombio/refinery/transmit"
 	"github.com/klauspost/compress/zstd"
+	"github.com/stretchr/testify/assert"
 	"github.com/vmihailenco/msgpack/v4"
+	_ "google.golang.org/grpc/encoding/gzip"
 	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/metadata"
 )
@@ -556,4 +557,22 @@ func TestGRPCHealthProbeWatch(t *testing.T) {
 
 	sentMessage := mockServer.GetSentMessages()[0]
 	assert.Equal(t, grpc_health_v1.HealthCheckResponse_SERVING, sentMessage.Status)
+}
+
+func Test_getEventTime(t *testing.T) {
+	tests := []struct {
+		name string
+		time string
+		want time.Time
+	}{
+		{"check python", "2022-09-11T17:17:21.904Z", time.Time{}},
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getEventTime(tt.time); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getEventTime() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/sample/sample_test.go
+++ b/sample/sample_test.go
@@ -1,7 +1,6 @@
 package sample
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -30,11 +29,11 @@ func TestDependencyInjection(t *testing.T) {
 }
 
 func TestDatasetPrefix(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "")
+	tmpDir, err := os.MkdirTemp("", "")
 	assert.NoError(t, err)
 	defer os.RemoveAll(tmpDir)
 
-	configFile, err := ioutil.TempFile(tmpDir, "*.toml")
+	configFile, err := os.CreateTemp(tmpDir, "*.toml")
 	assert.NoError(t, err)
 
 	_, err = configFile.Write([]byte(`
@@ -57,7 +56,7 @@ func TestDatasetPrefix(t *testing.T) {
 	assert.NoError(t, err)
 	configFile.Close()
 
-	rulesFile, err := ioutil.TempFile(tmpDir, "*.toml")
+	rulesFile, err := os.CreateTemp(tmpDir, "*.toml")
 	assert.NoError(t, err)
 
 	_, err = rulesFile.Write([]byte(`


### PR DESCRIPTION

## Which problem is this PR solving?

As noted in #513, errors that occur while Refinery is trying to send data to Honeycomb happen asynchronously. It's hard to relate any errors that show up in the logs with the spans that caused them to occur. However, there is a way provided by libhoney ([metadata](https://github.com/honeycombio/libhoney-go/blob/25068939fe8240ccc45e4c86271b6f057c5f833d/transmission/response.go#L11)) that makes it possible to attach data to the error. Before now, Refinery has attached the dataset, api host, and environment to the metadata. This helps but is not enough.


## Short description of the changes

This PR attempts to leverage that technique further by adding a new configuration value called `AdditionalErrorFields`. It allows the user to specify a list of field names. In the event of a transmission error, these fields (if they exist) will be copied from the failing span into the metadata, and will therefore show up as identified fields in the logs. 

The default value is `trace.span_id`.

This also removes the remaining instances of the obsolete standard library `ioutil`.

Closes #513 
