### PR TITLE
feat: Allow disabling reload monitoring

### DIFF
--- a/config.md
+++ b/config.md
@@ -1,7 +1,7 @@
 # Honeycomb Refinery Configuration Documentation
 
 This is the documentation for the configuration file for Honeycomb's Refinery.
-It was automatically generated on 2023-06-20 at 18:40:47 UTC.
+It was automatically generated on 2023-06-21 at 17:32:11 UTC.
 
 ## The Config file
 
@@ -95,6 +95,7 @@ ConfigReloadInterval is the average interval between attempts at reloading the c
 A single instance of Refinery will attempt to read its configuration and check for changes at approximately this interval.
 This time is varied by a random amount to avoid all instances refreshing together.
 Within a cluster, Refinery will gossip information about new configuration so that all instances can reload at close to the same time.
+This feature can be disabled with a value of 0s.
 
 - Not eligible for live reload.
 - Type: `duration`

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -411,9 +411,13 @@ func (f *fileConfig) monitor() {
 
 // Stop halts the monitor goroutine
 func (f *fileConfig) Stop() {
-	f.ticker.Stop()
-	close(f.done)
-	f.done = nil
+	if f.ticker != nil {
+		f.ticker.Stop()
+	}
+	if f.done != nil {
+		close(f.done)
+		f.done = nil
+	}
 }
 
 func (f *fileConfig) RegisterReloadCallback(cb func()) {

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -368,7 +368,9 @@ func NewConfig(opts *CmdEnv, errorCallback func(error)) (Config, error) {
 	cfg.callbacks = make([]func(), 0)
 	cfg.errorCallback = errorCallback
 
-	go cfg.monitor()
+	if cfg.mainConfig.General.ConfigReloadInterval > 0 {
+		go cfg.monitor()
+	}
 
 	return cfg, err
 }

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -58,7 +58,7 @@ groups:
         reload: false
         validations:
           - type: minimum
-            arg: 1s
+            arg: 0s
         summary: is the average interval between attempts at reloading the configuration file.
         description: >
           A single instance of Refinery will attempt to read its configuration
@@ -66,7 +66,7 @@ groups:
           varied by a random amount to avoid all instances refreshing together.
           Within a cluster, Refinery will gossip information about new
           configuration so that all instances can reload at close to the same
-          time.
+          time. This feature can be disabled with a value of 0s.
 
   - name: Network
     title: "Network Configuration"

--- a/tools/convert/Makefile
+++ b/tools/convert/Makefile
@@ -62,4 +62,4 @@ validateRules:
 	@echo
 	@echo "+++ validating sample rules"
 	@echo
-	go run . validate rules --input=rules_complete.yaml
+	go run . validate rules --input=../../rules_complete.yaml

--- a/tools/convert/templates/configV2.tmpl
+++ b/tools/convert/templates/configV2.tmpl
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created {{ now }} from {{ .Input }} using a template generated on 2023-06-20 at 18:40:46 UTC
+# created {{ now }} from {{ .Input }} using a template generated on 2023-06-21 at 17:32:10 UTC
 
 # This file contains the configuration for the Honeycomb Refinery.
 # More stuff will go here later.
@@ -58,7 +58,7 @@ General:
     ## varied by a random amount to avoid all instances refreshing together.
     ## Within a cluster, Refinery will gossip information about new
     ## configuration so that all instances can reload at close to the same
-    ## time.
+    ## time. This feature can be disabled with a value of 0s.
     ##
     ## Accepts a duration string with units, like "5m".
     ## default: 5m


### PR DESCRIPTION
## Which problem is this PR solving?

- Closes https://github.com/honeycombio/refinery/issues/726

## Short description of the changes

- Adds the ability to disable config polling by setting `ConfigReloadInterval` to `0s`.
- Adds new test that confirms the feature is disabled.
- Generates new configs with updated description

