### PR TITLE
fix: Improve balance of the sharding algorithm

### DIFF
--- a/sharder/deterministic.go
+++ b/sharder/deterministic.go
@@ -298,7 +298,7 @@ func (d *DeterministicSharder) loadPeerList() error {
 	// balance them by moving partitions from the most heavily loaded nodes to
 	// the least heavily loaded nodes. But it's only possible if the number of
 	// partitions per peer is > 1.
-	if partitionsPerPeer > 1 {
+	if len(newPeers) > 1 && partitionsPerPeer > 1 {
 		d.balanceProportions()
 	}
 	return nil

--- a/sharder/deterministic.go
+++ b/sharder/deterministic.go
@@ -296,8 +296,11 @@ func (d *DeterministicSharder) loadPeerList() error {
 	}
 	// the random partitioning may have significant imbalances, so we try to
 	// balance them by moving partitions from the most heavily loaded nodes to
-	// the least heavily loaded nodes
-	d.balanceProportions()
+	// the least heavily loaded nodes. But it's only possible if the number of
+	// partitions per peer is > 1.
+	if partitionsPerPeer > 1 {
+		d.balanceProportions()
+	}
 	return nil
 }
 

--- a/sharder/deterministic_test.go
+++ b/sharder/deterministic_test.go
@@ -208,12 +208,6 @@ func TestShardBulk(t *testing.T) {
 			expectedResult := ntraces / npeers
 			assert.Greater(t, expectedResult*2, max, "expected smaller max, got %d: %v", max, results)
 			assert.NotEqual(t, 0, min, "expected larger min, got %d: %v", min, results)
-
-			// acceptableDiff := expectedResult * 10 / 100
-			// assert.Less(t, max-min, acceptableDiff, "expected less than %d difference between max(%d) and min (%d): %v", acceptableDiff, max, min, results)
-			// // assert.Greater(t, int(float64(expectedResult)*(1+permittedError)), max, "expected smaller max, got %d: %v", max, results)
-			// // assert.Less(t, int(float64(expectedResult)*(1+permittedError)), min, "expected larger min, got %d: %v", min, results)
-
 		})
 	}
 }
@@ -283,6 +277,8 @@ func TestShardDrop(t *testing.T) {
 				}
 			}
 
+			// we have a fairly large range here because it's truly random
+			// and we've been having some flaky tests
 			expected := ntraces / (npeers - 1)
 			assert.Greater(t, nDiff, expected/4)
 			assert.Less(t, nDiff, expected*4)
@@ -354,6 +350,9 @@ func TestShardAddHash(t *testing.T) {
 					nMoved++
 				}
 			}
+
+			// we have a fairly large range here because it's truly random
+			// and we've been having some flaky tests
 			expectedToMove := ntraces / (npeers - 1)
 			assert.Greater(t, nMoved, expectedToMove/4)
 			assert.Less(t, nMoved, expectedToMove*4)

--- a/sharder/deterministic_test.go
+++ b/sharder/deterministic_test.go
@@ -208,6 +208,12 @@ func TestShardBulk(t *testing.T) {
 			expectedResult := ntraces / npeers
 			assert.Greater(t, expectedResult*2, max, "expected smaller max, got %d: %v", max, results)
 			assert.NotEqual(t, 0, min, "expected larger min, got %d: %v", min, results)
+
+			// acceptableDiff := expectedResult * 10 / 100
+			// assert.Less(t, max-min, acceptableDiff, "expected less than %d difference between max(%d) and min (%d): %v", acceptableDiff, max, min, results)
+			// // assert.Greater(t, int(float64(expectedResult)*(1+permittedError)), max, "expected smaller max, got %d: %v", max, results)
+			// // assert.Less(t, int(float64(expectedResult)*(1+permittedError)), min, "expected larger min, got %d: %v", min, results)
+
 		})
 	}
 }
@@ -278,8 +284,8 @@ func TestShardDrop(t *testing.T) {
 			}
 
 			expected := ntraces / (npeers - 1)
-			assert.Greater(t, expected*2, nDiff)
-			assert.Less(t, expected/2, nDiff)
+			assert.Greater(t, nDiff, expected/4)
+			assert.Less(t, nDiff, expected*4)
 		})
 	}
 }
@@ -340,17 +346,17 @@ func TestShardAddHash(t *testing.T) {
 			sharder.loadPeerList()
 
 			results = make(map[string]int)
-			nDiff := 0
+			nMoved := 0
 			for i := 0; i < ntraces; i++ {
 				s := sharder.WhichShard(placements[i].id)
 				results[s.GetAddress()]++
 				if s.GetAddress() != placements[i].shard {
-					nDiff++
+					nMoved++
 				}
 			}
-			expected := ntraces / (npeers - 1)
-			assert.Greater(t, expected*2, nDiff)
-			assert.Less(t, expected/2, nDiff)
+			expectedToMove := ntraces / (npeers - 1)
+			assert.Greater(t, nMoved, expectedToMove/4)
+			assert.Less(t, nMoved, expectedToMove*4)
 		})
 	}
 }


### PR DESCRIPTION
## Which problem is this PR solving?

- The deterministic sharding algorithm uses N randomly generated partitions for each shard. Since they're random, they can be unbalanced. For N > 1, we can move some partitions around to rebalance them. This does that.

## Short description of the changes

- Add rebalancing code. 
- Clean up flaky tests.
- Add more comments.

