### PR TITLE
feat: preregister libhoney metrics

### DIFF
--- a/cmd/refinery/main.go
+++ b/cmd/refinery/main.go
@@ -142,6 +142,21 @@ func main() {
 	upstreamMetricsRecorder := metrics.NewMetricsPrefixer("libhoney_upstream")
 	peerMetricsRecorder := metrics.NewMetricsPrefixer("libhoney_peer")
 
+	// these are the metrics that libhoney will emit; we preregister them so that they always appear
+	libhoneyMetricsName := map[string]string{
+		"queue_length":           "gauge",
+		"queue_overflow":         "counter",
+		"send_errors":            "counter",
+		"send_retries":           "counter",
+		"batches_sent":           "counter",
+		"messages_sent":          "counter",
+		"response_decode_errors": "counter",
+	}
+	for name, typ := range libhoneyMetricsName {
+		upstreamMetricsRecorder.Register(name, typ)
+		peerMetricsRecorder.Register(name, typ)
+	}
+
 	userAgentAddition := "refinery/" + version
 	upstreamClient, err := libhoney.NewClient(libhoney.ClientConfig{
 		Transmission: &transmission.Honeycomb{


### PR DESCRIPTION

## Which problem is this PR solving?

- Fixes #691 by pre-registering metrics generated by libhoney.

## Short description of the changes

- Pre-register two instances of metrics, once for peers and once for upstream.

