### PR TITLE
fix: API key logic

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -113,7 +113,7 @@ func newStartedApp(
 		GetPeerBufferSizeVal:                 10000,
 		GetListenAddrVal:                     "127.0.0.1:" + strconv.Itoa(basePort),
 		GetPeerListenAddrVal:                 "127.0.0.1:" + strconv.Itoa(basePort+1),
-		GetAPIKeysVal:                        []string{legacyAPIKey, nonLegacyAPIKey},
+		IsAPIKeyValidFunc:                    func(k string) bool { return k == legacyAPIKey || k == nonLegacyAPIKey },
 		GetHoneycombAPIVal:                   "http://api.honeycomb.io",
 		GetInMemoryCollectorCacheCapacityVal: config.CollectionConfig{CacheCapacity: 10000},
 		AddHostMetadataToTrace:               enableHostMetadata,
@@ -326,7 +326,7 @@ func TestAppIntegrationWithUnauthorizedKey(t *testing.T) {
 	data, err := io.ReadAll(resp.Body)
 	resp.Body.Close()
 	assert.NoError(t, err)
-	assert.Contains(t, string(data), "not found in list of authed keys")
+	assert.Contains(t, string(data), "not found in list of authorized keys")
 
 	err = startstop.Stop(graph.Objects(), nil)
 	assert.NoError(t, err)

--- a/config/config.go
+++ b/config/config.go
@@ -35,8 +35,8 @@ type Config interface {
 	// incoming events over gRPC
 	GetGRPCListenAddr() (string, error)
 
-	// GetAPIKeys returns a list of Honeycomb API keys
-	GetAPIKeys() ([]string, error)
+	// IsAPIKeyValid checks if the given API key is valid according to the rules
+	IsAPIKeyValid(key string) bool
 
 	// GetPeers returns a list of other servers participating in this proxy cluster
 	GetPeers() ([]string, error)

--- a/config/mock.go
+++ b/config/mock.go
@@ -10,8 +10,7 @@ import (
 // initialization
 type MockConfig struct {
 	Callbacks                            []func()
-	GetAPIKeysErr                        error
-	GetAPIKeysVal                        []string
+	IsAPIKeyValidFunc                    func(string) bool
 	GetCollectorTypeErr                  error
 	GetCollectorTypeVal                  string
 	GetInMemoryCollectorCacheCapacityErr error
@@ -107,11 +106,16 @@ func (m *MockConfig) RegisterReloadCallback(callback func()) {
 	m.Mux.Unlock()
 }
 
-func (m *MockConfig) GetAPIKeys() ([]string, error) {
+func (m *MockConfig) IsAPIKeyValid(key string) bool {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
-	return m.GetAPIKeysVal, m.GetAPIKeysErr
+	// if no function is set, assume the key is valid
+	if m.IsAPIKeyValidFunc == nil {
+		return true
+	}
+
+	return m.IsAPIKeyValidFunc(key)
 }
 
 func (m *MockConfig) GetCollectorType() (string, error) {

--- a/route/middleware.go
+++ b/route/middleware.go
@@ -37,25 +37,6 @@ func (r *Router) queryTokenChecker(next http.Handler) http.Handler {
 	})
 }
 
-func (r *Router) isKeyAllowed(key string) bool {
-	allowedKeys, err := r.Config.GetAPIKeys()
-	if len(allowedKeys) == 0 {
-		return true
-	}
-	if err != nil {
-		return false
-	}
-	for _, allowedKey := range allowedKeys {
-		if allowedKey == "*" {
-			return true
-		}
-		if allowedKey == key {
-			return true
-		}
-	}
-	return false
-}
-
 func (r *Router) apiKeyChecker(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		apiKey := req.Header.Get(types.APIKeyHeader)
@@ -67,11 +48,11 @@ func (r *Router) apiKeyChecker(next http.Handler) http.Handler {
 			r.handlerReturnWithError(w, ErrAuthNeeded, err)
 			return
 		}
-		if r.isKeyAllowed(apiKey) {
+		if r.Config.IsAPIKeyValid(apiKey) {
 			next.ServeHTTP(w, req)
 			return
 		}
-		err := fmt.Errorf("api key %s not found in list of authed keys", apiKey)
+		err := fmt.Errorf("api key %s not found in list of authorized keys", apiKey)
 		r.handlerReturnWithError(w, ErrAuthNeeded, err)
 	})
 }

--- a/route/otlp_trace.go
+++ b/route/otlp_trace.go
@@ -15,8 +15,8 @@ import (
 func (r *Router) postOTLP(w http.ResponseWriter, req *http.Request) {
 	ri := huskyotlp.GetRequestInfoFromHttpHeaders(req.Header)
 
-	if !r.isKeyAllowed(ri.ApiKey) {
-		err := fmt.Errorf("api key %s not found in list of authed keys", ri.ApiKey)
+	if !r.Config.IsAPIKeyValid(ri.ApiKey) {
+		err := fmt.Errorf("api key %s not found in list of authorized keys", ri.ApiKey)
 		r.handlerReturnWithError(w, ErrAuthNeeded, err)
 		return
 	}

--- a/route/otlp_trace_test.go
+++ b/route/otlp_trace_test.go
@@ -410,7 +410,7 @@ func TestOTLPHandler(t *testing.T) {
 		w := httptest.NewRecorder()
 		router.postOTLP(w, request)
 		assert.Equal(t, http.StatusBadRequest, w.Code)
-		assert.Contains(t, w.Body.String(), "not found in list of authed keys")
+		assert.Contains(t, w.Body.String(), "not found in list of authorized keys")
 
 		assert.Equal(t, 0, len(mockTransmission.Events))
 		mockTransmission.Flush()

--- a/route/otlp_trace_test.go
+++ b/route/otlp_trace_test.go
@@ -388,7 +388,7 @@ func TestOTLPHandler(t *testing.T) {
 	})
 
 	t.Run("rejects bad API keys", func(t *testing.T) {
-		router.Config.(*config.MockConfig).GetAPIKeysVal = []string{"bad-key"}
+		router.Config.(*config.MockConfig).IsAPIKeyValidFunc = func(k string) bool { return false }
 		req := &collectortrace.ExportTraceServiceRequest{
 			ResourceSpans: []*trace.ResourceSpans{{
 				ScopeSpans: []*trace.ScopeSpans{{


### PR DESCRIPTION

## Which problem is this PR solving?

- The new config changed the way that the list of authorized API keys is managed. This carries that through the internal logic and makes it faster as well.

## Short description of the changes

- Change GetAPIKeys() to IsAPIKeyValid
- Use the boolean flag as an early-out
- Store the list of keys in a set for O(1) access
- Fix tests that used it

Fixes #673.