### PR TITLE
Remove trace key params -> add meta sample_key

### DIFF
--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -362,14 +362,14 @@ func TestDryRunMode(t *testing.T) {
 	var traceID2 = "def456"
 	var traceID3 = "ghi789"
 	// sampling decisions based on trace ID
-	sampleRate1, keepTraceID1, _ := sampler.GetSampleRate(&types.Trace{TraceID: traceID1})
+	sampleRate1, keepTraceID1, _, _ := sampler.GetSampleRate(&types.Trace{TraceID: traceID1})
 	// would be dropped if dry run mode was not enabled
 	assert.False(t, keepTraceID1)
 	assert.Equal(t, uint(10), sampleRate1)
-	sampleRate2, keepTraceID2, _ := sampler.GetSampleRate(&types.Trace{TraceID: traceID2})
+	sampleRate2, keepTraceID2, _, _ := sampler.GetSampleRate(&types.Trace{TraceID: traceID2})
 	assert.True(t, keepTraceID2)
 	assert.Equal(t, uint(10), sampleRate2)
-	sampleRate3, keepTraceID3, _ := sampler.GetSampleRate(&types.Trace{TraceID: traceID3})
+	sampleRate3, keepTraceID3, _, _ := sampler.GetSampleRate(&types.Trace{TraceID: traceID3})
 	// would be dropped if dry run mode was not enabled
 	assert.False(t, keepTraceID3)
 	assert.Equal(t, uint(10), sampleRate3)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -370,35 +370,6 @@ func TestPeerManagementType(t *testing.T) {
 	}
 }
 
-func TestAbsentTraceKeyField(t *testing.T) {
-	config, rules := createTempConfigs(t, `
-	[InMemCollector]
-		CacheCapacity=1000
-
-	[HoneycombMetrics]
-		MetricsHoneycombAPI="http://honeycomb.io"
-		MetricsAPIKey="1234"
-		MetricsDataset="testDatasetName"
-		MetricsReportingInterval=3
-	`, `
-	[dataset1]
-		Sampler = "EMADynamicSampler"
-		GoalSampleRate = 10
-		UseTraceLength = true
-		AddSampleRateKeyToTrace = true
-		FieldList = [ "request.method" ]
-		Weight = 0.4
-	`)
-	defer os.Remove(rules)
-	defer os.Remove(config)
-	cfg, err := getConfig([]string{"--config", config, "--rules_config", rules})
-	assert.NoError(t, err)
-	_, samplerName, err := cfg.GetSamplerConfigForDestName("dataset1")
-	assert.Error(t, err)
-	assert.Equal(t, "EMADynamicSampler", samplerName)
-	assert.Contains(t, err.Error(), "Error:Field validation for 'AddSampleRateKeyToTraceField'")
-}
-
 func TestDebugServiceAddr(t *testing.T) {
 	config, rules := createTempConfigs(t, `
 	DebugServiceAddr = "localhost:8085"

--- a/config/sampler_config.go
+++ b/config/sampler_config.go
@@ -29,35 +29,29 @@ type DeterministicSamplerConfig struct {
 }
 
 type DynamicSamplerConfig struct {
-	SampleRate                   int64    `json:"samplerate" yaml:"SampleRate,omitempty" validate:"required,gte=1"`
-	ClearFrequencySec            int64    `json:"clearfrequencysec" yaml:"ClearFrequencySec,omitempty"`
-	FieldList                    []string `json:"fieldlist" yaml:"FieldList,omitempty" validate:"required"`
-	UseTraceLength               bool     `json:"usetracelength" yaml:"UseTraceLength,omitempty"`
-	AddSampleRateKeyToTrace      bool     `json:"addsampleratekeytotrace" yaml:"AddSampleRateKeyToTrace,omitempty"`
-	AddSampleRateKeyToTraceField string   `json:"addsampleratekeytotracefield" yaml:"AddSampleRateKeyToTraceField,omitempty" validate:"required_with=AddSampleRateKeyToTrace"`
+	SampleRate        int64    `json:"samplerate" yaml:"SampleRate,omitempty" validate:"required,gte=1"`
+	ClearFrequencySec int64    `json:"clearfrequencysec" yaml:"ClearFrequencySec,omitempty"`
+	FieldList         []string `json:"fieldlist" yaml:"FieldList,omitempty" validate:"required"`
+	UseTraceLength    bool     `json:"usetracelength" yaml:"UseTraceLength,omitempty"`
 }
 
 type EMADynamicSamplerConfig struct {
-	GoalSampleRate               int      `json:"goalsamplerate" yaml:"GoalSampleRate,omitempty" validate:"gte=1"`
-	AdjustmentInterval           int      `json:"adjustmentinterval" yaml:"AdjustmentInterval,omitempty"`
-	Weight                       float64  `json:"weight" yaml:"Weight,omitempty" validate:"gt=0,lt=1"`
-	AgeOutValue                  float64  `json:"ageoutvalue" yaml:"AgeOutValue,omitempty"`
-	BurstMultiple                float64  `json:"burstmultiple" yaml:"BurstMultiple,omitempty"`
-	BurstDetectionDelay          uint     `json:"burstdetectiondelay" yaml:"BurstDetectionDelay,omitempty"`
-	MaxKeys                      int      `json:"maxkeys" yaml:"MaxKeys,omitempty"`
-	FieldList                    []string `json:"fieldlist" yaml:"FieldList,omitempty" validate:"required"`
-	UseTraceLength               bool     `json:"usetracelength" yaml:"UseTraceLength,omitempty"`
-	AddSampleRateKeyToTrace      bool     `json:"addsampleratekeytotrace" yaml:"AddSampleRateKeyToTrace,omitempty"`
-	AddSampleRateKeyToTraceField string   `json:"addsampleratekeytotracefield" yaml:"AddSampleRateKeyToTraceField,omitempty" validate:"required_with=AddSampleRateKeyToTrace"`
+	GoalSampleRate      int      `json:"goalsamplerate" yaml:"GoalSampleRate,omitempty" validate:"gte=1"`
+	AdjustmentInterval  int      `json:"adjustmentinterval" yaml:"AdjustmentInterval,omitempty"`
+	Weight              float64  `json:"weight" yaml:"Weight,omitempty" validate:"gt=0,lt=1"`
+	AgeOutValue         float64  `json:"ageoutvalue" yaml:"AgeOutValue,omitempty"`
+	BurstMultiple       float64  `json:"burstmultiple" yaml:"BurstMultiple,omitempty"`
+	BurstDetectionDelay uint     `json:"burstdetectiondelay" yaml:"BurstDetectionDelay,omitempty"`
+	MaxKeys             int      `json:"maxkeys" yaml:"MaxKeys,omitempty"`
+	FieldList           []string `json:"fieldlist" yaml:"FieldList,omitempty" validate:"required"`
+	UseTraceLength      bool     `json:"usetracelength" yaml:"UseTraceLength,omitempty"`
 }
 
 type TotalThroughputSamplerConfig struct {
-	GoalThroughputPerSec         int64    `json:"goalthroughputpersec" yaml:"GoalThroughputPerSec,omitempty" validate:"gte=1"`
-	ClearFrequencySec            int64    `json:"clearfrequencysec" yaml:"ClearFrequencySec,omitempty"`
-	FieldList                    []string `json:"fieldlist" yaml:"FieldList,omitempty" validate:"required"`
-	UseTraceLength               bool     `json:"usetracelength" yaml:"UseTraceLength,omitempty"`
-	AddSampleRateKeyToTrace      bool     `json:"addsampleratekeytotrace" yaml:"AddSampleRateKeyToTrace,omitempty"`
-	AddSampleRateKeyToTraceField string   `json:"addsampleratekeytotracefield" yaml:"AddSampleRateKeyToTraceField,omitempty" validate:"required_with=AddSampleRateKeyToTrace"`
+	GoalThroughputPerSec int64    `json:"goalthroughputpersec" yaml:"GoalThroughputPerSec,omitempty" validate:"gte=1"`
+	ClearFrequencySec    int64    `json:"clearfrequencysec" yaml:"ClearFrequencySec,omitempty"`
+	FieldList            []string `json:"fieldlist" yaml:"FieldList,omitempty" validate:"required"`
+	UseTraceLength       bool     `json:"usetracelength" yaml:"UseTraceLength,omitempty"`
 }
 
 type RulesBasedSamplerConfig struct {

--- a/sample/deterministic.go
+++ b/sample/deterministic.go
@@ -35,11 +35,11 @@ func (d *DeterministicSampler) Start() error {
 	return nil
 }
 
-func (d *DeterministicSampler) GetSampleRate(trace *types.Trace) (rate uint, keep bool, reason string) {
+func (d *DeterministicSampler) GetSampleRate(trace *types.Trace) (rate uint, keep bool, reason string, key string) {
 	if d.sampleRate <= 1 {
-		return 1, true, "deterministic/always"
+		return 1, true, "deterministic/always", ""
 	}
 	sum := sha1.Sum([]byte(trace.TraceID + shardingSalt))
 	v := binary.BigEndian.Uint32(sum[:4])
-	return uint(d.sampleRate), v <= d.upperBound, "deterministic/chance"
+	return uint(d.sampleRate), v <= d.upperBound, "deterministic/chance", ""
 }

--- a/sample/deterministic_test.go
+++ b/sample/deterministic_test.go
@@ -50,10 +50,11 @@ func TestGetSampleRate(t *testing.T) {
 	ds.Start()
 
 	for i, tst := range tsts {
-		rate, keep, reason := ds.GetSampleRate(tst.trace)
+		rate, keep, reason, key := ds.GetSampleRate(tst.trace)
 		assert.Equal(t, uint(10), rate, "sample rate should be fixed")
 		assert.Equal(t, tst.sampled, keep, "%d: trace ID %s should be %v", i, tst.trace.TraceID, tst.sampled)
 		assert.Equal(t, "deterministic/chance", reason)
+		assert.Equal(t, "", key)
 	}
 
 }

--- a/sample/dynamic_ema_test.go
+++ b/sample/dynamic_ema_test.go
@@ -19,9 +19,7 @@ func TestDynamicEMAAddSampleRateKeyToTrace(t *testing.T) {
 
 	sampler := &EMADynamicSampler{
 		Config: &config.EMADynamicSamplerConfig{
-			FieldList:                    []string{"http.status_code", "request.path", "app.team.id", "important_field"},
-			AddSampleRateKeyToTrace:      true,
-			AddSampleRateKeyToTraceField: "meta.key",
+			FieldList: []string{"http.status_code", "request.path", "app.team.id", "important_field"},
 		},
 		Logger:  &logger.NullLogger{},
 		Metrics: &metrics,
@@ -41,18 +39,13 @@ func TestDynamicEMAAddSampleRateKeyToTrace(t *testing.T) {
 		})
 	}
 	sampler.Start()
-	sampler.GetSampleRate(trace)
+	rate, _, reason, key := sampler.GetSampleRate(trace)
 
 	spans := trace.GetSpans()
 
 	assert.Len(t, spans, spanCount, "should have the same number of spans as input")
-	for _, span := range spans {
-		assert.Equal(t, span.Event.Data, map[string]interface{}{
-			"http.status_code": 200,
-			"app.team.id":      float64(4),
-			"important_field":  true,
-			"request.path":     "/{slug}/fun",
-			"meta.key":         "4•,200•,true•,/{slug}/fun•,",
-		}, "should add the sampling key to all spans in the trace")
-	}
+	assert.Equal(t, uint(10), rate, "sample rate should be 10")
+	assert.Equal(t, "emadynamic", reason)
+	assert.Equal(t, "4•,200•,true•,/{slug}/fun•,", key)
+
 }

--- a/sample/dynamic_test.go
+++ b/sample/dynamic_test.go
@@ -19,9 +19,7 @@ func TestDynamicAddSampleRateKeyToTrace(t *testing.T) {
 
 	sampler := &DynamicSampler{
 		Config: &config.DynamicSamplerConfig{
-			FieldList:                    []string{"http.status_code"},
-			AddSampleRateKeyToTrace:      true,
-			AddSampleRateKeyToTraceField: "meta.key",
+			FieldList: []string{"http.status_code"},
 		},
 		Logger:  &logger.NullLogger{},
 		Metrics: &metrics,
@@ -42,10 +40,4 @@ func TestDynamicAddSampleRateKeyToTrace(t *testing.T) {
 
 	spans := trace.GetSpans()
 	assert.Len(t, spans, spanCount, "should have the same number of spans as input")
-	for _, span := range spans {
-		assert.Equal(t, span.Event.Data, map[string]interface{}{
-			"http.status_code": "200",
-			"meta.key":         "200•,",
-		}, "should add the sampling key to all spans in the trace")
-	}
 }

--- a/sample/sample.go
+++ b/sample/sample.go
@@ -11,7 +11,7 @@ import (
 )
 
 type Sampler interface {
-	GetSampleRate(trace *types.Trace) (rate uint, keep bool, reason string)
+	GetSampleRate(trace *types.Trace) (rate uint, keep bool, reason string, key string)
 	Start() error
 }
 

--- a/sample/totalthroughput_test.go
+++ b/sample/totalthroughput_test.go
@@ -19,9 +19,7 @@ func TestTotalThroughputAddSampleRateKeyToTrace(t *testing.T) {
 
 	sampler := &TotalThroughputSampler{
 		Config: &config.TotalThroughputSamplerConfig{
-			FieldList:                    []string{"http.status_code"},
-			AddSampleRateKeyToTrace:      true,
-			AddSampleRateKeyToTraceField: "meta.key",
+			FieldList: []string{"http.status_code"},
 		},
 		Logger:  &logger.NullLogger{},
 		Metrics: &metrics,
@@ -42,10 +40,4 @@ func TestTotalThroughputAddSampleRateKeyToTrace(t *testing.T) {
 
 	spans := trace.GetSpans()
 	assert.Len(t, spans, spanCount, "should have the same number of spans as input")
-	for _, span := range spans {
-		assert.Equal(t, span.Event.Data, map[string]interface{}{
-			"http.status_code": "200",
-			"meta.key":         "200•,",
-		}, "should add the sampling key to all spans in the trace")
-	}
 }

--- a/sample/trace_key.go
+++ b/sample/trace_key.go
@@ -9,35 +9,17 @@ import (
 )
 
 type traceKey struct {
-	fields            []string
-	useTraceLength    bool
-	addDynsampleKey   bool
-	addDynsampleField string
+	fields         []string
+	useTraceLength bool
 }
 
-func newTraceKey(fields []string, useTraceLength, addDynsampleKey bool, addDynsampleField string) *traceKey {
+func newTraceKey(fields []string, useTraceLength bool) *traceKey {
 	// always put the field list in sorted order for easier comparison
 	sort.Strings(fields)
 	return &traceKey{
-		fields:            fields,
-		useTraceLength:    useTraceLength,
-		addDynsampleKey:   addDynsampleKey,
-		addDynsampleField: addDynsampleField,
+		fields:         fields,
+		useTraceLength: useTraceLength,
 	}
-}
-
-// buildAndAdd, builds the trace key and adds it to the trace if configured to
-// do so
-func (d *traceKey) buildAndAdd(trace *types.Trace) string {
-	key := d.build(trace)
-
-	if d.addDynsampleKey {
-		for _, span := range trace.GetSpans() {
-			span.Data[d.addDynsampleField] = key
-		}
-	}
-
-	return key
 }
 
 // build, builds the trace key based on the configuration of the traceKeyGenerator

--- a/sample/trace_key_test.go
+++ b/sample/trace_key_test.go
@@ -9,11 +9,9 @@ import (
 
 func TestKeyGeneration(t *testing.T) {
 	fields := []string{"http.status_code", "request.path", "app.team.id", "important_field"}
-	addKey := true
-	key := "meta.key"
 	useTraceLength := true
 
-	generator := newTraceKey(fields, useTraceLength, addKey, key)
+	generator := newTraceKey(fields, useTraceLength)
 
 	trace := &types.Trace{}
 
@@ -33,11 +31,9 @@ func TestKeyGeneration(t *testing.T) {
 	assert.Equal(t, expected, generator.build(trace))
 
 	fields = []string{"http.status_code", "request.path", "app.team.id", "important_field"}
-	addKey = true
-	key = "meta.key"
 	useTraceLength = true
 
-	generator = newTraceKey(fields, useTraceLength, addKey, key)
+	generator = newTraceKey(fields, useTraceLength)
 
 	trace = &types.Trace{}
 
@@ -79,11 +75,9 @@ func TestKeyGeneration(t *testing.T) {
 
 	// now test that multiple values across spans are condensed correctly
 	fields = []string{"http.status_code"}
-	addKey = true
-	key = "meta.key"
 	useTraceLength = true
 
-	generator = newTraceKey(fields, useTraceLength, addKey, key)
+	generator = newTraceKey(fields, useTraceLength)
 
 	trace = &types.Trace{}
 
@@ -125,11 +119,9 @@ func TestKeyGeneration(t *testing.T) {
 
 	// now test that multiple values across spans in a different order are condensed the same
 	fields = []string{"http.status_code"}
-	addKey = true
-	key = "meta.key"
 	useTraceLength = true
 
-	generator = newTraceKey(fields, useTraceLength, addKey, key)
+	generator = newTraceKey(fields, useTraceLength)
 
 	trace = &types.Trace{}
 


### PR DESCRIPTION
## Which problem is this PR solving?

Refinery had rules configuration for dynamic samplers to "AddSampleRateKeyToTrace" which would inject the sample rate key into a field of the user's choice. We also have, in the normal configuration "AddRuleReasonToTrace", which also injected that key but as part of the rule reason in `meta.refinery.reason`, causing people to have to write derived columns to pull it off.

This PR addresses both of those.

## Short description of the changes

- Remove `AddSampleRateKeyToTrace` and `AddSampleRateKeyToTraceField` params from samplers
- Remove all the tests for it
- Modify the GetSampleRate function to return the reason and key separately (or a blank key)
- If the key isn't blank, add it to the spans under `meta.refinery.sample_key`
- Add tests for it

This looks big but it's a lot of small identical changes in multiple files.