### PR TITLE
feat: add ability to convert a helm chart

### DIFF
--- a/tools/convert/helpers.go
+++ b/tools/convert/helpers.go
@@ -172,7 +172,7 @@ func memorysize(data map[string]any, key, oldkey string, example string) string 
 		case int:
 			i64 = int64(i)
 		}
-		return units.HumanSize(float64(i64))
+		return fmt.Sprintf(`# %s: %s`, key, units.HumanSize(float64(i64)))
 	}
 	return fmt.Sprintf(`# %s: %v`, key, yamlf(example))
 }
@@ -411,7 +411,14 @@ func yamlf(a any) string {
 		if pat.MatchString(v) {
 			return v
 		}
-		return fmt.Sprintf(`"%s"`, v)
+		hasSingleQuote := strings.Contains(v, "'")
+		hasDoubleQuote := strings.Contains(v, `"`)
+		switch {
+		case hasDoubleQuote && !hasSingleQuote:
+			return fmt.Sprintf(`'%s'`, v)
+		default:
+			return fmt.Sprintf("%#v", v)
+		}
 	case int:
 		return _formatIntWithUnderscores(v)
 	case float64:

--- a/tools/convert/main.go
+++ b/tools/convert/main.go
@@ -272,6 +272,8 @@ func ConvertConfig(tmplData *configTemplateData, w io.Writer) {
 }
 
 func ConvertHelm(tmplData *configTemplateData, w io.Writer) {
+	const rulesConfigMapName = "RulesConfigMapName"
+	const liveReload = "LiveReload"
 	// convert config if we have it
 	helmConfigAny, ok := tmplData.Data["config"]
 	if ok {
@@ -279,6 +281,12 @@ func ConvertHelm(tmplData *configTemplateData, w io.Writer) {
 		if !ok {
 			panic("config in helm chart is the wrong format!")
 		}
+		// we need to promote this special key for Honeycomb configs
+		if mapname, ok := helmConfig[rulesConfigMapName]; ok {
+			tmplData.Data[rulesConfigMapName] = mapname
+			delete(helmConfig, rulesConfigMapName)
+		}
+
 		convertedConfig := &bytes.Buffer{}
 		// make a copy of this tmplData and overwrite the Data part
 		config := *tmplData
@@ -315,6 +323,12 @@ func ConvertHelm(tmplData *configTemplateData, w io.Writer) {
 		if !ok {
 			panic("config in helm chart is the wrong format!")
 		}
+		// we need to promote this special key for Honeycomb configs
+		if mapname, ok := helmRules[liveReload]; ok {
+			tmplData.Data[liveReload] = mapname
+			delete(helmRules, liveReload)
+		}
+
 		rules := convertRulesToNewConfig(helmRules)
 		tmplData.Data["rules"] = rules
 	}

--- a/tools/convert/main.go
+++ b/tools/convert/main.go
@@ -271,6 +271,20 @@ func ConvertConfig(tmplData *configTemplateData, w io.Writer) {
 	}
 }
 
+func removeEmpty(m map[string]any) map[string]any {
+	result := make(map[string]any)
+	for k, v := range m {
+		switch val := v.(type) {
+		case map[string]any:
+			result[k] = removeEmpty(val)
+		case nil:
+		default:
+			result[k] = v
+		}
+	}
+	return result
+}
+
 func ConvertHelm(tmplData *configTemplateData, w io.Writer) {
 	const rulesConfigMapName = "RulesConfigMapName"
 	const liveReload = "LiveReload"
@@ -313,7 +327,7 @@ func ConvertHelm(tmplData *configTemplateData, w io.Writer) {
 			}
 			panic(err)
 		}
-		tmplData.Data["config"] = decodedConfig
+		tmplData.Data["config"] = removeEmpty(decodedConfig)
 	}
 
 	// now try the rules

--- a/tools/convert/main.go
+++ b/tools/convert/main.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
+	"strings"
 	"text/template"
 
 	"github.com/honeycombio/refinery/config"
@@ -63,6 +65,11 @@ func getType(filename string) string {
 	}
 }
 
+type configTemplateData struct {
+	Input string
+	Data  map[string]any
+}
+
 func main() {
 	opts := Options{}
 
@@ -86,9 +93,14 @@ func main() {
 	filetype of the input file based on the extension, but you can override that with
 	the --type flag.
 
+	Because many organizations use helm charts to manage their refinery deployments, there
+	is a subcommand that can read a helm chart, extract both the rules and config from it,
+	and write them back out to a helm chart, while preserving the non-refinery portions.
+
 	It has other commands to help with the conversion process. Valid commands are:
 	    convert config:          convert a config file
 	    convert rules:           convert a rules file
+		convert helm: 			 convert a helm values file
 	    convert validate config: validate a config file against the 2.0 format
 	    convert validate rules:  validate a rules file against the 2.0 format
 	    convert doc config:      generate markdown documentation for the config file
@@ -161,7 +173,7 @@ func main() {
 			os.Exit(1)
 		}
 		os.Exit(0)
-	case "config", "rules", "validate":
+	case "config", "rules", "validate", "helm":
 		// do nothing yet because we need to parse the input file
 	default:
 		fmt.Fprintf(os.Stderr, "unknown subcommand %s; valid commands are config, doc config, validate config, rules, doc rules, validate rules\n", args[0])
@@ -190,31 +202,18 @@ func main() {
 		os.Exit(1)
 	}
 
-	tmplData := struct {
-		Input string
-		Data  map[string]any
-	}{
+	tmplData := &configTemplateData{
 		Input: opts.Input,
 		Data:  userConfig,
 	}
 
 	switch args[0] {
 	case "config":
-		tmpl := template.New("configV2.tmpl")
-		tmpl.Funcs(helpers())
-		tmpl, err = tmpl.ParseFS(filesystem, "templates/configV2.tmpl")
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "template error %v\n", err)
-			os.Exit(1)
-		}
-
-		err = tmpl.Execute(output, tmplData)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "template error %v\n", err)
-			os.Exit(1)
-		}
+		ConvertConfig(tmplData, output)
 	case "rules":
 		ConvertRules(userConfig, output)
+	case "helm":
+		ConvertHelm(tmplData, output)
 	case "validate":
 		if args[1] == "config" {
 			if !ValidateFromMetadata(userConfig, output) {
@@ -254,6 +253,79 @@ func loadRulesMetadata() *config.Metadata {
 	})
 
 	return m
+}
+
+func ConvertConfig(tmplData *configTemplateData, w io.Writer) {
+	tmpl := template.New("configV2.tmpl")
+	tmpl.Funcs(helpers())
+	tmpl, err := tmpl.ParseFS(filesystem, "templates/configV2.tmpl")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "template error %v\n", err)
+		os.Exit(1)
+	}
+
+	err = tmpl.Execute(w, tmplData)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "template error %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func ConvertHelm(tmplData *configTemplateData, w io.Writer) {
+	// convert config if we have it
+	helmConfigAny, ok := tmplData.Data["config"]
+	if ok {
+		helmConfig, ok := helmConfigAny.(map[string]any)
+		if !ok {
+			panic("config in helm chart is the wrong format!")
+		}
+		convertedConfig := &bytes.Buffer{}
+		// make a copy of this tmplData and overwrite the Data part
+		config := *tmplData
+		config.Data = helmConfig
+		// convert the config into the buffer
+		ConvertConfig(&config, convertedConfig)
+		// read the buffer as YAML
+		decoder := yaml.NewDecoder(convertedConfig)
+		var decodedConfig map[string]any
+		saved := convertedConfig.String()
+		err := decoder.Decode(&decodedConfig)
+		if err != nil {
+			s := err.Error()
+			pat := regexp.MustCompile("yaml: line ([0-9]+):")
+			m := pat.FindStringSubmatch(s)
+			if len(m) > 1 {
+				linenum, _ := strconv.Atoi(m[1])
+				lines := strings.Split(saved, "\n")
+				for i := linenum - 15; i < linenum+5; i++ {
+					if len(lines) > i {
+						fmt.Printf("%d: %s\n", i, lines[i])
+					}
+				}
+			}
+			panic(err)
+		}
+		tmplData.Data["config"] = decodedConfig
+	}
+
+	// now try the rules
+	helmRulesAny, ok := tmplData.Data["rules"]
+	if ok {
+		helmRules, ok := helmRulesAny.(map[string]any)
+		if !ok {
+			panic("config in helm chart is the wrong format!")
+		}
+		rules := convertRulesToNewConfig(helmRules)
+		tmplData.Data["rules"] = rules
+	}
+
+	// now we have our tmplData.Data with converted contents
+	// so we can just write it all back as YAML now
+	encoder := yaml.NewEncoder(w)
+	err := encoder.Encode(tmplData.Data)
+	if err != nil {
+		panic(err)
+	}
 }
 
 // This generates the template used by the convert tool.

--- a/tools/convert/ruleconvert.go
+++ b/tools/convert/ruleconvert.go
@@ -127,7 +127,7 @@ func CheckConfigForSampleRateChanges(cfg *config.V2SamplerConfig) map[string][]s
 	return warnings
 }
 
-func ConvertRules(rules map[string]any, w io.Writer) {
+func convertRulesToNewConfig(rules map[string]any) *config.V2SamplerConfig {
 	// get the sampler type for the default rule
 	defaultSamplerType, _ := getValueForCaseInsensitiveKey(rules, "sampler", "DeterministicSampler")
 
@@ -167,7 +167,11 @@ func ConvertRules(rules map[string]any, w io.Writer) {
 
 		newConfig.Samplers[k] = sampler
 	}
+	return newConfig
+}
 
+func ConvertRules(rules map[string]any, w io.Writer) {
+	newConfig := convertRulesToNewConfig(rules)
 	w.Write([]byte(fmt.Sprintf("# Automatically generated on %s\n", time.Now().Format(time.RFC3339))))
 	yaml.NewEncoder(w).Encode(newConfig)
 


### PR DESCRIPTION

## Which problem is this PR solving?

- This gives the convert tool the ability to read config and rules out of a helm chart, convert them, and write them back to a helm chart. All comments are stripped. If that's not cool for you, you'll have to do it manually.

## Short description of the changes

- Add helm command
- Load the helm chart as a map with YAML
- Extract config and run it through the config converter, then read that back into a map
- Extract rules and convert them
- Put both back into the map
- Write out the YAML again

