### PR TITLE
docs: Use correct config section name for sample cache (do not merge)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -95,7 +95,7 @@ Example:
 
 Refinery keeps a record of its trace decisions -- whether it kept or dropped a given trace. Past versions of refinery had a trace decision cache that was fixed to 5x the size of the trace cache. In v1.20, Refinery has a new cache strategy (called "cuckoo") that separates drop decisions (where all it needs to remember is that the trace was dropped) from kept decisions (where it also tracks some metadata about the trace, such as the number of spans in the trace). It can now cache millions of drop decisions, and many thousands of kept decisions, which should help ensure trace integrity for users with long-lived traces.
 
-It is controlled by the [SampleCacheConfig](https://github.com/honeycombio/refinery/blob/main/config_complete.toml#L466) section of the config file.
+It is controlled by the [SampleCache](https://github.com/honeycombio/refinery/blob/main/config_complete.toml#L466) section of the config file.
 
 To turn it on, set `Type = "cuckoo"`. For compatibility, it is disabled by default.
 

--- a/config_complete.toml
+++ b/config_complete.toml
@@ -470,7 +470,7 @@ MetricsReportingInterval = 30
 # Sample Cache Configuration controls the sample cache used to retain information about trace
 # status after the sampling decision has been made.
 
-[SampleCacheConfig]
+[SampleCache]
 
 # Type controls the type of sample cache used.
 # "legacy" is a strategy where both keep and drop decisions are stored in a circular buffer that is


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

The example configuration given in `config_complete.toml` didn't seem to turn on the cuckoo cache strategy when I uncommented the `Type` value and set it appropriately. After some digging, I found that [the code appears to look for `SampleCache` rather than `SampleCacheConfig`](https://github.com/honeycombio/refinery/blob/main/config/file_config.go#L709) (which is contained in the example file). When I changed my local config to use `SampleCache`, I saw my local installation pick up the config values and start using the new cache strategy. I assume this was a typo (it does match the name of implementation details in refinery itself).

## Short description of the changes

* Change `SampleCacheConfig` to `SampleCache` in `config_complete.toml`
* Change `SampleCacheConfig` to `SampleCache` in the release notes
