### PR TITLE
fix: Log reason for MinimumStartupDuration

### DIFF
--- a/collect/stressRelief.go
+++ b/collect/stressRelief.go
@@ -124,6 +124,7 @@ func (s *StressRelief) UpdateFromConfig(cfg config.StressReliefConfig) error {
 		if s.mode != Monitor && cfg.MinimumStartupDuration != 0 {
 			s.stressed = true
 			s.stayOnUntil = time.Now().Add(time.Duration(cfg.MinimumStartupDuration))
+			s.Logger.Info().WithField("stress_level", s.stressLevel).WithField("reason", "MinimumStartupDuration").Logf("StressRelief has been activated")
 		}
 		s.mode = Monitor
 	case "always":


### PR DESCRIPTION
## Which problem is this PR solving?

https://github.com/honeycombio/refinery/issues/702

Refinery doesn't log when starting stress relief mode on boot for `MinimumStartupDuration`

## Short description of the changes

Logs the reason for starting up in stress relief (reason is set to the name of the config in the code, `MinimumStartupDuration`)

