### PR TITLE
feat: Implement alternative sharding using rendezvous hash to improve dynamic scalability

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -41,6 +41,10 @@ type Config interface {
 
 	GetPeerManagementType() (string, error)
 
+	// GetPeerManagementStrategy returns the strategy specified for
+	// Peer management.
+	GetPeerManagementStrategy() (string, error)
+
 	// GetRedisHost returns the address of a Redis instance to use for peer
 	// management.
 	GetRedisHost() (string, error)

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -105,6 +105,7 @@ type PeerManagementConfig struct {
 	UseIPV6Identifier       bool
 	RedisIdentifier         string
 	Timeout                 time.Duration
+	Strategy                string `validate:"required,oneof= legacy hash"`
 }
 
 type SampleCacheConfig struct {
@@ -146,6 +147,7 @@ func NewConfig(config, rules string, errorCallback func(error)) (Config, error) 
 	c.SetDefault("PeerManagement.UseTLSInsecure", false)
 	c.SetDefault("PeerManagement.UseIPV6Identifier", false)
 	c.SetDefault("PeerManagement.Timeout", 5*time.Second)
+	c.SetDefault("PeerManagement.Strategy", "legacy")
 	c.SetDefault("HoneycombAPI", "https://api.honeycomb.io")
 	c.SetDefault("Logger", "logrus")
 	c.SetDefault("LoggingLevel", "debug")
@@ -459,6 +461,13 @@ func (f *fileConfig) GetPeerManagementType() (string, error) {
 	defer f.mux.RUnlock()
 
 	return f.conf.PeerManagement.Type, nil
+}
+
+func (f *fileConfig) GetPeerManagementStrategy() (string, error) {
+	f.mux.RLock()
+	defer f.mux.RUnlock()
+
+	return f.conf.PeerManagement.Strategy, nil
 }
 
 func (f *fileConfig) GetPeers() ([]string, error) {

--- a/config/mock.go
+++ b/config/mock.go
@@ -68,6 +68,7 @@ type MockConfig struct {
 	UseIPV6Identifier             bool
 	RedisIdentifier               string
 	PeerManagementType            string
+	PeerManagementStrategy        string
 	DebugServiceAddr              string
 	DryRun                        bool
 	DryRunFieldName               string
@@ -349,6 +350,13 @@ func (m *MockConfig) GetPeerManagementType() (string, error) {
 	defer m.Mux.RUnlock()
 
 	return m.PeerManagementType, nil
+}
+
+func (m *MockConfig) GetPeerManagementStrategy() (string, error) {
+	m.Mux.RLock()
+	defer m.Mux.RUnlock()
+
+	return m.PeerManagementStrategy, nil
 }
 
 func (m *MockConfig) GetDebugServiceAddr() (string, error) {

--- a/config_complete.toml
+++ b/config_complete.toml
@@ -252,6 +252,16 @@ Metrics = "honeycomb"
 # after 5s when communicating with Redis.
 # Timeout = "5s"
 
+# Strategy controls the way that traces are assigned to refinery nodes.
+# The "legacy" strategy uses a simple algorithm that unfortunately causes
+# 1/2 of the in-flight traces to be assigned to a different node whenever the
+# number of nodes changes.
+# The legacy strategy is deprecated and is intended to be removed in a future release.
+# The "hash" strategy is strongly recommended, as only 1/N traces (where N is the
+# number of nodes) are disrupted when the node count changes.
+# Not eligible for live reload.
+# Strategy = "hash"
+
 #########################
 ## In-Memory Collector ##
 #########################
@@ -275,7 +285,8 @@ CacheCapacity = 1000
 # supported.
 # If set to a non-zero value, once per tick (see SendTicker) the collector
 # will compare total allocated bytes to this value. If allocation is too
-# high, cache capacity will be reduced and an error will be logged.
+# high, cache capacity will be adjusted according to the setting for
+# CacheOverrunStrategy.
 # Useful values for this setting are generally in the range of 75%-90% of
 # available system memory.
 MaxAlloc = 0

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/davecgh/go-spew v1.1.1
+	github.com/dgryski/go-wyhash v0.0.0-20191203203029-c4841ae36371
 	github.com/facebookgo/inject v0.0.0-20180706035515-f23751cae28b
 	github.com/facebookgo/startstop v0.0.0-20161013234910-bc158412526d
 	github.com/fsnotify/fsnotify v1.6.0
@@ -17,6 +18,7 @@ require (
 	github.com/jessevdk/go-flags v1.5.0
 	github.com/json-iterator/go v1.1.12
 	github.com/klauspost/compress v1.15.12
+	github.com/panmari/cuckoofilter v1.0.3
 	github.com/pelletier/go-toml/v2 v2.0.5
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.13.0
@@ -26,7 +28,6 @@ require (
 	github.com/stretchr/testify v1.8.1
 	github.com/tidwall/gjson v1.14.3
 	github.com/vmihailenco/msgpack/v4 v4.3.11
-	golang.org/x/net v0.0.0-20220826154423-83b083e8dc8b // indirect
 	google.golang.org/grpc v1.50.1
 	google.golang.org/protobuf v1.28.1
 	gopkg.in/alexcesaro/statsd.v2 v2.0.0
@@ -52,7 +53,6 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
-	github.com/panmari/cuckoofilter v1.0.3 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
@@ -68,6 +68,7 @@ require (
 	github.com/vmihailenco/msgpack/v5 v5.3.5 // indirect
 	github.com/vmihailenco/tagparser v0.1.1 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
+	golang.org/x/net v0.0.0-20220826154423-83b083e8dc8b // indirect
 	golang.org/x/sys v0.0.0-20220908164124-27713097b956 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/appengine v1.6.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/go-metro v0.0.0-20200812162917-85c65e2d0165 h1:BS21ZUJ/B5X2UVUbczfmdWH7GapPWAhxcMsDnjJTU1E=
 github.com/dgryski/go-metro v0.0.0-20200812162917-85c65e2d0165/go.mod h1:c9O8+fpSOX1DM8cPNSkX/qsBWdkD4yd2dpciOWQjpBw=
+github.com/dgryski/go-wyhash v0.0.0-20191203203029-c4841ae36371 h1:bz5ApY1kzFBvw3yckuyRBCtqGvprWrKswYK468nm+Gs=
+github.com/dgryski/go-wyhash v0.0.0-20191203203029-c4841ae36371/go.mod h1:/ENMIO1SQeJ5YQeUWWpbX8f+bS8INHrrhFjXgEqi4LA=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/sharder/deterministic.go
+++ b/sharder/deterministic.go
@@ -24,7 +24,6 @@ import (
 const (
 	shardingSalt        = "gf4LqTwcJ6PEj2vO"
 	peerSeed     uint64 = 6789531204236
-	traceSeed    uint64 = 5498616120353
 )
 
 // DetShard implements Shard

--- a/sharder/deterministic.go
+++ b/sharder/deterministic.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/dgryski/go-wyhash"
 	"github.com/honeycombio/refinery/config"
 	"github.com/honeycombio/refinery/internal/peer"
 	"github.com/honeycombio/refinery/logger"
@@ -18,15 +19,24 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// shardingSalt is a random bit to make sure we don't shard the same as any
-// other sharding that uses the trace ID (eg deterministic sampling)
-const shardingSalt = "gf4LqTwcJ6PEj2vO"
+// These are random bits to make sure we differentiate between different
+// hash cases even if we use the same value (traceID).
+const (
+	shardingSalt        = "gf4LqTwcJ6PEj2vO"
+	peerSeed     uint64 = 6789531204236
+	traceSeed    uint64 = 5498616120353
+)
 
 // DetShard implements Shard
 type DetShard struct {
 	scheme   string
 	ipOrHost string
 	port     string
+}
+
+type hashShard struct {
+	uhash      uint64
+	shardIndex int
 }
 
 func (d *DetShard) Equals(other Shard) bool {
@@ -75,13 +85,32 @@ func (d *DetShard) String() string {
 	return d.GetAddress()
 }
 
+// GetHashesFor generates a number of hashShards for a given DetShard by repeatedly hashing the
+// seed with itself. The intent is to generate a repeatable pseudo-random sequence.
+func (d *DetShard) GetHashesFor(index int, n int, seed uint64) []hashShard {
+	hashes := make([]hashShard, 0)
+	addr := d.GetAddress()
+	for i := 0; i < n; i++ {
+		hashes = append(hashes, hashShard{
+			uhash:      wyhash.Hash([]byte(addr), seed),
+			shardIndex: index,
+		})
+		// generate another seed from the previous seed; we want this to be the same
+		// sequence for everything.
+		seed = wyhash.Hash([]byte("anything"), seed)
+	}
+	return hashes
+}
+
 type DeterministicSharder struct {
 	Config config.Config `inject:""`
 	Logger logger.Logger `inject:""`
 	Peers  peer.Peers    `inject:""`
 
-	myShard *DetShard
-	peers   []*DetShard
+	myShard   *DetShard
+	peers     []*DetShard
+	hashes    []hashShard
+	shardFunc func(traceID string) Shard
 
 	peerLock sync.RWMutex
 }
@@ -97,6 +126,21 @@ func (d *DeterministicSharder) Start() error {
 			d.Logger.Error().Logf("failed to reload peer list: %+v", err)
 		}
 	})
+
+	// this isn't runtime-reloadable because it would
+	// reassign nearly every trace to a new shard.
+	strat, err := d.Config.GetPeerManagementStrategy()
+	if err != nil {
+		return errors.Wrap(err, "failed to get peer management strategy")
+	}
+	switch strat {
+	case "legacy", "":
+		d.shardFunc = d.WhichShardLegacy
+	case "hash":
+		d.shardFunc = d.WhichShardHashed
+	default:
+		return fmt.Errorf("unknown PeerManagementStrategy '%s'", strat)
+	}
 
 	// Try up to 5 times to find myself in the peer list before giving up
 	var found bool
@@ -205,9 +249,10 @@ func (d *DeterministicSharder) loadPeerList() error {
 		return errors.New("refusing to load empty peer list")
 	}
 
-	// turn my peer list into a list of shards
-	newPeers := make([]*DetShard, 0, len(peerList))
-	for _, peer := range peerList {
+	// turn the peer list into a list of shards
+	// and a list of hashes
+	newPeers := make([]*DetShard, len(peerList))
+	for ix, peer := range peerList {
 		peerURL, err := url.Parse(peer)
 		if err != nil {
 			return errors.Wrap(err, "couldn't parse peer as a URL")
@@ -217,12 +262,32 @@ func (d *DeterministicSharder) loadPeerList() error {
 			ipOrHost: peerURL.Hostname(),
 			port:     peerURL.Port(),
 		}
-		newPeers = append(newPeers, peerShard)
+		newPeers[ix] = peerShard
 	}
 
-	// the redis peer discovery already sorts its content. Does every backend?
-	// well, it's not too much work, let's sort it one more time.
+	// make sure the list is in a stable, comparable order
 	sort.Sort(SortableShardList(newPeers))
+
+	// PartitionCount controls the minimum number of partitions used to control node assignment
+	// when we use the "hash" strategy.
+	// Ideally, this value should be 3-5x the maximum expected number of nodes.
+	// If necessary, it will (effectively) be increased to equal the number of nodes.
+	// A larger value will achieve more even trace distribution, at the cost of a minor performance
+	// hit once per span (roughly 1 microsecond per 50 partitions). Since the distribution isn't
+	// that even anyway (yay randomness) 50 seems to be a good balance; it helps with small
+	// installations and doesn't hurt for big ones.
+	const partitionCount = 50
+	// now build the hash list;
+	// We make a list of hash value and an index to a peer.
+	hashes := make([]hashShard, 0)
+	hashesPerPeer := partitionCount/len(peerList) + 1
+	for ix := range newPeers {
+		hashes = append(hashes, newPeers[ix].GetHashesFor(ix, hashesPerPeer, peerSeed)...)
+	}
+	// now sort the hash list by hash value so we can search it efficiently
+	sort.Slice(hashes, func(i, j int) bool {
+		return hashes[i].uhash < hashes[j].uhash
+	})
 
 	// if the peer list changed, load the new list
 	d.peerLock.RLock()
@@ -231,6 +296,7 @@ func (d *DeterministicSharder) loadPeerList() error {
 		d.peerLock.RUnlock()
 		d.peerLock.Lock()
 		d.peers = newPeers
+		d.hashes = hashes
 		d.peerLock.Unlock()
 	} else {
 		d.peerLock.RUnlock()
@@ -243,6 +309,16 @@ func (d *DeterministicSharder) MyShard() Shard {
 }
 
 func (d *DeterministicSharder) WhichShard(traceID string) Shard {
+	return d.shardFunc(traceID)
+}
+
+// WhichShardLegacy is the original sharding decider. It uses sha1, which is
+// slow and not well-distributed, and also simply partitions the sharding
+// space into N evenly-divided buckets, which means that on every change in
+// shard count, half of the traces get reassigned (which leads to broken traces).
+// We leave it here to avoid disrupting things and provide a fallback if needed,
+// but the intent is eventually to delete this.
+func (d *DeterministicSharder) WhichShardLegacy(traceID string) Shard {
 	d.peerLock.RLock()
 	defer d.peerLock.RUnlock()
 
@@ -261,4 +337,30 @@ func (d *DeterministicSharder) WhichShard(traceID string) Shard {
 	}
 
 	return d.peers[index]
+}
+
+// WhichShardHashed calculates which shard we want by keeping a list of partitions. Each
+// partition has a different hash value and a map from partition to a given shard.
+// We take the traceID and calculate a hash for each partition, using the partition
+// hash as the seed for the trace hash. Whichever one has the highest value is the
+// partition we use, which determines the shard we use.
+// This is O(N) where N is the number of partitions, but because we use an efficient hash,
+// (as opposed to SHA1) it executes in 1 uSec for 50 partitions, so it works out to about
+// the same cost as the legacy sharder.
+func (d *DeterministicSharder) WhichShardHashed(traceID string) Shard {
+	d.peerLock.RLock()
+	defer d.peerLock.RUnlock()
+
+	tid := []byte(traceID)
+
+	bestix := 0
+	var maxHash uint64
+	for _, hash := range d.hashes {
+		h := wyhash.Hash(tid, hash.uhash)
+		if h > maxHash {
+			maxHash = h
+			bestix = hash.shardIndex
+		}
+	}
+	return d.peers[bestix]
 }

--- a/sharder/deterministic_test.go
+++ b/sharder/deterministic_test.go
@@ -2,6 +2,8 @@ package sharder
 
 import (
 	"context"
+	"fmt"
+	"math/rand"
 	"testing"
 
 	"github.com/honeycombio/refinery/config"
@@ -86,4 +88,306 @@ func TestWhichShardAtEdge(t *testing.T) {
 	config.ReloadConfig()
 	assert.Equal(t, shard.GetAddress(), sharder.WhichShard(traceID).GetAddress(),
 		"should select the same peer if peer list becomes empty")
+}
+
+// GenID returns a random hex string of length numChars
+func GenID(numChars int) string {
+	const charset = "abcdef0123456789"
+
+	id := make([]byte, numChars)
+	for i := 0; i < numChars; i++ {
+		id[i] = charset[rand.Intn(len(charset))]
+	}
+	return string(id)
+}
+
+func BenchmarkShardBulk(b *testing.B) {
+	const (
+		selfAddr = "127.0.0.1:8081"
+		traceID  = "test"
+	)
+
+	const npeers = 11
+	peers := []string{
+		"http://" + selfAddr,
+	}
+	for i := 1; i < npeers; i++ {
+		peers = append(peers, fmt.Sprintf("http://2.2.2.%d/:8081", i))
+	}
+	config := &config.MockConfig{
+		GetPeerListenAddrVal:   selfAddr,
+		GetPeersVal:            peers,
+		PeerManagementType:     "file",
+		PeerManagementStrategy: "legacy",
+	}
+	filePeers, err := peer.NewPeers(context.Background(), config)
+	assert.Equal(b, nil, err)
+	sharder := DeterministicSharder{
+		Config: config,
+		Logger: &logger.NullLogger{},
+		Peers:  filePeers,
+	}
+
+	assert.NoError(b, sharder.Start(), "starting deterministic sharder should not error")
+
+	const ntraces = 10
+	ids := make([]string, ntraces)
+	for i := 0; i < ntraces; i++ {
+		ids[i] = GenID(32)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sharder.WhichShard(ids[i%ntraces])
+	}
+}
+
+func TestShardBulk(t *testing.T) {
+	const (
+		selfAddr = "127.0.0.1:8081"
+		traceID  = "test"
+	)
+
+	// this test should work for all strategies and a wide range of peer counts
+	for _, strategy := range []string{"legacy", "hash"} {
+		for i := 0; i < 5; i++ {
+			npeers := i*10 + 5
+			t.Run(fmt.Sprintf("bulk npeers=%d", npeers), func(t *testing.T) {
+				peers := []string{
+					"http://" + selfAddr,
+				}
+				for i := 1; i < npeers; i++ {
+					peers = append(peers, fmt.Sprintf("http://2.2.2.%d/:8081", i))
+				}
+
+				config := &config.MockConfig{
+					GetPeerListenAddrVal:   selfAddr,
+					GetPeersVal:            peers,
+					PeerManagementType:     "file",
+					PeerManagementStrategy: strategy,
+				}
+				filePeers, err := peer.NewPeers(context.Background(), config)
+				assert.Equal(t, nil, err)
+				sharder := DeterministicSharder{
+					Config: config,
+					Logger: &logger.NullLogger{},
+					Peers:  filePeers,
+				}
+
+				assert.NoError(t, sharder.Start(), "starting sharder should not error")
+
+				const ntraces = 1000
+				ids := make([]string, ntraces)
+				for i := 0; i < ntraces; i++ {
+					ids[i] = GenID(32)
+				}
+
+				results := make(map[string]int)
+				for i := 0; i < ntraces; i++ {
+					s := sharder.WhichShardHashed(ids[i])
+					results[s.GetAddress()]++
+				}
+				min := ntraces
+				max := 0
+				for _, r := range results {
+					if r < min {
+						min = r
+					}
+					if r > max {
+						max = r
+					}
+				}
+
+				// This is probabalistic, so could fail, but shouldn't be flaky as long as
+				// expectedResult is at least 20 or so.
+				expectedResult := ntraces / npeers
+				assert.Greater(t, expectedResult*2, max, "expected smaller max, got %d: %v", max, results)
+				assert.NotEqual(t, 0, min, "expected larger min, got %d: %v", min, results)
+			})
+		}
+	}
+}
+
+func TestShardDrop(t *testing.T) {
+	const (
+		selfAddr = "127.0.0.1:8081"
+		traceID  = "test"
+	)
+
+	for i := 0; i < 5; i++ {
+		npeers := i*10 + 5
+		t.Run(fmt.Sprintf("drop npeers=%d", npeers), func(t *testing.T) {
+			peers := []string{
+				"http://" + selfAddr,
+			}
+			for i := 1; i < npeers; i++ {
+				peers = append(peers, fmt.Sprintf("http://2.2.2.%d/:8081", i))
+			}
+
+			config := &config.MockConfig{
+				GetPeerListenAddrVal:   selfAddr,
+				GetPeersVal:            peers,
+				PeerManagementType:     "file",
+				PeerManagementStrategy: "hash",
+			}
+			filePeers, err := peer.NewPeers(context.Background(), config)
+			assert.Equal(t, nil, err)
+			sharder := DeterministicSharder{
+				Config: config,
+				Logger: &logger.NullLogger{},
+				Peers:  filePeers,
+			}
+
+			assert.NoError(t, sharder.Start(), "starting sharder should not error")
+
+			type placement struct {
+				id    string
+				shard string
+			}
+
+			const ntraces = 1000
+			placements := make([]placement, ntraces)
+			for i := 0; i < ntraces; i++ {
+				placements[i].id = GenID(32)
+			}
+
+			results := make(map[string]int)
+			for i := 0; i < ntraces; i++ {
+				s := sharder.WhichShard(placements[i].id)
+				results[s.GetAddress()]++
+				placements[i].shard = s.GetAddress()
+			}
+			fmt.Println(results)
+
+			// reach in and delete one of the peers, then reshard
+			config.GetPeersVal = config.GetPeersVal[1:]
+			sharder.loadPeerList()
+
+			results = make(map[string]int)
+			nDiff := 0
+			for i := 0; i < ntraces; i++ {
+				s := sharder.WhichShardHashed(placements[i].id)
+				results[s.GetAddress()]++
+				if s.GetAddress() != placements[i].shard {
+					nDiff++
+				}
+			}
+
+			expected := ntraces / (npeers - 1)
+			assert.Greater(t, expected*2, nDiff)
+			assert.Less(t, expected/2, nDiff)
+		})
+	}
+}
+
+func TestShardAddHash(t *testing.T) {
+	const (
+		selfAddr = "127.0.0.1:8081"
+		traceID  = "test"
+	)
+
+	for i := 0; i < 5; i++ {
+		npeers := i*10 + 7
+		t.Run(fmt.Sprintf("add npeers=%d", npeers), func(t *testing.T) {
+			peers := []string{
+				"http://" + selfAddr,
+			}
+			for i := 1; i < npeers; i++ {
+				peers = append(peers, fmt.Sprintf("http://2.2.2.%d/:8081", i))
+			}
+
+			config := &config.MockConfig{
+				GetPeerListenAddrVal:   selfAddr,
+				GetPeersVal:            peers,
+				PeerManagementType:     "file",
+				PeerManagementStrategy: "hash",
+			}
+			filePeers, err := peer.NewPeers(context.Background(), config)
+			assert.Equal(t, nil, err)
+			sharder := DeterministicSharder{
+				Config: config,
+				Logger: &logger.NullLogger{},
+				Peers:  filePeers,
+			}
+
+			assert.NoError(t, sharder.Start(), "starting sharder should not error")
+
+			type placement struct {
+				id    string
+				shard string
+			}
+
+			const ntraces = 1000
+			placements := make([]placement, ntraces)
+			for i := 0; i < ntraces; i++ {
+				placements[i].id = GenID(32)
+			}
+
+			results := make(map[string]int)
+			for i := 0; i < ntraces; i++ {
+				s := sharder.WhichShardHashed(placements[i].id)
+				results[s.GetAddress()]++
+				placements[i].shard = s.GetAddress()
+			}
+			fmt.Println(results)
+
+			// reach in and add a peer, then reshard
+			config.GetPeersVal = append(config.GetPeersVal, "http://2.2.2.255/:8081")
+			sharder.loadPeerList()
+
+			results = make(map[string]int)
+			nDiff := 0
+			for i := 0; i < ntraces; i++ {
+				s := sharder.WhichShard(placements[i].id)
+				results[s.GetAddress()]++
+				if s.GetAddress() != placements[i].shard {
+					nDiff++
+				}
+			}
+			expected := ntraces / (npeers - 1)
+			assert.Greater(t, expected*2, nDiff)
+			assert.Less(t, expected/2, nDiff)
+		})
+	}
+}
+
+func BenchmarkDeterministicShard(b *testing.B) {
+	const (
+		selfAddr = "127.0.0.1:8081"
+		traceID  = "test"
+	)
+	for _, strat := range []string{"legacy", "hash"} {
+		for i := 0; i < 5; i++ {
+			npeers := i*10 + 4
+			b.Run(fmt.Sprintf("benchmark_deterministic_%s_%d", strat, npeers), func(b *testing.B) {
+				peers := []string{
+					"http://" + selfAddr,
+				}
+				for i := 1; i < npeers; i++ {
+					peers = append(peers, fmt.Sprintf("http://2.2.2.%d/:8081", i))
+				}
+				config := &config.MockConfig{
+					GetPeerListenAddrVal:   selfAddr,
+					GetPeersVal:            peers,
+					PeerManagementType:     "file",
+					PeerManagementStrategy: strat,
+				}
+				filePeers, err := peer.NewPeers(context.Background(), config)
+				assert.Equal(b, nil, err)
+				sharder := DeterministicSharder{
+					Config: config,
+					Logger: &logger.NullLogger{},
+					Peers:  filePeers,
+				}
+
+				assert.NoError(b, sharder.Start(),
+					"starting deterministic sharder should not error")
+
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					sharder.WhichShard(traceID)
+				}
+			})
+		}
+	}
 }


### PR DESCRIPTION
## Which problem is this PR solving?

The legacy code in Refinery does a deterministic sharding calculation; for every span that comes in, we hash the traceID with SHA1, truncate to generate a 32-bit number, then divide the range by N if there are N shards. If there are 4 shards, the lowest values go to shard 0, the next block goes to shard 1, etc. 

The problem is that if the number of shards changes from 4 to 5, 1/5 of the shards that would have gone to 0 now go to 1. 2/5 of shard 1 now goes to shard 2; 3/5 of shard 2 (more than half!) goes to shard 3, and so forth. On average, half the shards move.

The practical result of this is that when a span arrives just after a change in shard count, there’s a chance that it will end up on a different shard from other spans in the same trace that arrived earlier. The two shards might make different sampling decisions, and therefore we could end up with missing spans in Honeycomb. 

A technique called "[Rendezvous Hashing](https://en.wikipedia.org/wiki/Rendezvous_hashing)" uses a double hash — both the traceID and the shardID are hashed, and then we do a calculation to find which trace should go with which shard. 

There are several algorithms for doing this; all the algorithms seem to be roughly similar in terms of their ability to balance the load among shards. The randomness of traceIDs can lead to variation anyway, so it’s mainly a probabalistic effect.

With one of these algorithms, adding or dropping a new shard usually affects approximately 1/N of the existing traces, where N is the number of shards. This is far better than half! Sometimes, random chance will be unlucky, and it might be closer to 2/N, but in general it's still quite a bit better than the legacy algorithm.

Implementing the new algorithm reduces the probability of being on a different shard from 1/2 to 1/N, which is most meaningful for large installations where N might be 15, 40, or even something like 120. This seems worthwhile.

Note that the point of these algorithms is to allow shard assignment decisions to be made independently by different shards yet generate the same results without requiring any synchronization between shards.

It should be noted that while the legacy sharder is O(1) in its operation, the hash sharder is O(N) where N is the number of partitions (which is either 50 or the number of shards, whichever is greater). It still runs in under a microsecond even with 128 shards.

## Short description of the changes

- Add configuration to choose legacy or hash sharding strategy (default to legacy)
- Update example config to explain it
- Add new sharding strategy
- Add mechanism to select a sharding strategy based on the config
- Add tests to show that it works 
- Add benchmarks to show that it's performant enough

