### PR TITLE
New cache management strategy

### DIFF
--- a/collect/cache/cache.go
+++ b/collect/cache/cache.go
@@ -145,9 +145,9 @@ func (d *DefaultInMemCache) TakeExpiredTraces(now time.Time) []*types.Trace {
 	return res
 }
 
-// RemoveSentTraces accepts a set of trace IDs and removes any matching ones from
+// RemoveTraces accepts a set of trace IDs and removes any matching ones from
 // the insertion list. This is used in the case of a cache overrun.
-func (d *DefaultInMemCache) RemoveSentTraces(toDelete map[string]struct{}) {
+func (d *DefaultInMemCache) RemoveTraces(toDelete map[string]struct{}) {
 	d.Metrics.Gauge("collect_cache_capacity", float64(len(d.insertionOrder)))
 	d.Metrics.Histogram("collect_cache_entries", float64(len(d.cache)))
 

--- a/collect/cache/cache.go
+++ b/collect/cache/cache.go
@@ -128,6 +128,8 @@ func (d *DefaultInMemCache) GetAll() []*types.Trace {
 	return tmp
 }
 
+// TakeExpiredTraces should be called to decide which traces are past their expiration time;
+// It removes and returns them.
 func (d *DefaultInMemCache) TakeExpiredTraces(now time.Time) []*types.Trace {
 	d.Metrics.Gauge("collect_cache_capacity", float64(len(d.insertionOrder)))
 	d.Metrics.Histogram("collect_cache_entries", float64(len(d.cache)))
@@ -141,4 +143,20 @@ func (d *DefaultInMemCache) TakeExpiredTraces(now time.Time) []*types.Trace {
 		}
 	}
 	return res
+}
+
+// RemoveSentTraces accepts a set of trace IDs and removes any matching ones from
+// the insertion list. This is used in the case of a cache overrun.
+func (d *DefaultInMemCache) RemoveSentTraces(toDelete map[string]struct{}) {
+	d.Metrics.Gauge("collect_cache_capacity", float64(len(d.insertionOrder)))
+	d.Metrics.Histogram("collect_cache_entries", float64(len(d.cache)))
+
+	for i, t := range d.insertionOrder {
+		if t != nil {
+			if _, ok := toDelete[t.TraceID]; ok {
+				d.insertionOrder[i] = nil
+				delete(d.cache, t.TraceID)
+			}
+		}
+	}
 }

--- a/collect/cache/cache_test.go
+++ b/collect/cache/cache_test.go
@@ -98,7 +98,7 @@ func TestRemoveSentTraces(t *testing.T) {
 		"5": {}, // not present
 	}
 
-	c.RemoveSentTraces(deletes)
+	c.RemoveTraces(deletes)
 
 	all := c.GetAll()
 	assert.Equal(t, 1, len(all))

--- a/collect/cache/cache_test.go
+++ b/collect/cache/cache_test.go
@@ -4,11 +4,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/honeycombio/refinery/logger"
 	"github.com/honeycombio/refinery/metrics"
 	"github.com/honeycombio/refinery/types"
+	"github.com/stretchr/testify/assert"
 )
 
 // TestCacheSetGet sets a value then fetches it back
@@ -33,9 +32,9 @@ func TestBufferOverrun(t *testing.T) {
 	c := NewInMemCache(2, s, &logger.NullLogger{})
 
 	traces := []*types.Trace{
-		&types.Trace{TraceID: "abc123"},
-		&types.Trace{TraceID: "def456"},
-		&types.Trace{TraceID: "ghi789"},
+		{TraceID: "abc123"},
+		{TraceID: "def456"},
+		{TraceID: "ghi789"},
 	}
 
 	c.Set(traces[0])
@@ -52,10 +51,10 @@ func TestTakeExpiredTraces(t *testing.T) {
 
 	now := time.Now()
 	traces := []*types.Trace{
-		&types.Trace{TraceID: "1", SendBy: now.Add(-time.Minute), Sent: true},
-		&types.Trace{TraceID: "2", SendBy: now.Add(-time.Minute)},
-		&types.Trace{TraceID: "3", SendBy: now.Add(time.Minute)},
-		&types.Trace{TraceID: "4"},
+		{TraceID: "1", SendBy: now.Add(-time.Minute), Sent: true},
+		{TraceID: "2", SendBy: now.Add(-time.Minute)},
+		{TraceID: "3", SendBy: now.Add(time.Minute)},
+		{TraceID: "4"},
 	}
 	for _, t := range traces {
 		c.Set(t)
@@ -74,4 +73,34 @@ func TestTakeExpiredTraces(t *testing.T) {
 	for i := range all {
 		assert.Equal(t, traces[2], all[i])
 	}
+}
+
+func TestRemoveSentTraces(t *testing.T) {
+	s := &metrics.MockMetrics{}
+	s.Start()
+	c := NewInMemCache(10, s, &logger.NullLogger{})
+
+	now := time.Now()
+	traces := []*types.Trace{
+		{TraceID: "1", SendBy: now.Add(-time.Minute), Sent: true},
+		{TraceID: "2", SendBy: now.Add(-time.Minute)},
+		{TraceID: "3", SendBy: now.Add(time.Minute)},
+		{TraceID: "4"},
+	}
+	for _, t := range traces {
+		c.Set(t)
+	}
+
+	deletes := map[string]struct{}{
+		"1": {},
+		"3": {},
+		"4": {},
+		"5": {}, // not present
+	}
+
+	c.RemoveSentTraces(deletes)
+
+	all := c.GetAll()
+	assert.Equal(t, 1, len(all))
+	assert.Equal(t, traces[1], all[0])
 }

--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -661,11 +661,11 @@ func TestStableMaxAlloc(t *testing.T) {
 	transmission := &transmit.MockTransmission{}
 	transmission.Start()
 	conf := &config.MockConfig{
-		GetSendDelayVal:          0,
-		GetTraceTimeoutVal:       10 * time.Minute,
-		GetSamplerTypeVal:        &config.DeterministicSamplerConfig{SampleRate: 1},
-		SendTickerVal:            2 * time.Millisecond,
-		UseStableCacheManagement: true,
+		GetSendDelayVal:      0,
+		GetTraceTimeoutVal:   10 * time.Minute,
+		GetSamplerTypeVal:    &config.DeterministicSamplerConfig{SampleRate: 1},
+		SendTickerVal:        2 * time.Millisecond,
+		CacheOverrunStrategy: "impact",
 	}
 	coll := &InMemCollector{
 		Config:       conf,

--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -2,8 +2,10 @@ package collect
 
 import (
 	"fmt"
+	"math/rand"
 	"runtime"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -562,7 +564,7 @@ func TestSampleConfigReload(t *testing.T) {
 	}, conf.GetTraceTimeoutVal*2, conf.SendTickerVal)
 }
 
-func TestMaxAlloc(t *testing.T) {
+func TestOldMaxAlloc(t *testing.T) {
 	transmission := &transmit.MockTransmission{}
 	transmission.Start()
 	conf := &config.MockConfig{
@@ -638,7 +640,7 @@ func TestMaxAlloc(t *testing.T) {
 		time.Sleep(conf.SendTickerVal)
 	}
 
-	assert.Equal(t, 450, len(traces), "should have shrunk cache to 90% of previous size")
+	assert.Equal(t, 450, len(traces), "should have shrunk cache to 90%% of previous size")
 	for i, trace := range traces {
 		assert.False(t, trace.Sent)
 		assert.Equal(t, strconv.Itoa(i+50), trace.TraceID)
@@ -647,10 +649,109 @@ func TestMaxAlloc(t *testing.T) {
 
 	// We discarded the first 50 spans, and sent them.
 	transmission.Mux.Lock()
-	assert.Equal(t, 50, len(transmission.Events), "should have sent 10% of traces")
+	assert.Equal(t, 50, len(transmission.Events), "should have sent 10%% of traces")
 	for i, ev := range transmission.Events {
 		assert.Equal(t, i, ev.Data["id"])
 	}
+
+	transmission.Mux.Unlock()
+}
+
+func TestStableMaxAlloc(t *testing.T) {
+	transmission := &transmit.MockTransmission{}
+	transmission.Start()
+	conf := &config.MockConfig{
+		GetSendDelayVal:          0,
+		GetTraceTimeoutVal:       10 * time.Minute,
+		GetSamplerTypeVal:        &config.DeterministicSamplerConfig{SampleRate: 1},
+		SendTickerVal:            2 * time.Millisecond,
+		UseStableCacheManagement: true,
+	}
+	coll := &InMemCollector{
+		Config:       conf,
+		Logger:       &logger.NullLogger{},
+		Transmission: transmission,
+		Metrics:      &metrics.NullMetrics{},
+		SamplerFactory: &sample.SamplerFactory{
+			Config: conf,
+			Logger: &logger.NullLogger{},
+		},
+	}
+	spandata := make([]map[string]interface{}, 500)
+	for i := 0; i < 500; i++ {
+		spandata[i] = map[string]interface{}{
+			"trace.parent_id": "unused",
+			"id":              i,
+			"str1":            strings.Repeat("abc", rand.Intn(100)+1),
+			"str2":            strings.Repeat("def", rand.Intn(100)+1),
+		}
+	}
+
+	c := cache.NewInMemCache(1000, &metrics.NullMetrics{}, &logger.NullLogger{})
+	coll.cache = c
+	stc, err := lru.New(15)
+	assert.NoError(t, err, "lru cache should start")
+	coll.sentTraceCache = stc
+
+	coll.incoming = make(chan *types.Span, 1000)
+	coll.fromPeer = make(chan *types.Span, 5)
+	coll.datasetSamplers = make(map[string]sample.Sampler)
+	go coll.collect()
+	defer coll.Stop()
+
+	for i := 0; i < 500; i++ {
+		span := &types.Span{
+			TraceID: strconv.Itoa(i),
+			Event: types.Event{
+				Dataset: "aoeu",
+				Data:    spandata[i],
+				APIKey:  legacyAPIKey,
+			},
+		}
+		coll.AddSpan(span)
+	}
+
+	for len(coll.incoming) > 0 {
+		time.Sleep(conf.SendTickerVal)
+	}
+
+	// Now there should be 500 traces in the cache.
+	coll.mutex.Lock()
+	assert.Equal(t, 500, len(coll.cache.GetAll()))
+
+	// We want to induce an eviction event, so set MaxAlloc a bit below
+	// our current post-GC alloc.
+	runtime.GC()
+	var mem runtime.MemStats
+	runtime.ReadMemStats(&mem)
+	// Set MaxAlloc, which should cause cache evictions.
+	conf.GetInMemoryCollectorCacheCapacityVal.MaxAlloc = mem.Alloc * 99 / 100
+
+	coll.mutex.Unlock()
+
+	// wait for the cache to take some action
+	var traces []*types.Trace
+	for {
+		coll.mutex.Lock()
+		traces = coll.cache.GetAll()
+		if len(traces) < 500 {
+			break
+		}
+		coll.mutex.Unlock()
+
+		time.Sleep(conf.SendTickerVal)
+	}
+
+	assert.Equal(t, 1000, coll.cache.(*cache.DefaultInMemCache).GetCacheSize(), "cache size shouldn't change")
+
+	tracesLeft := len(traces)
+	assert.Less(t, tracesLeft, 480, "should have sent some traces")
+	assert.Greater(t, tracesLeft, 100, "should have NOT sent some traces")
+	coll.mutex.Unlock()
+
+	// We discarded the most costly spans, and sent them.
+	transmission.Mux.Lock()
+	assert.Equal(t, 500-len(traces), len(transmission.Events), "should have sent traces that weren't kept")
 
 	transmission.Mux.Unlock()
 }

--- a/config/config.go
+++ b/config/config.go
@@ -169,5 +169,5 @@ type Config interface {
 
 	GetAddSpanCountToRoot() bool
 
-	GetUseStableCacheManagement() bool
+	GetCacheOverrunStrategy() string
 }

--- a/config/config.go
+++ b/config/config.go
@@ -168,4 +168,6 @@ type Config interface {
 	GetAdditionalErrorFields() []string
 
 	GetAddSpanCountToRoot() bool
+
+	GetUseStableCacheManagement() bool
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -336,7 +336,7 @@ func TestReadRulesConfig(t *testing.T) {
 	assert.NoError(t, err)
 	switch r := d.(type) {
 	case *RulesBasedSamplerConfig:
-		assert.Len(t, r.Rule, 5)
+		assert.Len(t, r.Rule, 6)
 
 		var rule *RulesBasedSamplerRule
 
@@ -350,11 +350,11 @@ func TestReadRulesConfig(t *testing.T) {
 		assert.Equal(t, "keep slow 500 errors", rule.Name)
 		assert.Len(t, rule.Condition, 2)
 
-		rule = r.Rule[3]
+		rule = r.Rule[4]
 		assert.Equal(t, 5, rule.SampleRate)
 		assert.Equal(t, "span", rule.Scope)
 
-		rule = r.Rule[4]
+		rule = r.Rule[5]
 		assert.Equal(t, 10, rule.SampleRate)
 		assert.Equal(t, "", rule.Scope)
 

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -56,6 +56,7 @@ type configContents struct {
 	GRPCServerParameters      GRPCServerParameters
 	AdditionalErrorFields     []string
 	AddSpanCountToRoot        bool
+	UseStableCacheManagement  bool
 }
 
 type InMemoryCollectorCacheCapacity struct {
@@ -157,6 +158,7 @@ func NewConfig(config, rules string, errorCallback func(error)) (Config, error) 
 	c.SetDefault("GRPCServerParameters.Timeout", 2*time.Second)
 	c.SetDefault("AdditionalErrorFields", []string{"trace.span_id"})
 	c.SetDefault("AddSpanCountToRoot", false)
+	c.SetDefault("UseStableCacheManagement", false)
 
 	c.SetConfigFile(config)
 	err := c.ReadInConfig()
@@ -887,4 +889,11 @@ func (f *fileConfig) GetAddSpanCountToRoot() bool {
 	defer f.mux.RUnlock()
 
 	return f.conf.AddSpanCountToRoot
+}
+
+func (f *fileConfig) GetUseStableCacheManagement() bool {
+	f.mux.RLock()
+	defer f.mux.RUnlock()
+
+	return f.conf.UseStableCacheManagement
 }

--- a/config/mock.go
+++ b/config/mock.go
@@ -84,7 +84,7 @@ type MockConfig struct {
 	PeerTimeout                   time.Duration
 	AdditionalErrorFields         []string
 	AddSpanCountToRoot            bool
-	UseStableCacheManagement      bool
+	CacheOverrunStrategy          string
 
 	Mux sync.RWMutex
 }
@@ -461,9 +461,9 @@ func (f *MockConfig) GetAddSpanCountToRoot() bool {
 	return f.AddSpanCountToRoot
 }
 
-func (f *MockConfig) GetUseStableCacheManagement() bool {
+func (f *MockConfig) GetCacheOverrunStrategy() string {
 	f.Mux.RLock()
 	defer f.Mux.RUnlock()
 
-	return f.UseStableCacheManagement
+	return f.CacheOverrunStrategy
 }

--- a/config/mock.go
+++ b/config/mock.go
@@ -84,6 +84,7 @@ type MockConfig struct {
 	PeerTimeout                   time.Duration
 	AdditionalErrorFields         []string
 	AddSpanCountToRoot            bool
+	UseStableCacheManagement      bool
 
 	Mux sync.RWMutex
 }
@@ -458,4 +459,11 @@ func (f *MockConfig) GetAddSpanCountToRoot() bool {
 	defer f.Mux.RUnlock()
 
 	return f.AddSpanCountToRoot
+}
+
+func (f *MockConfig) GetUseStableCacheManagement() bool {
+	f.Mux.RLock()
+	defer f.Mux.RUnlock()
+
+	return f.UseStableCacheManagement
 }

--- a/config_complete.toml
+++ b/config_complete.toml
@@ -143,15 +143,15 @@ AdditionalErrorFields = [
 # Eligible for live reload.
 # AddSpanCountToRoot = true
 
-# UseStableCacheManagement controls the use of a non-resizing cache management strategy.
-# It defaults to false, but is recommended to set to true, as the old strategy does not recover from
-# cache overruns.
-# In the previous strategy, under memory pressure the cache is shrunk and never grows again.
-# In the stable strategy, under memory pressure the items having the most impact on the cache size are
-# ejected from the cache early and the cache is not resized.
-# This only applies if MaxAlloc is nonzero.
+# CacheOverrunStrategy controls the cache management behavior under memory pressure.
+# "resize" means that when a cache overrun occurs, the cache is shrunk and never grows again,
+# which is generally not helpful unless it occurs because of a permanent change in traffic patterns.
+# In the "impact" strategy, the items having the most impact on the cache size are
+# ejected from the cache earlier than normal but the cache is not resized.
+# In all cases, it only applies if MaxAlloc is nonzero.
+# Default is "resize" for compatibility but "impact" is recommended for most installations.
 # Eligible for live reload.
-# UseStableCacheManagement = true
+# CacheOverrunStrategy = "impact"
 
 ############################
 ## Implementation Choices ##

--- a/config_complete.toml
+++ b/config_complete.toml
@@ -143,6 +143,16 @@ AdditionalErrorFields = [
 # Eligible for live reload.
 # AddSpanCountToRoot = true
 
+# UseStableCacheManagement controls the use of a non-resizing cache management strategy.
+# It defaults to false, but is recommended to set to true, as the old strategy does not recover from
+# cache overruns.
+# In the previous strategy, under memory pressure the cache is shrunk and never grows again.
+# In the stable strategy, under memory pressure the items having the most impact on the cache size are
+# ejected from the cache early and the cache is not resized.
+# This only applies if MaxAlloc is nonzero.
+# Eligible for live reload.
+# UseStableCacheManagement = true
+
 ############################
 ## Implementation Choices ##
 ############################

--- a/rules_complete.toml
+++ b/rules_complete.toml
@@ -242,6 +242,22 @@ SampleRate = 1
 			AddSampleRateKeyToTrace = true
 			AddSampleRateKeyToTraceField = "meta.refinery.dynsampler_key"
 
+	# Note that Refinery comparisons are type-dependent. If you are operating in an environment where different
+	# telemetry may send the same field with different types (for example, some systems send status codes as "200"
+	# instead of 200), you may need to create additional rules to cover these cases.
+	[[dataset4.rule]]
+		name = "dynamically sample 200 string responses"
+		[[dataset4.rule.condition]]
+			field = "status_code"
+			operator = "="
+			value = "200"
+		[dataset4.rule.sampler.EMADynamicSampler]
+			Sampler = "EMADynamicSampler"
+			GoalSampleRate = 15
+			FieldList = ["request.method", "request.route"]
+			AddSampleRateKeyToTrace = true
+			AddSampleRateKeyToTraceField = "meta.refinery.dynsampler_key"
+
 	[[dataset4.rule]]
 		name = "sample traces originating from a service"
 		# if scope is set to "span", a single span in the trace must match

--- a/types/event_test.go
+++ b/types/event_test.go
@@ -1,0 +1,83 @@
+package types
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestSpan_GetDataSize(t *testing.T) {
+	tests := []struct {
+		name       string
+		numInts    int
+		numStrings int
+		want       int
+	}{
+		{"all ints small", 10, 0, 80},
+		{"all ints large", 100, 0, 800},
+		{"all strings small", 0, 10, 45},
+		{"all strings large", 0, 100, 4950},
+		{"mixed small", 10, 10, 125},
+		{"mixed large", 100, 100, 5750},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sp := &Span{
+				TraceID: tt.name,
+				Event: Event{
+					Data: make(map[string]any),
+				},
+			}
+			for i := 0; i < tt.numInts; i++ {
+				sp.Data[tt.name+"int"+strconv.Itoa(i)] = i
+			}
+			for i := 0; i < tt.numStrings; i++ {
+				sp.Data[tt.name+"str"+strconv.Itoa(i)] = strings.Repeat("x", i)
+			}
+			if got := sp.GetDataSize(); got != tt.want {
+				t.Errorf("Span.CalculateSize() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// These benchmarks were just to verify that the size calculation is acceptable
+// even on big spans. The P99 for normal (20-field) spans shows that it will take ~1
+// microsecond (on an m1 laptop) but a 1000-field span (extremely rare!) will take
+// ~10 microseconds. Since these happen once per span, when adding it to a trace,
+// we don't expect this to be a performance issue.
+func BenchmarkSpan_CalculateSizeSmall(b *testing.B) {
+	sp := &Span{
+		Event: Event{
+			Data: make(map[string]any),
+		},
+	}
+	for i := 0; i < 10; i++ {
+		sp.Data["int"+strconv.Itoa(i)] = i
+	}
+	for i := 0; i < 10; i++ {
+		sp.Data["str"+strconv.Itoa(i)] = strings.Repeat("x", i)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sp.GetDataSize()
+	}
+}
+
+func BenchmarkSpan_CalculateSizeLarge(b *testing.B) {
+	sp := &Span{
+		Event: Event{
+			Data: make(map[string]any),
+		},
+	}
+	for i := 0; i < 500; i++ {
+		sp.Data["int"+strconv.Itoa(i)] = i
+	}
+	for i := 0; i < 500; i++ {
+		sp.Data["str"+strconv.Itoa(i)] = strings.Repeat("x", i)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sp.GetDataSize()
+	}
+}


### PR DESCRIPTION
Implements a new cache management strategy that ejects "large" items from the cache rather than resizing the cache.

## Which problem is this PR solving?

Currently, when Refinery is under memory pressure and exceeds the configured memory maximum, it attempts to resize the trace cache to 90% of its previous size, and ejects the oldest traces. But as the trace cache is sized by trace count, when a very large trace arrives, it can cause the cache to shrink repeatedly, discarding the smaller traces, which doesn't help much. The result is that the cache can be resized to a tiny fraction of its original size to very little benefit.

Furthermore, it never recovers until configuration is manually reloaded. 

This PR implements a different strategy:
* The memory size of individual spans is calculated when they are placed into the cache
* Spans also track their arrival time
* The "cacheImpact" of a span is a measure of how long the span has been in the cache, multiplied by the size of the span
* Traces keep track of the total impact of all the spans in the trace

When a memory overrun occurs, the system sorts the traces by cache impact and ejects (makes a sampling decision and drops or sends) those traces with the largest impact until memory usage falls below the maximum. The cache is not resized.

This strategy leads to more stable memory usage and fewer overruns.

## Short description of the changes

* The memory size of individual spans is calculated when they are placed into the cache
* Spans also track their arrival time
* The "cacheImpact" of a span is a measure of how long the span has been in the cache, multiplied by the size of the span
* Traces keep track of the total impact of all the spans in the trace
* There's some new telemetry
* There's a config value to control switching between the two modes dynamically and it shows up in the sample config
* There are tests for some of the algorithmic calculations as well as the strategy modes

Note to reviewers -- this is on the large side, but I didn't see a great way to break it up.