### PR TITLE
Properly set metadata to values that will work.

### DIFF
--- a/transmit/transmit.go
+++ b/transmit/transmit.go
@@ -156,10 +156,10 @@ func (d *DefaultTransmission) processResponses(
 		case r := <-responses:
 			if r.Err != nil || r.StatusCode > 202 {
 				var apiHost, dataset, environment string
-				if metadata, ok := r.Metadata.(map[string]string); ok {
-					apiHost = metadata["api_host"]
-					dataset = metadata["dataset"]
-					environment = metadata["environment"]
+				if metadata, ok := r.Metadata.(map[string]any); ok {
+					apiHost = metadata["api_host"].(string)
+					dataset = metadata["dataset"].(string)
+					environment = metadata["environment"].(string)
 				}
 				log := d.Logger.Error().WithFields(map[string]interface{}{
 					"status_code": r.StatusCode,


### PR DESCRIPTION
## Which problem is this PR solving?

- A previous PR (#514) changed the type of the metadata object from `map[string]string` to `map[string]any`, but I must have forgotten to hit save at some point, and this part of it (4 lines) didn't get committed. This bug actually will cause that feature to omit fields it knows about.

## Short description of the changes

- Change the type appropriately in processResponses

