### PR TITLE
refactor: Change Router to use TraceServer

### DIFF
--- a/route/otlp_trace_test.go
+++ b/route/otlp_trace_test.go
@@ -73,7 +73,8 @@ func TestOTLPHandler(t *testing.T) {
 				}},
 			}},
 		}
-		_, err := router.Export(ctx, req)
+		traceServer := NewTraceServer(router)
+		_, err := traceServer.Export(ctx, req)
 		if err != nil {
 			t.Errorf(`Unexpected error: %s`, err)
 		}
@@ -89,7 +90,8 @@ func TestOTLPHandler(t *testing.T) {
 				}},
 			}},
 		}
-		_, err := router.Export(ctx, req)
+		traceServer := NewTraceServer(router)
+		_, err := traceServer.Export(ctx, req)
 		if err != nil {
 			t.Errorf(`Unexpected error: %s`, err)
 		}
@@ -122,7 +124,8 @@ func TestOTLPHandler(t *testing.T) {
 				}},
 			}},
 		}
-		_, err := router.Export(ctx, req)
+		traceServer := NewTraceServer(router)
+		_, err := traceServer.Export(ctx, req)
 		if err != nil {
 			t.Errorf(`Unexpected error: %s`, err)
 		}
@@ -171,7 +174,8 @@ func TestOTLPHandler(t *testing.T) {
 				}},
 			}},
 		}
-		_, err := router.Export(ctx, req)
+		traceServer := NewTraceServer(router)
+		_, err := traceServer.Export(ctx, req)
 		if err != nil {
 			t.Errorf(`Unexpected error: %s`, err)
 		}
@@ -337,7 +341,8 @@ func TestOTLPHandler(t *testing.T) {
 				}},
 			}},
 		}
-		_, err := router.Export(ctx, req)
+		traceServer := NewTraceServer(router)
+		_, err := traceServer.Export(ctx, req)
 		if err != nil {
 			t.Errorf(`Unexpected error: %s`, err)
 		}
@@ -370,7 +375,8 @@ func TestOTLPHandler(t *testing.T) {
 				}},
 			}},
 		}
-		_, err := router.Export(ctx, req)
+		traceServer := NewTraceServer(router)
+		_, err := traceServer.Export(ctx, req)
 		if err != nil {
 			t.Errorf(`Unexpected error: %s`, err)
 		}

--- a/route/route.go
+++ b/route/route.go
@@ -82,9 +82,6 @@ type Router struct {
 	grpcServer *grpc.Server
 	doneWG     sync.WaitGroup
 
-	// used to identify Router as a OTLP TraceServer
-	collectortrace.UnimplementedTraceServiceServer
-
 	environmentCache *environmentCache
 }
 
@@ -229,8 +226,9 @@ func (r *Router) LnS(incomingOrPeer string) {
 				Timeout:               r.Config.GetGRPCTimeout(),
 			}),
 		}
+		traceServer := NewTraceServer(r)
 		r.grpcServer = grpc.NewServer(serverOpts...)
-		collectortrace.RegisterTraceServiceServer(r.grpcServer, r)
+		collectortrace.RegisterTraceServiceServer(r.grpcServer, traceServer)
 		grpc_health_v1.RegisterHealthServer(r.grpcServer, r)
 		go r.grpcServer.Serve(l)
 	}


### PR DESCRIPTION
## Which problem is this PR solving?

- Updates Refinery to use the gRPC server pattern that Shepherd uses.  This will allow us to add support for metrics and logs proxying in the future.

## Short description of the changes

- Adds new TraceServer that implements the `TraceServiceServer` interface.
- Unimplement `TraceServiceServer` for `Router`.

