### PR TITLE
chore: Publish every build to honeycomb's ecr

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,7 +150,8 @@ jobs:
           command: ./build-docker.sh
 
   publish_docker_to_ecr:
-    executor: aws-cli/default
+    docker:
+      - image: cimg/go:1.19
     steps:
       - setup_googleko
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,8 @@ commands:
       - restore_cache:
           keys:
             - v1-googleko
-      - run: go install github.com/google/ko@latest
+      # we're pinning to ko 11.2 because it v0.12 can't push to ecr
+      - run: go install github.com/google/ko@v0.11.2
       - save_cache:
           key: v1-googleko
           paths:
@@ -167,7 +168,7 @@ jobs:
 
             export TAG="$(test "${CIRCLE_BRANCH}" == "main" && echo "" || echo "branch-")${BUILD_ID}"
             export ECR_HOST=702835727665.dkr.ecr.us-east-1.amazonaws.com
-            export KO_DOCKER_REPO=${ECR_HOST}/refinery
+            export KO_DOCKER_REPO=${ECR_HOST}
 
             aws ecr get-login-password --region us-east-1 \
               | docker login --username AWS --password-stdin "${ECR_HOST}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,10 +166,11 @@ jobs:
 
             export TAG="$(test "${CIRCLE_BRANCH}" == "main" && echo "" || echo "branch-")${BUILD_ID}"
             export ECR_HOST=702835727665.dkr.ecr.us-east-1.amazonaws.com
+            export KO_DOCKER_REPO=${ECR_HOST}
 
             aws ecr get-login-password --region us-east-1 \
               | docker login --username AWS --password-stdin "${ECR_HOST}"
-            docker push ${ECR_HOST}/refinery-artifact:${TAG}
+            ./build-docker.sh
 
   publish_docker_to_dockerhub:
     docker:
@@ -183,7 +184,7 @@ jobs:
           environment:
             KO_DOCKER_REPO: honeycombio
           command: |
-            echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin;
+            echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
             ./build-docker.sh
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,7 +167,7 @@ jobs:
 
             export TAG="$(test "${CIRCLE_BRANCH}" == "main" && echo "" || echo "branch-")${BUILD_ID}"
             export ECR_HOST=702835727665.dkr.ecr.us-east-1.amazonaws.com
-            export KO_DOCKER_REPO=${ECR_HOST}
+            export KO_DOCKER_REPO=${ECR_HOST}/refinery
 
             aws ecr get-login-password --region us-east-1 \
               | docker login --username AWS --password-stdin "${ECR_HOST}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,6 +158,7 @@ jobs:
           aws-access-key-id: AWS_ACCESS_KEY_ID
           aws-secret-access-key: AWS_SECRET_ACCESS_KEY
           aws-region: AWS_REGION
+      - setup_remote_docker
       - run:
           name: publish docker image to aws ecr
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,16 +159,16 @@ jobs:
           aws-secret-access-key: AWS_SECRET_ACCESS_KEY
           aws-region: AWS_REGION
       - run:
-        name: publish docker image to aws ecr
-        command: |
-          set -x
+          name: publish docker image to aws ecr
+          command: |
+            set -x
 
-          export TAG="$(test "${CIRCLE_BRANCH}" == "main" && echo "" || echo "branch-")${BUILD_ID}"
-          export ECR_HOST=702835727665.dkr.ecr.us-east-1.amazonaws.com
+            export TAG="$(test "${CIRCLE_BRANCH}" == "main" && echo "" || echo "branch-")${BUILD_ID}"
+            export ECR_HOST=702835727665.dkr.ecr.us-east-1.amazonaws.com
 
-          aws ecr get-login-password --region us-east-1 \
-            | docker login --username AWS --password-stdin "${ECR_HOST}"
-          docker push ${ECR_HOST}/refinery-artifact:${TAG}
+            aws ecr get-login-password --region us-east-1 \
+              | docker login --username AWS --password-stdin "${ECR_HOST}"
+            docker push ${ECR_HOST}/refinery-artifact:${TAG}
 
   publish_docker_to_dockerhub:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,13 +152,13 @@ jobs:
   publish_docker_to_ecr:
     executor: aws-cli/default
     steps:
-      - attach_workspace:
-          at: ~/
+      - setup_googleko
+      - checkout
+      - setup_remote_docker
       - aws-cli/setup:
           aws-access-key-id: AWS_ACCESS_KEY_ID
           aws-secret-access-key: AWS_SECRET_ACCESS_KEY
           aws-region: AWS_REGION
-      - setup_remote_docker
       - run:
           name: publish docker image to aws ecr
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,7 +149,28 @@ jobs:
           name: build docker images and publish locally
           command: ./build-docker.sh
 
-  publish_docker:
+  publish_docker_to_ecr:
+    executor: aws-cli/default
+    steps:
+      - attach_workspace:
+          at: ~/
+      - aws-cli/setup:
+          aws-access-key-id: AWS_ACCESS_KEY_ID
+          aws-secret-access-key: AWS_SECRET_ACCESS_KEY
+          aws-region: AWS_REGION
+      - run:
+        name: publish docker image to aws ecr
+        command: |
+          set -x
+
+          export TAG="$(test "${CIRCLE_BRANCH}" == "main" && echo "" || echo "branch-")${BUILD_ID}"
+          export ECR_HOST=702835727665.dkr.ecr.us-east-1.amazonaws.com
+
+          aws ecr get-login-password --region us-east-1 \
+            | docker login --username AWS --password-stdin "${ECR_HOST}"
+          docker push ${ECR_HOST}/refinery-artifact:${TAG}
+
+  publish_docker_to_dockerhub:
     docker:
       - image: cimg/go:1.19
     steps:
@@ -183,6 +204,14 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - publish_docker_to_ecr:
+          context: Honeycomb Secrets for Public Repos
+          requires:
+            - build_binaries
+            - build_docker
+          filters:
+            tags:
+              only: /.*/
       - publish_github:
           context: Honeycomb Secrets for Public Repos
           requires:
@@ -203,7 +232,7 @@ workflows:
               only: /^v.*/
             branches:
               ignore: /.*/
-      - publish_docker:
+      - publish_docker_to_dockerhub:
           context: Honeycomb Secrets for Public Repos
           requires:
             - build_binaries


### PR DESCRIPTION
## Which problem is this PR solving?

- We want every build of refinery to get published to Honeycomb's ECR, so that we can deploy from there to internal sources.

## Short description of the changes

- Adds a new task to CircleCI and runs it on every commit.

