### PR TITLE
perf: Create fibcache alternative cache; not used yet

### DIFF
--- a/collect/cache/fibcache.go
+++ b/collect/cache/fibcache.go
@@ -1,0 +1,134 @@
+package cache
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/honeycombio/refinery/logger"
+	"github.com/honeycombio/refinery/metrics"
+	"github.com/honeycombio/refinery/types"
+
+	fibheap "github.com/starwander/GoFibonacciHeap"
+)
+
+// // Cache is a non-threadsafe cache. It must not be used for concurrent access.
+// type Cache interface {
+// 	// Set adds the trace to the cache. If it is kicking out a trace from the cache
+// 	// that has not yet been sent, it will return that trace. Otherwise returns nil.
+// 	Set(trace *types.Trace) *types.Trace
+// 	Get(traceID string) *types.Trace
+// 	// GetAll is used during shutdown to get all in-flight traces to flush them
+// 	GetAll() []*types.Trace
+
+// 	// Retrieve and remove all traces which are past their SendBy date.
+// 	// Does not check whether they've been sent.
+// 	TakeExpiredTraces(now time.Time) []*types.Trace
+// }
+
+// FibonacciCache keeps a bounded number of entries to avoid growing memory
+// forever. It uses a fibonacci heap to keep track of the expiration times of
+// the entries.
+type FibonacciCache struct {
+	Metrics metrics.Metrics
+	Logger  logger.Logger
+
+	heap     *fibheap.FibHeap
+	capacity int
+}
+
+const FibonacciCacheCapacity = 10000
+
+func NewFibonacciCache(capacity int, metrics metrics.Metrics, logger logger.Logger) *FibonacciCache {
+	logger.Debug().Logf("Starting FibonacciCache")
+	defer func() { logger.Debug().Logf("Finished starting FibonacciCache") }()
+
+	// buffer_overrun increments when the trace overwritten in the circular
+	// buffer has not yet been sent
+	metrics.Register("collect_cache_buffer_overrun", "counter")
+	metrics.Register("collect_cache_capacity", "gauge")
+	metrics.Register("collect_cache_entries", "histogram")
+
+	if capacity == 0 {
+		capacity = FibonacciCacheCapacity
+	}
+
+	return &FibonacciCache{
+		Metrics:  metrics,
+		Logger:   logger,
+		heap:     fibheap.NewFibHeap(),
+		capacity: capacity,
+	}
+
+}
+
+func (f *FibonacciCache) GetCacheSize() int {
+	return int(f.heap.Num())
+}
+
+// Set adds the trace to the cach. If it is kicking out a trace from the cache
+// that has not yet been sent, it will return that trace. Otherwise returns nil.
+func (f *FibonacciCache) Set(trace *types.Trace) *types.Trace {
+
+	// set retTrace to a trace if it is getting kicked out without having been
+	// sent. Leave it nil if we're not kicking out an unsent trace.
+	var retTrace *types.Trace
+
+	if int(f.heap.Num()) >= f.capacity {
+		// the heap is full, so prepare to return the oldest trace
+		// (if it hasn't been sent already)
+		oldTrace := f.heap.ExtractMinValue().(*types.Trace)
+		if !oldTrace.Sent {
+			// if it hasn't already been sent,
+			// record that we're overrunning the buffer
+			f.Metrics.Increment("collect_cache_buffer_overrun")
+			// and return the trace so it can be sent.
+			retTrace = oldTrace
+		}
+	}
+
+	// store the trace
+	f.heap.InsertValue(trace)
+	return retTrace
+}
+
+func (f *FibonacciCache) Get(traceID string) *types.Trace {
+	return f.heap.GetValue(traceID).(*types.Trace)
+}
+
+// GetAll is not thread safe and should only be used when that's ok
+// Returns all non-nil trace entries.
+func (f *FibonacciCache) GetAll() []*types.Trace {
+	tmp := make([]*types.Trace, 0, f.GetCacheSize())
+	for v := f.heap.ExtractMinValue(); v != nil; v = f.heap.ExtractMinValue() {
+		t := v.(*types.Trace)
+		fmt.Println(t.Key())
+		tmp = append(tmp, v.(*types.Trace))
+	}
+	return tmp
+}
+
+// TakeExpiredTraces should be called to decide which traces are past their expiration time;
+// It removes and returns them.
+func (f *FibonacciCache) TakeExpiredTraces(now time.Time) []*types.Trace {
+	f.Metrics.Gauge("collect_cache_capacity", float64(f.capacity))
+	f.Metrics.Histogram("collect_cache_entries", float64(f.heap.Num()))
+
+	var res []*types.Trace
+	// repeat while we're not empty and the minimum value is expired
+	for t := f.heap.MinimumValue().(*types.Trace); t != nil && now.After(t.SendBy); t = f.heap.MinimumValue().(*types.Trace) {
+		res = append(res, t)
+		f.heap.DeleteValue(t)
+	}
+	return res
+}
+
+// RemoveTraces accepts a set of trace IDs and removes any matching ones from
+// the insertion list. This is used in the case of a cache overrun.
+func (f *FibonacciCache) RemoveTraces(toDelete map[string]struct{}) {
+	f.Metrics.Gauge("collect_cache_capacity", float64(f.capacity))
+	f.Metrics.Histogram("collect_cache_entries", float64(f.heap.Num()))
+
+	for k := range toDelete {
+		f.heap.Delete(k)
+	}
+}

--- a/collect/cache/fibcache_test.go
+++ b/collect/cache/fibcache_test.go
@@ -1,0 +1,106 @@
+package cache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/honeycombio/refinery/logger"
+	"github.com/honeycombio/refinery/metrics"
+	"github.com/honeycombio/refinery/types"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestFibCacheSetGet sets a value then fetches it back
+func TestFibCacheSetGet(t *testing.T) {
+	s := &metrics.MockMetrics{}
+	s.Start()
+	c := NewFibonacciCache(10, s, &logger.NullLogger{})
+
+	trace := &types.Trace{
+		TraceID: "abc123",
+	}
+	c.Set(trace)
+	tr := c.Get(trace.TraceID)
+	assert.Equal(t, trace, tr, "fetched trace should equal what we put in")
+}
+
+// TestFibBufferOverrun verifies that when we have more in-flight traces than the
+// size of the buffer, we get a buffer overrun metric emitted
+func TestFibBufferOverrun(t *testing.T) {
+	s := &metrics.MockMetrics{}
+	s.Start()
+	c := NewFibonacciCache(2, s, &logger.NullLogger{})
+
+	traces := []*types.Trace{
+		{TraceID: "abc123"},
+		{TraceID: "def456"},
+		{TraceID: "ghi789"},
+	}
+
+	c.Set(traces[0])
+	c.Set(traces[1])
+	assert.Equal(t, 0, s.CounterIncrements["collect_cache_buffer_overrun"], "buffer should not yet have overrun")
+	c.Set(traces[2])
+	assert.Equal(t, 1, s.CounterIncrements["collect_cache_buffer_overrun"], "buffer should have overrun")
+}
+
+func TestFibTakeExpiredTraces(t *testing.T) {
+	s := &metrics.MockMetrics{}
+	s.Start()
+	c := NewFibonacciCache(10, s, &logger.NullLogger{})
+
+	now := time.Now()
+	traces := []*types.Trace{
+		{TraceID: "1", SendBy: now.Add(-time.Minute), Sent: true}, // third most old
+		{TraceID: "2", SendBy: now.Add(-2 * time.Minute)},         // second most old
+		{TraceID: "3", SendBy: now.Add(time.Minute)},
+		{TraceID: "4"}, // very old
+	}
+	for _, t := range traces {
+		c.Set(t)
+	}
+
+	expired := c.TakeExpiredTraces(now)
+	assert.Equal(t, 3, len(expired))
+	assert.Equal(t, traces[3], expired[0])
+	assert.Equal(t, traces[1], expired[1])
+	assert.Equal(t, traces[0], expired[2])
+
+	assert.Equal(t, 1, c.GetCacheSize())
+
+	all := c.GetAll()
+	assert.Equal(t, 1, len(all))
+	for i := range all {
+		assert.Equal(t, traces[2], all[i])
+	}
+}
+
+func TestFibRemoveSentTraces(t *testing.T) {
+	s := &metrics.MockMetrics{}
+	s.Start()
+	c := NewFibonacciCache(10, s, &logger.NullLogger{})
+
+	now := time.Now()
+	traces := []*types.Trace{
+		{TraceID: "1", SendBy: now.Add(-time.Minute), Sent: true},
+		{TraceID: "2", SendBy: now.Add(-time.Minute)},
+		{TraceID: "3", SendBy: now.Add(time.Minute)},
+		{TraceID: "4"},
+	}
+	for _, t := range traces {
+		c.Set(t)
+	}
+
+	deletes := map[string]struct{}{
+		"1": {},
+		"3": {},
+		"4": {},
+		"5": {}, // not present
+	}
+
+	c.RemoveTraces(deletes)
+
+	all := c.GetAll()
+	assert.Equal(t, 1, len(all))
+	assert.Equal(t, traces[1], all[0])
+}

--- a/go.mod
+++ b/go.mod
@@ -62,6 +62,7 @@ require (
 	github.com/prometheus/common v0.42.0 // indirect
 	github.com/prometheus/procfs v0.9.0 // indirect
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
+	github.com/starwander/GoFibonacciHeap v0.0.0-20190508061137-ba2e4f01000a // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/vmihailenco/msgpack/v5 v5.3.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -114,6 +114,8 @@ github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZV
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/sirupsen/logrus v1.9.2 h1:oxx1eChJGI6Uks2ZC4W1zpLlVgqB8ner4EuQwV4Ik1Y=
 github.com/sirupsen/logrus v1.9.2/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
+github.com/starwander/GoFibonacciHeap v0.0.0-20190508061137-ba2e4f01000a h1:HxQEVn2dC2DyalPmsBVsTRsB05UpBmbgZV2a939iEwE=
+github.com/starwander/GoFibonacciHeap v0.0.0-20190508061137-ba2e4f01000a/go.mod h1:0UZshEHv45sVxpYdRE55cbIVuvbXD3+liaXyrgm1Mr4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/types/event.go
+++ b/types/event.go
@@ -69,6 +69,20 @@ type Trace struct {
 	totalImpact int
 }
 
+// implement fibheap Value interface with Tag and Key methods
+// returns a unique tag for a given trace
+func (t *Trace) Tag() any {
+	return t.TraceID
+}
+
+// returns a value to sort traces by -- we use the send by time converted to a
+// float value -- we take the time in seconds and convert it to a float.
+func (t *Trace) Key() float64 {
+	v := float64(t.SendBy.Unix())
+	v += float64(t.SendBy.UnixNano()%1e9) / 1e9
+	return v
+}
+
 // AddSpan adds a span to this trace
 func (t *Trace) AddSpan(sp *Span) {
 	// We've done all the work to know this is a trace we are putting in our cache, so


### PR DESCRIPTION
## Which problem is this PR solving?

- The existing legacy in-memory cache uses a hand-coded circular buffer to manage cache entries, and will overwrite long-lived traces because it just marches through the buffer in receive order -- even if the buffer wasn't full. This PR replaces that with a Fibonacci Heap, which is a priority heap structure that offers O(1) insertion and O(log n) deletion without keeping old items in the heap. Therefore, we should see many fewer cache overruns.

The code is also quite small, and with a bit of rework to the cache interface, this library would make resizing the cache a lot cheaper.

This implementation preserves the cache size limit.

This is still a draft; needs some benchmarking and a bit more testing.

## Short description of the changes

- Add the FibHeap object
- Implement the Key and Tag functions on Trace so they can be stored in the heap easily
- Add some tests

Closes #545.
