### PR TITLE
Bump go version to 1.19

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ commands:
 jobs:
   test:
     docker:
-      - image: cimg/go:1.18
+      - image: cimg/go:1.19
       - image: redis:6
     steps:
       - checkout
@@ -64,7 +64,7 @@ jobs:
 
   build_binaries:
     docker:
-      - image: cimg/go:1.18
+      - image: cimg/go:1.19
     steps:
       - checkout
       - go-build:
@@ -140,7 +140,7 @@ jobs:
 
   build_docker:
     docker:
-      - image: cimg/go:1.18
+      - image: cimg/go:1.19
     steps:
       - setup_googleko
       - checkout
@@ -151,7 +151,7 @@ jobs:
 
   publish_docker:
     docker:
-      - image: cimg/go:1.18
+      - image: cimg/go:1.19
     steps:
       - setup_googleko
       - checkout

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/honeycombio/refinery
 
-go 1.18
+go 1.19
 
 require (
 	github.com/davecgh/go-spew v1.1.1


### PR DESCRIPTION
## Which problem is this PR solving?

- bumps minimum go version to 1.19

## Short description of the changes

- bumps module to use 1.19
- bump circleci to build targeting 1.19

