### PR TITLE
fix: Remove Stop() function from stress relief

### DIFF
--- a/collect/stressRelief.go
+++ b/collect/stressRelief.go
@@ -106,11 +106,6 @@ func (s *StressRelief) Start() error {
 	return nil
 }
 
-func (s *StressRelief) Stop() error {
-	close(s.Done)
-	return nil
-}
-
 func (s *StressRelief) UpdateFromConfig(cfg config.StressReliefConfig) error {
 	s.lock.Lock()
 	defer s.lock.Unlock()


### PR DESCRIPTION
## Which problem is this PR solving?

- A customer saw refinery crashes due to trying to close the StressRelief.Done channel twice.

## Short description of the changes

- Remove Stop() function, which was implemented to let the injection system shut down Stress Relief (symmetric to Start()). We don't need it, because the only thing it did was close the Done channel. The Done channel is closed externally by main() during shutdown and you can't close a channel more than once. This will prevent a confusing crash on shutdown.


