### PR TITLE
fix: Update dynamic samplers to use GetSampleRateMulti

### DIFF
--- a/sample/dynamic.go
+++ b/sample/dynamic.go
@@ -65,7 +65,8 @@ func (d *DynamicSampler) Start() error {
 
 func (d *DynamicSampler) GetSampleRate(trace *types.Trace) (rate uint, keep bool, reason string, key string) {
 	key = d.key.build(trace)
-	rate = uint(d.dynsampler.GetSampleRate(key))
+	count := int(trace.DescendantCount())
+	rate = uint(d.dynsampler.GetSampleRateMulti(key, count))
 	if rate < 1 { // protect against dynsampler being broken even though it shouldn't be
 		rate = 1
 	}
@@ -75,6 +76,7 @@ func (d *DynamicSampler) GetSampleRate(trace *types.Trace) (rate uint, keep bool
 		"sample_rate": rate,
 		"sample_keep": shouldKeep,
 		"trace_id":    trace.TraceID,
+		"span_count":  count,
 	}).Logf("got sample rate and decision")
 	if shouldKeep {
 		d.Metrics.Increment(d.prefix + "num_kept")

--- a/sample/dynamic_ema.go
+++ b/sample/dynamic_ema.go
@@ -73,7 +73,8 @@ func (d *EMADynamicSampler) Start() error {
 
 func (d *EMADynamicSampler) GetSampleRate(trace *types.Trace) (rate uint, keep bool, reason string, key string) {
 	key = d.key.build(trace)
-	rate = uint(d.dynsampler.GetSampleRate(key))
+	count := int(trace.DescendantCount())
+	rate = uint(d.dynsampler.GetSampleRateMulti(key, count))
 	if rate < 1 { // protect against dynsampler being broken even though it shouldn't be
 		rate = 1
 	}
@@ -83,6 +84,7 @@ func (d *EMADynamicSampler) GetSampleRate(trace *types.Trace) (rate uint, keep b
 		"sample_rate": rate,
 		"sample_keep": shouldKeep,
 		"trace_id":    trace.TraceID,
+		"span_count":  count,
 	}).Logf("got sample rate and decision")
 	if shouldKeep {
 		d.Metrics.Increment(d.prefix + "num_kept")

--- a/sample/ema_throughput.go
+++ b/sample/ema_throughput.go
@@ -77,7 +77,8 @@ func (d *EMAThroughputSampler) Start() error {
 
 func (d *EMAThroughputSampler) GetSampleRate(trace *types.Trace) (rate uint, keep bool, reason string, key string) {
 	key = d.key.build(trace)
-	rate = uint(d.dynsampler.GetSampleRate(key))
+	count := int(trace.DescendantCount())
+	rate = uint(d.dynsampler.GetSampleRateMulti(key, count))
 	if rate < 1 { // protect against dynsampler being broken even though it shouldn't be
 		rate = 1
 	}
@@ -87,6 +88,7 @@ func (d *EMAThroughputSampler) GetSampleRate(trace *types.Trace) (rate uint, kee
 		"sample_rate": rate,
 		"sample_keep": shouldKeep,
 		"trace_id":    trace.TraceID,
+		"span_count":  count,
 	}).Logf("got sample rate and decision")
 	if shouldKeep {
 		d.Metrics.Increment(d.prefix + "num_kept")

--- a/sample/totalthroughput.go
+++ b/sample/totalthroughput.go
@@ -69,7 +69,8 @@ func (d *TotalThroughputSampler) Start() error {
 
 func (d *TotalThroughputSampler) GetSampleRate(trace *types.Trace) (rate uint, keep bool, reason string, key string) {
 	key = d.key.build(trace)
-	rate = uint(d.dynsampler.GetSampleRate(key))
+	count := int(trace.DescendantCount())
+	rate = uint(d.dynsampler.GetSampleRateMulti(key, count))
 	if rate < 1 { // protect against dynsampler being broken even though it shouldn't be
 		rate = 1
 	}
@@ -79,6 +80,7 @@ func (d *TotalThroughputSampler) GetSampleRate(trace *types.Trace) (rate uint, k
 		"sample_rate": rate,
 		"sample_keep": shouldKeep,
 		"trace_id":    trace.TraceID,
+		"span_count":  count,
 	}).Logf("got sample rate and decision")
 	if shouldKeep {
 		d.Metrics.Increment(d.prefix + "num_kept")


### PR DESCRIPTION
## Which problem is this PR solving?

- As it says in #636, throughput and dynamic sampler calculations have been based on the wrong numbers for some time. They've been counting traces, not spans, and yet everything about Honeycomb is based on span count. Most people think it works by counting spans and are then surprised when sample rates seem incorrect for their volume, and in fact, our documentation says that it works this way.

## Short description of the changes

- This changes Refinery's dynamic and throughput sampler requests to use the span count, not the trace count, when calculating numbers for the dynamic samplers and throughput samplers. 

This will need to be reflected in updated documentation.

Closes #636.