### PR TITLE
chore: Change workflow to use Collections board

### DIFF
--- a/.github/workflows/add-to-project-v2.yml
+++ b/.github/workflows/add-to-project-v2.yml
@@ -11,5 +11,5 @@ jobs:
     steps:
       - uses: actions/add-to-project@main
         with:
-          project-url: https://github.com/orgs/honeycombio/projects/11
+          project-url: https://github.com/orgs/honeycombio/projects/14
           github-token: ${{ secrets.GHPROJECTS_TOKEN }}


### PR DESCRIPTION
This changes the workflow to use the Collections board instead of the Telemetry team.