### PR TITLE
Set content-type on marshalToFormat

### DIFF
--- a/route/route.go
+++ b/route/route.go
@@ -332,6 +332,7 @@ func (r *Router) marshalToFormat(w http.ResponseWriter, obj interface{}, format 
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
+	w.Header().Set("Content-Type", "application/"+format)
 	w.Write(body)
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?

The /query endpoints aren't setting Content-Type, which they should.

## Short description of the changes

- Set content-type based on the type asked for.

