### PR TITLE
fix: send probes to peers during stress relief

### DIFF
--- a/collect/stressRelief.go
+++ b/collect/stressRelief.go
@@ -327,5 +327,5 @@ func (s *StressRelief) GetSampleRate(traceID string) (rate uint, keep bool, reas
 		return 1, true, "stress_relief/always"
 	}
 	hash := wyhash.Hash([]byte(traceID), hashSeed)
-	return uint(s.sampleRate), hash <= s.upperBound, "stress_relief/deterministic"
+	return uint(s.sampleRate), hash <= s.upperBound, "stress_relief/deterministic/" + s.reason
 }

--- a/route/route.go
+++ b/route/route.go
@@ -497,6 +497,12 @@ func (r *Router) processEvent(ev *types.Event, reqID interface{}) error {
 		WithString("dataset", ev.Dataset).
 		WithString("environment", ev.Environment)
 
+	// check if this is a probe; if so, we should drop it
+	if ev.Data["meta.refinery.probe"] != nil {
+		debugLog.Logf("dropping probe")
+		return nil
+	}
+
 	// extract trace ID
 	var traceID string
 	for _, traceIdFieldName := range r.Config.GetTraceIdFieldNames() {
@@ -524,25 +530,42 @@ func (r *Router) processEvent(ev *types.Event, reqID interface{}) error {
 	// we know we're a span, but we need to check if we're in Stress Relief mode;
 	// if we are, then we want to make an immediate, deterministic trace decision
 	// and either drop or send the trace without even trying to cache or forward it.
+	sendProbe := false
 	if r.Collector.Stressed() {
 		rate, keep, reason := r.Collector.GetStressedSampleRate(traceID)
 
 		r.Collector.ProcessSpanImmediately(span, keep, rate, reason)
-		return nil
+
+		// If the span was kept, we want to generate a probe that we'll forward
+		// to a peer IFF this span would have been forwarded.
+		if keep {
+			ev.Data["meta.refinery.probe"] = true
+			sendProbe = true
+		} else {
+			return nil
+		}
 	}
 
 	// Figure out if we should handle this span locally or pass on to a peer
 	targetShard := r.Sharder.WhichShard(traceID)
-	if r.incomingOrPeer == "incoming" && !targetShard.Equals(r.Sharder.MyShard()) {
+	if r.incomingOrPeer == "incoming" && sendProbe && !targetShard.Equals(r.Sharder.MyShard()) {
 		r.Metrics.Increment(r.incomingOrPeer + "_router_peer")
-		debugLog.WithString("peer", targetShard.GetAddress()).
-			Logf("Sending span from batch to my peer")
+		debugLog.
+			WithString("peer", targetShard.GetAddress()).
+			WithField("isprobe", sendProbe).
+			Logf("Sending span from batch to peer")
 		ev.APIHost = targetShard.GetAddress()
 
 		// Unfortunately this doesn't tell us if the event was actually
 		// enqueued; we need to watch the response channel to find out, at
 		// which point it's too late to tell the client.
 		r.PeerTransmission.EnqueueEvent(ev)
+		return nil
+	}
+
+	if sendProbe {
+		// If we got here it's because the span we were using for a probe was
+		// intended for us, so just skip it.
 		return nil
 	}
 

--- a/route/route.go
+++ b/route/route.go
@@ -540,7 +540,7 @@ func (r *Router) processEvent(ev *types.Event, reqID interface{}) error {
 			return nil
 		}
 		// If the span was kept, we want to generate a probe that we'll forward
-		// to a peer IFF this span would have been forwarded.
+		// to a peer IF this span would have been forwarded.
 		ev.Data["meta.refinery.probe"] = true
 		isProbe = true
 	}

--- a/route/route.go
+++ b/route/route.go
@@ -536,14 +536,13 @@ func (r *Router) processEvent(ev *types.Event, reqID interface{}) error {
 
 		r.Collector.ProcessSpanImmediately(span, keep, rate, reason)
 
-		// If the span was kept, we want to generate a probe that we'll forward
-		// to a peer IFF this span would have been forwarded.
-		if keep {
-			ev.Data["meta.refinery.probe"] = true
-			isProbe = true
-		} else {
+		if !keep {
 			return nil
 		}
+		// If the span was kept, we want to generate a probe that we'll forward
+		// to a peer IFF this span would have been forwarded.
+		ev.Data["meta.refinery.probe"] = true
+		isProbe = true
 	}
 
 	// Figure out if we should handle this span locally or pass on to a peer


### PR DESCRIPTION
## Which problem is this PR solving?

- #688 

When stress relief activates, it stops sending peer traffic. But the metrics that update stress relief based on peer volume only update when there's peer traffic. 

This causes any trace that refinery keeps (forwards to Honeycomb) in stress relief mode to *also* be sent as a probe to the appropriate peer (which then drops it).  This ensures that a little bit of traffic also gets to peers, which keeps the system operating normally and updating metrics.

## Short description of the changes

- Make a copy of the incoming event as a probe whenever stress relief is active and would keep a span; if the probe would have been sent to a peer, send it. 
- When a probe is received from a peer, drop it without further examination.
- Log when this happens on both sides.
- Add the stress relief reason to the `meta.refinery.reason` field for kept spans so that it's not only found in the logs.

