### PR TITLE
Track span count and optionally add it to root

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,9 @@ dockerize.tar.gz:
 	@echo
 	@echo "+++ Retrieving dockerize tool for Redis readiness check."
 	@echo
+# make sure that file is available
+	sudo apt-get update
+	sudo apt-get -y install file
 	curl --location --silent --show-error \
 		--output dockerize.tar.gz \
 		https://github.com/jwilder/dockerize/releases/download/${DOCKERIZE_VERSION}/${DOCKERIZE_RELEASE_ASSET} \

--- a/collect/collect.go
+++ b/collect/collect.go
@@ -78,8 +78,9 @@ type InMemCollector struct {
 // our decision for the future, so any delinquent spans that show up later can
 // be dropped or passed along.
 type traceSentRecord struct {
-	keep bool // true if the trace was kept, false if it was dropped
-	rate uint // sample rate used when sending the trace
+	keep      bool // true if the trace was kept, false if it was dropped
+	rate      uint // sample rate used when sending the trace
+	spanCount int  // number of spans in the trace (we decorate the root span with this)
 }
 
 func (i *InMemCollector) Start() error {
@@ -271,7 +272,7 @@ func (i *InMemCollector) collect() {
 		i.Metrics.Histogram("collector_incoming_queue", float64(len(i.incoming)))
 		i.Metrics.Histogram("collector_peer_queue", float64(len(i.fromPeer)))
 
-		// Always drain peer channel before doing anyhting else. By processing peer
+		// Always drain peer channel before doing anything else. By processing peer
 		// traffic preferentially we avoid the situation where the cluster essentially
 		// deadlocks because peers are waiting to get their events handed off to each
 		// other.
@@ -329,7 +330,11 @@ func (i *InMemCollector) processSpan(sp *types.Span) {
 		if sentRecord, found := i.sentTraceCache.Get(sp.TraceID); found {
 			if sr, ok := sentRecord.(*traceSentRecord); ok {
 				i.Metrics.Increment("trace_sent_cache_hit")
-				i.dealWithSentTrace(sr.keep, sr.rate, sp)
+				// bump the count of records on this trace -- if the root span isn't
+				// the last late span, then it won't be perfect, but it will be better than
+				// having none at all
+				sentRecord.(*traceSentRecord).spanCount++
+				i.dealWithSentTrace(sr.keep, sr.rate, sentRecord.(*traceSentRecord).spanCount, sp)
 				return
 			}
 		}
@@ -360,7 +365,7 @@ func (i *InMemCollector) processSpan(sp *types.Span) {
 	// if the trace we got back from the cache has already been sent, deal with the
 	// span.
 	if trace.Sent {
-		i.dealWithSentTrace(trace.KeepSample, trace.SampleRate, sp)
+		i.dealWithSentTrace(trace.KeepSample, trace.SampleRate, trace.SpanCount(), sp)
 	}
 
 	// great! trace is live. add the span.
@@ -382,7 +387,7 @@ func (i *InMemCollector) processSpan(sp *types.Span) {
 // dealWithSentTrace handles a span that has arrived after the sampling decision
 // on the trace has already been made, and it obeys that decision by either
 // sending the span immediately or dropping it.
-func (i *InMemCollector) dealWithSentTrace(keep bool, sampleRate uint, sp *types.Span) {
+func (i *InMemCollector) dealWithSentTrace(keep bool, sampleRate uint, spanCount int, sp *types.Span) {
 	if i.Config.GetIsDryRun() {
 		field := i.Config.GetDryRunFieldName()
 		// if dry run mode is enabled, we keep all traces and mark the spans with the sampling decision
@@ -396,6 +401,10 @@ func (i *InMemCollector) dealWithSentTrace(keep bool, sampleRate uint, sp *types
 	if keep {
 		i.Logger.Debug().WithField("trace_id", sp.TraceID).Logf("Sending span because of previous decision to send trace")
 		mergeTraceAndSpanSampleRates(sp, sampleRate)
+		// if this span is a late root span, possibly update it with our current span count
+		if i.Config.GetAddSpanCountToRoot() && isRootSpan(sp) {
+			sp.Data["meta.span_count"] = spanCount
+		}
 		i.Transmission.EnqueueSpan(sp)
 		return
 	}
@@ -451,7 +460,7 @@ func (i *InMemCollector) send(trace *types.Trace) {
 
 	traceDur := time.Since(trace.StartTime)
 	i.Metrics.Histogram("trace_duration_ms", float64(traceDur.Milliseconds()))
-	i.Metrics.Histogram("trace_span_count", float64(len(trace.GetSpans())))
+	i.Metrics.Histogram("trace_span_count", float64(trace.SpanCount()))
 	if trace.HasRootSpan {
 		i.Metrics.Increment("trace_send_has_root")
 	} else {
@@ -486,8 +495,9 @@ func (i *InMemCollector) send(trace *types.Trace) {
 
 	// record this decision in the sent record LRU for future spans
 	sentRecord := traceSentRecord{
-		keep: shouldSend,
-		rate: rate,
+		keep:      shouldSend,
+		rate:      rate,
+		spanCount: trace.SpanCount(),
 	}
 	i.sentTraceCache.Add(trace.TraceID, &sentRecord)
 
@@ -507,6 +517,12 @@ func (i *InMemCollector) send(trace *types.Trace) {
 	for _, sp := range trace.GetSpans() {
 		if i.Config.GetAddRuleReasonToTrace() {
 			sp.Data["meta.refinery.reason"] = reason
+		}
+
+		// update the root span (if we have one, which we might not if the trace timed out)
+		// with the final total as of our send time
+		if i.Config.GetAddSpanCountToRoot() && isRootSpan(sp) {
+			sp.Data["meta.span_count"] = sentRecord.spanCount
 		}
 
 		if i.Config.GetIsDryRun() {

--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -723,3 +723,72 @@ func TestDependencyInjection(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+// TestAddSpanCount tests that adding a root span winds up with a trace object in
+// the cache and that that trace gets span count added to it
+func TestAddSpanCount(t *testing.T) {
+	transmission := &transmit.MockTransmission{}
+	transmission.Start()
+	conf := &config.MockConfig{
+		GetSendDelayVal:    0,
+		GetTraceTimeoutVal: 60 * time.Second,
+		GetSamplerTypeVal:  &config.DeterministicSamplerConfig{SampleRate: 1},
+		SendTickerVal:      2 * time.Millisecond,
+		AddSpanCountToRoot: true,
+	}
+	coll := &InMemCollector{
+		Config:       conf,
+		Logger:       &logger.NullLogger{},
+		Transmission: transmission,
+		Metrics:      &metrics.NullMetrics{},
+		SamplerFactory: &sample.SamplerFactory{
+			Config: conf,
+			Logger: &logger.NullLogger{},
+		},
+	}
+	c := cache.NewInMemCache(3, &metrics.NullMetrics{}, &logger.NullLogger{})
+	coll.cache = c
+	stc, err := lru.New(15)
+	assert.NoError(t, err, "lru cache should start")
+	coll.sentTraceCache = stc
+
+	coll.incoming = make(chan *types.Span, 5)
+	coll.fromPeer = make(chan *types.Span, 5)
+	coll.datasetSamplers = make(map[string]sample.Sampler)
+	go coll.collect()
+	defer coll.Stop()
+
+	var traceID = "mytrace"
+
+	span := &types.Span{
+		TraceID: traceID,
+		Event: types.Event{
+			Dataset: "aoeu",
+			Data: map[string]interface{}{
+				"trace.parent_id": "unused",
+			},
+			APIKey: legacyAPIKey,
+		},
+	}
+	coll.AddSpanFromPeer(span)
+	time.Sleep(conf.SendTickerVal * 2)
+	assert.Equal(t, traceID, coll.getFromCache(traceID).TraceID, "after adding the span, we should have a trace in the cache with the right trace ID")
+	assert.Equal(t, 0, len(transmission.Events), "adding a non-root span should not yet send the span")
+	// ok now let's add the root span and verify that both got sent
+	rootSpan := &types.Span{
+		TraceID: traceID,
+		Event: types.Event{
+			Dataset: "aoeu",
+			Data:    map[string]interface{}{},
+			APIKey:  legacyAPIKey,
+		},
+	}
+	coll.AddSpan(rootSpan)
+	time.Sleep(conf.SendTickerVal * 2)
+	assert.Nil(t, coll.getFromCache(traceID), "after adding a leaf and root span, it should be removed from the cache")
+	transmission.Mux.RLock()
+	assert.Equal(t, 2, len(transmission.Events), "adding a root span should send all spans in the trace")
+	assert.Equal(t, nil, transmission.Events[0].Data["meta.span_count"], "child span metadata should NOT be populated with span count")
+	assert.Equal(t, int64(2), transmission.Events[1].Data["meta.span_count"], "root span metadata should be populated with span count")
+	transmission.Mux.RUnlock()
+}

--- a/config/config.go
+++ b/config/config.go
@@ -166,4 +166,6 @@ type Config interface {
 	GetPeerTimeout() time.Duration
 
 	GetAdditionalErrorFields() []string
+
+	GetAddSpanCountToRoot() bool
 }

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -55,6 +55,7 @@ type configContents struct {
 	QueryAuthToken            string
 	GRPCServerParameters      GRPCServerParameters
 	AdditionalErrorFields     []string
+	AddSpanCountToRoot        bool
 }
 
 type InMemoryCollectorCacheCapacity struct {
@@ -155,6 +156,7 @@ func NewConfig(config, rules string, errorCallback func(error)) (Config, error) 
 	c.SetDefault("GRPCServerParameters.Time", 10*time.Second)
 	c.SetDefault("GRPCServerParameters.Timeout", 2*time.Second)
 	c.SetDefault("AdditionalErrorFields", []string{"trace.span_id"})
+	c.SetDefault("AddSpanCountToRoot", false)
 
 	c.SetConfigFile(config)
 	err := c.ReadInConfig()
@@ -878,4 +880,11 @@ func (f *fileConfig) GetAdditionalErrorFields() []string {
 	defer f.mux.RUnlock()
 
 	return f.conf.AdditionalErrorFields
+}
+
+func (f *fileConfig) GetAddSpanCountToRoot() bool {
+	f.mux.RLock()
+	defer f.mux.RUnlock()
+
+	return f.conf.AddSpanCountToRoot
 }

--- a/config/mock.go
+++ b/config/mock.go
@@ -83,6 +83,7 @@ type MockConfig struct {
 	GRPCTimeout                   time.Duration
 	PeerTimeout                   time.Duration
 	AdditionalErrorFields         []string
+	AddSpanCountToRoot            bool
 
 	Mux sync.RWMutex
 }
@@ -450,4 +451,11 @@ func (f *MockConfig) GetAdditionalErrorFields() []string {
 	defer f.Mux.RUnlock()
 
 	return f.AdditionalErrorFields
+}
+
+func (f *MockConfig) GetAddSpanCountToRoot() bool {
+	f.Mux.RLock()
+	defer f.Mux.RUnlock()
+
+	return f.AddSpanCountToRoot
 }

--- a/config_complete.toml
+++ b/config_complete.toml
@@ -135,6 +135,14 @@ AdditionalErrorFields = [
 	"trace.span_id"
 ]
 
+# AddSpanCountToRoot adds a new metadata field, `meta.span_count` to root spans to indicate
+# the number of child spans on the trace at the time the sampling decision was made.
+# This value is available to the rules-based sampler, making it possible to write rules that
+# are dependent upon the number of spans in the trace.
+# Default is false.
+# Eligible for live reload.
+# AddSpanCountToRoot = true
+
 ############################
 ## Implementation Choices ##
 ############################

--- a/sample/rules_test.go
+++ b/sample/rules_test.go
@@ -496,6 +496,48 @@ func TestRules(t *testing.T) {
 			ExpectedKeep: true,
 			ExpectedRate: 10,
 		},
+		{
+			Rules: &config.RulesBasedSamplerConfig{
+				Rule: []*config.RulesBasedSamplerRule{
+					{
+						Name:       "Check root span for span count",
+						SampleRate: 1,
+						Condition: []*config.RulesBasedSamplerCondition{
+							{
+								Field:    "meta.span_count",
+								Operator: "=",
+								Value:    int(2),
+							},
+						},
+					},
+				},
+			},
+			Spans: []*types.Span{
+				{
+					Event: types.Event{
+						Data: map[string]interface{}{
+							"trace.trace_id":  "12345",
+							"trace.span_id":   "54321",
+							"meta.span_count": int64(2),
+							"test":            int64(2),
+						},
+					},
+				},
+				{
+					Event: types.Event{
+						Data: map[string]interface{}{
+							"trace.trace_id":  "12345",
+							"trace.span_id":   "654321",
+							"trace.parent_id": "54321",
+							"test":            int64(2),
+						},
+					},
+				},
+			},
+			ExpectedName: "Check root span for span count",
+			ExpectedKeep: true,
+			ExpectedRate: 1,
+		},
 	}
 
 	for _, d := range data {

--- a/types/event.go
+++ b/types/event.go
@@ -52,7 +52,7 @@ type Trace struct {
 	// Used to calculate how long traces spend sitting in Refinery
 	StartTime time.Time
 
-	HasRootSpan bool
+	RootSpan *Span
 
 	// spans is the list of spans in this trace
 	spans []*Span

--- a/types/event.go
+++ b/types/event.go
@@ -68,9 +68,9 @@ func (t *Trace) GetSpans() []*Span {
 	return t.spans
 }
 
-// SpanCount gets the number of spans currently in this trace
-func (t *Trace) SpanCount() int {
-	return len(t.spans)
+// SpanCount gets the number of spans currently in this trace as int64
+func (t *Trace) SpanCount() int64 {
+	return int64(len(t.spans))
 }
 
 func (t *Trace) GetSamplerKey() (string, bool) {

--- a/types/event.go
+++ b/types/event.go
@@ -68,6 +68,11 @@ func (t *Trace) GetSpans() []*Span {
 	return t.spans
 }
 
+// SpanCount gets the number of spans currently in this trace
+func (t *Trace) SpanCount() int {
+	return len(t.spans)
+}
+
 func (t *Trace) GetSamplerKey() (string, bool) {
 	if IsLegacyAPIKey(t.APIKey) {
 		return t.Dataset, true


### PR DESCRIPTION
## Which problem is this PR solving?

Adds the ability to add the trace's span count to the root span of the trace, and does it in a way that allows the rules engine to query it as `meta.span_count`. This would allow rules that depend on span count -- for example, a rule that adjusts sample rate so that larger traces are kept less often.

Note that this value is not available if the root span hasn't arrived when the TraceTimeout completes; at this point, the rules will be evaluated without a `span_count` because there is no root span to put it on. 

If the root span arrives late, it will be updated with the total number of spans that have arrived at that point, so that the value stored in Honeycomb is close to correct. If more spans arrive later, they will not update the value in the root span.

Closes #524  
Closes #483 

