### PR TITLE
Add query endpoint that retrieves the running configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,19 +137,31 @@ Refinery emits a number of metrics to give some indication about the health of t
 
 The default logging level of `warn` is almost entirely silent. The `debug` level emits too much data to be used in production, but contains excellent information in a pre-production environment. Setting the logging level to `debug` during initial configuration will help understand what's working and what's not, but when traffic volumes increase it should be set to `warn`.
 
-### Configuration
+### Running Configuration
 
 Because the normal configuration file formats (TOML and YAML) can sometimes be confusing to read and write, it may be valuable to check the loaded configuration by using one of the `/query` endpoints from the command line on a server that can access a refinery host.
 
 The `/query` endpoints are protected and can be enabled by specifying `QueryAuthToken` in the configuration file or specifying `REFINERY_QUERY_AUTH_TOKEN` in the environment. All requests to any `/query` endpoint must include the header `X-Honeycomb-Refinery-Query` set to the value of the specified token.
 
-`curl --include --get $REFINERY_HOST/query/allrules/$FORMAT --header "x-honeycomb-refinery-query: my-local-token"` will retrieve the entire rules configuration.
+Available query paths:
 
-`curl --include --get $REFINERY_HOST/query/rules/$FORMAT/$DATASET --header "x-honeycomb-refinery-query: my-local-token"` will retrieve the rule set that refinery will use for the specified dataset. It comes back as a map of the sampler type to its rule set.
+- `/query/allrules/$FORMAT` retrieves the whole rules configuration
+- `/query/rules/$FORMAT/$DATASET` retrieves the rule set that refinery will use for the specified dataset. It comes back as a map of the sampler type to its rule set
+- `/query/config/$FORMAT` retrieves the running configuration with keys and passwords masked
+
+Using these environment variables:
 
 - `$REFINERY_HOST` should be the url of your refinery.
 - `$FORMAT` can be one of `json`, `yaml`, or `toml`.
 - `$DATASET` is the name of the dataset you want to check.
+
+You can access these endpoints using a curl statement like the below:
+
+`curl --include --get $REFINERY_HOST/query/allrules/$FORMAT --header "x-honeycomb-refinery-query: my-local-token"` 
+
+`curl --include --get $REFINERY_HOST/query/rules/$FORMAT/$DATASET --header "x-honeycomb-refinery-query: my-local-token"`
+
+`curl --include --get $REFINERY_HOST/query/config/$FORMAT --header "x-honeycomb-refinery-query: my-local-token"`
 
 ### Sampling
 

--- a/config/config.go
+++ b/config/config.go
@@ -108,6 +108,9 @@ type Config interface {
 	// GetAllSamplerRules returns all dataset rules in a map, including the default
 	GetAllSamplerRules() (map[string]interface{}, error)
 
+	// GetRunningConfig returns all configurations in a map, including the default
+	GetRunningConfig() (map[string]interface{}, error)
+
 	// GetMetricsType returns the type of metrics to use. Valid types are in the
 	// metrics package
 	GetMetricsType() (string, error)

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -550,6 +550,22 @@ func (f *fileConfig) GetCollectorType() (string, error) {
 	return f.conf.Collector, nil
 }
 
+func (f *fileConfig) GetRunningConfig() (map[string]interface{}, error) {
+	configs := make(map[string]interface{})
+	keys := f.config.AllKeys()
+	for _, key := range keys {
+		configs[key] = f.config.GetString(key)
+		// mask sensitive strings
+		maskKeys := []string{"key", "password", "token"}
+		for _, s := range maskKeys {
+			if(strings.Contains(strings.ToLower(key), s)) {
+				configs[key] = strings.Repeat("x", len(f.config.GetString(key)))
+			}	
+		}
+	}
+	return configs, nil
+}
+
 func (f *fileConfig) GetAllSamplerRules() (map[string]interface{}, error) {
 	samplers := make(map[string]interface{})
 

--- a/config/mock.go
+++ b/config/mock.go
@@ -299,6 +299,19 @@ func (m *MockConfig) GetAllSamplerRules() (map[string]interface{}, error) {
 	return v, m.GetSamplerTypeErr
 }
 
+func (m *MockConfig) GetRunningConfig() (map[string]interface{}, error) {
+	m.Mux.RLock()
+	defer m.Mux.RUnlock()
+
+	v := map[string]interface{}{
+		"addhostmetadatatotrace": "false",
+		"additionalerrorfields":  "",
+		"addrulereasontotrace":   "false",
+		"addspancounttoroot":     "false",
+	}
+	return v, nil
+}
+
 func (m *MockConfig) GetUpstreamBufferSize() int {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()

--- a/route/route.go
+++ b/route/route.go
@@ -164,6 +164,7 @@ func (r *Router) LnS(incomingOrPeer string) {
 	queryMuxxer.HandleFunc("/trace/{traceID}", r.debugTrace).Name("get debug information for given trace ID")
 	queryMuxxer.HandleFunc("/rules/{format}/{dataset}", r.getSamplerRules).Name("get formatted sampler rules for given dataset")
 	queryMuxxer.HandleFunc("/allrules/{format}", r.getAllSamplerRules).Name("get formatted sampler rules for all datasets")
+	queryMuxxer.HandleFunc("/config/{format}", r.getConfig).Name("get formatted running configuration")
 
 	// require an auth header for events and batches
 	authedMuxxer := muxxer.PathPrefix("/1/").Methods("POST").Subrouter()
@@ -294,6 +295,17 @@ func (r *Router) getSamplerRules(w http.ResponseWriter, req *http.Request) {
 func (r *Router) getAllSamplerRules(w http.ResponseWriter, req *http.Request) {
 	format := strings.ToLower(mux.Vars(req)["format"])
 	cfgs, err := r.Config.GetAllSamplerRules()
+	if err != nil {
+		w.Write([]byte(fmt.Sprintf("got error %v trying to fetch configs", err)))
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	r.marshalToFormat(w, cfgs, format)
+}
+
+func (r *Router) getConfig(w http.ResponseWriter, req *http.Request) {
+	format := strings.ToLower(mux.Vars(req)["format"])
+	cfgs, err := r.Config.GetRunningConfig()
 	if err != nil {
 		w.Write([]byte(fmt.Sprintf("got error %v trying to fetch configs", err)))
 		w.WriteHeader(http.StatusBadRequest)

--- a/route/route.go
+++ b/route/route.go
@@ -332,6 +332,7 @@ func (r *Router) marshalToFormat(w http.ResponseWriter, obj interface{}, format 
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
+	w.Header().Set("Content-Type", "application/" + format);
 	w.Write(body)
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- The query endpoint can retrieve the rules but does not include the configuration

## Short description of the changes

- This adds a new `/query` endpoint called `config` which pulls the running configuration the same way the rules endpoint pulls the rules out of the rules file. 

