### PR TITLE
On shutdown, remove ourself from the peers list

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -1,5 +1,3 @@
-//go:build all || race
-
 package app
 
 import (
@@ -123,7 +121,7 @@ func newStartedApp(
 
 	var err error
 	if peers == nil {
-		peers, err = peer.NewPeers(context.Background(), c)
+		peers, err = peer.NewPeers(context.Background(), c, make(chan struct{}))
 		assert.NoError(t, err)
 	}
 

--- a/cmd/refinery/main.go
+++ b/cmd/refinery/main.go
@@ -106,7 +106,8 @@ func main() {
 
 	ctx, cancel := context.WithTimeout(context.Background(), c.GetPeerTimeout())
 	defer cancel()
-	peers, err := peer.NewPeers(ctx, c)
+	done := make(chan struct{})
+	peers, err := peer.NewPeers(ctx, c, done)
 
 	if err != nil {
 		fmt.Printf("unable to load peers: %+v\n", err)
@@ -226,5 +227,8 @@ func main() {
 
 	// block on our signal handler to exit
 	sig := <-sigsToExit
+	// unregister ourselves before we go
+	close(done)
+	time.Sleep(100 * time.Millisecond)
 	a.Logger.Error().Logf("Caught signal \"%s\"", sig)
 }

--- a/config/config_test_reload_error_test.go
+++ b/config/config_test_reload_error_test.go
@@ -1,5 +1,3 @@
-//go:build all || !race
-
 package config
 
 import (

--- a/internal/peer/peers.go
+++ b/internal/peer/peers.go
@@ -3,6 +3,7 @@ package peer
 import (
 	"context"
 	"errors"
+
 	"github.com/honeycombio/refinery/config"
 )
 
@@ -13,7 +14,7 @@ type Peers interface {
 	RegisterUpdatedPeersCallback(callback func())
 }
 
-func NewPeers(ctx context.Context, c config.Config) (Peers, error) {
+func NewPeers(ctx context.Context, c config.Config, done chan struct{}) (Peers, error) {
 	t, err := c.GetPeerManagementType()
 
 	if err != nil {
@@ -24,7 +25,7 @@ func NewPeers(ctx context.Context, c config.Config) (Peers, error) {
 	case "file":
 		return newFilePeers(c), nil
 	case "redis":
-		return newRedisPeers(ctx, c)
+		return newRedisPeers(ctx, c, done)
 	default:
 		return nil, errors.New("invalid config option 'PeerManagement.Type'")
 	}

--- a/sample/rules_test.go
+++ b/sample/rules_test.go
@@ -538,6 +538,59 @@ func TestRules(t *testing.T) {
 			ExpectedKeep: true,
 			ExpectedRate: 1,
 		},
+		{
+			Rules: &config.RulesBasedSamplerConfig{
+				Rule: []*config.RulesBasedSamplerRule{
+					{
+						Name:       "Check root span for span count",
+						Drop:       true,
+						SampleRate: 0,
+						Condition: []*config.RulesBasedSamplerCondition{
+							{
+								Field:    "meta.span_count",
+								Operator: ">=",
+								Value:    int(2),
+							},
+						},
+					},
+				},
+			},
+			Spans: []*types.Span{
+				{
+					Event: types.Event{
+						Data: map[string]interface{}{
+							"trace.trace_id":  "12345",
+							"trace.span_id":   "54321",
+							"meta.span_count": int64(2),
+							"test":            int64(2),
+						},
+					},
+				},
+				{
+					Event: types.Event{
+						Data: map[string]interface{}{
+							"trace.trace_id":  "12345",
+							"trace.span_id":   "654321",
+							"trace.parent_id": "54321",
+							"test":            int64(2),
+						},
+					},
+				},
+				{
+					Event: types.Event{
+						Data: map[string]interface{}{
+							"trace.trace_id":  "12345",
+							"trace.span_id":   "754321",
+							"trace.parent_id": "54321",
+							"test":            int64(3),
+						},
+					},
+				},
+			},
+			ExpectedName: "Check root span for span count",
+			ExpectedKeep: false,
+			ExpectedRate: 0,
+		},
 	}
 
 	for _, d := range data {

--- a/sharder/deterministic_test.go
+++ b/sharder/deterministic_test.go
@@ -26,7 +26,9 @@ func TestWhichShard(t *testing.T) {
 		GetPeersVal:          peers,
 		PeerManagementType:   "file",
 	}
-	filePeers, err := peer.NewPeers(context.Background(), config)
+	done := make(chan struct{})
+	defer close(done)
+	filePeers, err := peer.NewPeers(context.Background(), config, done)
 	assert.Equal(t, nil, err)
 	sharder := DeterministicSharder{
 		Config: config,
@@ -67,7 +69,9 @@ func TestWhichShardAtEdge(t *testing.T) {
 		GetPeersVal:          peers,
 		PeerManagementType:   "file",
 	}
-	filePeers, err := peer.NewPeers(context.Background(), config)
+	done := make(chan struct{})
+	defer close(done)
+	filePeers, err := peer.NewPeers(context.Background(), config, done)
 	assert.Equal(t, nil, err)
 	sharder := DeterministicSharder{
 		Config: config,


### PR DESCRIPTION
## Which problem is this PR solving?

- In a redis-managed pool of peers, the peer group is updated only after a timeout. This adds explicit unregistration so that in the case of a deliberately terminated instance, redis is notified immediately that the peer has dropped.
- Doesn't change the behavior of refreshing the peer list, which is still a pull-based timeout.
- Fixes #393 

## Short description of the changes

- Add an Unregister method to redimem
- Add a done channel to the goroutines that keep redis updated
- Unregister when the done channel is closed
- Propagate the done channel through the app initialization
- Close the done channel on shutdown
- Update tests
- Add a new test to make sure that unregistration happens
- Also adds a new test case to rules; I wrote it to verify we didn't have a bug and thought it should probably stay in.
