### PR TITLE
maint: Add labels to docker image

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -21,4 +21,7 @@ ko publish \
   --tags "${TAGS}" \
   --base-import-paths \
   --platform "linux/amd64,linux/arm64" \
+  --image-label org.opencontainers.image.source=https://github.com/honeycombio/refinery \
+  --image-label org.opencontainers.image.licenses=Apache-2.0 \
+  --image-label org.opencontainers.image.revision=${CIRCLE_SHA1} \
   ./cmd/refinery


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Adds labels to the built images

## Short description of the changes

- adds 3 new labels to the built images
- tested these additions in https://github.com/honeycombio/honeycomb-kubernetes-agent/pull/354.  I don't really want to run the same steps for Refinery since they are risky and Refinery's build is more complicated so there is more risk of publishing an incorrect image.
