### PR TITLE
fix: Remove API key logging

### DIFF
--- a/route/route.go
+++ b/route/route.go
@@ -846,7 +846,7 @@ func (r *Router) lookupEnvironment(apiKey string) (string, error) {
 
 	req.Header.Set("x-Honeycomb-team", apiKey)
 
-	r.Logger.Debug().WithString("api_key", apiKey).WithString("endpoint", authURL.String()).Logf("Attempting to get environment name using API key")
+	r.Logger.Debug().WithString("endpoint", authURL.String()).Logf("Attempting to get environment name using API key")
 	resp, err := r.proxyClient.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("failed sending AuthInfo request to Honeycomb API. %w", err)


### PR DESCRIPTION
## Which problem is this PR solving?

- A customer noticed that one of our debug log includes the plaintext API key 

## Short description of the changes

- removes an api key from a debug log

