### PR TITLE
feat: Add sampler metrics

### DIFF
--- a/sample/dynamic_ema.go
+++ b/sample/dynamic_ema.go
@@ -24,6 +24,8 @@ type EMADynamicSampler struct {
 	burstMultiple       float64
 	burstDetectionDelay uint
 	maxKeys             int
+	prefix              string
+	lastMetrics         map[string]int64
 
 	key *traceKey
 
@@ -44,6 +46,7 @@ func (d *EMADynamicSampler) Start() error {
 	if d.maxKeys == 0 {
 		d.maxKeys = 500
 	}
+	d.prefix = "emadynamic_"
 
 	// spin up the actual dynamic sampler
 	d.dynsampler = &dynsampler.EMASampleRate{
@@ -58,10 +61,13 @@ func (d *EMADynamicSampler) Start() error {
 	d.dynsampler.Start()
 
 	// Register statistics this package will produce
-	d.Metrics.Register("dynsampler_num_dropped", "counter")
-	d.Metrics.Register("dynsampler_num_kept", "counter")
-	d.Metrics.Register("dynsampler_sample_rate", "histogram")
-
+	d.lastMetrics = d.dynsampler.GetMetrics(d.prefix)
+	for name := range d.lastMetrics {
+		d.Metrics.Register(name, getMetricType(name))
+	}
+	d.Metrics.Register(d.prefix+"num_dropped", "counter")
+	d.Metrics.Register(d.prefix+"num_kept", "counter")
+	d.Metrics.Register(d.prefix+"sample_rate", "histogram")
 	return nil
 }
 
@@ -79,10 +85,19 @@ func (d *EMADynamicSampler) GetSampleRate(trace *types.Trace) (rate uint, keep b
 		"trace_id":    trace.TraceID,
 	}).Logf("got sample rate and decision")
 	if shouldKeep {
-		d.Metrics.Increment("dynsampler_num_kept")
+		d.Metrics.Increment(d.prefix + "num_kept")
 	} else {
-		d.Metrics.Increment("dynsampler_num_dropped")
+		d.Metrics.Increment(d.prefix + "num_dropped")
 	}
-	d.Metrics.Histogram("dynsampler_sample_rate", float64(rate))
+	d.Metrics.Histogram(d.prefix+"sample_rate", float64(rate))
+	for name, val := range d.dynsampler.GetMetrics(d.prefix) {
+		switch getMetricType(name) {
+		case "counter":
+			delta := val - d.lastMetrics[name]
+			d.Metrics.Count(name, delta)
+		case "gauge":
+			d.Metrics.Gauge(name, val)
+		}
+	}
 	return rate, shouldKeep, "emadynamic", key
 }

--- a/sample/sample.go
+++ b/sample/sample.go
@@ -3,6 +3,7 @@ package sample
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/honeycombio/refinery/config"
 	"github.com/honeycombio/refinery/logger"
@@ -40,7 +41,7 @@ func (s *SamplerFactory) GetSamplerImplementationForKey(samplerKey string, isLeg
 
 	switch c := c.(type) {
 	case *config.DeterministicSamplerConfig:
-		sampler = &DeterministicSampler{Config: c, Logger: s.Logger}
+		sampler = &DeterministicSampler{Config: c, Logger: s.Logger, Metrics: s.Metrics}
 	case *config.DynamicSamplerConfig:
 		sampler = &DynamicSampler{Config: c, Logger: s.Logger, Metrics: s.Metrics}
 	case *config.EMADynamicSamplerConfig:
@@ -63,4 +64,11 @@ func (s *SamplerFactory) GetSamplerImplementationForKey(samplerKey string, isLeg
 	s.Logger.Debug().WithField("dataset", samplerKey).Logf("created implementation for sampler type %T", c)
 
 	return sampler
+}
+
+func getMetricType(name string) string {
+	if strings.HasSuffix(name, "_count") {
+		return "counter"
+	}
+	return "gauge"
 }

--- a/sample/totalthroughput.go
+++ b/sample/totalthroughput.go
@@ -20,6 +20,8 @@ type TotalThroughputSampler struct {
 	goalThroughputPerSec int64
 	clearFrequency       config.Duration
 	maxKeys              int
+	prefix               string
+	lastMetrics          map[string]int64
 
 	key *traceKey
 
@@ -43,6 +45,7 @@ func (d *TotalThroughputSampler) Start() error {
 	if d.maxKeys == 0 {
 		d.maxKeys = 500
 	}
+	d.prefix = "totalthroughput_"
 
 	// spin up the actual dynamic sampler
 	d.dynsampler = &dynsampler.TotalThroughput{
@@ -53,9 +56,13 @@ func (d *TotalThroughputSampler) Start() error {
 	d.dynsampler.Start()
 
 	// Register statistics this package will produce
-	d.Metrics.Register("dynsampler_num_dropped", "counter")
-	d.Metrics.Register("dynsampler_num_kept", "counter")
-	d.Metrics.Register("dynsampler_sample_rate", "histogram")
+	d.lastMetrics = d.dynsampler.GetMetrics(d.prefix)
+	for name := range d.lastMetrics {
+		d.Metrics.Register(name, getMetricType(name))
+	}
+	d.Metrics.Register(d.prefix+"num_dropped", "counter")
+	d.Metrics.Register(d.prefix+"num_kept", "counter")
+	d.Metrics.Register(d.prefix+"sample_rate", "histogram")
 
 	return nil
 }
@@ -74,10 +81,19 @@ func (d *TotalThroughputSampler) GetSampleRate(trace *types.Trace) (rate uint, k
 		"trace_id":    trace.TraceID,
 	}).Logf("got sample rate and decision")
 	if shouldKeep {
-		d.Metrics.Increment("dynsampler_num_kept")
+		d.Metrics.Increment(d.prefix + "num_kept")
 	} else {
-		d.Metrics.Increment("dynsampler_num_dropped")
+		d.Metrics.Increment(d.prefix + "num_dropped")
 	}
-	d.Metrics.Histogram("dynsampler_sample_rate", float64(rate))
+	d.Metrics.Histogram(d.prefix+"sample_rate", float64(rate))
+	for name, val := range d.dynsampler.GetMetrics(d.prefix) {
+		switch getMetricType(name) {
+		case "counter":
+			delta := val - d.lastMetrics[name]
+			d.Metrics.Count(name, delta)
+		case "gauge":
+			d.Metrics.Gauge(name, val)
+		}
+	}
 	return rate, shouldKeep, "totalthroughput", key
 }


### PR DESCRIPTION

## Which problem is this PR solving?

- Adds sampler-specific metrics now that dynsampler-go supports them.

## Short description of the changes

- Add getMetricType function to get the type from a metric by its name. This is required because Metrics can only increment counters, not set them to a value, so we need to treat metrics ending in _count specially by keeping track of their previous value so we can get a delta.
- Register all metrics provided by the sampler
- Record them on every call to GetSampleRate
- Add metrics to DeterministicSampler following the same pattern
- Update rules to do the same (and add support for new downstream sampler types)

Closes #704.