### PR TITLE
fix: correct syntax error in config_complete.toml

### DIFF
--- a/config_complete.toml
+++ b/config_complete.toml
@@ -573,7 +573,7 @@ MetricsReportingInterval = 3
 # enabled, once activated. This prevents oscillations.
 # Default = 10s
 # Eligible for live reload.
-# MinimumActivationDuration = 10s
+# MinimumActivationDuration = "10s"
 
 # MinimumStartupDuration is used when switching into Monitor mode.
 # When stress monitoring is enabled, it will start up in stressed mode for a
@@ -582,7 +582,7 @@ MetricsReportingInterval = 3
 # problem of trying to bring a new node into an already-overloaded
 # cluster. If this duration is 0, Refinery will not start in stressed mode.
 # This can provide faster startup at the possible cost of startup instability.
-# MinimumStartupDuration = 3s
+# MinimumStartupDuration = "3s"
 
 
 # AdditionalAttributes is a map that can be used for injecting user-defined


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

This PR fixes a small syntax error in the `config_complete.toml` file.
It's not a huge deal, but I tend to uncomment lines and go from there and didn't read the line closely enough before uncommenting it; I suspect another tired person would make a similar mistake :)

## Short description of the changes

It makes the strings stringier
