### PR TITLE
feat: Add ability to set Redis database and prefix in config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -57,6 +57,9 @@ type Config interface {
 	// management.
 	GetRedisPassword() (string, error)
 
+	// GetRedisDatabase returns the ID of the Redis database to use for peer management.
+	GetRedisDatabase() int
+
 	// GetUseTLS returns true when TLS must be enabled to dial the Redis instance to
 	// use for peer management.
 	GetUseTLS() (bool, error)

--- a/config/config.go
+++ b/config/config.go
@@ -57,6 +57,10 @@ type Config interface {
 	// management.
 	GetRedisPassword() (string, error)
 
+	// GetRedisPrefix returns the prefix string used in the keys for peer
+	// management.
+	GetRedisPrefix() string
+
 	// GetRedisDatabase returns the ID of the Redis database to use for peer management.
 	GetRedisDatabase() int
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -77,6 +77,23 @@ func TestRedisPasswordEnvVar(t *testing.T) {
 	}
 }
 
+func TestRedisDatabaseEnvVar(t *testing.T) {
+	const db = "7"
+	const envVarName = "REFINERY_REDIS_DATABASE"
+	os.Setenv(envVarName, db)
+	defer os.Unsetenv(envVarName)
+
+	c, err := NewConfig("../config.toml", "../rules.toml", func(err error) {})
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if d := c.GetRedisDatabase(); d != 7 {
+		t.Error("received", d, "expected", 7)
+	}
+}
+
 func TestMetricsAPIKeyEnvVar(t *testing.T) {
 	testCases := []struct {
 		name   string
@@ -379,6 +396,7 @@ func TestPeerManagementType(t *testing.T) {
 	[PeerManagement]
 		Type = "redis"
 		Peers = ["http://refinery-1231:8080"]
+		RedisDatabase = 9
 	`, "")
 	defer os.Remove(rules)
 	defer os.Remove(config)
@@ -388,6 +406,10 @@ func TestPeerManagementType(t *testing.T) {
 
 	if d, _ := c.GetPeerManagementType(); d != "redis" {
 		t.Error("received", d, "expected", "redis")
+	}
+
+	if db := c.GetRedisDatabase(); db != 9 {
+		t.Error("received", db, "expected", 9)
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -77,23 +77,6 @@ func TestRedisPasswordEnvVar(t *testing.T) {
 	}
 }
 
-func TestRedisDatabaseEnvVar(t *testing.T) {
-	const db = "7"
-	const envVarName = "REFINERY_REDIS_DATABASE"
-	os.Setenv(envVarName, db)
-	defer os.Unsetenv(envVarName)
-
-	c, err := NewConfig("../config.toml", "../rules.toml", func(err error) {})
-
-	if err != nil {
-		t.Error(err)
-	}
-
-	if d := c.GetRedisDatabase(); d != 7 {
-		t.Error("received", d, "expected", 7)
-	}
-}
-
 func TestMetricsAPIKeyEnvVar(t *testing.T) {
 	testCases := []struct {
 		name   string
@@ -396,6 +379,7 @@ func TestPeerManagementType(t *testing.T) {
 	[PeerManagement]
 		Type = "redis"
 		Peers = ["http://refinery-1231:8080"]
+		RedisPrefix = "testPrefix"
 		RedisDatabase = 9
 	`, "")
 	defer os.Remove(rules)
@@ -406,6 +390,10 @@ func TestPeerManagementType(t *testing.T) {
 
 	if d, _ := c.GetPeerManagementType(); d != "redis" {
 		t.Error("received", d, "expected", "redis")
+	}
+
+	if s := c.GetRedisPrefix(); s != "testPrefix" {
+		t.Error("received", s, "expected", "testPrefix")
 	}
 
 	if db := c.GetRedisDatabase(); db != 9 {

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -100,7 +100,8 @@ type PeerManagementConfig struct {
 	RedisHost               string
 	RedisUsername           string
 	RedisPassword           string
-	RedisDatabase           int `validate:"gte=0,lte=15"`
+	RedisPrefix             string `validate:"required"`
+	RedisDatabase           int    `validate:"gte=0,lte=15"`
 	UseTLS                  bool
 	UseTLSInsecure          bool
 	IdentifierInterfaceName string
@@ -145,7 +146,6 @@ func NewConfig(config, rules string, errorCallback func(error)) (Config, error) 
 	c.BindEnv("PeerManagement.RedisHost", "REFINERY_REDIS_HOST")
 	c.BindEnv("PeerManagement.RedisUsername", "REFINERY_REDIS_USERNAME")
 	c.BindEnv("PeerManagement.RedisPassword", "REFINERY_REDIS_PASSWORD")
-	c.BindEnv("PeerManagement.RedisDatabase", "REFINERY_REDIS_DATABASE")
 	c.BindEnv("HoneycombLogger.LoggerAPIKey", "REFINERY_HONEYCOMB_API_KEY")
 	c.BindEnv("HoneycombMetrics.MetricsAPIKey", "REFINERY_HONEYCOMB_METRICS_API_KEY", "REFINERY_HONEYCOMB_API_KEY")
 	c.BindEnv("QueryAuthToken", "REFINERY_QUERY_AUTH_TOKEN")
@@ -154,6 +154,7 @@ func NewConfig(config, rules string, errorCallback func(error)) (Config, error) 
 	c.SetDefault("CompressPeerCommunication", true)
 	c.SetDefault("APIKeys", []string{"*"})
 	c.SetDefault("PeerManagement.Peers", []string{"http://127.0.0.1:8081"})
+	c.SetDefault("PeerManagement.RedisPrefix", "refinery")
 	c.SetDefault("PeerManagement.Type", "file")
 	c.SetDefault("PeerManagement.UseTLS", false)
 	c.SetDefault("PeerManagement.UseTLSInsecure", false)
@@ -507,6 +508,13 @@ func (f *fileConfig) GetRedisUsername() (string, error) {
 	defer f.mux.RUnlock()
 
 	return f.config.GetString("PeerManagement.RedisUsername"), nil
+}
+
+func (f *fileConfig) GetRedisPrefix() string {
+	f.mux.RLock()
+	defer f.mux.RUnlock()
+
+	return f.config.GetString("PeerManagement.RedisPrefix")
 }
 
 func (f *fileConfig) GetRedisPassword() (string, error) {

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -100,6 +100,7 @@ type PeerManagementConfig struct {
 	RedisHost               string
 	RedisUsername           string
 	RedisPassword           string
+	RedisDatabase           int `validate:"gte=0,lte=15"`
 	UseTLS                  bool
 	UseTLSInsecure          bool
 	IdentifierInterfaceName string
@@ -144,6 +145,7 @@ func NewConfig(config, rules string, errorCallback func(error)) (Config, error) 
 	c.BindEnv("PeerManagement.RedisHost", "REFINERY_REDIS_HOST")
 	c.BindEnv("PeerManagement.RedisUsername", "REFINERY_REDIS_USERNAME")
 	c.BindEnv("PeerManagement.RedisPassword", "REFINERY_REDIS_PASSWORD")
+	c.BindEnv("PeerManagement.RedisDatabase", "REFINERY_REDIS_DATABASE")
 	c.BindEnv("HoneycombLogger.LoggerAPIKey", "REFINERY_HONEYCOMB_API_KEY")
 	c.BindEnv("HoneycombMetrics.MetricsAPIKey", "REFINERY_HONEYCOMB_METRICS_API_KEY", "REFINERY_HONEYCOMB_API_KEY")
 	c.BindEnv("QueryAuthToken", "REFINERY_QUERY_AUTH_TOKEN")
@@ -512,6 +514,13 @@ func (f *fileConfig) GetRedisPassword() (string, error) {
 	defer f.mux.RUnlock()
 
 	return f.config.GetString("PeerManagement.RedisPassword"), nil
+}
+
+func (f *fileConfig) GetRedisDatabase() int {
+	f.mux.RLock()
+	defer f.mux.RUnlock()
+
+	return f.config.GetInt("PeerManagement.RedisDatabase")
 }
 
 func (f *fileConfig) GetUseTLS() (bool, error) {

--- a/config/mock.go
+++ b/config/mock.go
@@ -42,6 +42,7 @@ type MockConfig struct {
 	GetRedisUsernameVal           string
 	GetRedisPasswordErr           error
 	GetRedisPasswordVal           string
+	GetRedisDatabaseVal           int
 	GetUseTLSErr                  error
 	GetUseTLSVal                  bool
 	GetUseTLSInsecureErr          error
@@ -222,6 +223,13 @@ func (m *MockConfig) GetRedisPassword() (string, error) {
 	defer m.Mux.RUnlock()
 
 	return m.GetRedisPasswordVal, m.GetRedisPasswordErr
+}
+
+func (m *MockConfig) GetRedisDatabase() int {
+	m.Mux.RLock()
+	defer m.Mux.RUnlock()
+
+	return m.GetRedisDatabaseVal
 }
 
 func (m *MockConfig) GetUseTLS() (bool, error) {

--- a/config/mock.go
+++ b/config/mock.go
@@ -43,6 +43,7 @@ type MockConfig struct {
 	GetRedisPasswordErr           error
 	GetRedisPasswordVal           string
 	GetRedisDatabaseVal           int
+	GetRedisPrefixVal             string
 	GetUseTLSErr                  error
 	GetUseTLSVal                  bool
 	GetUseTLSInsecureErr          error
@@ -223,6 +224,13 @@ func (m *MockConfig) GetRedisPassword() (string, error) {
 	defer m.Mux.RUnlock()
 
 	return m.GetRedisPasswordVal, m.GetRedisPasswordErr
+}
+
+func (m *MockConfig) GetRedisPrefix() string {
+	m.Mux.RLock()
+	defer m.Mux.RUnlock()
+
+	return m.GetRedisPrefixVal
 }
 
 func (m *MockConfig) GetRedisDatabase() int {

--- a/config_complete.toml
+++ b/config_complete.toml
@@ -219,6 +219,14 @@ Metrics = "honeycomb"
 # Not eligible for live reload.
 # RedisPassword = ""
 
+# RedisDatabase is an integer indicating the database number to use for the Redis instance storing
+# the peer membership. It might be useful to set this in any situation where multiple refinery clusters
+# or multiple applications want to share a single Redis instance.
+# If the environment variable 'REFINERY_REDIS_DATABASE' is set it takes
+# precedence and this value is ignored.
+# Default = 0
+# RedisDatabase = 1
+
 # UseTLS enables TLS when connecting to redis for peer cluster membership management, and sets the MinVersion to 1.2.
 # Not eligible for live reload.
 # UseTLS = false

--- a/config_complete.toml
+++ b/config_complete.toml
@@ -220,14 +220,16 @@ Metrics = "honeycomb"
 # RedisPassword = ""
 
 # RedisPrefix is a string used as a prefix for the keys in redis while storing
-# the peer membership. It might be useful to set this in any situation where multiple refinery clusters
-# or multiple applications want to share a single Redis instance. It may not be blank.
+# the peer membership. It might be useful to set this in any situation where
+# multiple refinery clusters or multiple applications want to share a single
+# Redis instance. It may not be blank.
 # Default = "refinery"
 # RedisPrefix = "customPrefix"
 
-# RedisDatabase is an integer indicating the database number to use for the Redis instance storing
-# the peer membership. It might be useful to set this in any situation where multiple refinery clusters
-# or multiple applications want to share a single Redis instance.
+# RedisDatabase is an integer from 0-15 indicating the database number to use
+# for the Redis instance storing the peer membership. It might be useful to set
+# this in any situation where multiple refinery clusters or multiple
+# applications want to share a single Redis instance.
 # Default = 0
 # RedisDatabase = 1
 

--- a/config_complete.toml
+++ b/config_complete.toml
@@ -219,11 +219,15 @@ Metrics = "honeycomb"
 # Not eligible for live reload.
 # RedisPassword = ""
 
+# RedisPrefix is a string used as a prefix for the keys in redis while storing
+# the peer membership. It might be useful to set this in any situation where multiple refinery clusters
+# or multiple applications want to share a single Redis instance. It may not be blank.
+# Default = "refinery"
+# RedisPrefix = "customPrefix"
+
 # RedisDatabase is an integer indicating the database number to use for the Redis instance storing
 # the peer membership. It might be useful to set this in any situation where multiple refinery clusters
 # or multiple applications want to share a single Redis instance.
-# If the environment variable 'REFINERY_REDIS_DATABASE' is set it takes
-# precedence and this value is ignored.
 # Default = 0
 # RedisDatabase = 1
 

--- a/internal/peer/redis.go
+++ b/internal/peer/redis.go
@@ -91,7 +91,7 @@ func newRedisPeers(ctx context.Context, c config.Config, done chan struct{}) (Pe
 
 	peers := &redisPeers{
 		store: &redimem.RedisMembership{
-			Prefix: "refinery",
+			Prefix: c.GetRedisPrefix(),
 			Pool:   pool,
 		},
 		peers:      make([]string, 1),

--- a/internal/peer/redis.go
+++ b/internal/peer/redis.go
@@ -225,7 +225,7 @@ func buildOptions(c config.Config) []redis.DialOption {
 	options := []redis.DialOption{
 		redis.DialReadTimeout(1 * time.Second),
 		redis.DialConnectTimeout(1 * time.Second),
-		redis.DialDatabase(0), // TODO enable multiple databases for multiple samproxies
+		redis.DialDatabase(c.GetRedisDatabase()),
 	}
 
 	username, _ := c.GetRedisUsername()


### PR DESCRIPTION
## Which problem is this PR solving?

In a blue/green deployment model, two refinery clusters might want to share the same instance of redis. It's also possible that multiple apps want to share one redis. This permits that by:
- allowing the redis "database" (an integer from 0-15) to be specified in the configuration
- allowing the redis "prefix" (a string used in the name of the keys stored in redis) to be set as well. It already existed but was hardcoded to "refinery".

## Short description of the changes

- Add RedisDatabase and RedisPrefix to the PeerManagement section of config.
- Add tests
- Add documentation

Fixes #544 