### PR TITLE
fix: Fix flaky tests, clean up logic on rules

### DIFF
--- a/config/sampler_config.go
+++ b/config/sampler_config.go
@@ -123,21 +123,12 @@ func tryConvertToFloat(v any) (float64, bool) {
 	}
 }
 
+// In the case of strings, we want to stringize everything we get through a
+// "standard" format, which we are defining as whatever Go does with the %v
+// operator to sprintf. This will make sure that no matter how people encode
+// their values, they compare on an equal footing.
 func tryConvertToString(v any) (string, bool) {
-	switch value := v.(type) {
-	case string:
-		return value, true
-	case int:
-		return strconv.Itoa(value), true
-	case int64:
-		return strconv.FormatInt(value, 10), true
-	case float64:
-		return strconv.FormatFloat(value, 'E', -1, 64), false
-	case bool:
-		return strconv.FormatBool(value), true
-	default:
-		return "", false
-	}
+	return fmt.Sprintf("%v", v), true
 }
 
 func tryConvertToBool(v any) bool {
@@ -357,7 +348,7 @@ func setMatchStringBasedOperators(r *RulesBasedSamplerCondition, condition strin
 	switch condition {
 	case "starts-with":
 		r.Matches = func(spanValue any, exists bool) bool {
-			s, ok := spanValue.(string)
+			s, ok := tryConvertToString(spanValue)
 			if ok {
 				return strings.HasPrefix(s, conditionValue)
 			}
@@ -365,7 +356,7 @@ func setMatchStringBasedOperators(r *RulesBasedSamplerCondition, condition strin
 		}
 	case "contains":
 		r.Matches = func(spanValue any, exists bool) bool {
-			s, ok := spanValue.(string)
+			s, ok := tryConvertToString(spanValue)
 			if ok {
 				return strings.Contains(s, conditionValue)
 			}
@@ -373,7 +364,7 @@ func setMatchStringBasedOperators(r *RulesBasedSamplerCondition, condition strin
 		}
 	case "does-not-contain":
 		r.Matches = func(spanValue any, exists bool) bool {
-			s, ok := spanValue.(string)
+			s, ok := tryConvertToString(spanValue)
 			if ok {
 				return !strings.Contains(s, conditionValue)
 			}

--- a/sample/rules_test.go
+++ b/sample/rules_test.go
@@ -1090,6 +1090,7 @@ func TestRulesDatatypes(t *testing.T) {
 				},
 			},
 			ExpectedKeep: true,
+			ExpectedRate: 10,
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -1118,6 +1119,7 @@ func TestRulesDatatypes(t *testing.T) {
 				},
 			},
 			ExpectedKeep: true,
+			ExpectedRate: 10,
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -1146,6 +1148,7 @@ func TestRulesDatatypes(t *testing.T) {
 				},
 			},
 			ExpectedKeep: true,
+			ExpectedRate: 10,
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -1174,6 +1177,7 @@ func TestRulesDatatypes(t *testing.T) {
 				},
 			},
 			ExpectedKeep: true,
+			ExpectedRate: 10,
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -1202,6 +1206,7 @@ func TestRulesDatatypes(t *testing.T) {
 				},
 			},
 			ExpectedKeep: true,
+			ExpectedRate: 10,
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -1212,8 +1217,8 @@ func TestRulesDatatypes(t *testing.T) {
 						Condition: []*config.RulesBasedSamplerCondition{
 							{
 								Field:    "test",
-								Operator: "=",
-								Value:    "blaaahhhh",
+								Operator: "contains",
+								Value:    "ru",
 								Datatype: "string",
 							},
 						},
@@ -1224,12 +1229,13 @@ func TestRulesDatatypes(t *testing.T) {
 				{
 					Event: types.Event{
 						Data: map[string]interface{}{
-							"test": false,
+							"test": true,
 						},
 					},
 				},
 			},
 			ExpectedKeep: true,
+			ExpectedRate: 10,
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -1258,6 +1264,7 @@ func TestRulesDatatypes(t *testing.T) {
 				},
 			},
 			ExpectedKeep: true,
+			ExpectedRate: 10,
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -1268,7 +1275,7 @@ func TestRulesDatatypes(t *testing.T) {
 						Condition: []*config.RulesBasedSamplerCondition{
 							{
 								Field:    "test",
-								Operator: "=",
+								Operator: "<",
 								Value:    float64(100.01),
 								Datatype: "float",
 							},
@@ -1286,6 +1293,7 @@ func TestRulesDatatypes(t *testing.T) {
 				},
 			},
 			ExpectedKeep: true,
+			ExpectedRate: 10,
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -1314,6 +1322,7 @@ func TestRulesDatatypes(t *testing.T) {
 				},
 			},
 			ExpectedKeep: true,
+			ExpectedRate: 10,
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -1342,6 +1351,7 @@ func TestRulesDatatypes(t *testing.T) {
 				},
 			},
 			ExpectedKeep: true,
+			ExpectedRate: 10,
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -1370,6 +1380,7 @@ func TestRulesDatatypes(t *testing.T) {
 				},
 			},
 			ExpectedKeep: true,
+			ExpectedRate: 10,
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -1380,7 +1391,7 @@ func TestRulesDatatypes(t *testing.T) {
 						Condition: []*config.RulesBasedSamplerCondition{
 							{
 								Field:    "test",
-								Operator: "<",
+								Operator: ">",
 								Value:    "10.3",
 								Datatype: "string",
 							},
@@ -1392,12 +1403,13 @@ func TestRulesDatatypes(t *testing.T) {
 				{
 					Event: types.Event{
 						Data: map[string]interface{}{
-							"test": 9.3,
+							"test": 9.3, // "9.3" is greater than "10.3" when compared as a string
 						},
 					},
 				},
 			},
 			ExpectedKeep: true,
+			ExpectedRate: 10,
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -1426,6 +1438,7 @@ func TestRulesDatatypes(t *testing.T) {
 				},
 			},
 			ExpectedKeep: true,
+			ExpectedRate: 10,
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -1454,6 +1467,7 @@ func TestRulesDatatypes(t *testing.T) {
 				},
 			},
 			ExpectedKeep: true,
+			ExpectedRate: 1,
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -1482,6 +1496,7 @@ func TestRulesDatatypes(t *testing.T) {
 				},
 			},
 			ExpectedKeep: true,
+			ExpectedRate: 10,
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -1509,18 +1524,19 @@ func TestRulesDatatypes(t *testing.T) {
 					},
 				},
 			},
-			ExpectedKeep: false,
+			ExpectedKeep: true,
+			ExpectedRate: 10,
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
 				Rule: []*config.RulesBasedSamplerRule{
 					{
-						Name:       "shouldFail",
+						Name:       "intsNotEqual",
 						SampleRate: 10,
 						Condition: []*config.RulesBasedSamplerCondition{
 							{
 								Field:    "test",
-								Operator: "=",
+								Operator: "!=",
 								Value:    int64(1),
 								Datatype: "int",
 							},
@@ -1532,35 +1548,38 @@ func TestRulesDatatypes(t *testing.T) {
 				{
 					Event: types.Event{
 						Data: map[string]interface{}{
-							"test": int64(1),
+							"test": int64(11),
 						},
 					},
 				},
 			},
-			ExpectedKeep: false,
+			ExpectedKeep: true,
+			ExpectedRate: 10,
 		},
 	}
 
 	for _, d := range data {
-		sampler := &RulesBasedSampler{
-			Config:  d.Rules,
-			Logger:  &logger.NullLogger{},
-			Metrics: &metrics.NullMetrics{},
-		}
+		t.Run(d.Rules.Rule[0].Name, func(t *testing.T) {
+			sampler := &RulesBasedSampler{
+				Config:  d.Rules,
+				Logger:  &logger.NullLogger{},
+				Metrics: &metrics.NullMetrics{},
+			}
 
-		sampler.Start()
+			sampler.Start()
 
-		trace := &types.Trace{}
+			trace := &types.Trace{}
 
-		for _, span := range d.Spans {
-			trace.AddSpan(span)
-		}
+			for _, span := range d.Spans {
+				trace.AddSpan(span)
+			}
 
-		_, keep, _ := sampler.GetSampleRate(trace)
-
-		// // we can only test when we don't expect to keep the trace
-		if !d.ExpectedKeep {
-			assert.Equal(t, d.ExpectedKeep, keep, d.Rules)
-		}
+			rate, keep, _ := sampler.GetSampleRate(trace)
+			assert.Equal(t, d.ExpectedRate, rate, d.Rules)
+			// because keep depends on sampling rate, we can only test expectedKeep when it should be false
+			if !d.ExpectedKeep {
+				assert.Equal(t, d.ExpectedKeep, keep, d.Rules)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Which problem is this PR solving?

- Some of the tests for rules were dependent on random numbers. This fixes that, and also cleans up some of the datatype conversion rules to work in more cases

## Short description of the changes

- Fix tests to check both the keep and rate values
- Fix logic in some tests
- Change `tryConvertToString` to just use sprintf("%v"), even for strings, for consistency
- fix string operators to use tryConvertToString everywhere

