### PR TITLE
fix: Various config fixes

### DIFF
--- a/tools/convert/config.md
+++ b/tools/convert/config.md
@@ -6,7 +6,9 @@ This is the documentation for the configuration file for Honeycomb's Refinery.
 ## General: General Configuration
 
 Contains general configuration options that apply to the entire 
-refinery process. ### ConfigurationVersion
+refinery process. 
+
+### ConfigurationVersion
 
 ConfigurationVersion is the file format of this particular 
 configuration file. 
@@ -43,7 +45,9 @@ Default: `v2.0`
 ---
 ## Network: Network Configuration
 
-Contains network configuration options. ### ListenAddr
+Contains network configuration options. 
+
+### ListenAddr
 
 ListenAddr is the address refinery listens to for incoming requests. 
 
@@ -99,7 +103,9 @@ Default: `https://api.honeycomb.io`
 
 Contains access keys -- API keys that the proxy will treat specially, 
 and other flags that control how the proxy handles API keys. 
- ### ReceiveKeys
+ 
+
+### ReceiveKeys
 
 ReceiveKeys is a set of Honeycomb API keys that the proxy will treat 
 specially. 
@@ -137,15 +143,18 @@ Type: `bool`
 ## RefineryTelemetry: Refinery Telemetry
 
 Configuration info for the telemetry that Refinery uses to record its 
-own operation. ### AddRuleReasonToTrace
+own operation. 
+
+### AddRuleReasonToTrace
 
 AddRuleReasonToTrace controls whether to decorate traces with refinery 
 rule evaluation results. 
 
 AddRuleReasonToTrace causes traces that are sent to Honeycomb to 
-include the field `meta.refinery.reason`. This field contains text 
-indicating which rule was evaluated that caused the trace to be 
-included. 
+include the field `meta.refinery.reason`, indicating which sampler 
+made the decision to keep the trace. For samplers that use a key to 
+make their decision, the key is also included in the field 
+`meta.refinery.sampler_key`. 
  
 
 Eligible for live reload.
@@ -196,7 +205,9 @@ Default: `true`
 ---
 ## Traces: Traces
 
-Configuration for how traces are managed. ### SendDelay
+Configuration for how traces are managed. 
+
+### SendDelay
 
 SendDelay is the duration to wait before sending a trace. 
 
@@ -289,7 +300,9 @@ Default: `100ms`
 ---
 ## Debugging: Debugging
 
-Configuration values used when setting up and debugging Refinery. ### DebugServiceAddr
+Configuration values used when setting up and debugging Refinery. 
+
+### DebugServiceAddr
 
 DebugServiceAddr is the IP and port the debug service will run on. 
 
@@ -366,10 +379,32 @@ Type: `bool`
 
 Example: `true`
 
+### DryRun
+
+DryRun controls whether sampling is applied to incoming traces. 
+
+If enabled, marks the traces that would be dropped given the current 
+sampling rules, and sends all traces regardless of the sampling 
+decision. This is useful for evaluating sampling rules. In DryRun 
+mode, traces will be decorated with meta.refinery.dryrun.enabled set 
+to true. In addition, SampleRate will be set to the incoming rate for 
+all traces, and the field meta.refinery.dryrun.sample_rate will be set 
+to the sample rate that would have been used. 
+ 
+
+Eligible for live reload.
+
+Type: `bool`
+
+
+Example: `true`
+
 ---
 ## Logger: Refinery Logger
 
-Configuration for logging. ### Type
+Configuration for logging. 
+
+### Type
 
 Type is the type of logger to use. 
 
@@ -407,7 +442,9 @@ Options: debug info warn error panic
 ## HoneycombLogger: Honeycomb Logger
 
 Configuration for logging to Honeycomb. Only used if Logger.Type is 
-"honeycomb". ### APIHost
+"honeycomb". 
+
+### APIHost
 
 APIHost is the URL of the Honeycomb API to which logs will be sent. 
 
@@ -485,13 +522,15 @@ Not eligible for live reload.
 Type: `float`
 
 Default: `10`
-
+Example: `10`
 
 ---
 ## StdoutLogger: Stdout Logger
 
 Configuration for logging to stdout. Only used if Logger.Type is 
-"stdout". ### Structured
+"stdout". 
+
+### Structured
 
 Structured controls whether to used structured logging. 
 
@@ -510,7 +549,9 @@ Type: `bool`
 ## PrometheusMetrics: Prometheus Metrics
 
 Configuration for Refinery's internally-generated metrics as made 
-available through Prometheus. ### Enabled
+available through Prometheus. 
+
+### Enabled
 
 Enabled controls whether to expose refinery metrics over 
 PromethusListenAddr 
@@ -549,7 +590,9 @@ Default: `localhost:2112`
 Configuration for Refinery's legacy metrics. Version 1.x of Refinery 
 used this configuration for sending Metrics to Honeycomb. The metrics 
 generated that way are nonstandard and will be deprecated in a future 
-release. New installations should prefer OTelMetrics. ### Enabled
+release. New installations should prefer OTelMetrics. 
+
+### Enabled
 
 Enabled controls whether to send metrics to Honeycomb. 
 
@@ -631,10 +674,14 @@ Default: `30s`
 Configuration for Refinery's OpenTelemetry metrics. This is the 
 preferred way to send metrics to Honeycomb. New installations should 
 prefer OTelMetrics. 
- ---
+ 
+
+---
 ## PeerManagement: Peer Management
 
-Controls how the Refinery cluster communicates between peers. ### Type
+Controls how the Refinery cluster communicates between peers. 
+
+### Type
 
 Type is the type of peer management to use. 
 
@@ -731,7 +778,9 @@ Example: `192.168.1.11:8081,192.168.1.12:8081`
 
 Controls how the Refinery cluster communicates between peers when 
 using Redis. Only applies when PeerManagement.Type is "redis" 
- ### Host
+ 
+
+### Host
 
 Host is the host and port of the redis instance to use. 
 
@@ -862,7 +911,9 @@ Default: `5s`
 
 Brings together the settings that are relevant to collecting spans 
 together to make traces. 
- ### CacheCapacity
+ 
+
+### CacheCapacity
 
 CacheCapacity is the number of traces to keep in the cache's circular 
 buffer. 
@@ -903,7 +954,7 @@ Eligible for live reload.
 Type: `percentage`
 
 Default: `75`
-
+Example: `75`
 
 ### MaxAlloc
 
@@ -926,7 +977,9 @@ Type: `int`
 
 Brings together the settings that are relevant to the sizes of 
 communications buffers. 
- ### UpstreamBufferSize
+ 
+
+### UpstreamBufferSize
 
 UpstreamBufferSize is the size of the queue used to buffer spans to 
 send to the upstream API. 
@@ -965,7 +1018,9 @@ Default: `100000`
 ---
 ## Specialized: Specialized Configuration
 
-Special-purpose configuration options that are not typically needed. ### EnvironmentCacheTTL
+Special-purpose configuration options that are not typically needed. 
+
+### EnvironmentCacheTTL
 
 EnvironmentCacheTTL is the duration for which environment information 
 is cached. 
@@ -1026,7 +1081,9 @@ Example: `ClusterName:MyCluster,environment:production`
 
 Controls the field names to use for the event ID fields. These fields 
 are used to identify events that are part of the same trace. 
- ### TraceIDFieldNames
+ 
+
+### TraceIDFieldNames
 
 TraceIDFieldNames is the list of field names to use for the trace ID. 
 
@@ -1065,7 +1122,9 @@ Example: `trace.parent_id,parentId`
 
 Controls the parameters of the gRPC server used to receive Open 
 Telemetry data in gRPC format. 
- ### Enabled
+ 
+
+### Enabled
 
 Enabled specifies whether the gRPC server is enabled. 
 
@@ -1191,7 +1250,9 @@ Default: `20s`
 
 Controls the sample cache used to retain information about trace 
 status after the sampling decision has been made. 
- ### KeptSize
+ 
+
+### KeptSize
 
 KeptSize is the number of traces preserved in the cuckoo kept traces 
 cache. 
@@ -1202,7 +1263,7 @@ Honeycomb, along with some statistical information. This is most
 useful in cases where the trace was sent before sending the root span, 
 so that the root span can be decorated with accurate metadata. Default 
 is 10_000 traces (each trace in this cache consumes roughly 200 
-bytes). Does not apply to the "legacy" type of cache. 
+bytes). 
  
 
 Eligible for live reload.
@@ -1219,8 +1280,7 @@ DroppedSize is the size of the cuckoo dropped traces cache.
 Controls the size of the cuckoo dropped traces cache. This cache 
 consumes 4-6 bytes per trace at a scale of millions of traces. 
 Changing its size with live reload sets a future limit, but does not 
-have an immediate effect. Does not apply to the "legacy" type of 
-cache. 
+have an immediate effect. 
  
 
 Eligible for live reload.
@@ -1239,7 +1299,7 @@ Controls the duration the cuckoo cache uses to determine how often it
 re-evaluates the remaining capacity of its dropped traces cache and 
 possibly cycles it. This cache is quite resilient so it doesn't need 
 to happen very often, but the operation is also inexpensive. Default 
-is 10 seconds. Does not apply to the "legacy" type of cache. 
+is 10 seconds. 
  
 
 Eligible for live reload.
@@ -1280,7 +1340,9 @@ Activation parameters.
 Stress Relief is not a substitute for proper configuration and 
 scaling, but it can be used as a safety valve to prevent Refinery from 
 becoming unstable under heavy load. 
- ### Mode
+ 
+
+### Mode
 
 Mode is a string indicating how to use Stress Relief. 
 

--- a/tools/convert/configData.yaml
+++ b/tools/convert/configData.yaml
@@ -1,24 +1,4 @@
 # this contains a list of all of the config items supported by refinery
-# if v1name is missing, it's the same as name
-# if firstversion is missing, it's v1.x (meaning it's part of the legacy config)
-# if lastversion is present, it was valid in that version but not after
-
-# fields
-    # - v1name -- the name of this field in v1 (if empty, same as name)
-    # - v1group -- the group of this field in v1 (if empty, no group)
-    # - name -- the name of this field in v2 (required)
-    # - group -- the group of this field in v2 (if empty, no group)
-    # - firstversion -- the version where the property was introduced (if empty, it's v1)
-    # - lastversion -- the version where this property was obsoleted (allows for deleted properties to stay in config files without error)
-    # - type -- bool, string, int, float, duration, ipport, url
-    # - default -- default value (if empty, the zero value of the type)
-    # - validation -- validation flags
-    # - reload -- (bool) can be reloaded at runtime
-    # - summary -- brief description for tools
-    # - details -- could be extended description for documentation
-    # - envvar -- if present, environment variable name. If specified, overrides config files
-    # - commandLine -- if present, overrides envvar
-
 groups:
   - name: "General"
     title: "General Configuration"
@@ -26,7 +6,7 @@ groups:
     fields:
       - name: ConfigurationVersion
         type: int
-        valuetype: new
+        valuetype: assigndefault
         default: 2
         validation: required
         reload: false
@@ -40,7 +20,7 @@ groups:
 
       - name: MinRefineryVersion
         type: string
-        valuetype: new
+        valuetype: assigndefault
         default: "v2.0"
         validation: required
         reload: false
@@ -138,8 +118,11 @@ groups:
         reload: true
         summary: controls whether to decorate traces with refinery rule evaluation results.
         description: >
-          AddRuleReasonToTrace causes traces that are sent to Honeycomb to include the field `meta.refinery.reason`.
-          This field contains text indicating which rule was evaluated that caused the trace to be included.
+          AddRuleReasonToTrace causes traces that are sent to Honeycomb to
+          include the field `meta.refinery.reason`, indicating which sampler
+          made the decision to keep the trace. For samplers that use a key to
+          make their decision, the key is also included in the field
+          `meta.refinery.sampler_key`.
 
       - name: AddSpanCountToRoot
         type: bool
@@ -293,6 +276,22 @@ groups:
           useful for debugging and understanding the behavior of your refinery
           installation.
 
+      - name: DryRun
+        type: bool
+        valuetype: showexample
+        default: false
+        example: true
+        reload: true
+        summary: controls whether sampling is applied to incoming traces.
+        description: >
+          If enabled, marks the traces that would be dropped given the current
+          sampling rules, and sends all traces regardless of the sampling
+          decision. This is useful for evaluating sampling rules. In DryRun
+          mode, traces will be decorated with meta.refinery.dryrun.enabled set
+          to true. In addition, SampleRate will be set to the incoming rate for
+          all traces, and the field meta.refinery.dryrun.sample_rate will be set
+          to the sample rate that would have been used.
+
   - name: Logger
     title: "Refinery Logger"
     description: Configuration for logging.
@@ -379,9 +378,10 @@ groups:
           sample rate is controlled by the SamplerThroughput setting.
 
       - name: SamplerThroughput
-        valuetype: new
+        valuetype: showexample
         type: float
         default: 10
+        example: 10
         reload: false
         summary: is the sampling throughput for logs in events per second.
         description: >
@@ -741,8 +741,9 @@ groups:
 
       - name: MaxMemory
         type: percentage
-        valuetype: new
+        valuetype: showexample
         default: 75
+        example: 75
         reload: true
         summary: is the maximum percentage of memory that should be allocated by the collector.
         description: >
@@ -1013,7 +1014,9 @@ groups:
       status after the sampling decision has been made.
     fields:
       - name: Type
-        v1group: SampleCacheConfig
+        # we had a bug in the v1 config where this was implemented as SampleCache but documented as SampleCacheConfig;
+        # we need to allow both names to be safe
+        v1group: SampleCacheConfig/SampleCache
         v1name: Type
         type: string
         valuetype: nondefault
@@ -1033,7 +1036,7 @@ groups:
           later.
 
       - name: KeptSize
-        v1group: SampleCacheConfig
+        v1group: SampleCacheConfig/SampleCache
         v1name: KeptSize
         type: int
         valuetype: nondefault
@@ -1047,10 +1050,10 @@ groups:
           most useful in cases where the trace was sent before sending the root
           span, so that the root span can be decorated with accurate metadata.
           Default is 10_000 traces (each trace in this cache consumes roughly
-          200 bytes). Does not apply to the "legacy" type of cache.
+          200 bytes).
 
       - name: DroppedSize
-        v1group: SampleCacheConfig
+        v1group: SampleCacheConfig/SampleCache
         v1name: DroppedSize
         type: int
         valuetype: nondefault
@@ -1061,10 +1064,9 @@ groups:
           Controls the size of the cuckoo dropped traces cache.
           This cache consumes 4-6 bytes per trace at a scale of millions of traces.
           Changing its size with live reload sets a future limit, but does not have an immediate effect.
-          Does not apply to the "legacy" type of cache.
 
       - name: SizeCheckInterval
-        v1group: SampleCacheConfig
+        v1group: SampleCacheConfig/SampleCache
         v1name: SizeCheckInterval
         type: duration
         valuetype: nondefault
@@ -1078,7 +1080,6 @@ groups:
           This cache is quite resilient so it doesn't need to happen very often,
           but the operation is also inexpensive.
           Default is 10 seconds.
-          Does not apply to the "legacy" type of cache.
 
   - name: StressRelief
     title: "Stress Relief"

--- a/tools/convert/helpers.go
+++ b/tools/convert/helpers.go
@@ -399,9 +399,12 @@ func _fetch(data map[string]any, key string) (any, bool) {
 	}
 	if strings.Contains(key, ".") {
 		parts := strings.SplitN(key, ".", 2)
-		if value, ok := data[parts[0]]; ok {
-			if submap, ok := value.(map[string]any); ok {
-				return _fetch(submap, parts[1])
+		groups := strings.Split(parts[0], "/")
+		for _, g := range groups {
+			if value, ok := data[g]; ok {
+				if submap, ok := value.(map[string]any); ok {
+					return _fetch(submap, parts[1])
+				}
 			}
 		}
 	}

--- a/tools/convert/templates/configV2.tmpl
+++ b/tools/convert/templates/configV2.tmpl
@@ -22,7 +22,7 @@ General:
     ## This field is required. It exists to allow the configuration system to
     ## adapt to future changes in the configuration file format.
     ##  
-    ## 
+    ## default: 2
     ## Not eligible for live reload.
     ConfigurationVersion: 2
 
@@ -33,7 +33,7 @@ General:
     ## the features used in this file. Refinery will refuse to start if its
     ## version is less than this.
     ##  
-    ## 
+    ## default: v2.0
     ## Not eligible for live reload.
     MinRefineryVersion: v2.0
 
@@ -52,6 +52,7 @@ Network:
     ## requirement, put something like nginx in front to do the decryption.
     ##  
     ## Should be an ip:port like "0.0.0.0:8080".
+    ## default: 0.0.0.0:8080
     ## Not eligible for live reload.
     {{ nonDefaultOnly .Data "ListenAddr" "ListenAddr" "0.0.0.0:8080" }}
 
@@ -62,6 +63,7 @@ Network:
     ## like nginx or a load balancer to do the decryption.
     ##  
     ## Should be an ip:port like "0.0.0.0:8081".
+    ## default: 0.0.0.0:8081
     ## Not eligible for live reload.
     {{ nonDefaultOnly .Data "PeerListenAddr" "PeerListenAddr" "0.0.0.0:8081" }}
 
@@ -72,7 +74,7 @@ Network:
     ## destination to which refinery sends all events that it decides to
     ## keep.
     ##  
-    ## 
+    ## default: https://api.honeycomb.io
     ## Eligible for live reload.
     {{ nonDefaultOnly .Data "HoneycombAPI" "HoneycombAPI" "https://api.honeycomb.io" }}
 
@@ -91,7 +93,6 @@ AccessKeys:
     ## will be proxied through to the upstream API directly without modifying
     ## keys.
     ##  
-    ## 
     ## Not eligible for live reload.
     {{ renderStringarray .Data "ReceiveKeys" "ReceiveKeys" "your-key-goes-here" }}
 
@@ -102,7 +103,6 @@ AccessKeys:
     ## Events arriving with API keys not in the ReceiveKeys list will be
     ## rejected with an HTTP 401 error.
     ##  
-    ## 
     ## Eligible for live reload.
     {{ conditional .Data "AcceptOnlyListedKeys" "nostar APIKeys" }}
 
@@ -117,11 +117,11 @@ RefineryTelemetry:
     ## rule evaluation results.
     ##  
     ## AddRuleReasonToTrace causes traces that are sent to Honeycomb to
-    ## include the field `meta.refinery.reason`. This field contains text
-    ## indicating which rule was evaluated that caused the trace to be
-    ## included.
+    ## include the field `meta.refinery.reason`, indicating which sampler
+    ## made the decision to keep the trace. For samplers that use a key to
+    ## make their decision, the key is also included in the field
+    ## `meta.refinery.sampler_key`.
     ##  
-    ## 
     ## Eligible for live reload.
     {{ nonDefaultOnly .Data "AddRuleReasonToTrace" "AddRuleReasonToTrace" false }}
 
@@ -135,7 +135,7 @@ RefineryTelemetry:
     ## of spans in the trace. If true, Refinery will add meta.span_count to
     ## the root span.
     ##  
-    ## 
+    ## default: true
     ## Eligible for live reload.
     {{ nonDefaultOnly .Data "AddSpanCountToRoot" "AddSpanCountToRoot" true }}
 
@@ -147,7 +147,7 @@ RefineryTelemetry:
     ## meta.refinery.local_hostname: the hostname of the Refinery node (we
     ## should consider adding more metadata here, like IP address, etc)
     ##  
-    ## 
+    ## default: true
     ## Eligible for live reload.
     {{ nonDefaultOnly .Data "AddHostMetadataToTrace" "AddHostMetadataToTrace" true }}
 
@@ -166,6 +166,7 @@ Traces:
     ## actually sending the trace. Set to 0 for immediate sends.
     ##  
     ## Accepts a duration string with units, like "2s".
+    ## default: 2s
     ## Eligible for live reload.
     {{ nonDefaultOnly .Data "SendDelay" "SendDelay" "2s" }}
 
@@ -192,6 +193,7 @@ Traces:
     ## refinery.
     ##  
     ## Accepts a duration string with units, like "60s".
+    ## default: 60s
     ## Eligible for live reload.
     {{ nonDefaultOnly .Data "TraceTimeout" "TraceTimeout" "60s" }}
 
@@ -202,7 +204,7 @@ Traces:
     ## particularly large traces you should increase this value. Note that
     ## this will also increase the memory requirements for refinery.
     ##  
-    ## 
+    ## default: 500
     ## Eligible for live reload.
     {{ nonDefaultOnly .Data "MaxBatchSize" "MaxBatchSize" 500 }}
 
@@ -214,6 +216,7 @@ Traces:
     ## this will check the trace cache for timeouts more frequently.
     ##  
     ## Accepts a duration string with units, like "100ms".
+    ## default: 100ms
     ## Eligible for live reload.
     {{ nonDefaultOnly .Data "SendTicker" "SendTicker" "100ms" }}
 
@@ -244,7 +247,6 @@ Debugging:
     ## and are not typically needed in normal operation. If not specified,
     ## the /query endpoints are inaccessible.
     ##  
-    ## 
     ## Not eligible for live reload.
     {{ nonEmptyString .Data "QueryAuthToken" "QueryAuthToken" "some-private-value" }}
 
@@ -258,7 +260,6 @@ Debugging:
     ## `environment` are always included. If a field is not present in the
     ## span, it will not be present in the error log.
     ##  
-    ## 
     ## Eligible for live reload.
     {{ renderStringarray .Data "AdditionalErrorFields" "AdditionalErrorFields" "trace.span_id" }}
 
@@ -272,9 +273,21 @@ Debugging:
     ## useful for debugging and understanding the behavior of your refinery
     ## installation.
     ##  
-    ## 
     ## Eligible for live reload.
     {{ nonDefaultOnly .Data "AddRuleReasonToTrace" "AddRuleReasonToTrace" false }}
+
+    ## DryRun controls whether sampling is applied to incoming traces.
+    ##  
+    ## If enabled, marks the traces that would be dropped given the current
+    ## sampling rules, and sends all traces regardless of the sampling
+    ## decision. This is useful for evaluating sampling rules. In DryRun
+    ## mode, traces will be decorated with meta.refinery.dryrun.enabled set
+    ## to true. In addition, SampleRate will be set to the incoming rate for
+    ## all traces, and the field meta.refinery.dryrun.sample_rate will be set
+    ## to the sample rate that would have been used.
+    ##  
+    ## Eligible for live reload.
+    # DryRun: true
 
 #####################
 ## Refinery Logger ##
@@ -289,7 +302,7 @@ Logger:
     ## honeycomb as events according to the settings below. "stdout" means
     ## that logs will be written to stdout.
     ##  
-    ## 
+    ## default: stdout
     ## Not eligible for live reload.
     ## Options: stdout honeycomb none
     {{ choice .Data "Type" "Type" (makeSlice "stdout" "honeycomb" "none") "stdout" }}
@@ -301,7 +314,7 @@ Logger:
     ## logger. Debug is very verbose, and should not be used in production
     ## environments. Warn is the recommended level for production.
     ##  
-    ## 
+    ## default: warn
     ## Not eligible for live reload.
     ## Options: debug info warn error panic
     {{ choice .Data "LoggingLevel" "LoggingLevel" (makeSlice "debug" "info" "warn" "error" "panic") "warn" }}
@@ -318,7 +331,7 @@ HoneycombLogger:
     ## Sets the upstream Honeycomb API for logs; this is the destination to
     ## which refinery sends its own logs.
     ##  
-    ## 
+    ## default: https://api.honeycomb.io
     ## Not eligible for live reload.
     {{ nonDefaultOnly .Data "APIHost" "HoneycombLogger.LoggerHoneycombAPI" "https://api.honeycomb.io" }}
 
@@ -328,7 +341,6 @@ HoneycombLogger:
     ## Honeycomb. It is recommended that you create a separate team and key
     ## for Refinery logs.
     ##  
-    ## 
     ## Not eligible for live reload.
     {{ nonEmptyString .Data "APIKey" "HoneycombLogger.LoggerAPIKey" "set-this-to-your-api-key" }}
 
@@ -336,7 +348,7 @@ HoneycombLogger:
     ##  
     ## Specifies the dataset to which logs will be sent.
     ##  
-    ## 
+    ## default: Refinery Logs
     ## Not eligible for live reload.
     {{ nonEmptyString .Data "Dataset" "HoneycombLogger.LoggerDataset" "" }}
 
@@ -345,7 +357,7 @@ HoneycombLogger:
     ## Controls whether logs are sampled before sending to Honeycomb. The
     ## sample rate is controlled by the SamplerThroughput setting.
     ##  
-    ## 
+    ## default: true
     ## Not eligible for live reload.
     {{ nonDefaultOnly .Data "SamplerEnabled" "HoneycombLogger.LoggerSamplerEnabled" true }}
 
@@ -359,9 +371,9 @@ HoneycombLogger:
     ## period. The default value is 10 events per second. TODO: THROUGHPUT
     ## FOR THE CLUSTER
     ##  
-    ## 
+    ## default: 10
     ## Not eligible for live reload.
-    SamplerThroughput: 10
+    # SamplerThroughput: 10
 
 ###################
 ## Stdout Logger ##
@@ -375,7 +387,6 @@ StdoutLogger:
     ## Specifies whether the stdout logger generates structured logs (JSON)
     ## or not (plain text).
     ##  
-    ## 
     ## Not eligible for live reload.
     {{ nonDefaultOnly .Data "Structured" "Structured" false }}
 
@@ -392,7 +403,6 @@ PrometheusMetrics:
     ## The flag specifies whether Refinery should expose its own metrics over
     ## the PrometheusListenAddr port.
     ##  
-    ## 
     ## Not eligible for live reload.
     {{ conditional .Data "Enabled" "eq Metrics prometheus" }}
 
@@ -404,6 +414,7 @@ PrometheusMetrics:
     ## listener. Only used if "Enabled" is true in PrometheusMetrics.
     ##  
     ## Should be an ip:port like "localhost:2112".
+    ## default: localhost:2112
     ## Not eligible for live reload.
     {{ nonDefaultOnly .Data "PrometheusListenAddr" "PrometheusMetrics.MetricsListenAddr" "localhost:2112" }}
 
@@ -421,7 +432,6 @@ LegacyMetrics:
     ## Enabled controls whether to send legacy-formatted metrics to
     ## Honeycomb.
     ##  
-    ## 
     ## Not eligible for live reload.
     {{ conditional .Data "Enabled" "eq Metrics honeycomb" }}
 
@@ -430,7 +440,7 @@ LegacyMetrics:
     ## Specifies the URL for the upstream Honeycomb API for metrics; this is
     ## the destination to which refinery sends its own metrics.
     ##  
-    ## 
+    ## default: https://api.honeycomb.io
     ## Not eligible for live reload.
     {{ nonDefaultOnly .Data "APIHost" "HoneycombMetrics.MetricsHoneycombAPI" "https://api.honeycomb.io" }}
 
@@ -440,7 +450,6 @@ LegacyMetrics:
     ## recommended that you create a separate team and key for Refinery
     ## metrics.
     ##  
-    ## 
     ## Not eligible for live reload.
     {{ nonDefaultOnly .Data "APIKey" "HoneycombMetrics.MetricsAPIKey" "" }}
 
@@ -448,7 +457,7 @@ LegacyMetrics:
     ##  
     ## Specifies the dataset to which refinery sends its own metrics.
     ##  
-    ## 
+    ## default: Refinery Metrics
     ## Not eligible for live reload.
     {{ nonDefaultOnly .Data "Dataset" "HoneycombMetrics.MetricsDataset" "Refinery Metrics" }}
 
@@ -459,6 +468,7 @@ LegacyMetrics:
     ## seconds is typical.
     ##  
     ## Accepts a duration string with units, like "30s".
+    ## default: 30s
     ## Not eligible for live reload.
     {{ secondsToDuration .Data "ReportingInterval" "HoneycombMetrics.MetricsReportingInterval" "" }}
 
@@ -485,7 +495,7 @@ PeerManagement:
     ## self-registers with a redis instance and gets its peer list from
     ## there.
     ##  
-    ## 
+    ## default: redis
     ## Not eligible for live reload.
     ## Options: redis file
     {{ choice .Data "Type" "PeerManagement.Type" (makeSlice "redis" "file") "redis" }}
@@ -501,7 +511,6 @@ PeerManagement:
     ## address that it finds on the specified network interface as its
     ## identifier.
     ##  
-    ## 
     ## Not eligible for live reload.
     {{ nonEmptyString .Data "IdentifierInterfaceName" "PeerManagement.IdentifierInterfaceName" "eth0" }}
 
@@ -513,7 +522,6 @@ PeerManagement:
     ## value is specified, Refinery will use the first IPV6 unicast address
     ## found.
     ##  
-    ## 
     ## Not eligible for live reload.
     {{ nonDefaultOnly .Data "UseIPV6Identifier" "PeerManagement.UseIPV6Identifier" false }}
 
@@ -526,7 +534,6 @@ PeerManagement:
     ## other by name), you can specify the exact identifier (IP address, etc)
     ## to use here. Overrides IdentifierInterfaceName, if both are set.
     ##  
-    ## 
     ## Not eligible for live reload.
     {{ nonEmptyString .Data "RedisIdentifier" "PeerManagement.RedisIdentifier" "192.168.1.1" }}
 
@@ -536,7 +543,6 @@ PeerManagement:
     ## This list is ignored when Type is "redis". The format is a list of
     ## strings of the form "host:port".
     ##  
-    ## 
     ## Not eligible for live reload.
     {{ renderStringarray .Data "Peers" "PeerManagement.Peers" "192.168.1.11:8081,192.168.1.12:8081" }}
 
@@ -562,7 +568,6 @@ RedisPeerManagement:
     ## The username used to connect to redis for peer cluster membership
     ## management.
     ##  
-    ## 
     ## Not eligible for live reload.
     {{ nonEmptyString .Data "Username" "PeerManagement.RedisUsername" "" }}
 
@@ -571,7 +576,6 @@ RedisPeerManagement:
     ## Sets the password used to connect to redis for peer cluster membership
     ## management.
     ##  
-    ## 
     ## Not eligible for live reload.
     {{ nonEmptyString .Data "Password" "PeerManagement.Password" "" }}
 
@@ -583,7 +587,7 @@ RedisPeerManagement:
     ## applications want to share a single Redis instance. It may not be
     ## blank.
     ##  
-    ## 
+    ## default: refinery
     ## Not eligible for live reload.
     {{ nonDefaultOnly .Data "Prefix" "PeerManagement.Prefix" "refinery" }}
 
@@ -595,7 +599,6 @@ RedisPeerManagement:
     ## this in any situation where multiple refinery clusters or multiple
     ## applications want to share a single Redis instance.
     ##  
-    ## 
     ## Not eligible for live reload.
     {{ nonDefaultOnly .Data "Database" "PeerManagement.Database" 0 }}
 
@@ -604,7 +607,6 @@ RedisPeerManagement:
     ## Enables TLS when connecting to redis for peer cluster membership
     ## management, and sets the MinVersion in the TLS configuration to 1.2.
     ##  
-    ## 
     ## Not eligible for live reload.
     {{ nonDefaultOnly .Data "UseTLS" "PeerManagement.UseTLS" false }}
 
@@ -613,7 +615,6 @@ RedisPeerManagement:
     ## Disables certificate checks when connecting to redis for peer cluster
     ## membership management.
     ##  
-    ## 
     ## Not eligible for live reload.
     {{ nonDefaultOnly .Data "UseTLSInsecure" "PeerManagement.UseTLSInsecure" false }}
 
@@ -623,6 +624,7 @@ RedisPeerManagement:
     ## Redis.
     ##  
     ## Accepts a duration string with units, like "5s".
+    ## default: 5s
     ## Not eligible for live reload.
     {{ nonDefaultOnly .Data "Timeout" "PeerManagement.Timeout" "5s" }}
 
@@ -644,7 +646,7 @@ Collection:
     ## many multiples (100x to 1000x) of the total number of concurrently
     ## active traces (trace throughput * trace duration).
     ##  
-    ## 
+    ## default: 10000
     ## Eligible for live reload.
     {{ nonDefaultOnly .Data "CacheCapacity" "InMemCollector.CacheCapacity" 10000 }}
 
@@ -661,9 +663,9 @@ Collection:
     ## system memory information may not be available; if it is not, a
     ## warning will be logged and the value of MaxAlloc will be used.
     ##  
-    ## 
+    ## default: 75
     ## Eligible for live reload.
-    MaxMemory: 75
+    # MaxMemory: 75
 
     ## MaxAlloc is the maximum number of bytes that should be allocated by
     ## the collector.
@@ -671,7 +673,6 @@ Collection:
     ## If set, it must be an integer >= 0. 64-bit values are supported. See
     ## MaxMemory for more details.
     ##  
-    ## 
     ## Eligible for live reload.
     {{ nonDefaultOnly .Data "MaxAlloc" "InMemCollector.MaxAlloc" 0 }}
 
@@ -691,7 +692,7 @@ BufferSizes:
     ## degrade because Refinery will block while waiting for space to become
     ## available. If this happens, you should increase the buffer size.
     ##  
-    ## 
+    ## default: 10000
     ## Eligible for live reload.
     {{ nonDefaultOnly .Data "UpstreamBufferSize" "UpstreamBufferSize" 10000 }}
 
@@ -703,7 +704,7 @@ BufferSizes:
     ## Refinery will block while waiting for space to become available. If
     ## this happens, you should increase the buffer size.
     ##  
-    ## 
+    ## default: 100000
     ## Eligible for live reload.
     {{ nonDefaultOnly .Data "PeerBufferSize" "PeerBufferSize" 100000 }}
 
@@ -724,6 +725,7 @@ Specialized:
     ## want to decrease this value.
     ##  
     ## Accepts a duration string with units, like "1h".
+    ## default: 1h
     ## Eligible for live reload.
     {{ nonDefaultOnly .Data "EnvironmentCacheTTL" "EnvironmentCacheTTL" "1h" }}
 
@@ -736,7 +738,7 @@ Specialized:
     ## disable it is provided as an escape hatch for deployments that value
     ## lower CPU utilization over data transfer costs.
     ##  
-    ## 
+    ## default: true
     ## Not eligible for live reload.
     {{ nonDefaultOnly .Data "CompressPeerCommunication" "CompressPeerCommunication" true }}
 
@@ -747,7 +749,6 @@ Specialized:
     ## every span. For example, it could be used for naming a refinery
     ## cluster. Both keys and values must be strings.
     ##  
-    ## 
     ## Eligible for live reload.
     {{ renderMap .Data "AdditionalAttributes" "AdditionalAttributes" "ClusterName:MyCluster,environment:production" }}
 
@@ -766,7 +767,6 @@ IDFieldNames:
     ## ID. If none of the fields are present, refinery treats the span as not
     ## being part of a trace and forwards it immediately to Honeycomb.
     ##  
-    ## 
     ## Eligible for live reload.
     {{ renderStringarray .Data "TraceIDFieldNames" "TraceIDFieldNames" "trace.trace_id,traceId" }}
 
@@ -777,7 +777,6 @@ IDFieldNames:
     ## ID. The first field in the list that is present in an event will be
     ## used as the parent ID.
     ##  
-    ## 
     ## Eligible for live reload.
     {{ renderStringarray .Data "ParentIDFieldNames" "ParentIDFieldNames" "trace.parent_id,parentId" }}
 
@@ -795,7 +794,6 @@ GRPCServerParameters:
     ## server is not started and no gRPC traffic is accepted. TODO: WE NEED
     ## TO DEFAULT THIS TO TRUE IF PREVIOUS CONFIG HAS A LISTEN ADDRESS
     ##  
-    ## 
     ## Not eligible for live reload.
     {{ nonDefaultOnly .Data "Enabled" "Enabled" false }}
 
@@ -818,6 +816,7 @@ GRPCServerParameters:
     ## the load balancer from distributing load evenly among peers.
     ##  
     ## Accepts a duration string with units, like "0s".
+    ## default: 0s
     ## Not eligible for live reload.
     {{ nonDefaultOnly .Data "MaxConnectionIdle" "GRPCServerParameters.MaxConnectionIdle" "0s" }}
 
@@ -831,6 +830,7 @@ GRPCServerParameters:
     ## will help load balancers to distribute load among peers more evenly.
     ##  
     ## Accepts a duration string with units, like "3m".
+    ## default: 3m
     ## Not eligible for live reload.
     {{ nonDefaultOnly .Data "MaxConnectionAge" "GRPCServerParameters.MaxConnectionAge" "3m" }}
 
@@ -842,6 +842,7 @@ GRPCServerParameters:
     ## the GoAway request). 0s sets duration to infinity.
     ##  
     ## Accepts a duration string with units, like "60s".
+    ## default: 60s
     ## Not eligible for live reload.
     {{ nonDefaultOnly .Data "MaxConnectionAgeGrace" "GRPCServerParameters.MaxConnectionAgeGrace" "60s" }}
 
@@ -853,6 +854,7 @@ GRPCServerParameters:
     ## instead. 0s sets duration to 2 hours.
     ##  
     ## Accepts a duration string with units, like "1m".
+    ## default: 1m
     ## Not eligible for live reload.
     {{ nonDefaultOnly .Data "KeepAlive" "GRPCServerParameters.Time" "1m" }}
 
@@ -865,6 +867,7 @@ GRPCServerParameters:
     ## duration to 20 seconds.
     ##  
     ## Accepts a duration string with units, like "20s".
+    ## default: 20s
     ## Not eligible for live reload.
     {{ nonDefaultOnly .Data "KeepAliveTimeout" "GRPCServerParameters.Timeout" "20s" }}
 
@@ -885,23 +888,22 @@ SampleCache:
     ## useful in cases where the trace was sent before sending the root span,
     ## so that the root span can be decorated with accurate metadata. Default
     ## is 10_000 traces (each trace in this cache consumes roughly 200
-    ## bytes). Does not apply to the "legacy" type of cache.
+    ## bytes).
     ##  
-    ## 
+    ## default: 10000
     ## Eligible for live reload.
-    {{ nonDefaultOnly .Data "KeptSize" "SampleCacheConfig.KeptSize" 10000 }}
+    {{ nonDefaultOnly .Data "KeptSize" "SampleCacheConfig/SampleCache.KeptSize" 10000 }}
 
     ## DroppedSize is the size of the cuckoo dropped traces cache.
     ##  
     ## Controls the size of the cuckoo dropped traces cache. This cache
     ## consumes 4-6 bytes per trace at a scale of millions of traces.
     ## Changing its size with live reload sets a future limit, but does not
-    ## have an immediate effect. Does not apply to the "legacy" type of
-    ## cache.
+    ## have an immediate effect.
     ##  
-    ## 
+    ## default: 1000000
     ## Eligible for live reload.
-    {{ nonDefaultOnly .Data "DroppedSize" "SampleCacheConfig.DroppedSize" 1000000 }}
+    {{ nonDefaultOnly .Data "DroppedSize" "SampleCacheConfig/SampleCache.DroppedSize" 1000000 }}
 
     ## SizeCheckInterval controls how often the cuckoo cache re-evaluates its
     ## capacity.
@@ -910,11 +912,12 @@ SampleCache:
     ## re-evaluates the remaining capacity of its dropped traces cache and
     ## possibly cycles it. This cache is quite resilient so it doesn't need
     ## to happen very often, but the operation is also inexpensive. Default
-    ## is 10 seconds. Does not apply to the "legacy" type of cache.
+    ## is 10 seconds.
     ##  
     ## Accepts a duration string with units, like "10s".
+    ## default: 10s
     ## Eligible for live reload.
-    {{ nonDefaultOnly .Data "SizeCheckInterval" "SampleCacheConfig.SizeCheckInterval" "10s" }}
+    {{ nonDefaultOnly .Data "SizeCheckInterval" "SampleCacheConfig/SampleCache.SizeCheckInterval" "10s" }}
 
 ###################
 ## Stress Relief ##
@@ -958,7 +961,7 @@ StressRelief:
     ## according to the levels set below. "always" means that Stress Relief
     ## is always on, which may be useful in an emergency situation.
     ##  
-    ## 
+    ## default: never
     ## Eligible for live reload.
     {{ nonDefaultOnly .Data "Mode" "StressRelief.Mode" "never" }}
 
@@ -968,7 +971,7 @@ StressRelief:
     ## Sets the stress_level (from 0-100) at which Stress Relief is
     ## triggered.
     ##  
-    ## 
+    ## default: 90
     ## Eligible for live reload.
     {{ nonDefaultOnly .Data "ActivationLevel" "StressRelief.ActivationLevel" 90 }}
 
@@ -979,7 +982,7 @@ StressRelief:
     ## off (subject to MinimumActivationDuration). It must be less than
     ## ActivationLevel.
     ##  
-    ## 
+    ## default: 70
     ## Eligible for live reload.
     {{ nonDefaultOnly .Data "DeactivationLevel" "StressRelief.DeactivationLevel" 70 }}
 
@@ -994,7 +997,7 @@ StressRelief:
     ## 1 in 10, then Stress Relief should be configured to sample at a rate
     ## of at least 1 in 30.
     ##  
-    ## 
+    ## default: 100
     ## Eligible for live reload.
     {{ nonDefaultOnly .Data "SamplingRate" "StressRelief.StressSamplingRate" 100 }}
 
@@ -1005,6 +1008,7 @@ StressRelief:
     ## activated. This helps to prevent oscillations.
     ##  
     ## Accepts a duration string with units, like "10s".
+    ## default: 10s
     ## Eligible for live reload.
     {{ nonDefaultOnly .Data "MinimumActivationDuration" "StressRelief.MinimumActivationDuration" "10s" }}
 
@@ -1021,6 +1025,7 @@ StressRelief:
     ## startup instability.
     ##  
     ## Accepts a duration string with units, like "3s".
+    ## default: 3s
     ## Eligible for live reload.
     {{ nonDefaultOnly .Data "MinimumStartupDuration" "StressRelief.MinimumStartupDuration" "3s" }}
 
@@ -1033,4 +1038,4 @@ StressRelief:
     ## - PeerManagement.Strategy
     ## - Collector
     ## - CacheOverrunStrategy
-    ## - SampleCacheConfig.Type
+    ## - SampleCacheConfig/SampleCache.Type

--- a/tools/convert/templates/docgroup.tmpl
+++ b/tools/convert/templates/docgroup.tmpl
@@ -3,6 +3,8 @@
 ## {{ $group.Name }}: {{ $group.Title }}
 
 {{ $group.Description | wordwrap }}
+{{- println -}}
+{{- println -}}
 
 {{- range $group.Fields -}}
 {{- if .LastVersion -}}

--- a/tools/convert/templates/genfield.tmpl
+++ b/tools/convert/templates/genfield.tmpl
@@ -9,9 +9,18 @@
 {{- end -}}
 {{ println }}
 {{- println $field.Name $field.Summary | wci 4 -}}
-{{- if $field.Description }}
+{{- println -}}
 {{ $field.Description | wci 4 }}
-{{ formatExample $field.Type $field.Default $field.Example | comment | indent 4 }}
+{{- println -}}
+{{- $specialExample := formatExample $field.Type $field.Default $field.Example -}}
+{{- if $specialExample -}}
+  {{- $specialExample | comment | indent 4 -}}
+  {{- println -}}
+{{- end -}}
+{{- if $field.Default -}}
+  {{- printf "default: %v" $field.Default | comment | indent 4 -}}
+  {{- println -}}
+{{- end -}}
 {{ reload $field.Reload | indent 4 }}
 {{- if eq $field.ValueType "nondefault" }}
 {{ printf "nonDefaultOnly .Data \"%s\" \"%s\" %#v" $field.Name $oldname $field.Default | meta | indent 4 }}
@@ -24,7 +33,9 @@
 {{- else if eq $field.ValueType "choice" }}
 {{ printf "Options: %s" (join $field.Choices " ") | comment | indent 4 }}
 {{ printf "choice .Data \"%s\" \"%s\" %s \"%s\"" $field.Name $oldname (genSlice $field.Choices) $field.Default | meta | indent 4 }}
-{{- else if eq $field.ValueType "new" }}
+{{- else if eq $field.ValueType "showexample" }}
+{{ print "# " $field.Name ": " $field.Example | indent 4 }}
+{{- else if eq $field.ValueType "assigndefault" }}
 {{ print $field.Name ": " $field.Default | indent 4 }}
 {{- else if eq $field.ValueType "map" }}
 {{ printf "renderMap .Data \"%s\" \"%s\" \"%s\"" $field.Name $oldname $field.Example | meta | indent 4 }}
@@ -35,5 +46,4 @@
 {{- else }}
 {{ printf "******** ERROR %#v has bad ValueType %v" $field.Name $field.ValueType }}
 {{ end -}}
-{{- end -}}
 {{- println -}}


### PR DESCRIPTION
## Which problem is this PR solving?

Several issues with config in progress. 

## Short description of the changes

- A bug in Refinery v1 means that some configs will have values under `SampleCache`, and others under `SampleCacheConfig`. This gives us the ability to use both.
- There was a vertical spacing error in doc generation
- Add default values to the generated config
- Differentiate between values we always want and values where we always want to show an example.
- Regenerate the generated files with all of the above.

