### PR TITLE
fix: avoid type conversion in GetDataSize()

### DIFF
--- a/types/event.go
+++ b/types/event.go
@@ -136,13 +136,15 @@ func (sp *Span) GetDataSize() int {
 	// the data types we should be getting from JSON are:
 	// float64, int64, bool, string
 	for _, v := range sp.Data {
-		switch v.(type) {
+		switch value := v.(type) { // make value the type of v
 		case bool:
 			total += 1
 		case float64, int64, int:
 			total += 8
-		case string, []byte:
-			total += len(v.(string))
+		case string:
+			total += len(value)
+		case []byte: // should cover []uint8 as well
+			total += len(value)
 		default:
 			total += 8 // catchall
 		}


### PR DESCRIPTION
## Which problem is this PR solving?

I hit the following panic repeatedly in one of our refinery clusters:
```
panic: interface conversion: interface {} is []uint8, not string

goroutine 62 [running]:
github.com/honeycombio/refinery/types.(*Span).GetDataSize(...)
        github.com/honeycombio/refinery/types/event.go:145
github.com/honeycombio/refinery/types.(*Trace).AddSpan(0x446fdbcfd0, 0x4277f52210)
        github.com/honeycombio/refinery/types/event.go:78 +0x304
github.com/honeycombio/refinery/collect.(*InMemCollector).processSpan(0x400042f040, 0x4277f52210)
        github.com/honeycombio/refinery/collect/collect.go:515 +0x2f0
github.com/honeycombio/refinery/collect.(*InMemCollector).collect(0x400042f040)
        github.com/honeycombio/refinery/collect/collect.go:414 +0x30c
created by github.com/honeycombio/refinery/collect.(*InMemCollector).Start
        github.com/honeycombio/refinery/collect/collect.go:158 +0xa4c
```

## Short description of the changes

I changed GetDataSize() case statement so `value` will now be the type of the `v` interface. I then added a separate case for `[]byte` (which is also the underlying type of `[]uint8`)

