### PR TITLE
ci: add permissions

### DIFF
--- a/.github/workflows/apply-labels.yml
+++ b/.github/workflows/apply-labels.yml
@@ -4,6 +4,9 @@ jobs:
   apply-labels:
     runs-on: ubuntu-latest
     name: Apply common project labels
+    permissions:
+      pull-requests: write
+
     steps:
       - uses: honeycombio/oss-management-actions/labels@v1
         with:

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -11,6 +11,9 @@ jobs:
   main:
     name: Validate PR title
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
     steps:
       - uses: amannn/action-semantic-pull-request@v5
         id: lint_pr_title


### PR DESCRIPTION
## Which problem is this PR solving?

Workflows that require write permissions need to declare them, otherwise they will fail in repositories with more conservative default permissions (`read`)

## Short description of the changes

- specify `pull-requests: write`