### PR TITLE
chore: switch to temp credentials for CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  aws-cli: circleci/aws-cli@2.1.0
+  aws-cli: circleci/aws-cli@3.2.0
 
 commands:
   go-build:
@@ -161,8 +161,8 @@ jobs:
       - attach_workspace:
           at: ~/
       - aws-cli/setup:
-          aws-access-key-id: AWS_ACCESS_KEY_ID
-          aws-secret-access-key: AWS_SECRET_ACCESS_KEY
+          role-arn: "arn:aws:iam::702835727665:role/circleci-public-repos"
+          role-session-name: "refinery"
           aws-region: AWS_REGION
       - run:
           name: sync_s3_artifacts
@@ -190,8 +190,8 @@ jobs:
       - checkout
       - setup_remote_docker
       - aws-cli/setup:
-          aws-access-key-id: AWS_ACCESS_KEY_ID
-          aws-secret-access-key: AWS_SECRET_ACCESS_KEY
+          role-arn: "arn:aws:iam::702835727665:role/circleci-public-repos"
+          role-session-name: "refinery"
           aws-region: AWS_REGION
       - run:
           name: publish docker image to aws ecr


### PR DESCRIPTION
## Which problem is this PR solving?

- Use temporary creds for CI

## Short description of the changes

- Use the OIDC integration
- Bump the aws orb version

