### PR TITLE
Cloud support

### DIFF
--- a/config/mock.go
+++ b/config/mock.go
@@ -22,6 +22,8 @@ type MockConfig struct {
 	GetListenAddrVal                     string
 	GetPeerListenAddrErr                 error
 	GetPeerListenAddrVal                 string
+	GetPeerPublicAddrErr                 error
+	GetPeerPublicAddrVal                 string
 	GetCompressPeerCommunicationsVal     bool
 	GetGRPCListenAddrErr                 error
 	GetGRPCListenAddrVal                 string
@@ -142,6 +144,13 @@ func (m *MockConfig) GetPeerListenAddr() (string, error) {
 	defer m.Mux.RUnlock()
 
 	return m.GetPeerListenAddrVal, m.GetPeerListenAddrErr
+}
+
+func (m *MockConfig) GetPeerPublicAddr() (string, error) {
+	m.Mux.RLock()
+	defer m.Mux.RUnlock()
+
+	return m.GetPeerPublicAddrVal, m.GetPeerPublicAddrErr
 }
 
 func (m *MockConfig) GetCompressPeerCommunication() bool {

--- a/config/mock.go
+++ b/config/mock.go
@@ -22,8 +22,6 @@ type MockConfig struct {
 	GetListenAddrVal                     string
 	GetPeerListenAddrErr                 error
 	GetPeerListenAddrVal                 string
-	GetPeerPublicAddrErr                 error
-	GetPeerPublicAddrVal                 string
 	GetCompressPeerCommunicationsVal     bool
 	GetGRPCListenAddrErr                 error
 	GetGRPCListenAddrVal                 string
@@ -144,13 +142,6 @@ func (m *MockConfig) GetPeerListenAddr() (string, error) {
 	defer m.Mux.RUnlock()
 
 	return m.GetPeerListenAddrVal, m.GetPeerListenAddrErr
-}
-
-func (m *MockConfig) GetPeerPublicAddr() (string, error) {
-	m.Mux.RLock()
-	defer m.Mux.RUnlock()
-
-	return m.GetPeerPublicAddrVal, m.GetPeerPublicAddrErr
 }
 
 func (m *MockConfig) GetCompressPeerCommunication() bool {

--- a/internal/peer/redis.go
+++ b/internal/peer/redis.go
@@ -83,6 +83,7 @@ func newRedisPeers(ctx context.Context, c config.Config) (Peers, error) {
 	}
 
 	// deal with this error
+	// address, err := c.GetPeerPublicAddr()
 	address, err := publicAddr(c)
 
 	if err != nil {

--- a/internal/peer/redis.go
+++ b/internal/peer/redis.go
@@ -83,7 +83,6 @@ func newRedisPeers(ctx context.Context, c config.Config) (Peers, error) {
 	}
 
 	// deal with this error
-	// address, err := c.GetPeerPublicAddr()
 	address, err := publicAddr(c)
 
 	if err != nil {

--- a/sharder/deterministic.go
+++ b/sharder/deterministic.go
@@ -128,12 +128,11 @@ func (d *DeterministicSharder) Start() error {
 			localAddrCidrs[i] = addr.String()
 		}
 
-		// If RedisIdentifier is an IP, add it to localAddrs.
+		// If RedisIdentifier is an IP, add it to localAddrCidrs.
 		redisIdentifier, err := d.Config.GetRedisIdentifier()
-		if err == nil {
-			d.Logger.Debug().Logf("Using RedisIdentifier as self: %s", redisIdentifier)
+		if err == nil && redisIdentifier != "" {
 			if ip := net.ParseIP(redisIdentifier); ip != nil {
-				d.Logger.Debug().Logf("RedisIdentifier is an IP")
+				d.Logger.Debug().Logf("Using RedisIdentifier as public IP: %s", redisIdentifier)
 				localAddrCidrs = append(localAddrCidrs, fmt.Sprintf("%s/32", redisIdentifier))
 			}
 		}

--- a/sharder/deterministic.go
+++ b/sharder/deterministic.go
@@ -145,7 +145,7 @@ func (d *DeterministicSharder) Start() error {
 			d.Logger.Debug().WithFields(logrus.Fields{
 				"peer": peerShard,
 				"self": localAddrCidrs,
-			).Logf("Considering peer looking for self")
+			}).Logf("Considering peer looking for self")
 			peerIPList, err := net.LookupHost(peerShard.ipOrHost)
 			if err != nil {
 				// TODO something better than fail to start if peer is missing

--- a/sharder/deterministic.go
+++ b/sharder/deterministic.go
@@ -142,7 +142,10 @@ func (d *DeterministicSharder) Start() error {
 		// local interface. Note that this assumes only one instance of Refinery per
 		// host can run.
 		for i, peerShard := range d.peers {
-			d.Logger.Debug().WithField("peer", peerShard).WithField("self", localAddrCidrs).Logf("Considering peer looking for self")
+			d.Logger.Debug().WithFields(logrus.Fields{
+				"peer": peerShard,
+				"self": localAddrCidrs,
+			).Logf("Considering peer looking for self")
 			peerIPList, err := net.LookupHost(peerShard.ipOrHost)
 			if err != nil {
 				// TODO something better than fail to start if peer is missing


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
When hosting Refinery in a cloud environment, certain network assumptions are no longer true. 
 Issues arise from these assumptions while hosting in our cloud environment using [Nomad](https://www.nomadproject.io/) as container orchestration.

Terms, as used in Nomad:
- Task: Single deployed container.
- Group: Group of tasks running as a scalable service (e.g. Refinery).

This assumption is not necessarily true under Nomad:
- The IP assigned to a task's `eth0` can be accessed by other tasks in the group.

Redis peering expects peers to talk to each other using their `eth0` IP.  This behavior can be overridden by specifying `RedisIdentifier` in config.  This value will be advertised as the peer's IP in the peer list.

However, on startup, peering uses its `eth0` IP to cross-reference in the peers list found in Redis.  Since the internal `eth0` IP is not the true public IP (set by `RedisIdentifier`), this check will always fail and the container exits in error.

## Short description of the changes
A workaround is to treat `RedisIdentifier` as the true public IP address of the task.  Thus, it should be one of the "self" IPs when checking the peers list.

This behavior is reinforced in existing code in [`internal/peer/redis.go`](https://github.com/honeycombio/refinery/blob/main/internal/peer/redis.go#L291-L298) where `RedisIdentifier` is used to create a URL with the value being the host.
