### PR TITLE
feat: MaxKeys fixes

### DIFF
--- a/config/config_test_reload_error_test.go
+++ b/config/config_test_reload_error_test.go
@@ -26,7 +26,7 @@ func TestErrorReloading(t *testing.T) {
 	defer os.Remove(rules)
 	defer os.Remove(config)
 
-	opts, err := NewCmdEnvOptions([]string{"--no-validate", "--config", config, "--rules_config", rules})
+	opts, err := NewCmdEnvOptions([]string{"--config", config, "--rules_config", rules})
 	assert.NoError(t, err)
 
 	ch := make(chan interface{}, 1)

--- a/config/config_test_reload_error_test.go
+++ b/config/config_test_reload_error_test.go
@@ -26,7 +26,7 @@ func TestErrorReloading(t *testing.T) {
 	defer os.Remove(rules)
 	defer os.Remove(config)
 
-	opts, err := NewCmdEnvOptions([]string{"--config", config, "--rules_config", rules})
+	opts, err := NewCmdEnvOptions([]string{"--no-validate", "--config", config, "--rules_config", rules})
 	assert.NoError(t, err)
 
 	ch := make(chan interface{}, 1)

--- a/sample/dynamic.go
+++ b/sample/dynamic.go
@@ -19,6 +19,7 @@ type DynamicSampler struct {
 
 	sampleRate     int64
 	clearFrequency config.Duration
+	maxKeys        int
 
 	key *traceKey
 
@@ -34,12 +35,16 @@ func (d *DynamicSampler) Start() error {
 	}
 	d.clearFrequency = d.Config.ClearFrequency
 	d.key = newTraceKey(d.Config.FieldList, d.Config.UseTraceLength)
+	d.maxKeys = d.Config.MaxKeys
+	if d.maxKeys == 0 {
+		d.maxKeys = 500
+	}
 
 	// spin up the actual dynamic sampler
 	d.dynsampler = &dynsampler.AvgSampleRate{
 		GoalSampleRate:         int(d.sampleRate),
 		ClearFrequencyDuration: time.Duration(d.clearFrequency),
-		MaxKeys:                d.Config.MaxKeys,
+		MaxKeys:                d.maxKeys,
 	}
 	d.dynsampler.Start()
 

--- a/sample/dynamic_ema.go
+++ b/sample/dynamic_ema.go
@@ -39,8 +39,11 @@ func (d *EMADynamicSampler) Start() error {
 	d.ageOutValue = d.Config.AgeOutValue
 	d.burstMultiple = d.Config.BurstMultiple
 	d.burstDetectionDelay = d.Config.BurstDetectionDelay
-	d.maxKeys = d.Config.MaxKeys
 	d.key = newTraceKey(d.Config.FieldList, d.Config.UseTraceLength)
+	d.maxKeys = d.Config.MaxKeys
+	if d.maxKeys == 0 {
+		d.maxKeys = 500
+	}
 
 	// spin up the actual dynamic sampler
 	d.dynsampler = &dynsampler.EMASampleRate{

--- a/sample/ema_throughput.go
+++ b/sample/ema_throughput.go
@@ -41,8 +41,11 @@ func (d *EMAThroughputSampler) Start() error {
 	d.ageOutValue = d.Config.AgeOutValue
 	d.burstMultiple = d.Config.BurstMultiple
 	d.burstDetectionDelay = d.Config.BurstDetectionDelay
-	d.maxKeys = d.Config.MaxKeys
 	d.key = newTraceKey(d.Config.FieldList, d.Config.UseTraceLength)
+	d.maxKeys = d.Config.MaxKeys
+	if d.maxKeys == 0 {
+		d.maxKeys = 500
+	}
 
 	// spin up the actual dynamic sampler
 	d.dynsampler = &dynsampler.EMAThroughput{

--- a/sample/totalthroughput.go
+++ b/sample/totalthroughput.go
@@ -19,6 +19,7 @@ type TotalThroughputSampler struct {
 
 	goalThroughputPerSec int64
 	clearFrequency       config.Duration
+	maxKeys              int
 
 	key *traceKey
 
@@ -38,11 +39,16 @@ func (d *TotalThroughputSampler) Start() error {
 	}
 	d.clearFrequency = d.Config.ClearFrequency
 	d.key = newTraceKey(d.Config.FieldList, d.Config.UseTraceLength)
+	d.maxKeys = d.Config.MaxKeys
+	if d.maxKeys == 0 {
+		d.maxKeys = 500
+	}
 
 	// spin up the actual dynamic sampler
 	d.dynsampler = &dynsampler.TotalThroughput{
 		GoalThroughputPerSec:   int(d.goalThroughputPerSec),
 		ClearFrequencyDuration: time.Duration(d.clearFrequency),
+		MaxKeys:                d.maxKeys,
 	}
 	d.dynsampler.Start()
 

--- a/sample/windowed_throughput.go
+++ b/sample/windowed_throughput.go
@@ -33,8 +33,11 @@ func (d *WindowedThroughputSampler) Start() error {
 	d.goalthroughputpersec = d.Config.GoalThroughputPerSec
 	d.updatefrequency = d.Config.UpdateFrequency
 	d.lookbackfrequency = d.Config.LookbackFrequency
-	d.maxKeys = d.Config.MaxKeys
 	d.key = newTraceKey(d.Config.FieldList, d.Config.UseTraceLength)
+	d.maxKeys = d.Config.MaxKeys
+	if d.maxKeys == 0 {
+		d.maxKeys = 500
+	}
 
 	// spin up the actual dynamic sampler
 	d.dynsampler = &dynsampler.WindowedThroughput{

--- a/tools/convert/rules.md
+++ b/tools/convert/rules.md
@@ -1126,7 +1126,7 @@ Type: `string`
 
 
 ---
-## Samplers: 
+## Samplers:
 
 Samplers is a mapping of targets to samplers. Each target is a
 Honeycomb environment (or, for classic keys, a dataset). The value is


### PR DESCRIPTION
Depends on #709 

## Which problem is this PR solving?

- The MaxKeys value is supported in most samplers, but it wasn't always included in the config
- It defaulted to 0 which means "no max" -- Honeycomb CAs agree this is not a useful setting.

## Short description of the changes

- Support MaxKeys in all dynamic samplers
- 0 now means 500

