### PR TITLE
maint: remove remaining references to obsolete fields

### DIFF
--- a/collect/collect.go
+++ b/collect/collect.go
@@ -491,9 +491,8 @@ func (i *InMemCollector) dealWithSentTrace(keep bool, sampleRate uint, spanCount
 	}
 	isDryRun := i.Config.GetIsDryRun()
 	if isDryRun {
-		field := i.Config.GetDryRunFieldName()
 		// if dry run mode is enabled, we keep all traces and mark the spans with the sampling decision
-		sp.Data[field] = keep
+		sp.Data[config.DryRunFieldName] = keep
 		if !keep {
 			i.Logger.Debug().WithField("trace_id", sp.TraceID).Logf("Sending span that would have been dropped, but dry run mode is enabled")
 			i.addAdditionalAttributes(sp)
@@ -639,8 +638,7 @@ func (i *InMemCollector) send(trace *types.Trace, reason string) {
 
 		isDryRun := i.Config.GetIsDryRun()
 		if isDryRun {
-			field := i.Config.GetDryRunFieldName()
-			sp.Data[field] = shouldSend
+			sp.Data[config.DryRunFieldName] = shouldSend
 		}
 		if i.hostname != "" {
 			sp.Data["meta.refinery.local_hostname"] = i.hostname

--- a/collect/collect.go
+++ b/collect/collect.go
@@ -2,7 +2,6 @@ package collect
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"runtime"
 	"sort"
@@ -33,20 +32,7 @@ type Collector interface {
 }
 
 func GetCollectorImplementation(c config.Config) Collector {
-	var collector Collector
-	collectorType, err := c.GetCollectorType()
-	if err != nil {
-		fmt.Printf("unable to get collector type from config: %v\n", err)
-		os.Exit(1)
-	}
-	switch collectorType {
-	case "InMemCollector":
-		collector = &InMemCollector{}
-	default:
-		fmt.Printf("unknown collector type %s. Exiting.\n", collectorType)
-		os.Exit(1)
-	}
-	return collector
+	return &InMemCollector{}
 }
 
 // These are the names of the metrics we use to track our send decisions.

--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -633,12 +633,11 @@ func TestStableMaxAlloc(t *testing.T) {
 	transmission := &transmit.MockTransmission{}
 	transmission.Start()
 	conf := &config.MockConfig{
-		GetSendDelayVal:      0,
-		GetTraceTimeoutVal:   10 * time.Minute,
-		GetSamplerTypeVal:    &config.DeterministicSamplerConfig{SampleRate: 1},
-		SendTickerVal:        2 * time.Millisecond,
-		CacheOverrunStrategy: "impact",
-		ParentIdFieldNames:   []string{"trace.parent_id", "parentId"},
+		GetSendDelayVal:    0,
+		GetTraceTimeoutVal: 10 * time.Minute,
+		GetSamplerTypeVal:  &config.DeterministicSamplerConfig{SampleRate: 1},
+		SendTickerVal:      2 * time.Millisecond,
+		ParentIdFieldNames: []string{"trace.parent_id", "parentId"},
 	}
 	coll := &InMemCollector{
 		Config:       conf,

--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -340,7 +340,6 @@ func TestDryRunMode(t *testing.T) {
 		},
 		SendTickerVal:      20 * time.Millisecond,
 		DryRun:             true,
-		DryRunFieldName:    field,
 		ParentIdFieldNames: []string{"trace.parent_id", "parentId"},
 	}
 	samplerFactory := &sample.SamplerFactory{

--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -331,7 +331,6 @@ func TestAddSpan(t *testing.T) {
 func TestDryRunMode(t *testing.T) {
 	transmission := &transmit.MockTransmission{}
 	transmission.Start()
-	field := "test_kept"
 	conf := &config.MockConfig{
 		GetSendDelayVal:    0,
 		GetTraceTimeoutVal: 60 * time.Second,
@@ -399,7 +398,7 @@ func TestDryRunMode(t *testing.T) {
 	assert.Nil(t, coll.getFromCache(traceID1), "after sending the span, it should be removed from the cache")
 	transmission.Mux.RLock()
 	assert.Equal(t, 1, len(transmission.Events), "adding a root span should send the span")
-	assert.Equal(t, keepTraceID1, transmission.Events[0].Data[field], "field should match sampling decision for its trace ID")
+	assert.Equal(t, keepTraceID1, transmission.Events[0].Data[config.DryRunFieldName], "config.DryRunFieldName should match sampling decision for its trace ID")
 	transmission.Mux.RUnlock()
 
 	// add a non-root span, create the trace in the cache
@@ -430,8 +429,8 @@ func TestDryRunMode(t *testing.T) {
 	transmission.Mux.RLock()
 	assert.Equal(t, 3, len(transmission.Events), "adding another root span should send the span")
 	// both spans should be marked with the sampling decision
-	assert.Equal(t, keepTraceID2, transmission.Events[1].Data[field], "field should match sampling decision for its trace ID")
-	assert.Equal(t, keepTraceID2, transmission.Events[2].Data[field], "field should match sampling decision for its trace ID")
+	assert.Equal(t, keepTraceID2, transmission.Events[1].Data[config.DryRunFieldName], "config.DryRunFieldName should match sampling decision for its trace ID")
+	assert.Equal(t, keepTraceID2, transmission.Events[2].Data[config.DryRunFieldName], "config.DryRunFieldName should match sampling decision for its trace ID")
 	// check that meta value associated with dry run mode is properly applied
 	assert.Equal(t, uint(10), transmission.Events[1].Data["meta.dryrun.sample_rate"])
 	// check expected sampleRate against span data
@@ -455,7 +454,7 @@ func TestDryRunMode(t *testing.T) {
 	assert.Nil(t, coll.getFromCache(traceID3), "after sending the span, it should be removed from the cache")
 	transmission.Mux.RLock()
 	assert.Equal(t, 4, len(transmission.Events), "adding a root span should send the span")
-	assert.Equal(t, keepTraceID3, transmission.Events[3].Data[field], "field should match sampling decision for its trace ID")
+	assert.Equal(t, keepTraceID3, transmission.Events[3].Data[config.DryRunFieldName], "field should match sampling decision for its trace ID")
 	transmission.Mux.RUnlock()
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -176,8 +176,6 @@ type Config interface {
 
 	GetAddSpanCountToRoot() bool
 
-	GetCacheOverrunStrategy() string
-
 	GetConfigMetadata() []ConfigMetadata
 
 	GetSampleCacheConfig() SampleCacheConfig

--- a/config/config.go
+++ b/config/config.go
@@ -4,6 +4,10 @@ import (
 	"time"
 )
 
+const (
+	DryRunFieldName = "meta.refinery.dryrun.kept"
+)
+
 // Config defines the interface the rest of the code uses to get items from the
 // config. There are different implementations of the config using different
 // backends to store the config. FileConfig is the default and uses a
@@ -142,8 +146,6 @@ type Config interface {
 	GetDebugServiceAddr() (string, error)
 
 	GetIsDryRun() bool
-
-	GetDryRunFieldName() string
 
 	GetAddHostMetadataToTrace() bool
 

--- a/config/config.go
+++ b/config/config.go
@@ -112,10 +112,6 @@ type Config interface {
 	// GetAllSamplerRules returns all rules in a single map, including the default rules
 	GetAllSamplerRules() (*V2SamplerConfig, error)
 
-	// GetMetricsType returns the type of metrics to use. Valid types are in the
-	// metrics package
-	GetMetricsType() (string, error)
-
 	// GetLegacyMetricsConfig returns the config specific to LegacyMetrics
 	GetLegacyMetricsConfig() LegacyMetricsConfig
 

--- a/config/config.go
+++ b/config/config.go
@@ -98,10 +98,6 @@ type Config interface {
 	// GetHoneycombLoggerConfig returns the config specific to the HoneycombLogger
 	GetHoneycombLoggerConfig() (HoneycombLoggerConfig, error)
 
-	// GetCollectorType returns the type of the collector to use. Valid types
-	// are in the collect package
-	GetCollectorType() (string, error)
-
 	// GetInMemCollectorCacheCapacity returns the config specific to the InMemCollector
 	GetInMemCollectorCacheCapacity() (CollectionConfig, error)
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -278,10 +278,6 @@ func TestReadDefaults(t *testing.T) {
 		t.Error("received", d, "expected", false)
 	}
 
-	if d := c.GetDryRunFieldName(); d != "meta.refinery.dryrun.kept" {
-		t.Error("received", d, "expected", "meta.refinery.dryrun.kept")
-	}
-
 	if d := c.GetAddHostMetadataToTrace(); d != false {
 		t.Error("received", d, "expected", false)
 	}

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -707,14 +707,6 @@ func (f *fileConfig) GetIsDryRun() bool {
 	return f.mainConfig.Debugging.DryRun
 }
 
-// TODO: DEPRECATED
-func (f *fileConfig) GetDryRunFieldName() string {
-	f.mux.RLock()
-	defer f.mux.RUnlock()
-
-	return "meta.refinery.dryrun.kept"
-}
-
 func (f *fileConfig) GetAddHostMetadataToTrace() bool {
 	f.mux.RLock()
 	defer f.mux.RUnlock()

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -611,14 +611,6 @@ func (f *fileConfig) GetInMemCollectorCacheCapacity() (CollectionConfig, error) 
 	return f.mainConfig.Collection, nil
 }
 
-// TODO: REMOVE THIS
-func (f *fileConfig) GetMetricsType() (string, error) {
-	f.mux.RLock()
-	defer f.mux.RUnlock()
-
-	return "", nil
-}
-
 func (f *fileConfig) GetLegacyMetricsConfig() LegacyMetricsConfig {
 	f.mux.RLock()
 	defer f.mux.RUnlock()

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -571,14 +571,6 @@ func (f *fileConfig) GetHoneycombLoggerConfig() (HoneycombLoggerConfig, error) {
 	return f.mainConfig.HoneycombLogger, nil
 }
 
-// TODO: DEPRECATED
-func (f *fileConfig) GetCollectorType() (string, error) {
-	f.mux.RLock()
-	defer f.mux.RUnlock()
-
-	return "InMemCollector", nil
-}
-
 func (f *fileConfig) GetAllSamplerRules() (*V2SamplerConfig, error) {
 	f.mux.RLock()
 	defer f.mux.RUnlock()

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -814,14 +814,6 @@ func (f *fileConfig) GetAddSpanCountToRoot() bool {
 	return f.mainConfig.Telemetry.AddSpanCountToRoot
 }
 
-// TODO: DEPRECATE
-func (f *fileConfig) GetCacheOverrunStrategy() string {
-	f.mux.RLock()
-	defer f.mux.RUnlock()
-
-	return "impact"
-}
-
 func (f *fileConfig) GetSampleCacheConfig() SampleCacheConfig {
 	f.mux.RLock()
 	defer f.mux.RUnlock()

--- a/config/mock.go
+++ b/config/mock.go
@@ -11,8 +11,6 @@ import (
 type MockConfig struct {
 	Callbacks                            []func()
 	IsAPIKeyValidFunc                    func(string) bool
-	GetCollectorTypeErr                  error
-	GetCollectorTypeVal                  string
 	GetInMemoryCollectorCacheCapacityErr error
 	GetInMemoryCollectorCacheCapacityVal CollectionConfig
 	GetHoneycombAPIErr                   error
@@ -115,13 +113,6 @@ func (m *MockConfig) IsAPIKeyValid(key string) bool {
 	}
 
 	return m.IsAPIKeyValidFunc(key)
-}
-
-func (m *MockConfig) GetCollectorType() (string, error) {
-	m.Mux.RLock()
-	defer m.Mux.RUnlock()
-
-	return m.GetCollectorTypeVal, m.GetCollectorTypeErr
 }
 
 func (m *MockConfig) GetInMemCollectorCacheCapacity() (CollectionConfig, error) {

--- a/config/mock.go
+++ b/config/mock.go
@@ -80,7 +80,6 @@ type MockConfig struct {
 	PeerTimeout                          time.Duration
 	AdditionalErrorFields                []string
 	AddSpanCountToRoot                   bool
-	CacheOverrunStrategy                 string
 	SampleCache                          SampleCacheConfig
 	StressRelief                         StressReliefConfig
 	AdditionalAttributes                 map[string]string
@@ -496,13 +495,6 @@ func (f *MockConfig) GetAddSpanCountToRoot() bool {
 	defer f.Mux.RUnlock()
 
 	return f.AddSpanCountToRoot
-}
-
-func (f *MockConfig) GetCacheOverrunStrategy() string {
-	f.Mux.RLock()
-	defer f.Mux.RUnlock()
-
-	return f.CacheOverrunStrategy
 }
 
 func (f *MockConfig) GetSampleCacheConfig() SampleCacheConfig {

--- a/config/mock.go
+++ b/config/mock.go
@@ -44,8 +44,6 @@ type MockConfig struct {
 	GetSamplerTypeErr                    error
 	GetSamplerTypeName                   string
 	GetSamplerTypeVal                    interface{}
-	GetMetricsTypeErr                    error
-	GetMetricsTypeVal                    string
 	GetLegacyMetricsConfigVal            LegacyMetricsConfig
 	GetPrometheusMetricsConfigVal        PrometheusMetricsConfig
 	GetOTelMetricsConfigVal              OTelMetricsConfig
@@ -231,13 +229,6 @@ func (m *MockConfig) GetUseTLSInsecure() (bool, error) {
 	defer m.Mux.RUnlock()
 
 	return m.GetUseTLSInsecureVal, m.GetUseTLSInsecureErr
-}
-
-func (m *MockConfig) GetMetricsType() (string, error) {
-	m.Mux.RLock()
-	defer m.Mux.RUnlock()
-
-	return m.GetMetricsTypeVal, m.GetMetricsTypeErr
 }
 
 func (m *MockConfig) GetLegacyMetricsConfig() LegacyMetricsConfig {

--- a/config/mock.go
+++ b/config/mock.go
@@ -64,7 +64,6 @@ type MockConfig struct {
 	PeerManagementType                   string
 	DebugServiceAddr                     string
 	DryRun                               bool
-	DryRunFieldName                      string
 	AddHostMetadataToTrace               bool
 	AddRuleReasonToTrace                 bool
 	EnvironmentCacheTTL                  time.Duration
@@ -388,13 +387,6 @@ func (m *MockConfig) GetIsDryRun() bool {
 	defer m.Mux.RUnlock()
 
 	return m.DryRun
-}
-
-func (m *MockConfig) GetDryRunFieldName() string {
-	m.Mux.RLock()
-	defer m.Mux.RUnlock()
-
-	return m.DryRunFieldName
 }
 
 func (m *MockConfig) GetAddHostMetadataToTrace() bool {


### PR DESCRIPTION

## Which problem is this PR solving?

- Config rework had left some accessor functions for fields no longer in the config. This removes them.

