### PR TITLE
chore: publish should only happen on main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,8 +214,8 @@ workflows:
             - build_binaries
             - build_docker
           filters:
-            tags:
-              only: /.*/
+            branches:
+              only: main
       - publish_github:
           context: Honeycomb Secrets for Public Repos
           requires:


### PR DESCRIPTION
## Which problem is this PR solving?

- The ECR publish should only happen on pushes to main, for two reasons:
  -  not every branch (like dependabot's branches) has a right to do it
  - we deploy on push to main, and that's what uses this publish

## Short description of the changes

- change workflow so it only applies to the main branch

