### PR TITLE
docs: Fix up docs, especially envvar and cmdline

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Refinery supports the following environment variables.  Environment variables ta
 | `REFINERY_REDIS_USERNAME`                                         | `PeerManagement.RedisUsername`   |
 | `REFINERY_REDIS_PASSWORD`                                         | `PeerManagement.RedisPassword`   |
 | `REFINERY_HONEYCOMB_API_KEY`                                      | `HoneycombLogger.LoggerAPIKey`   |
-| `REFINERY_LEGACY_METRICS_API_KEY` `REFINERY_HONEYCOMB_API_KEY`    | `LegacyMetrics.APIKey`           |
+| `REFINERY_HONEYCOMB_METRICS_API_KEY` `REFINERY_HONEYCOMB_API_KEY`    | `LegacyMetrics.APIKey`           |
 | `REFINERY_QUERY_AUTH_TOKEN`                                       | `QueryAuthToken`                 |
 
 Note, `REFINERY_HONEYCOMB_METRICS_API_KEY` takes precedence over `REFINERY_HONEYCOMB_API_KEY` for the `LegacyMetrics.APIKey` configuration.

--- a/config.md
+++ b/config.md
@@ -1,7 +1,7 @@
 # Honeycomb Refinery Configuration Documentation
 
 This is the documentation for the configuration file for Honeycomb's Refinery.
-It was automatically generated on 2023-06-22 at 23:17:30 UTC.
+It was automatically generated on 2023-06-24 at 14:59:24 UTC.
 
 ## The Config file
 
@@ -110,7 +110,7 @@ Incoming traffic is expected to be HTTP, so if SSL is a requirement, put somethi
 - Not eligible for live reload.
 - Type: `hostport`
 - Default: `0.0.0.0:8080`
-- Environment variable: `REFINERY_HTTP_LISTEN_ADDR`
+- Environment variable: `REFINERY_HTTP_LISTEN_ADDRESS`
 - Command line switch: `--http-listen-addr`
 
 ### `PeerListenAddr`
@@ -122,7 +122,7 @@ Incoming traffic is expected to be HTTP, so if using SSL use something like ngin
 - Not eligible for live reload.
 - Type: `hostport`
 - Default: `0.0.0.0:8081`
-- Environment variable: `REFINERY_PEER_LISTEN_ADDR`
+- Environment variable: `REFINERY_PEER_LISTEN_ADDRESS`
 - Command line switch: `--peer-listen-addr`
 
 ### `HoneycombAPI`
@@ -480,7 +480,7 @@ It is recommended that you create a separate team and key for Refinery metrics.
 - Not eligible for live reload.
 - Type: `string`
 - Example: `SetThisToAHoneycombKey`
-- Environment variable: `REFINERY_LEGACY_METRICS_API_KEY, HONEYCOMB_API_KEY`
+- Environment variable: `REFINERY_HONEYCOMB_METRICS_API_KEY, HONEYCOMB_API_KEY`
 
 ### `Dataset`
 
@@ -894,7 +894,7 @@ Incoming traffic is expected to be unencrypted, so if using SSL, then put someth
 
 - Not eligible for live reload.
 - Type: `hostport`
-- Environment variable: `REFINERY_GRPC_LISTEN_ADDR`
+- Environment variable: `REFINERY_GRPC_LISTEN_ADDRESS`
 - Command line switch: `--grpc-listen-addr`
 
 ### `MaxConnectionIdle`

--- a/config.md
+++ b/config.md
@@ -1,7 +1,7 @@
 # Honeycomb Refinery Configuration Documentation
 
 This is the documentation for the configuration file for Honeycomb's Refinery.
-It was automatically generated on 2023-06-21 at 19:39:45 UTC.
+It was automatically generated on 2023-06-22 at 23:17:30 UTC.
 
 ## The Config file
 
@@ -48,9 +48,7 @@ The remainder of this document describes the sections within the file and the fi
 - [Stress Relief](#stress-relief)
 ## General Configuration
 
-### Section Name: `General`
-
-Contains general configuration options that apply to the entire refinery process.
+`General` contains general configuration options that apply to the entire Refinery process.
 ### `ConfigurationVersion`
 
 ConfigurationVersion is the file format of this particular configuration file.
@@ -67,8 +65,8 @@ It exists to allow the configuration system to adapt to future changes in the co
 
 MinRefineryVersion is the minimum version of Refinery that can load this configuration file.
 
-This specifies the lowest Refinery version capable of loading all of the features used in this file.
-If this value is present, Refinery will refuse to start if its version is less than this.
+This setting specifies the lowest Refinery version capable of loading all of the features used in this file.
+If this value is present, then Refinery will refuse to start if its version is less than this setting.
 
 - Not eligible for live reload.
 - Type: `string`
@@ -78,8 +76,9 @@ If this value is present, Refinery will refuse to start if its version is less t
 
 DatasetPrefix is a prefix that can be used to distinguish a dataset from an environment in the rules.
 
-If telemetry is being sent to both a classic dataset and a new environment called the same thing (eg `production`), this parameter can be used to distinguish these cases.
-When Refinery receives telemetry using an API key associated with a classic dataset, it will then use the prefix in the form `{prefix}.{dataset}` when trying to resolve the rules definition.
+If telemetry is being sent to both a classic dataset and a new environment called the same thing, such as `production`, then this parameter can be used to distinguish these cases.
+When Refinery receives telemetry using an API key associated with a Honeycomb Classic dataset, it will then use the prefix in the form `{prefix}.
+{dataset}` when trying to resolve the rules definition.
 
 - Not eligible for live reload.
 - Type: `string`
@@ -91,7 +90,7 @@ ConfigReloadInterval is the average interval between attempts at reloading the c
 A single instance of Refinery will attempt to read its configuration and check for changes at approximately this interval.
 This time is varied by a random amount to avoid all instances refreshing together.
 Within a cluster, Refinery will gossip information about new configuration so that all instances can reload at close to the same time.
-This feature can be disabled with a value of 0s.
+Disable this feature with a value of `0s`.
 
 - Not eligible for live reload.
 - Type: `duration`
@@ -99,20 +98,20 @@ This feature can be disabled with a value of 0s.
 
 ## Network Configuration
 
-### Section Name: `Network`
-
-Contains network configuration options.
+`Network` contains network configuration options.
 ### `ListenAddr`
 
-ListenAddr is the address refinery listens to for incoming requests.
+ListenAddr is the address where Refinery listens for incoming requests.
 
-This is the IP and port on which to listen for incoming HTTP requests.
-These requests include traffic formatted as Honeycomb events, proxied requests to the Honeycomb API, and Open Telemetry data using the http protocol.
-Incoming traffic is expected to be HTTP, so if SSL is a requirement, put something like nginx in front to do the decryption.
+This setting is the IP and port on which Refinery listens for incoming HTTP requests.
+These requests include traffic formatted as Honeycomb events, proxied requests to the Honeycomb API, and OpenTelemetry data using the `http` protocol.
+Incoming traffic is expected to be HTTP, so if SSL is a requirement, put something like `nginx` in front to do the decryption.
 
 - Not eligible for live reload.
 - Type: `hostport`
 - Default: `0.0.0.0:8080`
+- Environment variable: `REFINERY_HTTP_LISTEN_ADDR`
+- Command line switch: `--http-listen-addr`
 
 ### `PeerListenAddr`
 
@@ -123,22 +122,24 @@ Incoming traffic is expected to be HTTP, so if using SSL use something like ngin
 - Not eligible for live reload.
 - Type: `hostport`
 - Default: `0.0.0.0:8081`
+- Environment variable: `REFINERY_PEER_LISTEN_ADDR`
+- Command line switch: `--peer-listen-addr`
 
 ### `HoneycombAPI`
 
-HoneycombAPI is the URL of the Honeycomb API to which data will be sent.
+HoneycombAPI is the URL of the upstream Honeycomb API where the data will be sent.
 
-HoneycombAPI is the URL for the upstream Honeycomb API; this is the destination to which refinery sends all events that it decides to keep.
+This setting is the destination to which Refinery sends all events that it decides to keep.
 
 - Eligible for live reload.
 - Type: `url`
 - Default: `https://api.honeycomb.io`
+- Environment variable: `REFINERY_HONEYCOMB_API`
+- Command line switch: `--honeycomb-api`
 
 ## Access Key Configuration
 
-### Section Name: `AccessKeys`
-
-Contains access keys -- API keys that the proxy will treat specially, and other flags that control how the proxy handles API keys.
+`AccessKeys` Contains access keys -- API keys that the proxy will treat specially, and other flags that control how the proxy handles API keys.
 
 ### `ReceiveKeys`
 
@@ -152,28 +153,26 @@ This list only applies to span traffic - other Honeycomb API actions will be pro
 
 ### `AcceptOnlyListedKeys`
 
-AcceptOnlyListedKeys is a boolean flag that causes events arriving with API keys not in the ReceiveKeys list to be rejected.
+AcceptOnlyListedKeys is a boolean flag that causes events arriving with API keys not in the `ReceiveKeys` list to be rejected.
 
-If true, only traffic using the keys listed in APIKeys is accepted.
-Events arriving with API keys not in the ReceiveKeys list will be rejected with an HTTP 401 error.
-If false, all traffic is accepted and ReceiveKeys is ignored.
-Must be specified if APIKeys is specified.
+If `true`, then only traffic using the keys listed in `APIKeys` is accepted.
+Events arriving with API keys not in the `ReceiveKeys` list will be rejected with an HTTP `401` error.
+If `false`, then all traffic is accepted and `ReceiveKeys` is ignored.
+Must be specified if `APIKeys` is specified.
 
 - Eligible for live reload.
 - Type: `bool`
 
 ## Refinery Telemetry
 
-### Section Name: `RefineryTelemetry`
-
-Configuration info for the telemetry that Refinery uses to record its own operation.
+`RefineryTelemetry` contains configuration information for the telemetry that Refinery uses to record its own operation.
 ### `AddRuleReasonToTrace`
 
-AddRuleReasonToTrace controls whether to decorate traces with refinery rule evaluation results.
+AddRuleReasonToTrace controls whether to decorate traces with Refinery rule evaluation results.
 
-This causes traces that are sent to Honeycomb to include the field `meta.refinery.reason`.
+When enabled, this setting causes traces that are sent to Honeycomb to include the field `meta.refinery.reason`.
 This field contains text indicating which rule was evaluated that caused the trace to be included.
-We recommend enabling this field whenever a rules-based sampler is in use, as it is useful for debugging and understanding the behavior of your refinery installation.
+We recommend enabling this setting whenever a rules-based sampler is in use, as it is useful for debugging and understanding the behavior of your Refinery installation.
 
 - Eligible for live reload.
 - Type: `bool`
@@ -181,11 +180,12 @@ We recommend enabling this field whenever a rules-based sampler is in use, as it
 
 ### `AddSpanCountToRoot`
 
-AddSpanCountToRoot controls whether to add a metadata field to root spans indicating the number of child spans.
+AddSpanCountToRoot controls whether to add a metadata field to root spans that indicates the number of child spans.
 
-Adds a new metadata field, `meta.span_count` to root spans to indicate the number of child spans on the trace at the time the sampling decision was made.
+The added metadata field, `meta.span_count`, indicates the number of child spans on the trace at the time the sampling decision was made.
 This value is available to the rules-based sampler, making it possible to write rules that are dependent upon the number of spans in the trace.
-If true, Refinery will add meta.span_count to the root span.
+If `true`, then Refinery will add `meta.
+span_count` to the root span.
 
 - Eligible for live reload.
 - Type: `bool`
@@ -195,8 +195,7 @@ If true, Refinery will add meta.span_count to the root span.
 
 AddHostMetadataToTrace specifies whether to add host metadata to traces.
 
-AddHostMetadataToTrace specifies whether to add host metadata to traces.
-If true, Refinery will add the following tags to all traces: - meta.refinery.local_hostname: the hostname of the Refinery node (we should consider adding more metadata here, like IP address, etc)
+If `true`, then Refinery will add the following tag to all traces: - `meta.refinery.local_hostname`: the hostname of the Refinery node
 
 - Eligible for live reload.
 - Type: `bool`
@@ -204,17 +203,15 @@ If true, Refinery will add the following tags to all traces: - meta.refinery.loc
 
 ## Traces
 
-### Section Name: `Traces`
-
-Configuration for how traces are managed.
+`Traces` contains configuration for how traces are managed.
 ### `SendDelay`
 
 SendDelay is the duration to wait before sending a trace.
 
-This is a short timer that will be triggered when a trace is complete.
-Refinery will wait this duration before actually sending the trace.
-The reason for this short delay is to allow for small network delays or clock jitters to elapse and any final spans to arrive before actually sending the trace.
-Set to 0 for immediate sends.
+This setting is a short timer that is triggered when a trace is complete.
+Refinery waits for this duration before sending the trace.
+The reason for this setting is to allow for small network delays or clock jitters to elapse and any final spans to arrive before sending the trace.
+Set to "0" for immediate sending.
 
 - Eligible for live reload.
 - Type: `duration`
@@ -224,8 +221,7 @@ Set to 0 for immediate sends.
 
 BatchTimeout is how frequently Refinery sends unfulfilled batches.
 
-Dictates how frequently to send unfulfilled batches.
-By default this will use the DefaultBatchTimeout in libhoney as its value, which is 100ms.
+By default, this setting uses the `DefaultBatchTimeout` in `libhoney` as its value, which is `100ms`.
 
 - Eligible for live reload.
 - Type: `duration`
@@ -237,9 +233,9 @@ TraceTimeout is the duration to wait before making the trace decision on an inco
 
 A long timer; it represents the outside boundary of how long to wait before making the trace decision about an incomplete trace.
 Normally trace decisions (send or drop) are made when the root span arrives.
-Sometimes the root span never arrives (due to crashes or whatever), and this timer will send a trace even without having received the root span.
-If you have particularly long-lived traces you should increase this timer.
-Note that this will also increase the memory requirements for refinery.
+Sometimes the root span never arrives (for example, due to crashes) and this timer ensures sending a trace even without having received the root span.
+If particularly long-lived traces are present in your data, then you should increase this timer.
+Note that this increase will also increase the memory requirements for Refinery.
 
 - Eligible for live reload.
 - Type: `duration`
@@ -249,9 +245,9 @@ Note that this will also increase the memory requirements for refinery.
 
 MaxBatchSize is the maximum number of events to be included in each batch for sending.
 
-This value is used to set the BatchSize field in the libhoney library used to send data to Honeycomb.
-If you have particularly large traces you should increase this value.
-Note that this will also increase the memory requirements for refinery.
+This value is used to set the `BatchSize` field in the `libhoney` library used to send data to Honeycomb.
+If you have particularly large traces, then you should increase this value.
+Note that this will also increase the memory requirements for Refinery.
 
 - Eligible for live reload.
 - Type: `int`
@@ -262,7 +258,7 @@ Note that this will also increase the memory requirements for refinery.
 SendTicker is the interval between checks for traces to send.
 
 A short timer that determines the duration between trace cache review runs to send.
-Increasing this will spend more time processing incoming events to reduce incoming_ or peer_router_dropped spikes.
+Increasing this will spend more time processing incoming events to reduce `incoming_` or `peer_router_dropped` spikes.
 Decreasing this will check the trace cache for timeouts more frequently.
 
 - Eligible for live reload.
@@ -271,16 +267,13 @@ Decreasing this will check the trace cache for timeouts more frequently.
 
 ## Debugging
 
-### Section Name: `Debugging`
-
-Configuration values used when setting up and debugging Refinery.
+`Debugging` contains configuration values used when setting up and debugging Refinery.
 ### `DebugServiceAddr`
 
-DebugServiceAddr is the IP and port the debug service will run on.
+DebugServiceAddr is the IP and port where the debug service runs.
 
-Sets the IP and port for the debug service.
-The debug service is generally only used when debugging Refinery itself, and will only run if the command line flag -d is specified.
-If this value is not specified, the debug service runs on the first open port between localhost:6060 and :6069.
+The debug service is generally only used when debugging Refinery itself, and will only run if the command line option `-d` is specified.
+If this value is not specified, then the debug service runs on the first open port between `localhost:6060` and `localhost:6069`.
 
 - Not eligible for live reload.
 - Type: `hostport`
@@ -288,24 +281,25 @@ If this value is not specified, the debug service runs on the first open port be
 
 ### `QueryAuthToken`
 
-QueryAuthToken is the token that must be specified to access the /query endpoint.
+QueryAuthToken is the token that must be specified to access the `/query` endpoint.
 
-Provides a token that must be specified with the header "X-Honeycomb-Refinery-Query" in order for a /query request to succeed.
-These /query requests are intended for debugging refinery during setup and are not typically needed in normal operation.
-If not specified, the /query endpoints are inaccessible.
+This token must be specified with the header "X-Honeycomb-Refinery-Query" in order for a `/query` request to succeed.
+These `/query` requests are intended for debugging Refinery during setup and are not typically needed in normal operation.
+If not specified, then the `/query` endpoints are inaccessible.
 
 - Not eligible for live reload.
 - Type: `string`
 - Example: `some-private-value`
+- Environment variable: `REFINERY_QUERY_AUTH_TOKEN`
 
 ### `AdditionalErrorFields`
 
-AdditionalErrorFields is a list of span fields to include when logging errors.
+AdditionalErrorFields is a list of span fields to include when logging errors happen during the ingestion of events.
 
-A list of span fields that should be included when logging errors that happen during ingestion of events (for example, the span too large error).
+For example, the span too large error.
 This is primarily useful in trying to track down misbehaving senders in a large installation.
 The fields `dataset`, `apihost`, and `environment` are always included.
-If a field is not present in the span, it will not be present in the error log.
+If a field is not present in the span, then it will not be present in the error log.
 
 - Eligible for live reload.
 - Type: `stringarray`
@@ -315,10 +309,11 @@ If a field is not present in the span, it will not be present in the error log.
 
 DryRun controls whether sampling is applied to incoming traces.
 
-If enabled, marks the traces that would be dropped given the current sampling rules, and sends all traces regardless of the sampling decision.
+If enabled, then Refinery marks the traces that would be dropped given the current sampling rules, and sends all traces regardless of the sampling decision.
 This is useful for evaluating sampling rules.
-In DryRun mode, traces will be decorated with meta.refinery.dryrun.kept set to true or false based on whether the trace would be kept or dropped.
-In addition, SampleRate will be set to the incoming rate for all traces, and the field meta.refinery.dryrun.sample_rate will be set to the sample rate that would have been used.
+When DryRun is enabled, traces is decorated with `meta.refinery.
+dryrun.kept` that is set to `true` or `false`, based on whether the trace would be kept or dropped.
+In addition, `SampleRate` will be set to the incoming rate for all traces, and the field `meta.refinery.dryrun.sample_rate` will be set to the sample rate that would have been used.
 
 - Eligible for live reload.
 - Type: `bool`
@@ -326,17 +321,15 @@ In addition, SampleRate will be set to the incoming rate for all traces, and the
 
 ## Refinery Logger
 
-### Section Name: `Logger`
-
-Configuration for logging.
+`Logger` contains configuration for logging.
 ### `Type`
 
 Type is the type of logger to use.
 
-Specifies where (and if) refinery sends logs.
+The setting specifies where (and if) Refinery sends logs.
 `none` means that logs are discarded.
-`honeycomb` means that logs will be forwarded to honeycomb as events according to the settings below.
-`stdout` means that logs will be written to stdout.
+`honeycomb` means that logs will be forwarded to Honeycomb as events according to the set Logging settings.
+`stdout` means that logs will be written to `stdout`.
 
 - Not eligible for live reload.
 - Type: `string`
@@ -345,11 +338,10 @@ Specifies where (and if) refinery sends logs.
 
 ### `Level`
 
-Level is the logging level above which refinery should send a log.
+Level is the logging level above which Refinery should send a log to the logger.
 
-Sets the logging level above which refinery should send logs to the logger.
-`debug` is very verbose, and should not be used in production environments.
 `warn` is the recommended level for production.
+`debug` is very verbose, and should not be used in production environments.
 
 - Not eligible for live reload.
 - Type: `string`
@@ -358,15 +350,13 @@ Sets the logging level above which refinery should send logs to the logger.
 
 ## Honeycomb Logger
 
-### Section Name: `HoneycombLogger`
-
-Configuration for logging to Honeycomb.
-Only used if Logger.Type is "honeycomb".
+`HoneycombLogger` contains configuration for logging to Honeycomb.
+Only used if `Logger.Type` is "honeycomb".
 ### `APIHost`
 
-APIHost is the URL of the Honeycomb API to which logs will be sent.
+APIHost is the URL of the Honeycomb API where Refinery sends its logs.
 
-Sets the upstream Honeycomb API for logs; this is the destination to which refinery sends its own logs.
+Refinery's internal logs will be sent to this host using the standard Honeycomb Events API.
 
 - Not eligible for live reload.
 - Type: `url`
@@ -374,20 +364,20 @@ Sets the upstream Honeycomb API for logs; this is the destination to which refin
 
 ### `APIKey`
 
-APIKey is the API key to use when sending logs to Honeycomb.
+APIKey is the API key used to send Refinery's logs to Honeycomb.
 
-This is the API key to use for Refinery's logs when sending them to Honeycomb.
 It is recommended that you create a separate team and key for Refinery logs.
 
 - Not eligible for live reload.
 - Type: `string`
 - Example: `SetThisToAHoneycombKey`
+- Environment variable: `REFINERY_HONEYCOMB_LOGGER_API_KEY, REFINERY_HONEYCOMB_API_KEY`
 
 ### `Dataset`
 
 Dataset is the dataset to which logs will be sent.
 
-Specifies the Honeycomb dataset to which logs will be sent.
+Only used if `APIKey` is specified.
 
 - Not eligible for live reload.
 - Type: `string`
@@ -395,10 +385,9 @@ Specifies the Honeycomb dataset to which logs will be sent.
 
 ### `SamplerEnabled`
 
-SamplerEnabled controls whether to sample logs.
+SamplerEnabled controls whether logs are sampled before sending to Honeycomb.
 
-Controls whether logs are sampled before sending to Honeycomb.
-The sample rate is controlled by the SamplerThroughput setting.
+The sample rate is controlled by the `SamplerThroughput` setting.
 
 - Not eligible for live reload.
 - Type: `bool`
@@ -408,9 +397,7 @@ The sample rate is controlled by the SamplerThroughput setting.
 
 SamplerThroughput is the sampling throughput for logs in events per second.
 
-SamplerThroughput is the sampling throughput for logs measured in events per second.
 The sampling algorithm attempts to make sure that the average throughput approximates this value, while also ensuring that all unique logs arrive at Honeycomb at least once per sampling period.
-TODO: THROUGHPUT FOR THE CLUSTER
 
 - Not eligible for live reload.
 - Type: `float`
@@ -419,15 +406,14 @@ TODO: THROUGHPUT FOR THE CLUSTER
 
 ## Stdout Logger
 
-### Section Name: `StdoutLogger`
-
-Configuration for logging to stdout.
-Only used if Logger.Type is "stdout".
+`StdoutLogger` contains configuration for logging to `stdout`.
+Only used if `Logger.Type` is "stdout".
 ### `Structured`
 
-Structured controls whether to used structured logging.
+Structured controls whether to use structured logging.
 
-Specifies whether the stdout logger generates structured logs (JSON) or not (plain text).
+`true` generates structured logs (JSON).
+`false` generates plain text logs.
 
 - Not eligible for live reload.
 - Type: `bool`
@@ -435,25 +421,24 @@ Specifies whether the stdout logger generates structured logs (JSON) or not (pla
 
 ## Prometheus Metrics
 
-### Section Name: `PrometheusMetrics`
-
-Configuration for Refinery's internally-generated metrics as made available through Prometheus.
+`PrometheusMetrics` contains configuration for Refinery's internally-generated metrics as made available through Prometheus.
 ### `Enabled`
 
-Enabled controls whether to expose refinery metrics over PromethusListenAddr
+Enabled controls whether to expose Refinery metrics over the `PrometheusListenAddr` port.
 
-The flag specifies whether Refinery should expose its own metrics over the PrometheusListenAddr port.
+Each of the metrics providers can be enabled or disabled independently.
+Metrics can be sent to multiple destinations.
 
 - Not eligible for live reload.
 - Type: `bool`
 
 ### `ListenAddr`
 
-ListenAddr is the IP and port the prometheus metrics server will run on.
+ListenAddr is the IP and port the Prometheus Metrics server will run on.
 
-Determines the interface and port on which Prometheus will listen for requests for /metrics.
+Determines the interface and port on which Prometheus will listen for requests for `/metrics`.
 Must be different from the main Refinery listener.
-Only used if "Enabled" is true in PrometheusMetrics.
+Only used if `Enabled` is `true` in `PrometheusMetrics`.
 
 - Not eligible for live reload.
 - Type: `hostport`
@@ -461,27 +446,26 @@ Only used if "Enabled" is true in PrometheusMetrics.
 
 ## Legacy Metrics
 
-### Section Name: `LegacyMetrics`
-
-Configuration for Refinery's legacy metrics.
+`LegacyMetrics` `LegacyMetrics` contains configuration for Refinery's legacy metrics.
 Version 1.x of Refinery used this format for sending Metrics to Honeycomb.
 The metrics generated that way are nonstandard and will be deprecated in a future release.
-New installations should prefer OTelMetrics.
+New installations should prefer `OTelMetrics`.
 
 ### `Enabled`
 
-Enabled controls whether to send metrics to Honeycomb.
+Enabled controls whether to send legacy-formatted metrics to Honeycomb.
 
-This controls whether to send legacy-formatted metrics to Honeycomb.
+Each of the metrics providers can be enabled or disabled independently.
+Metrics can be sent to multiple destinations.
 
 - Not eligible for live reload.
 - Type: `bool`
 
 ### `APIHost`
 
-APIHost is the URL of the Honeycomb API to which metrics will be sent.
+APIHost is the URL of the Honeycomb API where legacy metrics are sent.
 
-Specifies the URL for the upstream Honeycomb API for legacy metrics.
+Refinery's internal metrics will be sent to this host using the standard Honeycomb Events API.
 
 - Not eligible for live reload.
 - Type: `url`
@@ -489,20 +473,20 @@ Specifies the URL for the upstream Honeycomb API for legacy metrics.
 
 ### `APIKey`
 
-APIKey is the API key used to send Honeycomb metrics.
+APIKey is the API key used by Refinery to send its metrics to Honeycomb.
 
-Specifies the API key used when refinery sends its own metrics.
 It is recommended that you create a separate team and key for Refinery metrics.
 
 - Not eligible for live reload.
 - Type: `string`
 - Example: `SetThisToAHoneycombKey`
+- Environment variable: `REFINERY_LEGACY_METRICS_API_KEY, HONEYCOMB_API_KEY`
 
 ### `Dataset`
 
-Dataset is the Honeycomb dataset to which metrics will be sent.
+Dataset is the Honeycomb dataset where Refinery sends its metrics.
 
-Specifies the dataset to which refinery sends its own metrics.
+Only used if `APIKey` is specified.
 
 - Not eligible for live reload.
 - Type: `string`
@@ -512,7 +496,6 @@ Specifies the dataset to which refinery sends its own metrics.
 
 ReportingInterval is the interval between sending legacy metrics to Honeycomb.
 
-The interval between sending metrics to Honeycomb.
 Between 1 and 60 seconds is typical.
 
 - Not eligible for live reload.
@@ -521,26 +504,25 @@ Between 1 and 60 seconds is typical.
 
 ## OpenTelemetry Metrics
 
-### Section Name: `OTelMetrics`
-
-Configuration for Refinery's OpenTelemetry metrics.
+`OTelMetrics` `OTelMetrics` contains configuration for Refinery's OpenTelemetry (OTel) metrics.
 This is the preferred way to send metrics to Honeycomb.
-New installations should prefer OTelMetrics.
+New installations should prefer `OTelMetrics`.
 
 ### `Enabled`
 
-Enabled controls whether to send metrics via OTel.
+Enabled controls whether to send metrics via OpenTelemetry.
 
-Enabled controls whether to send OpenTelemetry metrics to Honeycomb.
+Each of the metrics providers can be enabled or disabled independently.
+Metrics can be sent to multiple destinations.
 
 - Not eligible for live reload.
 - Type: `bool`
 
 ### `APIHost`
 
-APIHost is the URL of the OTel API to which metrics will be sent.
+APIHost is the URL of the OpenTelemetry API to which metrics will be sent.
 
-Specifies a URL for the upstream API to receive refinery's own OTel metrics.
+Refinery's internal metrics will be sent to the `/v1/metrics` endpoint on this host.
 
 - Not eligible for live reload.
 - Type: `url`
@@ -548,22 +530,21 @@ Specifies a URL for the upstream API to receive refinery's own OTel metrics.
 
 ### `APIKey`
 
-APIKey is the API key used to send Honeycomb metrics via OTel.
+APIKey is the API key used to send Honeycomb metrics via OpenTelemetry.
 
-Specifies the API key used when refinery sends its own metrics.
 It is recommended that you create a separate team and key for Refinery metrics.
-If this is blank, Refinery will not set the Honeycomb-specific headers for OTel, and your APIHost must be set to a valid OTel endpoint.
+If this is blank, then Refinery will not set the Honeycomb-specific headers for OpenTelemetry, and your `APIHost` must be set to a valid OpenTelemetry endpoint.
 
 - Not eligible for live reload.
 - Type: `string`
 - Example: `SetThisToAHoneycombKey`
+- Environment variable: `REFINERY_METRICS_OTEL_API_KEY, HONEYCOMB_API_KEY`
 
 ### `Dataset`
 
-Dataset is the Honeycomb dataset to which OTel metrics will be sent.
+Dataset is the Honeycomb dataset that Refinery sends its OpenTelemetry metrics.
 
-Specifies the dataset to which refinery sends its own OTel metrics.
-Only used if APIKey is specified.
+Only used if `APIKey` is specified.
 
 - Not eligible for live reload.
 - Type: `string`
@@ -571,10 +552,9 @@ Only used if APIKey is specified.
 
 ### `ReportingInterval`
 
-ReportingInterval is the interval between sending OTel metrics to Honeycomb.
+ReportingInterval is the interval between sending OpenTelemetry metrics to Honeycomb.
 
-The interval between sending metrics to Honeycomb.
-Between 1 and 60 seconds is typical.
+Between `1` and `60` seconds is typical.
 
 - Not eligible for live reload.
 - Type: `duration`
@@ -582,9 +562,8 @@ Between 1 and 60 seconds is typical.
 
 ### `Compression`
 
-Compression is the compression algorithm to use when sending OTel metrics.
+Compression is the compression algorithm to use when sending OpenTelemetry metrics to Honeycomb.
 
-The compression algorithm to use when sending metrics to Honeycomb.
 `gzip` is the default and recommended value.
 In rare circumstances, compression costs may outweigh the benefits, in which case `none` may be used.
 
@@ -595,16 +574,14 @@ In rare circumstances, compression costs may outweigh the benefits, in which cas
 
 ## Peer Management
 
-### Section Name: `PeerManagement`
-
-Controls how the Refinery cluster communicates between peers.
+`PeerManagement` controls how the Refinery cluster communicates between peers.
 ### `Type`
 
 Type is the type of peer management to use.
 
-Sets the type of peer management (the mechanism by which Refinery locates its peers).
+Peer management is the mechanism by which Refinery locates its peers.
 `file` means that Refinery gets its peer list from the Peers list in this config file.
-`redis` means that refinery self-registers with a redis instance and gets its peer list from there.
+`redis` means that Refinery self-registers with a Redis instance and gets its peer list from there.
 
 - Not eligible for live reload.
 - Type: `string`
@@ -616,8 +593,8 @@ Sets the type of peer management (the mechanism by which Refinery locates its pe
 Identifier specifies the identifier to use when registering itself with peers.
 
 By default, when using a peer registry, Refinery will use the local hostname to identify itself to other peers.
-If your environment requires something else, (for example, if peers can't resolve each other by name), you can specify the exact identifier (IP address, etc) to use here.
-Overrides IdentifierInterfaceName, if both are set.
+If your environment requires something else, (for example, if peers cannot resolve each other by name), then you can specify the exact identifier, such as an IP address, to use here.
+Overrides `IdentifierInterfaceName`, if both are set.
 
 - Not eligible for live reload.
 - Type: `string`
@@ -628,7 +605,7 @@ Overrides IdentifierInterfaceName, if both are set.
 IdentifierInterfaceName specifies a network interface to use when finding a local hostname.
 
 By default, when using a peer registry, Refinery will use the local hostname to identify itself to other peers.
-If your environment requires that you use IPs as identifiers (for example, if peers can't resolve eachother by name), you can specify the network interface that Refinery is listening on here.
+If your environment requires that you use IPs as identifiers (for example, if peers cannot resolve each other by name), then you can specify the network interface that Refinery is listening on here.
 Refinery will use the first unicast address that it finds on the specified network interface as its identifier.
 
 - Not eligible for live reload.
@@ -639,17 +616,16 @@ Refinery will use the first unicast address that it finds on the specified netwo
 
 UseIPV6Identifier specifies that Refinery should use an IPV6 address as its identifier.
 
-If using IdentifierInterfaceName, Refinery will default to the first IPv4 unicast address it finds for the specified interface.
-If this value is specified, Refinery will use the first IPV6 unicast address found.
+If using `IdentifierInterfaceName`, Refinery will default to the first IPv4 unicast address it finds for the specified interface.
+If this value is specified, then Refinery will use the first IPV6 unicast address found.
 
 - Not eligible for live reload.
 - Type: `bool`
 
 ### `Peers`
 
-Peers is the list of peers to use when Type is "file".
+Peers is the list of peers to use when Type is "file", excluding self.
 
-Sets the list of peers to use when Type is "file", excluding self.
 This list is ignored when Type is "redis".
 The format is a list of strings of the form "host:port".
 
@@ -659,45 +635,45 @@ The format is a list of strings of the form "host:port".
 
 ## Redis Peer Management
 
-### Section Name: `RedisPeerManagement`
-
-Controls how the Refinery cluster communicates between peers when using Redis.
-Only applies when PeerManagement.Type is "redis".
+`RedisPeerManagement` `RedisPeerManagement` controls how the Refinery cluster communicates between peers when using Redis.
+Only applies when `PeerManagement.Type` is "redis".
 
 ### `Host`
 
-Host is the host and port of the redis instance to use.
+Host is the host and port of the Redis instance to use for peer cluster membership management.
 
-Sets the host and port of the redis instance to use for peer cluster membership management.
+Must be in the form `host:port`.
 
 - Not eligible for live reload.
 - Type: `hostport`
 - Example: `localhost:6379`
+- Environment variable: `REFINERY_REDIS_HOST`
 
 ### `Username`
 
-Username is the username used to connect to redis.
+Username is the username used to connect to Redis for peer cluster membership management.
 
-The username used to connect to redis for peer cluster membership management.
+Many Redis installations do not use this field.
 
 - Not eligible for live reload.
 - Type: `string`
+- Environment variable: `REFINERY_REDIS_USERNAME`
 
 ### `Password`
 
-Password is the password used to connect to redis.
+Password is the password used to connect to Redis for peer cluster membership management.
 
-Sets the password used to connect to redis for peer cluster membership management.
+Many Redis installations do not use this field.
 
 - Not eligible for live reload.
 - Type: `string`
+- Environment variable: `REFINERY_REDIS_PASSWORD`
 
 ### `Prefix`
 
-Prefix is a string used as a prefix for the keys in redis.
+Prefix is a string used as a prefix for the keys in Redis while storing the peer membership.
 
-Specifies a string to be used as a prefix for the keys in redis while storing the peer membership.
-It might be useful to override this in any situation where multiple refinery clusters or multiple applications want to share a single Redis instance.
+It might be useful to override this in any situation where multiple Refinery clusters or multiple applications want to share a single Redis instance.
 It may not be blank.
 
 - Not eligible for live reload.
@@ -710,7 +686,7 @@ It may not be blank.
 Database is the database number to use for the Redis instance storing the peer membership.
 
 An integer from 0-15 indicating the database number to use for the Redis instance storing the peer membership.
-It might be useful to set this in any situation where multiple refinery clusters or multiple applications want to share a single Redis instance.
+It might be useful to set this in any situation where multiple Refinery clusters or multiple applications want to share a single Redis instance.
 
 - Not eligible for live reload.
 - Type: `int`
@@ -718,18 +694,18 @@ It might be useful to set this in any situation where multiple refinery clusters
 
 ### `UseTLS`
 
-UseTLS enables TLS when connecting to redis.
+UseTLS enables TLS when connecting to Redis for peer cluster membership management.
 
-Enables TLS when connecting to redis for peer cluster membership management, and sets the MinVersion in the TLS configuration to 1.2.
+When enabled, this setting sets the `MinVersion` in the TLS configuration to `1.2`.
 
 - Not eligible for live reload.
 - Type: `bool`
 
 ### `UseTLSInsecure`
 
-UseTLSInsecure disables certificate checks when connecting to redis.
+UseTLSInsecure disables certificate checks when connecting to Redis for peer cluster membership management.
 
-Disables certificate checks when connecting to redis for peer cluster membership management.
+This setting is intended for use with self-signed certificates and sets the `InsecureSkipVerify` flag within Redis.
 
 - Not eligible for live reload.
 - Type: `bool`
@@ -738,7 +714,7 @@ Disables certificate checks when connecting to redis for peer cluster membership
 
 Timeout is the timeout to use when communicating with Redis.
 
-Refinery will timeout after this duration when communicating with Redis.
+It is rarely necessary to adjust this value.
 
 - Not eligible for live reload.
 - Type: `duration`
@@ -746,9 +722,7 @@ Refinery will timeout after this duration when communicating with Redis.
 
 ## Collection Settings
 
-### Section Name: `Collection`
-
-Brings together the settings that are relevant to collecting spans together to make traces.
+`Collection` `Collection` contains the settings that are relevant to collecting spans together to make traces.
 If none of the memory settings are used, then Refinery will not attempt to limit its memory usage.
 This is not recommended for production use since a burst of traffic could cause Refinery to run out of memory and crash.
 
@@ -765,28 +739,29 @@ The number of traces in the cache should be many multiples (100x to 1000x) of th
 
 ### `AvailableMemory`
 
-AvailableMemory is the amount of system memory available to the refinery process.
+AvailableMemory is the amount of system memory available to the Refinery process.
 
-The amount of system memory available to the refinery process.
 This value will typically be set through an environment variable controlled by the container or deploy script.
-If this value is zero or not set, MaxMemory cannot be used to calculate the maximum allocation and MaxAlloc will be used instead.
-If set, this must be a memory size.
+If this value is zero or not set, then `MaxMemory` cannot be used to calculate the maximum allocation and `MaxAlloc` will be used instead.
+If set, then this must be a memory size.
 64-bit values are supported.
 Sizes with standard unit suffixes like "MB" and "GiB" are also supported.
 
 - Eligible for live reload.
 - Type: `memorysize`
 - Example: `4Gb`
+- Environment variable: `REFINERY_AVAILABLE_MEMORY`
+- Command line switch: `--available-memory`
 
 ### `MaxMemoryPercentage`
 
 MaxMemoryPercentage is the maximum percentage of memory that should be allocated by the span collector.
 
-If nonzero, it must be an integer value between 1 and 100, representing the target maximum percentage of memory that should be allocated by the span collector.
-If set to a non-zero value, once per tick (see SendTicker) the collector will compare total allocated bytes to this calculated value.
-If allocation is too high, traces will be ejected from the cache early to reduce memory.
+If nonzero, then it must be an integer value between 1 and 100, representing the target maximum percentage of memory that should be allocated by the span collector.
+If set to a non-zero value, then once per tick (see `SendTicker`) the collector will compare total allocated bytes to this calculated value.
+If allocation is too high, then traces will be ejected from the cache early to reduce memory.
 Useful values for this setting are generally in the range of 70-90.
-If this value is 0, MaxAlloc will be used.
+If this value is `0`, then `MaxAlloc` will be used.
 
 - Eligible for live reload.
 - Type: `percentage`
@@ -795,30 +770,28 @@ If this value is 0, MaxAlloc will be used.
 
 ### `MaxAlloc`
 
-MaxAlloc is the maximum number of bytes that should be allocated by the collector.
+MaxAlloc is the maximum number of bytes that should be allocated by the Collector.
 
-If set, this must be a memory size.
+If set, then this must be a memory size.
 64-bit values are supported.
 Sizes with standard unit suffixes like "MB" and "GiB" are also supported.
 The full list of supported values can be found at https://pkg.go.dev/github.com/docker/go-units#pkg-constants.
-See MaxMemory for more details.
+See `MaxMemory` for more details.
 
 - Eligible for live reload.
 - Type: `memorysize`
 
 ## Buffer Sizes
 
-### Section Name: `BufferSizes`
-
-Brings together the settings that are relevant to the sizes of communications buffers.
+`BufferSizes` `BufferSizes` contains the settings that are relevant to the sizes of communications buffers.
 
 ### `UpstreamBufferSize`
 
-UpstreamBufferSize is the size of the queue used to buffer spans to send to the upstream API.
+UpstreamBufferSize is the size of the queue used to buffer spans to send to the upstream Collector.
 
-Sets the size of the buffer (measured in spans) used to send spans to the upstream collector.
-If the buffer fills up, performance will degrade because Refinery will block while waiting for space to become available.
-If this happens, you should increase the buffer size.
+The size of the buffer is measured in spans.
+If the buffer fills up, then performance will degrade because Refinery will block while waiting for space to become available.
+If this happens, then you should increase the buffer size.
 
 - Eligible for live reload.
 - Type: `int`
@@ -828,9 +801,9 @@ If this happens, you should increase the buffer size.
 
 PeerBufferSize is the size of the queue used to buffer spans to send to peer nodes.
 
-Sets the size of the buffer (measured in spans) used to send spans to peer nodes.
-If the buffer fills up, performance will degrade because Refinery will block while waiting for space to become available.
-If this happens, you should increase this buffer size.
+The size of the buffer is measured in spans.
+If the buffer fills up, then performance will degrade because Refinery will block while waiting for space to become available.
+If this happens, then you should increase this buffer size.
 
 - Eligible for live reload.
 - Type: `int`
@@ -838,16 +811,14 @@ If this happens, you should increase this buffer size.
 
 ## Specialized Configuration
 
-### Section Name: `Specialized`
-
-Special-purpose configuration options that are not typically needed.
+`Specialized` contains special-purpose configuration options that are not typically needed.
 ### `EnvironmentCacheTTL`
 
 EnvironmentCacheTTL is the duration for which environment information is cached.
 
-This is the amount of time for which refinery caches environment information, which it looks up from Honeycomb for each different APIKey.
+This is the amount of time for which Refinery caches environment information, which it looks up from Honeycomb for each different `APIKey`.
 This information is used when making sampling decisions.
-If you have a very large number of environments, you may want to increase this value.
+If you have a very large number of environments, then you may want to increase this value.
 
 - Eligible for live reload.
 - Type: `duration`
@@ -855,10 +826,9 @@ If you have a very large number of environments, you may want to increase this v
 
 ### `CompressPeerCommunication`
 
-CompressPeerCommunication determines whether refinery will compress span data it forwards to peers.
+CompressPeerCommunication determines whether Refinery will compress span data it forwards to peers.
 
-If it costs money to transmit data between refinery instances (e.g.
-they're spread across AWS availability zones), then you almost certainly want compression enabled to reduce your bill.
+If it costs money to transmit data between Refinery instances (for example, when spread across AWS availability zones), then you almost certainly want compression enabled to reduce your bill.
 The option to disable it is provided as an escape hatch for deployments that value lower CPU utilization over data transfer costs.
 
 - Not eligible for live reload.
@@ -867,10 +837,9 @@ The option to disable it is provided as an escape hatch for deployments that val
 
 ### `AdditionalAttributes`
 
-AdditionalAttributes is a map that can be used for injecting user-defined attributes.
+AdditionalAttributes is a map that can be used for injecting user-defined attributes into every span.
 
-A map that can be used for injecting user-defined attributes into every span.
-For example, it could be used for naming a refinery cluster.
+For example, it could be used for naming a Refinery cluster.
 Both keys and values must be strings.
 
 - Eligible for live reload.
@@ -879,18 +848,15 @@ Both keys and values must be strings.
 
 ## ID Fields
 
-### Section Name: `IDFields`
-
-Controls the field names to use for the event ID fields.
+`IDFields` `IDFields` controls the field names to use for the event ID fields.
 These fields are used to identify events that are part of the same trace.
 
 ### `TraceNames`
 
 TraceNames is the list of field names to use for the trace ID.
 
-The list of field names to use for the trace ID.
 The first field in the list that is present in an incoming span will be used as the trace ID.
-If none of the fields are present, refinery treats the span as not being part of a trace and forwards it immediately to Honeycomb.
+If none of the fields are present, then Refinery treats the span as not being part of a trace and forwards it immediately to Honeycomb.
 
 - Eligible for live reload.
 - Type: `stringarray`
@@ -900,9 +866,8 @@ If none of the fields are present, refinery treats the span as not being part of
 
 ParentNames is the list of field names to use for the parent ID.
 
-The list of field names to use for the parent ID.
 The first field in the list that is present in an event will be used as the parent ID.
-A trace without a parent_id is assumed to be a root span.
+A trace without a `parent_id` is assumed to be a root span.
 
 - Eligible for live reload.
 - Type: `stringarray`
@@ -910,29 +875,27 @@ A trace without a parent_id is assumed to be a root span.
 
 ## gRPC Server Parameters
 
-### Section Name: `GRPCServerParameters`
-
-Controls the parameters of the gRPC server used to receive Open Telemetry data in gRPC format.
+`GRPCServerParameters` `GRPCServerParameters` controls the parameters of the gRPC server used to receive OpenTelemetry data in gRPC format.
 
 ### `Enabled`
 
 Enabled specifies whether the gRPC server is enabled.
 
-Specifies whether the gRPC server is enabled.
-If false, the gRPC server is not started and no gRPC traffic is accepted.
-TODO: WE NEED TO DEFAULT THIS TO TRUE IF PREVIOUS CONFIG HAS A LISTEN ADDRESS
+If `false`, then the gRPC server is not started and no gRPC traffic is accepted.
 
 - Not eligible for live reload.
 - Type: `bool`
 
 ### `ListenAddr`
 
-ListenAddr is the address refinery listens to for incoming GRPC Open Telemetry events.
+ListenAddr is the address Refinery listens to for incoming GRPC OpenTelemetry events.
 
-Incoming traffic is expected to be unencrypted, so if using SSL put something like nginx in front to do the decryption.
+Incoming traffic is expected to be unencrypted, so if using SSL, then put something like `nginx` in front to do the decryption.
 
 - Not eligible for live reload.
 - Type: `hostport`
+- Environment variable: `REFINERY_GRPC_LISTEN_ADDR`
+- Command line switch: `--grpc-listen-addr`
 
 ### `MaxConnectionIdle`
 
@@ -940,7 +903,7 @@ MaxConnectionIdle is the amount of time to permit an idle connection.
 
 A duration for the amount of time after which an idle connection will be closed by sending a GoAway.
 "Idle" means that there are no active RPCs.
-0s sets duration to infinity, but this is not recommended for refinery deployments behind a load balancer, because it will prevent the load balancer from distributing load evenly among peers.
+"0s" sets duration to infinity, but this is not recommended for Refinery deployments behind a load balancer, because it will prevent the load balancer from distributing load evenly among peers.
 
 - Not eligible for live reload.
 - Type: `duration`
@@ -951,9 +914,9 @@ A duration for the amount of time after which an idle connection will be closed 
 
 MaxConnectionAge is the maximum amount of time a gRPC connection may exist.
 
-Sets a duration for the maximum amount of time a connection may exist before it will be closed by sending a GoAway.
-A random jitter of +/-10% will be added to MaxConnectionAge to spread out connection storms.
-0s sets duration to infinity; a value measured in low minutes will help load balancers to distribute load among peers more evenly.
+After this duration, the gRPC connection is closed by sending a `GoAway`.
+A random jitter of +/-10% will be added to `MaxConnectionAge` to spread out connection storms.
+`0s` sets duration to infinity; a value measured in low minutes will help load balancers to distribute load among peers more evenly.
 
 - Not eligible for live reload.
 - Type: `duration`
@@ -961,10 +924,10 @@ A random jitter of +/-10% will be added to MaxConnectionAge to spread out connec
 
 ### `MaxConnectionAgeGrace`
 
-MaxConnectionAgeGrace is the duration beyond MaxConnectionAge after which the connection will be forcibly closed.
+MaxConnectionAgeGrace is the duration beyond `MaxConnectionAge` after which the connection will be forcibly closed.
 
-This is an additive period after MaxConnectionAge after which the connection will be forcibly closed (in case the upstream node ignores the GoAway request).
-0s sets duration to infinity.
+This setting is in case the upstream node ignores the `GoAway` request.
+"0s" sets duration to infinity.
 
 - Not eligible for live reload.
 - Type: `duration`
@@ -974,8 +937,8 @@ This is an additive period after MaxConnectionAge after which the connection wil
 
 KeepAlive is the duration between keep-alive pings.
 
-Sets a duration for the amount of time after which if the client doesn't see any activity it pings the server to see if the transport is still alive.
-0s sets duration to 2 hours.
+After this amount of time, if the client does not see any activity, then it pings the server to see if the transport is still alive.
+"0s" sets duration to 2 hours.
 
 - Not eligible for live reload.
 - Type: `duration`
@@ -985,8 +948,8 @@ Sets a duration for the amount of time after which if the client doesn't see any
 
 KeepAliveTimeout is the duration the server waits for activity on the connection.
 
-This is the amount of time after which if the server doesn't see any activity, it pings the client to see if the transport is still alive.
-0s sets duration to 20 seconds.
+This is the amount of time after which if the server does not see any activity, then it pings the client to see if the transport is still alive.
+"0s" sets duration to 20 seconds.
 
 - Not eligible for live reload.
 - Type: `duration`
@@ -994,18 +957,16 @@ This is the amount of time after which if the server doesn't see any activity, i
 
 ## Sample Cache
 
-### Section Name: `SampleCache`
-
-Controls the sample cache used to retain information about trace status after the sampling decision has been made.
+`SampleCache` `SampleCache` controls the sample cache used to retain information about trace status after the sampling decision has been made.
 
 ### `KeptSize`
 
 KeptSize is the number of traces preserved in the cuckoo kept traces cache.
 
-Controls the number of traces preserved in the cuckoo kept traces cache.
 Refinery keeps a record of each trace that was kept and sent to Honeycomb, along with some statistical information.
 This is most useful in cases where the trace was sent before sending the root span, so that the root span can be decorated with accurate metadata.
-Default is 10_000 traces (each trace in this cache consumes roughly 200 bytes).
+Default is `10_000` traces.
+Each trace in this cache consumes roughly 200 bytes.
 
 - Eligible for live reload.
 - Type: `int`
@@ -1015,7 +976,6 @@ Default is 10_000 traces (each trace in this cache consumes roughly 200 bytes).
 
 DroppedSize is the size of the cuckoo dropped traces cache.
 
-Controls the size of the cuckoo dropped traces cache.
 This cache consumes 4-6 bytes per trace at a scale of millions of traces.
 Changing its size with live reload sets a future limit, but does not have an immediate effect.
 
@@ -1025,10 +985,9 @@ Changing its size with live reload sets a future limit, but does not have an imm
 
 ### `SizeCheckInterval`
 
-SizeCheckInterval controls how often the cuckoo cache re-evaluates its capacity.
+SizeCheckInterval controls how often the cuckoo cache re-evaluates its remaining capacity.
 
-Controls the duration the cuckoo cache uses to determine how often it re-evaluates the remaining capacity of its dropped traces cache and possibly cycles it.
-This cache is quite resilient so it doesn't need to happen very often, but the operation is also inexpensive.
+This cache is quite resilient so it does not need to happen very often, but the operation is also inexpensive.
 Default is 10 seconds.
 
 - Eligible for live reload.
@@ -1037,16 +996,14 @@ Default is 10 seconds.
 
 ## Stress Relief
 
-### Section Name: `StressRelief`
-
-Controls the stress relief mechanism, which is used to prevent Refinery from being overwhelmed by a large number of traces.
-There is a metric called stress_level that is emitted as part of refinery metrics.
-It is a measure of refinery's throughput rate relative to its processing rate, combined with the amount of room in its internal queues, and ranges from 0 to 100.
-It is generally expected to be 0 except under heavy load.
-When stress levels reach 100, there is an increased chance that refinery will become unstable.
-To avoid this problem, the Stress Relief system can do deterministic sampling on new trace traffic based solely on TraceID, without having to store traces in the cache or take the time processing sampling rules.
-Existing traces in flight will be processed normally, but when Stress Relief is active, trace decisions are made deterministically on a per-span basis; all spans will be sampled according to the SamplingRate specified here.
-Once Stress Relief activates (by exceeding the ActivationLevel), it will not deactivate until stress_level falls below the DeactivationLevel.
+`StressRelief` `StressRelief` controls the Stress Relief mechanism, which is used to prevent Refinery from being overwhelmed by a large number of traces.
+There is a metric called `stress_level` that is emitted as part of Refinery metrics.
+It is a measure of Refinery's throughput rate relative to its processing rate, combined with the amount of room in its internal queues, and ranges from `0` to `100`.
+`stress_level` is generally expected to be `0` except under heavy load.
+When stress levels reach `100`, there is an increased chance that Refinery will become unstable.
+To avoid this problem, the Stress Relief system can do deterministic sampling on new trace traffic based solely on `TraceID`, without having to store traces in the cache or take the time processing sampling rules.
+Existing traces in flight will be processed normally, but when Stress Relief is active, trace decisions are made deterministically on a per-span basis; all spans will be sampled according to the `SamplingRate` specified here.
+Once Stress Relief activates (by exceeding the `ActivationLevel`), it will not deactivate until `stress_level` falls below the `DeactivationLevel`.
 When it deactivates, normal trace decisions are made -- and any additional spans that arrive for traces that were active during Stress Relief will respect the decisions made during that time.
 The measurement of stress is a lagging indicator and is highly dependent on Refinery configuration and scaling.
 Other configuration values should be well tuned first, before adjusting the Stress Relief Activation parameters.
@@ -1056,8 +1013,9 @@ Stress Relief is not a substitute for proper configuration and scaling, but it c
 
 Mode is a string indicating how to use Stress Relief.
 
-Sets the stress relief mode.
-"never" means that Stress Relief will never activate "monitor" is the recommended setting, and means that Stress Relief will monitor the status of refinery and activate according to the levels set below.
+This setting sets the Stress Relief mode.
+"never" means that Stress Relief will never activate.
+"monitor" is the recommended setting, and means that Stress Relief will monitor the status of Refinery and activate according to the levels set by fields such as `ActivationLevel`.
 "always" means that Stress Relief is always on, which may be useful in an emergency situation.
 
 - Eligible for live reload.
@@ -1066,9 +1024,9 @@ Sets the stress relief mode.
 
 ### `ActivationLevel`
 
-ActivationLevel is the stress_level (from 0-100) at which Stress Relief is triggered.
+ActivationLevel is the `stress_level` (from 0-100) at which Stress Relief is triggered.
 
-Sets the stress_level (from 0-100) at which Stress Relief is triggered.
+This value must be greater than `DeactivationLevel` and should be high enough that it is not reached in normal operation.
 
 - Eligible for live reload.
 - Type: `percentage`
@@ -1076,10 +1034,10 @@ Sets the stress_level (from 0-100) at which Stress Relief is triggered.
 
 ### `DeactivationLevel`
 
-DeactivationLevel is the stress_level (from 0-100) at which Stress Relief is turned off.
+DeactivationLevel is the `stress_level` (from 0-100) at which Stress Relief is turned off.
 
-Sets the stress_level (from 0-100) at which Stress Relief is turned off (subject to MinimumActivationDuration).
-It must be less than ActivationLevel.
+This setting is subject to `MinimumActivationDuration`.
+The value must be less than `ActivationLevel`.
 
 - Eligible for live reload.
 - Type: `percentage`
@@ -1089,8 +1047,7 @@ It must be less than ActivationLevel.
 
 SamplingRate is the sampling rate to use when Stress Relief is activated.
 
-Controls the sampling rate to use when Stress Relief is activated.
-All new traces will be deterministically sampled at this rate based only on the traceID.
+All new traces will be deterministically sampled at this rate based only on the `traceID`.
 It should be chosen to be a rate that sends fewer samples than the average sampling rate Refinery is expected to generate.
 For example, if Refinery is configured to normally sample at a rate of 1 in 10, then Stress Relief should be configured to sample at a rate of at least 1 in 30.
 
@@ -1100,10 +1057,9 @@ For example, if Refinery is configured to normally sample at a rate of 1 in 10, 
 
 ### `MinimumActivationDuration`
 
-MinimumActivationDuration is the minimum time that stress relief will stay enabled.
+MinimumActivationDuration is the minimum time that Stress Relief will stay enabled once activated.
 
-Sets the minimum time that stress relief will stay enabled, once activated.
-This helps to prevent oscillations.
+This setting helps to prevent oscillations.
 
 - Eligible for live reload.
 - Type: `duration`
@@ -1111,12 +1067,12 @@ This helps to prevent oscillations.
 
 ### `MinimumStartupDuration`
 
-MinimumStartupDuration is the minimum time that stress relief will stay enabled.
+MinimumStartupDuration is the minimum time that Stress Relief will stay enabled.
 
-Used when switching into Monitor mode.
-When stress monitoring is enabled, it will start up in stressed mode for a at least this amount of time to try to make sure that Refinery can handle the load before it begins processing it in earnest.
+This setting is used when switching into Monitor mode.
+When Stress Relief is enabled, it will start up in stressed mode for at least this set duration of time to try to make sure that Refinery can handle the load before it begins processing it in earnest.
 This is to help address the problem of trying to bring a new node into an already-overloaded cluster.
-If this duration is 0, Refinery will not start in stressed mode, which will provide faster startup at the possible cost of startup instability.
+If this duration is `0`, then Refinery will not start in stressed mode, which will provide faster startup at the possible cost of startup instability.
 
 - Eligible for live reload.
 - Type: `duration`

--- a/config/cmdenv.go
+++ b/config/cmdenv.go
@@ -28,16 +28,16 @@ import (
 type CmdEnv struct {
 	ConfigLocation        string `short:"c" long:"config" env:"REFINERY_CONFIG" default:"/etc/refinery/refinery.yaml" description:"config file or URL to load"`
 	RulesLocation         string `short:"r" long:"rules_config" env:"REFINERY_RULES_CONFIG" default:"/etc/refinery/rules.yaml" description:"config file or URL to load"`
-	HTTPListenAddr        string `long:"http-listen-addr" env:"REFINERY_HTTP_LISTEN_ADDR" description:"HTTP listen address for incoming traffic"`
-	PeerListenAddr        string `long:"peer-listen-addr" env:"REFINERY_PEER_LISTEN_ADDR" description:"Peer listen address"`
-	GRPCListenAddr        string `long:"grpc-listen-addr" env:"REFINERY_GRPC_LISTEN_ADDR" description:"gRPC listen address for OTLP traffic"`
+	HTTPListenAddr        string `long:"http-listen-address" env:"REFINERY_HTTP_LISTEN_ADDRESS" description:"HTTP listen address for incoming event traffic"`
+	PeerListenAddr        string `long:"peer-listen-address" env:"REFINERY_PEER_LISTEN_ADDRESS" description:"Peer listen address for communication between Refinery instances"`
+	GRPCListenAddr        string `long:"grpc-listen-address" env:"REFINERY_GRPC_LISTEN_ADDRESS" description:"gRPC listen address for OTLP traffic"`
 	RedisHost             string `long:"redis-host" env:"REFINERY_REDIS_HOST" description:"Redis host address"`
 	RedisUsername         string `long:"redis-username" env:"REFINERY_REDIS_USERNAME" description:"Redis username"`
 	RedisPassword         string `long:"redis-password" env:"REFINERY_REDIS_PASSWORD" description:"Redis password"`
 	HoneycombAPI          string `long:"honeycomb-api" env:"REFINERY_HONEYCOMB_API" description:"Honeycomb API URL"`
 	HoneycombAPIKey       string `long:"honeycomb-api-key" env:"REFINERY_HONEYCOMB_API_KEY" description:"Honeycomb API key (for logger and metrics)"`
 	HoneycombLoggerAPIKey string `long:"logger-api-key" env:"REFINERY_HONEYCOMB_LOGGER_API_KEY" description:"Honeycomb logger API key"`
-	LegacyMetricsAPIKey   string `long:"legacy-metrics-api-key" env:"REFINERY_LEGACY_METRICS_API_KEY" description:"API key for legacy Honeycomb metrics"`
+	LegacyMetricsAPIKey   string `long:"legacy-metrics-api-key" env:"REFINERY_HONEYCOMB_METRICS_API_KEY" description:"API key for legacy Honeycomb metrics"`
 	OTelMetricsAPIKey     string `long:"otel-metrics-api-key" env:"REFINERY_OTEL_METRICS_API_KEY" description:"API key for OTel metrics if being sent to Honeycomb"`
 	QueryAuthToken        string `long:"query-auth-token" env:"REFINERY_QUERY_AUTH_TOKEN" description:"Token for debug/management queries"`
 	AvailableMemory       string `long:"available-memory" env:"REFINERY_AVAILABLE_MEMORY" description:"The maximum memory available for Refinery to use."`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -67,7 +67,7 @@ func makeYAML(args ...interface{}) string {
 
 func TestGRPCListenAddrEnvVar(t *testing.T) {
 	const address = "127.0.0.1:4317"
-	const envVarName = "REFINERY_GRPC_LISTEN_ADDR"
+	const envVarName = "REFINERY_GRPC_LISTEN_ADDRESS"
 	os.Setenv(envVarName, address)
 	defer os.Unsetenv(envVarName)
 
@@ -129,7 +129,7 @@ func TestMetricsAPIKeyEnvVar(t *testing.T) {
 	}{
 		{
 			name:   "Specific env var",
-			envVar: "REFINERY_LEGACY_METRICS_API_KEY",
+			envVar: "REFINERY_HONEYCOMB_METRICS_API_KEY",
 			key:    "abc123",
 		},
 		{
@@ -158,7 +158,7 @@ func TestMetricsAPIKeyEnvVar(t *testing.T) {
 
 func TestMetricsAPIKeyMultipleEnvVar(t *testing.T) {
 	const specificKey = "abc123"
-	const specificEnvVarName = "REFINERY_LEGACY_METRICS_API_KEY"
+	const specificEnvVarName = "REFINERY_HONEYCOMB_METRICS_API_KEY"
 	const fallbackKey = "this should not be set in the config"
 	const fallbackEnvVarName = "REFINERY_HONEYCOMB_API_KEY"
 

--- a/config/metadata.go
+++ b/config/metadata.go
@@ -27,34 +27,36 @@ func (v *Validation) GetArgAsStringSlice() []string {
 }
 
 type Field struct {
-	Name         string       `json:"name"`
-	V1Group      string       `json:"v1group"`
-	V1Name       string       `json:"v1name"`
-	FirstVersion string       `json:"firstversion"`
-	LastVersion  string       `json:"lastversion"`
-	Type         string       `json:"type"`
-	ValueType    string       `json:"valuetype"`
-	Extra        string       `json:"extra"`
-	Default      any          `json:"default,omitempty"`
-	Choices      []string     `json:"choices,omitempty"`
-	Example      string       `json:"example,omitempty"`
-	Validations  []Validation `json:"validations,omitempty"`
-	Reload       bool         `json:"reload"`
-	Summary      string       `json:"summary"`
-	Description  string       `json:"description"`
-	Pattern      string       `json:"pattern,omitempty"`
+	Name         string       `yaml:"name"`
+	V1Group      string       `yaml:"v1group"`
+	V1Name       string       `yaml:"v1name"`
+	FirstVersion string       `yaml:"firstversion"`
+	LastVersion  string       `yaml:"lastversion"`
+	Type         string       `yaml:"type"`
+	ValueType    string       `yaml:"valuetype"`
+	Extra        string       `yaml:"extra"`
+	Default      any          `yaml:"default,omitempty"`
+	Choices      []string     `yaml:"choices,omitempty"`
+	Example      string       `yaml:"example,omitempty"`
+	Validations  []Validation `yaml:"validations,omitempty"`
+	Reload       bool         `yaml:"reload"`
+	Summary      string       `yaml:"summary"`
+	Description  string       `yaml:"description"`
+	Pattern      string       `yaml:"pattern,omitempty"`
+	Envvar       string       `yaml:"envvar,omitempty"`
+	CommandLine  string       `yaml:"commandLine,omitempty"`
 }
 
 type Group struct {
-	Name        string  `json:"name"`
-	Title       string  `json:"title"`
-	Description string  `json:"description"`
-	Fields      []Field `json:"fields,omitempty"`
-	SortOrder   int     `json:"sortorder"`
+	Name        string  `yaml:"name"`
+	Title       string  `yaml:"title"`
+	Description string  `yaml:"description"`
+	Fields      []Field `yaml:"fields,omitempty"`
+	SortOrder   int     `yaml:"sortorder"`
 }
 
 type Metadata struct {
-	Groups []Group `json:"groups"`
+	Groups []Group `yaml:"groups"`
 }
 
 func (c *Metadata) GetField(name string) *Field {

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -80,8 +80,8 @@ groups:
         reload: false
         validations:
           - type: notempty
-        envvar: REFINERY_HTTP_LISTEN_ADDR
-        commandLine: http-listen-addr
+        envvar: REFINERY_HTTP_LISTEN_ADDRESS
+        commandLine: http-listen-address
         summary: is the address where Refinery listens for incoming requests.
         description: >
           This setting is the IP and port on which Refinery listens for
@@ -98,8 +98,8 @@ groups:
         reload: false
         validations:
           - type: notempty
-        envvar: REFINERY_PEER_LISTEN_ADDR
-        commandLine: peer-listen-addr
+        envvar: REFINERY_PEER_LISTEN_ADDRESS
+        commandLine: peer-listen-address
         summary: is the IP and port on which to listen for traffic being rerouted from a peer.
         description: >
           Incoming traffic is expected to be HTTP, so if using SSL
@@ -539,7 +539,7 @@ groups:
         reload: false
         validations:
           - type: requiredInGroup
-        envvar: REFINERY_LEGACY_METRICS_API_KEY, HONEYCOMB_API_KEY
+        envvar: REFINERY_HONEYCOMB_METRICS_API_KEY, HONEYCOMB_API_KEY
         commandline: legacy-metrics-api-key
         summary: is the API key used by Refinery to send its metrics to Honeycomb.
         description: >
@@ -1141,8 +1141,8 @@ groups:
         valuetype: nondefault
         default: ""
         reload: false
-        envvar: REFINERY_GRPC_LISTEN_ADDR
-        commandLine: grpc-listen-addr
+        envvar: REFINERY_GRPC_LISTEN_ADDRESS
+        commandLine: grpc-listen-address
         summary: is the address Refinery listens to for incoming GRPC OpenTelemetry events.
         description: >
           Incoming traffic is expected to be unencrypted, so if using SSL, then

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -80,8 +80,8 @@ groups:
         reload: false
         validations:
           - type: notempty
-        envvar: REFINERY_LISTEN_ADDRESS
-        commandLine: ListenAddr
+        envvar: REFINERY_HTTP_LISTEN_ADDR
+        commandLine: http-listen-addr
         summary: is the address where Refinery listens for incoming requests.
         description: >
           This setting is the IP and port on which Refinery listens for
@@ -98,8 +98,8 @@ groups:
         reload: false
         validations:
           - type: notempty
-        envvar: REFINERY_PEER_LISTEN_ADDRESS
-        commandLine: PeerListenAddr
+        envvar: REFINERY_PEER_LISTEN_ADDR
+        commandLine: peer-listen-addr
         summary: is the IP and port on which to listen for traffic being rerouted from a peer.
         description: >
           Incoming traffic is expected to be HTTP, so if using SSL
@@ -113,7 +113,7 @@ groups:
         validations:
           - type: notempty
         envvar: REFINERY_HONEYCOMB_API
-        commandLine: HoneycombAPI
+        commandLine: honeycomb-api
         summary: is the URL of the upstream Honeycomb API where the data will be sent.
         description: >
           This setting is the destination to which Refinery sends all events
@@ -133,8 +133,6 @@ groups:
         validations:
           - type: elementType
             arg: string
-        envvar: REFINERY_RECEIVE_KEYS
-        commandLine: APIKeys
         summary: is a set of Honeycomb API keys that the proxy will treat specially.
         description: >
           This list only applies to span traffic - other Honeycomb API actions
@@ -301,6 +299,7 @@ groups:
         example: "some-private-value"
         reload: false
         envvar: REFINERY_QUERY_AUTH_TOKEN
+        commandline: query-auth-token
         summary: is the token that must be specified to access the `/query` endpoint.
         description: >
           This token must be specified with the header
@@ -393,7 +392,6 @@ groups:
         valuetype: nondefault
         default: "https://api.honeycomb.io"
         reload: false
-        envvar: REFINERY_LOGS_HONEYCOMB_API
         summary: is the URL of the Honeycomb API where Refinery sends its logs.
         description: >
           Refinery's internal logs will be sent to this host using the standard
@@ -408,7 +406,8 @@ groups:
         default: ""
         example: "SetThisToAHoneycombKey"
         reload: false
-        envvar: REFINERY_LOGS_API_KEY
+        envvar: REFINERY_HONEYCOMB_LOGGER_API_KEY, REFINERY_HONEYCOMB_API_KEY
+        commandline: logger-api-key
         validations:
           - type: requiredInGroup
           - type: format
@@ -427,7 +426,6 @@ groups:
         reload: false
         validations:
           - type: notempty
-        envvar: REFINERY_LOGS_DATASET
         summary: is the dataset to which logs will be sent.
         description: >
           Only used if `APIKey` is specified.
@@ -439,7 +437,7 @@ groups:
         valuetype: nondefault
         default: true
         reload: false
-        summary: controls whether to logs are sampled before sending to Honeycomb.
+        summary: controls whether logs are sampled before sending to Honeycomb.
         description: >
           The sample rate is controlled by the `SamplerThroughput` setting.
 
@@ -465,7 +463,7 @@ groups:
         valuetype: nondefault
         default: true
         reload: false
-        summary: controls whether to used structured logging.
+        summary: controls whether to use structured logging.
         description: >
           `true` generates structured logs (JSON).
           `false` generates plain text logs.
@@ -525,7 +523,6 @@ groups:
         valuetype: nondefault
         default: "https://api.honeycomb.io"
         reload: false
-        envvar: REFINERY_METRICS_HONEYCOMB_API
         summary: is the URL of the Honeycomb API where legacy metrics are sent.
         description: >
           Refinery's internal metrics will be sent to this host using the
@@ -542,7 +539,8 @@ groups:
         reload: false
         validations:
           - type: requiredInGroup
-        envvar: REFINERY_METRICS_API_KEY
+        envvar: REFINERY_LEGACY_METRICS_API_KEY, HONEYCOMB_API_KEY
+        commandline: legacy-metrics-api-key
         summary: is the API key used by Refinery to send its metrics to Honeycomb.
         description: >
           It is recommended that you create a separate team and key for
@@ -557,7 +555,6 @@ groups:
         reload: false
         validations:
           - type: notempty
-        envvar: REFINERY_METRICS_DATASET
         summary: is the Honeycomb dataset where Refinery sends its metrics.
         description: >
           Only used if `APIKey` is specified.
@@ -596,7 +593,6 @@ groups:
         valuetype: nondefault
         default: "https://api.honeycomb.io"
         reload: false
-        envvar: REFINERY_METRICS_OTEL_API
         firstversion: v2.0
         summary: is the URL of the OpenTelemetry API to which metrics will be sent.
         description: >
@@ -610,7 +606,8 @@ groups:
         default: ""
         example: "SetThisToAHoneycombKey"
         reload: false
-        envvar: REFINERY_METRICS_OTEL_API_KEY
+        envvar: REFINERY_METRICS_OTEL_API_KEY, HONEYCOMB_API_KEY
+        commandline: otel-metrics-api-key
         firstversion: v2.0
         summary: is the API key used to send Honeycomb metrics via OpenTelemetry.
         description: >
@@ -628,7 +625,6 @@ groups:
         reload: false
         validations:
           - type: notempty
-        envvar: REFINERY_METRICS_DATASET
         firstversion: v2.0
         summary: is the Honeycomb dataset that Refinery sends its OpenTelemetry metrics.
         description: >
@@ -759,6 +755,7 @@ groups:
         example: "localhost:6379"
         reload: false
         envvar: REFINERY_REDIS_HOST
+        commandline: redis-host
         summary: is the host and port of the Redis instance to use for peer cluster membership management.
         description: >
           Must be in the form `host:port`.
@@ -771,6 +768,7 @@ groups:
         valuetype: nonemptystring
         reload: false
         envvar: REFINERY_REDIS_USERNAME
+        commandline: redis-username
         summary: is the username used to connect to Redis for peer cluster membership management.
         description: >
           Many Redis installations do not use this field.
@@ -783,6 +781,7 @@ groups:
         valuetype: nonemptystring
         reload: false
         envvar: REFINERY_REDIS_PASSWORD
+        commandline: redis-password
         summary: is the password used to connect to Redis for peer cluster membership management.
         description: >
           Many Redis installations do not use this field.
@@ -797,7 +796,6 @@ groups:
         reload: false
         validations:
           - type: notempty
-        envvar: REFINERY_REDIS_PREFIX
         summary: is a string used as a prefix for the keys in Redis while
           storing the peer membership.
         description: >
@@ -818,7 +816,6 @@ groups:
             arg: 0
           - type: maximum
             arg: 15
-        envvar: REFINERY_REDIS_DATABASE
         summary: is the database number to use for the Redis instance storing the peer membership.
         description: >
           An integer from 0-15 indicating the database number to use for the
@@ -920,7 +917,7 @@ groups:
         example: "4Gb"
         reload: true
         envvar: REFINERY_AVAILABLE_MEMORY
-        commandLine: AvailableMemory
+        commandLine: available-memory
         summary: is the amount of system memory available to the Refinery process.
         description: >
           This value will typically be set through an environment variable
@@ -1144,8 +1141,8 @@ groups:
         valuetype: nondefault
         default: ""
         reload: false
-        envvar: REFINERY_GRPC_LISTEN_ADDRESS
-        commandLine: GRPCListenAddr
+        envvar: REFINERY_GRPC_LISTEN_ADDR
+        commandLine: grpc-listen-addr
         summary: is the address Refinery listens to for incoming GRPC OpenTelemetry events.
         description: >
           Incoming traffic is expected to be unencrypted, so if using SSL, then

--- a/refinery_config.md
+++ b/refinery_config.md
@@ -85,7 +85,7 @@ Incoming traffic is expected to be HTTP, so if SSL is a requirement, put somethi
 - Not eligible for live reload.
 - Type: `hostport`
 - Default: `0.0.0.0:8080`
-- Environment variable: `REFINERY_HTTP_LISTEN_ADDR`
+- Environment variable: `REFINERY_HTTP_LISTEN_ADDRESS`
 - Command line switch: `--http-listen-addr`
 
 ### `PeerListenAddr`
@@ -97,7 +97,7 @@ Incoming traffic is expected to be HTTP, so if using SSL use something like ngin
 - Not eligible for live reload.
 - Type: `hostport`
 - Default: `0.0.0.0:8081`
-- Environment variable: `REFINERY_PEER_LISTEN_ADDR`
+- Environment variable: `REFINERY_PEER_LISTEN_ADDRESS`
 - Command line switch: `--peer-listen-addr`
 
 ### `HoneycombAPI`
@@ -462,7 +462,7 @@ It is recommended that you create a separate team and key for Refinery metrics.
 - Not eligible for live reload.
 - Type: `string`
 - Example: `SetThisToAHoneycombKey`
-- Environment variable: `REFINERY_LEGACY_METRICS_API_KEY, HONEYCOMB_API_KEY`
+- Environment variable: `REFINERY_HONEYCOMB_METRICS_API_KEY, HONEYCOMB_API_KEY`
 
 ### `Dataset`
 
@@ -878,7 +878,7 @@ Incoming traffic is expected to be unencrypted, so if using SSL, then put someth
 
 - Not eligible for live reload.
 - Type: `hostport`
-- Environment variable: `REFINERY_GRPC_LISTEN_ADDR`
+- Environment variable: `REFINERY_GRPC_LISTEN_ADDRESS`
 - Command line switch: `--grpc-listen-addr`
 
 ### `MaxConnectionIdle`

--- a/refinery_config.md
+++ b/refinery_config.md
@@ -21,13 +21,11 @@ The remainder of this document describes the sections within the file and the fi
 
 ## General Configuration
 
-Contains general configuration options that apply to the entire refinery process.
-
-Section Name: `General`
+`General` contains general configuration options that apply to the entire Refinery process.
 
 ### `ConfigurationVersion`
 
-ConfigurationVersion is the file format of this particular configuration file.
+`ConfigurationVersion` is the file format of this particular configuration file.
 
 This file is version 2.
 This field is required.
@@ -39,10 +37,10 @@ It exists to allow the configuration system to adapt to future changes in the co
 
 ### `MinRefineryVersion`
 
-MinRefineryVersion is the minimum version of Refinery that can load this configuration file.
+`MinRefineryVersion` is the minimum version of Refinery that can load this configuration file.
 
-This specifies the lowest Refinery version capable of loading all of the features used in this file.
-If this value is present, Refinery will refuse to start if its version is less than this.
+This setting specifies the lowest Refinery version capable of loading all of the features used in this file.
+If this value is present, then Refinery will refuse to start if its version is less than this setting.
 
 - Not eligible for live reload.
 - Type: `string`
@@ -50,22 +48,23 @@ If this value is present, Refinery will refuse to start if its version is less t
 
 ### `DatasetPrefix`
 
-DatasetPrefix is a prefix that can be used to distinguish a dataset from an environment in the rules.
+`DatasetPrefix` is a prefix that can be used to distinguish a dataset from an environment in the rules.
 
-If telemetry is being sent to both a classic dataset and a new environment called the same thing (eg `production`), this parameter can be used to distinguish these cases.
-When Refinery receives telemetry using an API key associated with a classic dataset, it will then use the prefix in the form `{prefix}.{dataset}` when trying to resolve the rules definition.
+If telemetry is being sent to both a classic dataset and a new environment called the same thing, such as `production`, then this parameter can be used to distinguish these cases.
+When Refinery receives telemetry using an API key associated with a Honeycomb Classic dataset, it will then use the prefix in the form `{prefix}.
+{dataset}` when trying to resolve the rules definition.
 
 - Not eligible for live reload.
 - Type: `string`
 
 ### `ConfigReloadInterval`
 
-ConfigReloadInterval is the average interval between attempts at reloading the configuration file.
+`ConfigReloadInterval` is the average interval between attempts at reloading the configuration file.
 
 A single instance of Refinery will attempt to read its configuration and check for changes at approximately this interval.
 This time is varied by a random amount to avoid all instances refreshing together.
 Within a cluster, Refinery will gossip information about new configuration so that all instances can reload at close to the same time.
-This feature can be disabled with a value of 0s.
+Disable this feature with a value of `0s`.
 
 - Not eligible for live reload.
 - Type: `duration`
@@ -73,51 +72,53 @@ This feature can be disabled with a value of 0s.
 
 ## Network Configuration
 
-Contains network configuration options.
-
-Section Name: `Network`
+`Network` contains network configuration options.
 
 ### `ListenAddr`
 
-ListenAddr is the address refinery listens to for incoming requests.
+`ListenAddr` is the address where Refinery listens for incoming requests.
 
-This is the IP and port on which to listen for incoming HTTP requests.
-These requests include traffic formatted as Honeycomb events, proxied requests to the Honeycomb API, and Open Telemetry data using the http protocol.
-Incoming traffic is expected to be HTTP, so if SSL is a requirement, put something like nginx in front to do the decryption.
+This setting is the IP and port on which Refinery listens for incoming HTTP requests.
+These requests include traffic formatted as Honeycomb events, proxied requests to the Honeycomb API, and OpenTelemetry data using the `http` protocol.
+Incoming traffic is expected to be HTTP, so if SSL is a requirement, put something like `nginx` in front to do the decryption.
 
 - Not eligible for live reload.
 - Type: `hostport`
 - Default: `0.0.0.0:8080`
+- Environment variable: `REFINERY_HTTP_LISTEN_ADDR`
+- Command line switch: `--http-listen-addr`
 
 ### `PeerListenAddr`
 
-PeerListenAddr is the IP and port on which to listen for traffic being rerouted from a peer.
+`PeerListenAddr` is the IP and port on which to listen for traffic being rerouted from a peer.
 
 Incoming traffic is expected to be HTTP, so if using SSL use something like nginx or a load balancer to do the decryption.
 
 - Not eligible for live reload.
 - Type: `hostport`
 - Default: `0.0.0.0:8081`
+- Environment variable: `REFINERY_PEER_LISTEN_ADDR`
+- Command line switch: `--peer-listen-addr`
 
 ### `HoneycombAPI`
 
-HoneycombAPI is the URL of the Honeycomb API to which data will be sent.
+`HoneycombAPI` is the URL of the upstream Honeycomb API where the data will be sent.
 
-HoneycombAPI is the URL for the upstream Honeycomb API; this is the destination to which refinery sends all events that it decides to keep.
+This setting is the destination to which Refinery sends all events that it decides to keep.
 
 - Eligible for live reload.
 - Type: `url`
 - Default: `https://api.honeycomb.io`
+- Environment variable: `REFINERY_HONEYCOMB_API`
+- Command line switch: `--honeycomb-api`
 
 ## Access Key Configuration
 
-Contains access keys -- API keys that the proxy will treat specially, and other flags that control how the proxy handles API keys.
-
-Section Name: `AccessKeys`
+`AccessKeys` Contains access keys -- API keys that the proxy will treat specially, and other flags that control how the proxy handles API keys.
 
 ### `ReceiveKeys`
 
-ReceiveKeys is a set of Honeycomb API keys that the proxy will treat specially.
+`ReceiveKeys` is a set of Honeycomb API keys that the proxy will treat specially.
 
 This list only applies to span traffic - other Honeycomb API actions will be proxied through to the upstream API directly without modifying keys.
 
@@ -127,29 +128,27 @@ This list only applies to span traffic - other Honeycomb API actions will be pro
 
 ### `AcceptOnlyListedKeys`
 
-AcceptOnlyListedKeys is a boolean flag that causes events arriving with API keys not in the ReceiveKeys list to be rejected.
+`AcceptOnlyListedKeys` is a boolean flag that causes events arriving with API keys not in the `ReceiveKeys` list to be rejected.
 
-If true, only traffic using the keys listed in APIKeys is accepted.
-Events arriving with API keys not in the ReceiveKeys list will be rejected with an HTTP 401 error.
-If false, all traffic is accepted and ReceiveKeys is ignored.
-Must be specified if APIKeys is specified.
+If `true`, then only traffic using the keys listed in `APIKeys` is accepted.
+Events arriving with API keys not in the `ReceiveKeys` list will be rejected with an HTTP `401` error.
+If `false`, then all traffic is accepted and `ReceiveKeys` is ignored.
+Must be specified if `APIKeys` is specified.
 
 - Eligible for live reload.
 - Type: `bool`
 
 ## Refinery Telemetry
 
-Configuration info for the telemetry that Refinery uses to record its own operation.
-
-Section Name: `RefineryTelemetry`
+`RefineryTelemetry` contains configuration information for the telemetry that Refinery uses to record its own operation.
 
 ### `AddRuleReasonToTrace`
 
-AddRuleReasonToTrace controls whether to decorate traces with refinery rule evaluation results.
+`AddRuleReasonToTrace` controls whether to decorate traces with Refinery rule evaluation results.
 
-This causes traces that are sent to Honeycomb to include the field `meta.refinery.reason`.
+When enabled, this setting causes traces that are sent to Honeycomb to include the field `meta.refinery.reason`.
 This field contains text indicating which rule was evaluated that caused the trace to be included.
-We recommend enabling this field whenever a rules-based sampler is in use, as it is useful for debugging and understanding the behavior of your refinery installation.
+We recommend enabling this setting whenever a rules-based sampler is in use, as it is useful for debugging and understanding the behavior of your Refinery installation.
 
 - Eligible for live reload.
 - Type: `bool`
@@ -157,11 +156,12 @@ We recommend enabling this field whenever a rules-based sampler is in use, as it
 
 ### `AddSpanCountToRoot`
 
-AddSpanCountToRoot controls whether to add a metadata field to root spans indicating the number of child spans.
+`AddSpanCountToRoot` controls whether to add a metadata field to root spans that indicates the number of child spans.
 
-Adds a new metadata field, `meta.span_count` to root spans to indicate the number of child spans on the trace at the time the sampling decision was made.
+The added metadata field, `meta.span_count`, indicates the number of child spans on the trace at the time the sampling decision was made.
 This value is available to the rules-based sampler, making it possible to write rules that are dependent upon the number of spans in the trace.
-If true, Refinery will add meta.span_count to the root span.
+If `true`, then Refinery will add `meta.
+span_count` to the root span.
 
 - Eligible for live reload.
 - Type: `bool`
@@ -169,10 +169,9 @@ If true, Refinery will add meta.span_count to the root span.
 
 ### `AddHostMetadataToTrace`
 
-AddHostMetadataToTrace specifies whether to add host metadata to traces.
+`AddHostMetadataToTrace` specifies whether to add host metadata to traces.
 
-AddHostMetadataToTrace specifies whether to add host metadata to traces.
-If true, Refinery will add the following tags to all traces: - meta.refinery.local_hostname: the hostname of the Refinery node (we should consider adding more metadata here, like IP address, etc)
+If `true`, then Refinery will add the following tag to all traces: - `meta.refinery.local_hostname`: the hostname of the Refinery node
 
 - Eligible for live reload.
 - Type: `bool`
@@ -180,18 +179,16 @@ If true, Refinery will add the following tags to all traces: - meta.refinery.loc
 
 ## Traces
 
-Configuration for how traces are managed.
-
-Section Name: `Traces`
+`Traces` contains configuration for how traces are managed.
 
 ### `SendDelay`
 
-SendDelay is the duration to wait before sending a trace.
+`SendDelay` is the duration to wait before sending a trace.
 
-This is a short timer that will be triggered when a trace is complete.
-Refinery will wait this duration before actually sending the trace.
-The reason for this short delay is to allow for small network delays or clock jitters to elapse and any final spans to arrive before actually sending the trace.
-Set to 0 for immediate sends.
+This setting is a short timer that is triggered when a trace is complete.
+Refinery waits for this duration before sending the trace.
+The reason for this setting is to allow for small network delays or clock jitters to elapse and any final spans to arrive before sending the trace.
+Set to "0" for immediate sending.
 
 - Eligible for live reload.
 - Type: `duration`
@@ -199,10 +196,9 @@ Set to 0 for immediate sends.
 
 ### `BatchTimeout`
 
-BatchTimeout is how frequently Refinery sends unfulfilled batches.
+`BatchTimeout` is how frequently Refinery sends unfulfilled batches.
 
-Dictates how frequently to send unfulfilled batches.
-By default this will use the DefaultBatchTimeout in libhoney as its value, which is 100ms.
+By default, this setting uses the `DefaultBatchTimeout` in `libhoney` as its value, which is `100ms`.
 
 - Eligible for live reload.
 - Type: `duration`
@@ -210,13 +206,13 @@ By default this will use the DefaultBatchTimeout in libhoney as its value, which
 
 ### `TraceTimeout`
 
-TraceTimeout is the duration to wait before making the trace decision on an incomplete trace.
+`TraceTimeout` is the duration to wait before making the trace decision on an incomplete trace.
 
 A long timer; it represents the outside boundary of how long to wait before making the trace decision about an incomplete trace.
 Normally trace decisions (send or drop) are made when the root span arrives.
-Sometimes the root span never arrives (due to crashes or whatever), and this timer will send a trace even without having received the root span.
-If you have particularly long-lived traces you should increase this timer.
-Note that this will also increase the memory requirements for refinery.
+Sometimes the root span never arrives (for example, due to crashes) and this timer ensures sending a trace even without having received the root span.
+If particularly long-lived traces are present in your data, then you should increase this timer.
+Note that this increase will also increase the memory requirements for Refinery.
 
 - Eligible for live reload.
 - Type: `duration`
@@ -224,11 +220,11 @@ Note that this will also increase the memory requirements for refinery.
 
 ### `MaxBatchSize`
 
-MaxBatchSize is the maximum number of events to be included in each batch for sending.
+`MaxBatchSize` is the maximum number of events to be included in each batch for sending.
 
-This value is used to set the BatchSize field in the libhoney library used to send data to Honeycomb.
-If you have particularly large traces you should increase this value.
-Note that this will also increase the memory requirements for refinery.
+This value is used to set the `BatchSize` field in the `libhoney` library used to send data to Honeycomb.
+If you have particularly large traces, then you should increase this value.
+Note that this will also increase the memory requirements for Refinery.
 
 - Eligible for live reload.
 - Type: `int`
@@ -236,10 +232,10 @@ Note that this will also increase the memory requirements for refinery.
 
 ### `SendTicker`
 
-SendTicker is the interval between checks for traces to send.
+`SendTicker` is the interval between checks for traces to send.
 
 A short timer that determines the duration between trace cache review runs to send.
-Increasing this will spend more time processing incoming events to reduce incoming_ or peer_router_dropped spikes.
+Increasing this will spend more time processing incoming events to reduce `incoming_` or `peer_router_dropped` spikes.
 Decreasing this will check the trace cache for timeouts more frequently.
 
 - Eligible for live reload.
@@ -248,17 +244,14 @@ Decreasing this will check the trace cache for timeouts more frequently.
 
 ## Debugging
 
-Configuration values used when setting up and debugging Refinery.
-
-Section Name: `Debugging`
+`Debugging` contains configuration values used when setting up and debugging Refinery.
 
 ### `DebugServiceAddr`
 
-DebugServiceAddr is the IP and port the debug service will run on.
+`DebugServiceAddr` is the IP and port where the debug service runs.
 
-Sets the IP and port for the debug service.
-The debug service is generally only used when debugging Refinery itself, and will only run if the command line flag -d is specified.
-If this value is not specified, the debug service runs on the first open port between localhost:6060 and :6069.
+The debug service is generally only used when debugging Refinery itself, and will only run if the command line option `-d` is specified.
+If this value is not specified, then the debug service runs on the first open port between `localhost:6060` and `localhost:6069`.
 
 - Not eligible for live reload.
 - Type: `hostport`
@@ -266,24 +259,25 @@ If this value is not specified, the debug service runs on the first open port be
 
 ### `QueryAuthToken`
 
-QueryAuthToken is the token that must be specified to access the /query endpoint.
+`QueryAuthToken` is the token that must be specified to access the `/query` endpoint.
 
-Provides a token that must be specified with the header "X-Honeycomb-Refinery-Query" in order for a /query request to succeed.
-These /query requests are intended for debugging refinery during setup and are not typically needed in normal operation.
-If not specified, the /query endpoints are inaccessible.
+This token must be specified with the header "X-Honeycomb-Refinery-Query" in order for a `/query` request to succeed.
+These `/query` requests are intended for debugging Refinery during setup and are not typically needed in normal operation.
+If not specified, then the `/query` endpoints are inaccessible.
 
 - Not eligible for live reload.
 - Type: `string`
 - Example: `some-private-value`
+- Environment variable: `REFINERY_QUERY_AUTH_TOKEN`
 
 ### `AdditionalErrorFields`
 
-AdditionalErrorFields is a list of span fields to include when logging errors.
+`AdditionalErrorFields` is a list of span fields to include when logging errors happen during the ingestion of events.
 
-A list of span fields that should be included when logging errors that happen during ingestion of events (for example, the span too large error).
+For example, the span too large error.
 This is primarily useful in trying to track down misbehaving senders in a large installation.
 The fields `dataset`, `apihost`, and `environment` are always included.
-If a field is not present in the span, it will not be present in the error log.
+If a field is not present in the span, then it will not be present in the error log.
 
 - Eligible for live reload.
 - Type: `stringarray`
@@ -291,12 +285,13 @@ If a field is not present in the span, it will not be present in the error log.
 
 ### `DryRun`
 
-DryRun controls whether sampling is applied to incoming traces.
+`DryRun` controls whether sampling is applied to incoming traces.
 
-If enabled, marks the traces that would be dropped given the current sampling rules, and sends all traces regardless of the sampling decision.
+If enabled, then Refinery marks the traces that would be dropped given the current sampling rules, and sends all traces regardless of the sampling decision.
 This is useful for evaluating sampling rules.
-In DryRun mode, traces will be decorated with meta.refinery.dryrun.kept set to true or false based on whether the trace would be kept or dropped.
-In addition, SampleRate will be set to the incoming rate for all traces, and the field meta.refinery.dryrun.sample_rate will be set to the sample rate that would have been used.
+When DryRun is enabled, traces is decorated with `meta.refinery.
+dryrun.kept` that is set to `true` or `false`, based on whether the trace would be kept or dropped.
+In addition, `SampleRate` will be set to the incoming rate for all traces, and the field `meta.refinery.dryrun.sample_rate` will be set to the sample rate that would have been used.
 
 - Eligible for live reload.
 - Type: `bool`
@@ -304,18 +299,16 @@ In addition, SampleRate will be set to the incoming rate for all traces, and the
 
 ## Refinery Logger
 
-Configuration for logging.
-
-Section Name: `Logger`
+`Logger` contains configuration for logging.
 
 ### `Type`
 
-Type is the type of logger to use.
+`Type` is the type of logger to use.
 
-Specifies where (and if) refinery sends logs.
+The setting specifies where (and if) Refinery sends logs.
 `none` means that logs are discarded.
-`honeycomb` means that logs will be forwarded to honeycomb as events according to the settings below.
-`stdout` means that logs will be written to stdout.
+`honeycomb` means that logs will be forwarded to Honeycomb as events according to the set Logging settings.
+`stdout` means that logs will be written to `stdout`.
 
 - Not eligible for live reload.
 - Type: `string`
@@ -324,11 +317,10 @@ Specifies where (and if) refinery sends logs.
 
 ### `Level`
 
-Level is the logging level above which refinery should send a log.
+`Level` is the logging level above which Refinery should send a log to the logger.
 
-Sets the logging level above which refinery should send logs to the logger.
-`debug` is very verbose, and should not be used in production environments.
 `warn` is the recommended level for production.
+`debug` is very verbose, and should not be used in production environments.
 
 - Not eligible for live reload.
 - Type: `string`
@@ -337,16 +329,14 @@ Sets the logging level above which refinery should send logs to the logger.
 
 ## Honeycomb Logger
 
-Configuration for logging to Honeycomb.
-Only used if Logger.Type is "honeycomb".
-
-Section Name: `HoneycombLogger`
+`HoneycombLogger` contains configuration for logging to Honeycomb.
+Only used if `Logger.Type` is "honeycomb".
 
 ### `APIHost`
 
-APIHost is the URL of the Honeycomb API to which logs will be sent.
+`APIHost` is the URL of the Honeycomb API where Refinery sends its logs.
 
-Sets the upstream Honeycomb API for logs; this is the destination to which refinery sends its own logs.
+Refinery's internal logs will be sent to this host using the standard Honeycomb Events API.
 
 - Not eligible for live reload.
 - Type: `url`
@@ -354,20 +344,20 @@ Sets the upstream Honeycomb API for logs; this is the destination to which refin
 
 ### `APIKey`
 
-APIKey is the API key to use when sending logs to Honeycomb.
+`APIKey` is the API key used to send Refinery's logs to Honeycomb.
 
-This is the API key to use for Refinery's logs when sending them to Honeycomb.
 It is recommended that you create a separate team and key for Refinery logs.
 
 - Not eligible for live reload.
 - Type: `string`
 - Example: `SetThisToAHoneycombKey`
+- Environment variable: `REFINERY_HONEYCOMB_LOGGER_API_KEY, REFINERY_HONEYCOMB_API_KEY`
 
 ### `Dataset`
 
-Dataset is the dataset to which logs will be sent.
+`Dataset` is the dataset to which logs will be sent.
 
-Specifies the Honeycomb dataset to which logs will be sent.
+Only used if `APIKey` is specified.
 
 - Not eligible for live reload.
 - Type: `string`
@@ -375,10 +365,9 @@ Specifies the Honeycomb dataset to which logs will be sent.
 
 ### `SamplerEnabled`
 
-SamplerEnabled controls whether to sample logs.
+`SamplerEnabled` controls whether logs are sampled before sending to Honeycomb.
 
-Controls whether logs are sampled before sending to Honeycomb.
-The sample rate is controlled by the SamplerThroughput setting.
+The sample rate is controlled by the `SamplerThroughput` setting.
 
 - Not eligible for live reload.
 - Type: `bool`
@@ -386,11 +375,9 @@ The sample rate is controlled by the SamplerThroughput setting.
 
 ### `SamplerThroughput`
 
-SamplerThroughput is the sampling throughput for logs in events per second.
+`SamplerThroughput` is the sampling throughput for logs in events per second.
 
-SamplerThroughput is the sampling throughput for logs measured in events per second.
 The sampling algorithm attempts to make sure that the average throughput approximates this value, while also ensuring that all unique logs arrive at Honeycomb at least once per sampling period.
-TODO: THROUGHPUT FOR THE CLUSTER
 
 - Not eligible for live reload.
 - Type: `float`
@@ -399,16 +386,15 @@ TODO: THROUGHPUT FOR THE CLUSTER
 
 ## Stdout Logger
 
-Configuration for logging to stdout.
-Only used if Logger.Type is "stdout".
-
-Section Name: `StdoutLogger`
+`StdoutLogger` contains configuration for logging to `stdout`.
+Only used if `Logger.Type` is "stdout".
 
 ### `Structured`
 
-Structured controls whether to used structured logging.
+`Structured` controls whether to use structured logging.
 
-Specifies whether the stdout logger generates structured logs (JSON) or not (plain text).
+`true` generates structured logs (JSON).
+`false` generates plain text logs.
 
 - Not eligible for live reload.
 - Type: `bool`
@@ -416,26 +402,25 @@ Specifies whether the stdout logger generates structured logs (JSON) or not (pla
 
 ## Prometheus Metrics
 
-Configuration for Refinery's internally-generated metrics as made available through Prometheus.
-
-Section Name: `PrometheusMetrics`
+`PrometheusMetrics` contains configuration for Refinery's internally-generated metrics as made available through Prometheus.
 
 ### `Enabled`
 
-Enabled controls whether to expose refinery metrics over PromethusListenAddr
+`Enabled` controls whether to expose Refinery metrics over the `PrometheusListenAddr` port.
 
-The flag specifies whether Refinery should expose its own metrics over the PrometheusListenAddr port.
+Each of the metrics providers can be enabled or disabled independently.
+Metrics can be sent to multiple destinations.
 
 - Not eligible for live reload.
 - Type: `bool`
 
 ### `ListenAddr`
 
-ListenAddr is the IP and port the prometheus metrics server will run on.
+`ListenAddr` is the IP and port the Prometheus Metrics server will run on.
 
-Determines the interface and port on which Prometheus will listen for requests for /metrics.
+Determines the interface and port on which Prometheus will listen for requests for `/metrics`.
 Must be different from the main Refinery listener.
-Only used if "Enabled" is true in PrometheusMetrics.
+Only used if `Enabled` is `true` in `PrometheusMetrics`.
 
 - Not eligible for live reload.
 - Type: `hostport`
@@ -443,27 +428,26 @@ Only used if "Enabled" is true in PrometheusMetrics.
 
 ## Legacy Metrics
 
-Configuration for Refinery's legacy metrics.
+`LegacyMetrics` `LegacyMetrics` contains configuration for Refinery's legacy metrics.
 Version 1.x of Refinery used this format for sending Metrics to Honeycomb.
 The metrics generated that way are nonstandard and will be deprecated in a future release.
-New installations should prefer OTelMetrics.
-
-Section Name: `LegacyMetrics`
+New installations should prefer `OTelMetrics`.
 
 ### `Enabled`
 
-Enabled controls whether to send metrics to Honeycomb.
+`Enabled` controls whether to send legacy-formatted metrics to Honeycomb.
 
-This controls whether to send legacy-formatted metrics to Honeycomb.
+Each of the metrics providers can be enabled or disabled independently.
+Metrics can be sent to multiple destinations.
 
 - Not eligible for live reload.
 - Type: `bool`
 
 ### `APIHost`
 
-APIHost is the URL of the Honeycomb API to which metrics will be sent.
+`APIHost` is the URL of the Honeycomb API where legacy metrics are sent.
 
-Specifies the URL for the upstream Honeycomb API for legacy metrics.
+Refinery's internal metrics will be sent to this host using the standard Honeycomb Events API.
 
 - Not eligible for live reload.
 - Type: `url`
@@ -471,20 +455,20 @@ Specifies the URL for the upstream Honeycomb API for legacy metrics.
 
 ### `APIKey`
 
-APIKey is the API key used to send Honeycomb metrics.
+`APIKey` is the API key used by Refinery to send its metrics to Honeycomb.
 
-Specifies the API key used when refinery sends its own metrics.
 It is recommended that you create a separate team and key for Refinery metrics.
 
 - Not eligible for live reload.
 - Type: `string`
 - Example: `SetThisToAHoneycombKey`
+- Environment variable: `REFINERY_LEGACY_METRICS_API_KEY, HONEYCOMB_API_KEY`
 
 ### `Dataset`
 
-Dataset is the Honeycomb dataset to which metrics will be sent.
+`Dataset` is the Honeycomb dataset where Refinery sends its metrics.
 
-Specifies the dataset to which refinery sends its own metrics.
+Only used if `APIKey` is specified.
 
 - Not eligible for live reload.
 - Type: `string`
@@ -492,9 +476,8 @@ Specifies the dataset to which refinery sends its own metrics.
 
 ### `ReportingInterval`
 
-ReportingInterval is the interval between sending legacy metrics to Honeycomb.
+`ReportingInterval` is the interval between sending legacy metrics to Honeycomb.
 
-The interval between sending metrics to Honeycomb.
 Between 1 and 60 seconds is typical.
 
 - Not eligible for live reload.
@@ -503,26 +486,25 @@ Between 1 and 60 seconds is typical.
 
 ## OpenTelemetry Metrics
 
-Configuration for Refinery's OpenTelemetry metrics.
+`OTelMetrics` `OTelMetrics` contains configuration for Refinery's OpenTelemetry (OTel) metrics.
 This is the preferred way to send metrics to Honeycomb.
-New installations should prefer OTelMetrics.
-
-Section Name: `OTelMetrics`
+New installations should prefer `OTelMetrics`.
 
 ### `Enabled`
 
-Enabled controls whether to send metrics via OTel.
+`Enabled` controls whether to send metrics via OpenTelemetry.
 
-Enabled controls whether to send OpenTelemetry metrics to Honeycomb.
+Each of the metrics providers can be enabled or disabled independently.
+Metrics can be sent to multiple destinations.
 
 - Not eligible for live reload.
 - Type: `bool`
 
 ### `APIHost`
 
-APIHost is the URL of the OTel API to which metrics will be sent.
+`APIHost` is the URL of the OpenTelemetry API to which metrics will be sent.
 
-Specifies a URL for the upstream API to receive refinery's own OTel metrics.
+Refinery's internal metrics will be sent to the `/v1/metrics` endpoint on this host.
 
 - Not eligible for live reload.
 - Type: `url`
@@ -530,22 +512,21 @@ Specifies a URL for the upstream API to receive refinery's own OTel metrics.
 
 ### `APIKey`
 
-APIKey is the API key used to send Honeycomb metrics via OTel.
+`APIKey` is the API key used to send Honeycomb metrics via OpenTelemetry.
 
-Specifies the API key used when refinery sends its own metrics.
 It is recommended that you create a separate team and key for Refinery metrics.
-If this is blank, Refinery will not set the Honeycomb-specific headers for OTel, and your APIHost must be set to a valid OTel endpoint.
+If this is blank, then Refinery will not set the Honeycomb-specific headers for OpenTelemetry, and your `APIHost` must be set to a valid OpenTelemetry endpoint.
 
 - Not eligible for live reload.
 - Type: `string`
 - Example: `SetThisToAHoneycombKey`
+- Environment variable: `REFINERY_METRICS_OTEL_API_KEY, HONEYCOMB_API_KEY`
 
 ### `Dataset`
 
-Dataset is the Honeycomb dataset to which OTel metrics will be sent.
+`Dataset` is the Honeycomb dataset that Refinery sends its OpenTelemetry metrics.
 
-Specifies the dataset to which refinery sends its own OTel metrics.
-Only used if APIKey is specified.
+Only used if `APIKey` is specified.
 
 - Not eligible for live reload.
 - Type: `string`
@@ -553,10 +534,9 @@ Only used if APIKey is specified.
 
 ### `ReportingInterval`
 
-ReportingInterval is the interval between sending OTel metrics to Honeycomb.
+`ReportingInterval` is the interval between sending OpenTelemetry metrics to Honeycomb.
 
-The interval between sending metrics to Honeycomb.
-Between 1 and 60 seconds is typical.
+Between `1` and `60` seconds is typical.
 
 - Not eligible for live reload.
 - Type: `duration`
@@ -564,9 +544,8 @@ Between 1 and 60 seconds is typical.
 
 ### `Compression`
 
-Compression is the compression algorithm to use when sending OTel metrics.
+`Compression` is the compression algorithm to use when sending OpenTelemetry metrics to Honeycomb.
 
-The compression algorithm to use when sending metrics to Honeycomb.
 `gzip` is the default and recommended value.
 In rare circumstances, compression costs may outweigh the benefits, in which case `none` may be used.
 
@@ -577,17 +556,15 @@ In rare circumstances, compression costs may outweigh the benefits, in which cas
 
 ## Peer Management
 
-Controls how the Refinery cluster communicates between peers.
-
-Section Name: `PeerManagement`
+`PeerManagement` controls how the Refinery cluster communicates between peers.
 
 ### `Type`
 
-Type is the type of peer management to use.
+`Type` is the type of peer management to use.
 
-Sets the type of peer management (the mechanism by which Refinery locates its peers).
+Peer management is the mechanism by which Refinery locates its peers.
 `file` means that Refinery gets its peer list from the Peers list in this config file.
-`redis` means that refinery self-registers with a redis instance and gets its peer list from there.
+`redis` means that Refinery self-registers with a Redis instance and gets its peer list from there.
 
 - Not eligible for live reload.
 - Type: `string`
@@ -596,11 +573,11 @@ Sets the type of peer management (the mechanism by which Refinery locates its pe
 
 ### `Identifier`
 
-Identifier specifies the identifier to use when registering itself with peers.
+`Identifier` specifies the identifier to use when registering itself with peers.
 
 By default, when using a peer registry, Refinery will use the local hostname to identify itself to other peers.
-If your environment requires something else, (for example, if peers can't resolve each other by name), you can specify the exact identifier (IP address, etc) to use here.
-Overrides IdentifierInterfaceName, if both are set.
+If your environment requires something else, (for example, if peers cannot resolve each other by name), then you can specify the exact identifier, such as an IP address, to use here.
+Overrides `IdentifierInterfaceName`, if both are set.
 
 - Not eligible for live reload.
 - Type: `string`
@@ -608,10 +585,10 @@ Overrides IdentifierInterfaceName, if both are set.
 
 ### `IdentifierInterfaceName`
 
-IdentifierInterfaceName specifies a network interface to use when finding a local hostname.
+`IdentifierInterfaceName` specifies a network interface to use when finding a local hostname.
 
 By default, when using a peer registry, Refinery will use the local hostname to identify itself to other peers.
-If your environment requires that you use IPs as identifiers (for example, if peers can't resolve eachother by name), you can specify the network interface that Refinery is listening on here.
+If your environment requires that you use IPs as identifiers (for example, if peers cannot resolve each other by name), then you can specify the network interface that Refinery is listening on here.
 Refinery will use the first unicast address that it finds on the specified network interface as its identifier.
 
 - Not eligible for live reload.
@@ -620,19 +597,18 @@ Refinery will use the first unicast address that it finds on the specified netwo
 
 ### `UseIPV6Identifier`
 
-UseIPV6Identifier specifies that Refinery should use an IPV6 address as its identifier.
+`UseIPV6Identifier` specifies that Refinery should use an IPV6 address as its identifier.
 
-If using IdentifierInterfaceName, Refinery will default to the first IPv4 unicast address it finds for the specified interface.
-If this value is specified, Refinery will use the first IPV6 unicast address found.
+If using `IdentifierInterfaceName`, Refinery will default to the first IPv4 unicast address it finds for the specified interface.
+If this value is specified, then Refinery will use the first IPV6 unicast address found.
 
 - Not eligible for live reload.
 - Type: `bool`
 
 ### `Peers`
 
-Peers is the list of peers to use when Type is "file".
+`Peers` is the list of peers to use when Type is "file", excluding self.
 
-Sets the list of peers to use when Type is "file", excluding self.
 This list is ignored when Type is "redis".
 The format is a list of strings of the form "host:port".
 
@@ -642,45 +618,45 @@ The format is a list of strings of the form "host:port".
 
 ## Redis Peer Management
 
-Controls how the Refinery cluster communicates between peers when using Redis.
-Only applies when PeerManagement.Type is "redis".
-
-Section Name: `RedisPeerManagement`
+`RedisPeerManagement` `RedisPeerManagement` controls how the Refinery cluster communicates between peers when using Redis.
+Only applies when `PeerManagement.Type` is "redis".
 
 ### `Host`
 
-Host is the host and port of the redis instance to use.
+`Host` is the host and port of the Redis instance to use for peer cluster membership management.
 
-Sets the host and port of the redis instance to use for peer cluster membership management.
+Must be in the form `host:port`.
 
 - Not eligible for live reload.
 - Type: `hostport`
 - Example: `localhost:6379`
+- Environment variable: `REFINERY_REDIS_HOST`
 
 ### `Username`
 
-Username is the username used to connect to redis.
+`Username` is the username used to connect to Redis for peer cluster membership management.
 
-The username used to connect to redis for peer cluster membership management.
+Many Redis installations do not use this field.
 
 - Not eligible for live reload.
 - Type: `string`
+- Environment variable: `REFINERY_REDIS_USERNAME`
 
 ### `Password`
 
-Password is the password used to connect to redis.
+`Password` is the password used to connect to Redis for peer cluster membership management.
 
-Sets the password used to connect to redis for peer cluster membership management.
+Many Redis installations do not use this field.
 
 - Not eligible for live reload.
 - Type: `string`
+- Environment variable: `REFINERY_REDIS_PASSWORD`
 
 ### `Prefix`
 
-Prefix is a string used as a prefix for the keys in redis.
+`Prefix` is a string used as a prefix for the keys in Redis while storing the peer membership.
 
-Specifies a string to be used as a prefix for the keys in redis while storing the peer membership.
-It might be useful to override this in any situation where multiple refinery clusters or multiple applications want to share a single Redis instance.
+It might be useful to override this in any situation where multiple Refinery clusters or multiple applications want to share a single Redis instance.
 It may not be blank.
 
 - Not eligible for live reload.
@@ -690,10 +666,10 @@ It may not be blank.
 
 ### `Database`
 
-Database is the database number to use for the Redis instance storing the peer membership.
+`Database` is the database number to use for the Redis instance storing the peer membership.
 
 An integer from 0-15 indicating the database number to use for the Redis instance storing the peer membership.
-It might be useful to set this in any situation where multiple refinery clusters or multiple applications want to share a single Redis instance.
+It might be useful to set this in any situation where multiple Refinery clusters or multiple applications want to share a single Redis instance.
 
 - Not eligible for live reload.
 - Type: `int`
@@ -701,27 +677,27 @@ It might be useful to set this in any situation where multiple refinery clusters
 
 ### `UseTLS`
 
-UseTLS enables TLS when connecting to redis.
+`UseTLS` enables TLS when connecting to Redis for peer cluster membership management.
 
-Enables TLS when connecting to redis for peer cluster membership management, and sets the MinVersion in the TLS configuration to 1.2.
+When enabled, this setting sets the `MinVersion` in the TLS configuration to `1.2`.
 
 - Not eligible for live reload.
 - Type: `bool`
 
 ### `UseTLSInsecure`
 
-UseTLSInsecure disables certificate checks when connecting to redis.
+`UseTLSInsecure` disables certificate checks when connecting to Redis for peer cluster membership management.
 
-Disables certificate checks when connecting to redis for peer cluster membership management.
+This setting is intended for use with self-signed certificates and sets the `InsecureSkipVerify` flag within Redis.
 
 - Not eligible for live reload.
 - Type: `bool`
 
 ### `Timeout`
 
-Timeout is the timeout to use when communicating with Redis.
+`Timeout` is the timeout to use when communicating with Redis.
 
-Refinery will timeout after this duration when communicating with Redis.
+It is rarely necessary to adjust this value.
 
 - Not eligible for live reload.
 - Type: `duration`
@@ -729,15 +705,13 @@ Refinery will timeout after this duration when communicating with Redis.
 
 ## Collection Settings
 
-Brings together the settings that are relevant to collecting spans together to make traces.
+`Collection` `Collection` contains the settings that are relevant to collecting spans together to make traces.
 If none of the memory settings are used, then Refinery will not attempt to limit its memory usage.
 This is not recommended for production use since a burst of traffic could cause Refinery to run out of memory and crash.
 
-Section Name: `Collection`
-
 ### `CacheCapacity`
 
-CacheCapacity is the number of traces to keep in the cache's circular buffer.
+`CacheCapacity` is the number of traces to keep in the cache's circular buffer.
 
 The collection cache is used to collect all spans into a trace as well as remember the sampling decision for any spans that might come in after the trace has been marked "complete" (either by timing out or seeing the root span).
 The number of traces in the cache should be many multiples (100x to 1000x) of the total number of concurrently active traces (trace throughput * trace duration).
@@ -748,28 +722,29 @@ The number of traces in the cache should be many multiples (100x to 1000x) of th
 
 ### `AvailableMemory`
 
-AvailableMemory is the amount of system memory available to the refinery process.
+`AvailableMemory` is the amount of system memory available to the Refinery process.
 
-The amount of system memory available to the refinery process.
 This value will typically be set through an environment variable controlled by the container or deploy script.
-If this value is zero or not set, MaxMemory cannot be used to calculate the maximum allocation and MaxAlloc will be used instead.
-If set, this must be a memory size.
+If this value is zero or not set, then `MaxMemory` cannot be used to calculate the maximum allocation and `MaxAlloc` will be used instead.
+If set, then this must be a memory size.
 64-bit values are supported.
 Sizes with standard unit suffixes like "MB" and "GiB" are also supported.
 
 - Eligible for live reload.
 - Type: `memorysize`
 - Example: `4Gb`
+- Environment variable: `REFINERY_AVAILABLE_MEMORY`
+- Command line switch: `--available-memory`
 
 ### `MaxMemoryPercentage`
 
-MaxMemoryPercentage is the maximum percentage of memory that should be allocated by the span collector.
+`MaxMemoryPercentage` is the maximum percentage of memory that should be allocated by the span collector.
 
-If nonzero, it must be an integer value between 1 and 100, representing the target maximum percentage of memory that should be allocated by the span collector.
-If set to a non-zero value, once per tick (see SendTicker) the collector will compare total allocated bytes to this calculated value.
-If allocation is too high, traces will be ejected from the cache early to reduce memory.
+If nonzero, then it must be an integer value between 1 and 100, representing the target maximum percentage of memory that should be allocated by the span collector.
+If set to a non-zero value, then once per tick (see `SendTicker`) the collector will compare total allocated bytes to this calculated value.
+If allocation is too high, then traces will be ejected from the cache early to reduce memory.
 Useful values for this setting are generally in the range of 70-90.
-If this value is 0, MaxAlloc will be used.
+If this value is `0`, then `MaxAlloc` will be used.
 
 - Eligible for live reload.
 - Type: `percentage`
@@ -778,30 +753,28 @@ If this value is 0, MaxAlloc will be used.
 
 ### `MaxAlloc`
 
-MaxAlloc is the maximum number of bytes that should be allocated by the collector.
+`MaxAlloc` is the maximum number of bytes that should be allocated by the Collector.
 
-If set, this must be a memory size.
+If set, then this must be a memory size.
 64-bit values are supported.
 Sizes with standard unit suffixes like "MB" and "GiB" are also supported.
 The full list of supported values can be found at https://pkg.go.dev/github.com/docker/go-units#pkg-constants.
-See MaxMemory for more details.
+See `MaxMemory` for more details.
 
 - Eligible for live reload.
 - Type: `memorysize`
 
 ## Buffer Sizes
 
-Brings together the settings that are relevant to the sizes of communications buffers.
-
-Section Name: `BufferSizes`
+`BufferSizes` `BufferSizes` contains the settings that are relevant to the sizes of communications buffers.
 
 ### `UpstreamBufferSize`
 
-UpstreamBufferSize is the size of the queue used to buffer spans to send to the upstream API.
+`UpstreamBufferSize` is the size of the queue used to buffer spans to send to the upstream Collector.
 
-Sets the size of the buffer (measured in spans) used to send spans to the upstream collector.
-If the buffer fills up, performance will degrade because Refinery will block while waiting for space to become available.
-If this happens, you should increase the buffer size.
+The size of the buffer is measured in spans.
+If the buffer fills up, then performance will degrade because Refinery will block while waiting for space to become available.
+If this happens, then you should increase the buffer size.
 
 - Eligible for live reload.
 - Type: `int`
@@ -809,11 +782,11 @@ If this happens, you should increase the buffer size.
 
 ### `PeerBufferSize`
 
-PeerBufferSize is the size of the queue used to buffer spans to send to peer nodes.
+`PeerBufferSize` is the size of the queue used to buffer spans to send to peer nodes.
 
-Sets the size of the buffer (measured in spans) used to send spans to peer nodes.
-If the buffer fills up, performance will degrade because Refinery will block while waiting for space to become available.
-If this happens, you should increase this buffer size.
+The size of the buffer is measured in spans.
+If the buffer fills up, then performance will degrade because Refinery will block while waiting for space to become available.
+If this happens, then you should increase this buffer size.
 
 - Eligible for live reload.
 - Type: `int`
@@ -821,17 +794,15 @@ If this happens, you should increase this buffer size.
 
 ## Specialized Configuration
 
-Special-purpose configuration options that are not typically needed.
-
-Section Name: `Specialized`
+`Specialized` contains special-purpose configuration options that are not typically needed.
 
 ### `EnvironmentCacheTTL`
 
-EnvironmentCacheTTL is the duration for which environment information is cached.
+`EnvironmentCacheTTL` is the duration for which environment information is cached.
 
-This is the amount of time for which refinery caches environment information, which it looks up from Honeycomb for each different APIKey.
+This is the amount of time for which Refinery caches environment information, which it looks up from Honeycomb for each different `APIKey`.
 This information is used when making sampling decisions.
-If you have a very large number of environments, you may want to increase this value.
+If you have a very large number of environments, then you may want to increase this value.
 
 - Eligible for live reload.
 - Type: `duration`
@@ -839,10 +810,9 @@ If you have a very large number of environments, you may want to increase this v
 
 ### `CompressPeerCommunication`
 
-CompressPeerCommunication determines whether refinery will compress span data it forwards to peers.
+`CompressPeerCommunication` determines whether Refinery will compress span data it forwards to peers.
 
-If it costs money to transmit data between refinery instances (e.g.
-they're spread across AWS availability zones), then you almost certainly want compression enabled to reduce your bill.
+If it costs money to transmit data between Refinery instances (for example, when spread across AWS availability zones), then you almost certainly want compression enabled to reduce your bill.
 The option to disable it is provided as an escape hatch for deployments that value lower CPU utilization over data transfer costs.
 
 - Not eligible for live reload.
@@ -851,10 +821,9 @@ The option to disable it is provided as an escape hatch for deployments that val
 
 ### `AdditionalAttributes`
 
-AdditionalAttributes is a map that can be used for injecting user-defined attributes.
+`AdditionalAttributes` is a map that can be used for injecting user-defined attributes into every span.
 
-A map that can be used for injecting user-defined attributes into every span.
-For example, it could be used for naming a refinery cluster.
+For example, it could be used for naming a Refinery cluster.
 Both keys and values must be strings.
 
 - Eligible for live reload.
@@ -863,18 +832,15 @@ Both keys and values must be strings.
 
 ## ID Fields
 
-Controls the field names to use for the event ID fields.
+`IDFields` `IDFields` controls the field names to use for the event ID fields.
 These fields are used to identify events that are part of the same trace.
-
-Section Name: `IDFields`
 
 ### `TraceNames`
 
-TraceNames is the list of field names to use for the trace ID.
+`TraceNames` is the list of field names to use for the trace ID.
 
-The list of field names to use for the trace ID.
 The first field in the list that is present in an incoming span will be used as the trace ID.
-If none of the fields are present, refinery treats the span as not being part of a trace and forwards it immediately to Honeycomb.
+If none of the fields are present, then Refinery treats the span as not being part of a trace and forwards it immediately to Honeycomb.
 
 - Eligible for live reload.
 - Type: `stringarray`
@@ -882,11 +848,10 @@ If none of the fields are present, refinery treats the span as not being part of
 
 ### `ParentNames`
 
-ParentNames is the list of field names to use for the parent ID.
+`ParentNames` is the list of field names to use for the parent ID.
 
-The list of field names to use for the parent ID.
 The first field in the list that is present in an event will be used as the parent ID.
-A trace without a parent_id is assumed to be a root span.
+A trace without a `parent_id` is assumed to be a root span.
 
 - Eligible for live reload.
 - Type: `stringarray`
@@ -894,37 +859,35 @@ A trace without a parent_id is assumed to be a root span.
 
 ## gRPC Server Parameters
 
-Controls the parameters of the gRPC server used to receive Open Telemetry data in gRPC format.
-
-Section Name: `GRPCServerParameters`
+`GRPCServerParameters` `GRPCServerParameters` controls the parameters of the gRPC server used to receive OpenTelemetry data in gRPC format.
 
 ### `Enabled`
 
-Enabled specifies whether the gRPC server is enabled.
+`Enabled` specifies whether the gRPC server is enabled.
 
-Specifies whether the gRPC server is enabled.
-If false, the gRPC server is not started and no gRPC traffic is accepted.
-TODO: WE NEED TO DEFAULT THIS TO TRUE IF PREVIOUS CONFIG HAS A LISTEN ADDRESS
+If `false`, then the gRPC server is not started and no gRPC traffic is accepted.
 
 - Not eligible for live reload.
 - Type: `bool`
 
 ### `ListenAddr`
 
-ListenAddr is the address refinery listens to for incoming GRPC Open Telemetry events.
+`ListenAddr` is the address Refinery listens to for incoming GRPC OpenTelemetry events.
 
-Incoming traffic is expected to be unencrypted, so if using SSL put something like nginx in front to do the decryption.
+Incoming traffic is expected to be unencrypted, so if using SSL, then put something like `nginx` in front to do the decryption.
 
 - Not eligible for live reload.
 - Type: `hostport`
+- Environment variable: `REFINERY_GRPC_LISTEN_ADDR`
+- Command line switch: `--grpc-listen-addr`
 
 ### `MaxConnectionIdle`
 
-MaxConnectionIdle is the amount of time to permit an idle connection.
+`MaxConnectionIdle` is the amount of time to permit an idle connection.
 
 A duration for the amount of time after which an idle connection will be closed by sending a GoAway.
 "Idle" means that there are no active RPCs.
-0s sets duration to infinity, but this is not recommended for refinery deployments behind a load balancer, because it will prevent the load balancer from distributing load evenly among peers.
+"0s" sets duration to infinity, but this is not recommended for Refinery deployments behind a load balancer, because it will prevent the load balancer from distributing load evenly among peers.
 
 - Not eligible for live reload.
 - Type: `duration`
@@ -933,11 +896,11 @@ A duration for the amount of time after which an idle connection will be closed 
 
 ### `MaxConnectionAge`
 
-MaxConnectionAge is the maximum amount of time a gRPC connection may exist.
+`MaxConnectionAge` is the maximum amount of time a gRPC connection may exist.
 
-Sets a duration for the maximum amount of time a connection may exist before it will be closed by sending a GoAway.
-A random jitter of +/-10% will be added to MaxConnectionAge to spread out connection storms.
-0s sets duration to infinity; a value measured in low minutes will help load balancers to distribute load among peers more evenly.
+After this duration, the gRPC connection is closed by sending a `GoAway`.
+A random jitter of +/-10% will be added to `MaxConnectionAge` to spread out connection storms.
+`0s` sets duration to infinity; a value measured in low minutes will help load balancers to distribute load among peers more evenly.
 
 - Not eligible for live reload.
 - Type: `duration`
@@ -945,10 +908,10 @@ A random jitter of +/-10% will be added to MaxConnectionAge to spread out connec
 
 ### `MaxConnectionAgeGrace`
 
-MaxConnectionAgeGrace is the duration beyond MaxConnectionAge after which the connection will be forcibly closed.
+`MaxConnectionAgeGrace` is the duration beyond `MaxConnectionAge` after which the connection will be forcibly closed.
 
-This is an additive period after MaxConnectionAge after which the connection will be forcibly closed (in case the upstream node ignores the GoAway request).
-0s sets duration to infinity.
+This setting is in case the upstream node ignores the `GoAway` request.
+"0s" sets duration to infinity.
 
 - Not eligible for live reload.
 - Type: `duration`
@@ -956,10 +919,10 @@ This is an additive period after MaxConnectionAge after which the connection wil
 
 ### `KeepAlive`
 
-KeepAlive is the duration between keep-alive pings.
+`KeepAlive` is the duration between keep-alive pings.
 
-Sets a duration for the amount of time after which if the client doesn't see any activity it pings the server to see if the transport is still alive.
-0s sets duration to 2 hours.
+After this amount of time, if the client does not see any activity, then it pings the server to see if the transport is still alive.
+"0s" sets duration to 2 hours.
 
 - Not eligible for live reload.
 - Type: `duration`
@@ -967,10 +930,10 @@ Sets a duration for the amount of time after which if the client doesn't see any
 
 ### `KeepAliveTimeout`
 
-KeepAliveTimeout is the duration the server waits for activity on the connection.
+`KeepAliveTimeout` is the duration the server waits for activity on the connection.
 
-This is the amount of time after which if the server doesn't see any activity, it pings the client to see if the transport is still alive.
-0s sets duration to 20 seconds.
+This is the amount of time after which if the server does not see any activity, then it pings the client to see if the transport is still alive.
+"0s" sets duration to 20 seconds.
 
 - Not eligible for live reload.
 - Type: `duration`
@@ -978,18 +941,16 @@ This is the amount of time after which if the server doesn't see any activity, i
 
 ## Sample Cache
 
-Controls the sample cache used to retain information about trace status after the sampling decision has been made.
-
-Section Name: `SampleCache`
+`SampleCache` `SampleCache` controls the sample cache used to retain information about trace status after the sampling decision has been made.
 
 ### `KeptSize`
 
-KeptSize is the number of traces preserved in the cuckoo kept traces cache.
+`KeptSize` is the number of traces preserved in the cuckoo kept traces cache.
 
-Controls the number of traces preserved in the cuckoo kept traces cache.
 Refinery keeps a record of each trace that was kept and sent to Honeycomb, along with some statistical information.
 This is most useful in cases where the trace was sent before sending the root span, so that the root span can be decorated with accurate metadata.
-Default is 10_000 traces (each trace in this cache consumes roughly 200 bytes).
+Default is `10_000` traces.
+Each trace in this cache consumes roughly 200 bytes.
 
 - Eligible for live reload.
 - Type: `int`
@@ -997,9 +958,8 @@ Default is 10_000 traces (each trace in this cache consumes roughly 200 bytes).
 
 ### `DroppedSize`
 
-DroppedSize is the size of the cuckoo dropped traces cache.
+`DroppedSize` is the size of the cuckoo dropped traces cache.
 
-Controls the size of the cuckoo dropped traces cache.
 This cache consumes 4-6 bytes per trace at a scale of millions of traces.
 Changing its size with live reload sets a future limit, but does not have an immediate effect.
 
@@ -1009,10 +969,9 @@ Changing its size with live reload sets a future limit, but does not have an imm
 
 ### `SizeCheckInterval`
 
-SizeCheckInterval controls how often the cuckoo cache re-evaluates its capacity.
+`SizeCheckInterval` controls how often the cuckoo cache re-evaluates its remaining capacity.
 
-Controls the duration the cuckoo cache uses to determine how often it re-evaluates the remaining capacity of its dropped traces cache and possibly cycles it.
-This cache is quite resilient so it doesn't need to happen very often, but the operation is also inexpensive.
+This cache is quite resilient so it does not need to happen very often, but the operation is also inexpensive.
 Default is 10 seconds.
 
 - Eligible for live reload.
@@ -1021,27 +980,26 @@ Default is 10 seconds.
 
 ## Stress Relief
 
-Controls the stress relief mechanism, which is used to prevent Refinery from being overwhelmed by a large number of traces.
-There is a metric called stress_level that is emitted as part of refinery metrics.
-It is a measure of refinery's throughput rate relative to its processing rate, combined with the amount of room in its internal queues, and ranges from 0 to 100.
-It is generally expected to be 0 except under heavy load.
-When stress levels reach 100, there is an increased chance that refinery will become unstable.
-To avoid this problem, the Stress Relief system can do deterministic sampling on new trace traffic based solely on TraceID, without having to store traces in the cache or take the time processing sampling rules.
-Existing traces in flight will be processed normally, but when Stress Relief is active, trace decisions are made deterministically on a per-span basis; all spans will be sampled according to the SamplingRate specified here.
-Once Stress Relief activates (by exceeding the ActivationLevel), it will not deactivate until stress_level falls below the DeactivationLevel.
+`StressRelief` `StressRelief` controls the Stress Relief mechanism, which is used to prevent Refinery from being overwhelmed by a large number of traces.
+There is a metric called `stress_level` that is emitted as part of Refinery metrics.
+It is a measure of Refinery's throughput rate relative to its processing rate, combined with the amount of room in its internal queues, and ranges from `0` to `100`.
+`stress_level` is generally expected to be `0` except under heavy load.
+When stress levels reach `100`, there is an increased chance that Refinery will become unstable.
+To avoid this problem, the Stress Relief system can do deterministic sampling on new trace traffic based solely on `TraceID`, without having to store traces in the cache or take the time processing sampling rules.
+Existing traces in flight will be processed normally, but when Stress Relief is active, trace decisions are made deterministically on a per-span basis; all spans will be sampled according to the `SamplingRate` specified here.
+Once Stress Relief activates (by exceeding the `ActivationLevel`), it will not deactivate until `stress_level` falls below the `DeactivationLevel`.
 When it deactivates, normal trace decisions are made -- and any additional spans that arrive for traces that were active during Stress Relief will respect the decisions made during that time.
 The measurement of stress is a lagging indicator and is highly dependent on Refinery configuration and scaling.
 Other configuration values should be well tuned first, before adjusting the Stress Relief Activation parameters.
 Stress Relief is not a substitute for proper configuration and scaling, but it can be used as a safety valve to prevent Refinery from becoming unstable under heavy load.
 
-Section Name: `StressRelief`
-
 ### `Mode`
 
-Mode is a string indicating how to use Stress Relief.
+`Mode` is a string indicating how to use Stress Relief.
 
-Sets the stress relief mode.
-"never" means that Stress Relief will never activate "monitor" is the recommended setting, and means that Stress Relief will monitor the status of refinery and activate according to the levels set below.
+This setting sets the Stress Relief mode.
+"never" means that Stress Relief will never activate.
+"monitor" is the recommended setting, and means that Stress Relief will monitor the status of Refinery and activate according to the levels set by fields such as `ActivationLevel`.
 "always" means that Stress Relief is always on, which may be useful in an emergency situation.
 
 - Eligible for live reload.
@@ -1050,9 +1008,9 @@ Sets the stress relief mode.
 
 ### `ActivationLevel`
 
-ActivationLevel is the stress_level (from 0-100) at which Stress Relief is triggered.
+`ActivationLevel` is the `stress_level` (from 0-100) at which Stress Relief is triggered.
 
-Sets the stress_level (from 0-100) at which Stress Relief is triggered.
+This value must be greater than `DeactivationLevel` and should be high enough that it is not reached in normal operation.
 
 - Eligible for live reload.
 - Type: `percentage`
@@ -1060,10 +1018,10 @@ Sets the stress_level (from 0-100) at which Stress Relief is triggered.
 
 ### `DeactivationLevel`
 
-DeactivationLevel is the stress_level (from 0-100) at which Stress Relief is turned off.
+`DeactivationLevel` is the `stress_level` (from 0-100) at which Stress Relief is turned off.
 
-Sets the stress_level (from 0-100) at which Stress Relief is turned off (subject to MinimumActivationDuration).
-It must be less than ActivationLevel.
+This setting is subject to `MinimumActivationDuration`.
+The value must be less than `ActivationLevel`.
 
 - Eligible for live reload.
 - Type: `percentage`
@@ -1071,10 +1029,9 @@ It must be less than ActivationLevel.
 
 ### `SamplingRate`
 
-SamplingRate is the sampling rate to use when Stress Relief is activated.
+`SamplingRate` is the sampling rate to use when Stress Relief is activated.
 
-Controls the sampling rate to use when Stress Relief is activated.
-All new traces will be deterministically sampled at this rate based only on the traceID.
+All new traces will be deterministically sampled at this rate based only on the `traceID`.
 It should be chosen to be a rate that sends fewer samples than the average sampling rate Refinery is expected to generate.
 For example, if Refinery is configured to normally sample at a rate of 1 in 10, then Stress Relief should be configured to sample at a rate of at least 1 in 30.
 
@@ -1084,10 +1041,9 @@ For example, if Refinery is configured to normally sample at a rate of 1 in 10, 
 
 ### `MinimumActivationDuration`
 
-MinimumActivationDuration is the minimum time that stress relief will stay enabled.
+`MinimumActivationDuration` is the minimum time that Stress Relief will stay enabled once activated.
 
-Sets the minimum time that stress relief will stay enabled, once activated.
-This helps to prevent oscillations.
+This setting helps to prevent oscillations.
 
 - Eligible for live reload.
 - Type: `duration`
@@ -1095,12 +1051,12 @@ This helps to prevent oscillations.
 
 ### `MinimumStartupDuration`
 
-MinimumStartupDuration is the minimum time that stress relief will stay enabled.
+`MinimumStartupDuration` is the minimum time that Stress Relief will stay enabled.
 
-Used when switching into Monitor mode.
-When stress monitoring is enabled, it will start up in stressed mode for a at least this amount of time to try to make sure that Refinery can handle the load before it begins processing it in earnest.
+This setting is used when switching into Monitor mode.
+When Stress Relief is enabled, it will start up in stressed mode for at least this set duration of time to try to make sure that Refinery can handle the load before it begins processing it in earnest.
 This is to help address the problem of trying to bring a new node into an already-overloaded cluster.
-If this duration is 0, Refinery will not start in stressed mode, which will provide faster startup at the possible cost of startup instability.
+If this duration is `0`, then Refinery will not start in stressed mode, which will provide faster startup at the possible cost of startup instability.
 
 - Eligible for live reload.
 - Type: `duration`

--- a/rules.md
+++ b/rules.md
@@ -1,7 +1,7 @@
 # Honeycomb Refinery Rules Documentation
 
 This is the documentation for the rules configuration for Honeycomb's Refinery.
-It was automatically generated on 2023-06-21 at 23:08:48 UTC.
+It was automatically generated on 2023-06-22 at 23:17:31 UTC.
 
 ## The Rules file
 

--- a/tools/convert/templates/cfg_docrepo.tmpl
+++ b/tools/convert/templates/cfg_docrepo.tmpl
@@ -41,9 +41,7 @@ The remainder of this document describes the sections within the file and the fi
 
 ## {{ $group.Title }}
 
-### Section Name: `{{ $group.Name }}`
-
-{{ $group.Description | wrapForDocs }}
+{{ printf "`%s` %s" $group.Name $group.Description | wrapForDocs }}
 {{- println -}}
 {{- range $group.Fields -}}
 {{- if .LastVersion -}}
@@ -76,6 +74,14 @@ The remainder of this document describes the sections within the file and the fi
 {{- end -}}
 {{- if eq $field.ValueType "choice" -}}
 - Options: `{{- printf "%s" (join $field.Choices " ") -}}`
+{{- println -}}
+{{- end -}}
+{{- if $field.Envvar -}}
+- Environment variable: `{{ $field.Envvar }}`
+{{- println -}}
+{{- end -}}
+{{- if $field.CommandLine -}}
+- Command line switch: `--{{ $field.CommandLine }}`
 {{- println -}}
 {{- end -}}
 {{- println -}}

--- a/tools/convert/templates/cfg_docsite.tmpl
+++ b/tools/convert/templates/cfg_docsite.tmpl
@@ -30,7 +30,7 @@ The remainder of this document describes the sections within the file and the fi
 
 ## {{ $group.Title }}
 
-{{ $group.Description | wrapForDocs }}
+{{ printf "`%s` %s" $group.Name $group.Description | wrapForDocs }}
 {{- println -}}
 {{- println -}}
 Section Name: `{{ $group.Name }}`
@@ -50,7 +50,7 @@ Section Name: `{{ $group.Name }}`
 
 ### `{{ $field.Name }}`
 
-{{ printf "%s %s" $field.Name $field.Summary }}
+{{ printf "`%s` %s" $field.Name $field.Summary }}
 
 {{ $field.Description | wrapForDocs -}}
 {{- println -}}

--- a/tools/convert/templates/cfg_docsite.tmpl
+++ b/tools/convert/templates/cfg_docsite.tmpl
@@ -33,8 +33,6 @@ The remainder of this document describes the sections within the file and the fi
 {{ printf "`%s` %s" $group.Name $group.Description | wrapForDocs }}
 {{- println -}}
 {{- println -}}
-Section Name: `{{ $group.Name }}`
-{{- println -}}
 {{- println -}}
 {{- range $group.Fields -}}
 {{- if .LastVersion -}}
@@ -67,6 +65,14 @@ Section Name: `{{ $group.Name }}`
 {{- end -}}
 {{- if eq $field.ValueType "choice" -}}
 - Options: `{{- printf "%s" (join $field.Choices " ") -}}`
+{{- println -}}
+{{- end -}}
+{{- if $field.Envvar -}}
+- Environment variable: `{{ $field.Envvar }}`
+{{- println -}}
+{{- end -}}
+{{- if $field.CommandLine -}}
+- Command line switch: `--{{ $field.CommandLine }}`
 {{- println -}}
 {{- end -}}
 {{- println -}}

--- a/tools/convert/templates/configV2.tmpl
+++ b/tools/convert/templates/configV2.tmpl
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created {{ now }} from {{ .Input }} using a template generated on 2023-06-21 at 23:04:55 UTC
+# created {{ now }} from {{ .Input }} using a template generated on 2023-06-22 at 23:17:29 UTC
 
 # This file contains the configuration for the Honeycomb Refinery.
 # More stuff will go here later.
@@ -12,8 +12,8 @@
 ## General Configuration ##
 ###########################
 General:
-  ## Contains general configuration options that apply to the entire
-  ## refinery process.
+  ## contains general configuration options that apply to the entire
+  ## Refinery process.
   ####
     ## ConfigurationVersion is the file format of this particular
     ## configuration file.
@@ -29,9 +29,10 @@ General:
     ## MinRefineryVersion is the minimum version of Refinery that can load
     ## this configuration file.
     ##
-    ## This specifies the lowest Refinery version capable of loading all of
-    ## the features used in this file. If this value is present, Refinery
-    ## will refuse to start if its version is less than this.
+    ## This setting specifies the lowest Refinery version capable of loading
+    ## all of the features used in this file. If this value is present, then
+    ## Refinery will refuse to start if its version is less than this
+    ## setting.
     ##
     ## default: v2.0
     ## Not eligible for live reload.
@@ -41,11 +42,11 @@ General:
     ## from an environment in the rules.
     ##
     ## If telemetry is being sent to both a classic dataset and a new
-    ## environment called the same thing (eg `production`), this parameter
-    ## can be used to distinguish these cases. When Refinery receives
-    ## telemetry using an API key associated with a classic dataset, it will
-    ## then use the prefix in the form `{prefix}.{dataset}` when trying to
-    ## resolve the rules definition.
+    ## environment called the same thing, such as `production`, then this
+    ## parameter can be used to distinguish these cases. When Refinery
+    ## receives telemetry using an API key associated with a Honeycomb
+    ## Classic dataset, it will then use the prefix in the form `{prefix}.
+    ## {dataset}` when trying to resolve the rules definition.
     ##
     ## Not eligible for live reload.
     {{ nonDefaultOnly .Data "DatasetPrefix" "DatasetPrefix" "" }}
@@ -58,7 +59,7 @@ General:
     ## varied by a random amount to avoid all instances refreshing together.
     ## Within a cluster, Refinery will gossip information about new
     ## configuration so that all instances can reload at close to the same
-    ## time. This feature can be disabled with a value of 0s.
+    ## time. Disable this feature with a value of `0s`.
     ##
     ## Accepts a duration string with units, like "5m".
     ## default: 5m
@@ -69,15 +70,17 @@ General:
 ## Network Configuration ##
 ###########################
 Network:
-  ## Contains network configuration options.
+  ## contains network configuration options.
   ####
-    ## ListenAddr is the address refinery listens to for incoming requests.
+    ## ListenAddr is the address where Refinery listens for incoming
+    ## requests.
     ##
-    ## This is the IP and port on which to listen for incoming HTTP requests.
-    ## These requests include traffic formatted as Honeycomb events, proxied
-    ## requests to the Honeycomb API, and Open Telemetry data using the http
-    ## protocol. Incoming traffic is expected to be HTTP, so if SSL is a
-    ## requirement, put something like nginx in front to do the decryption.
+    ## This setting is the IP and port on which Refinery listens for incoming
+    ## HTTP requests. These requests include traffic formatted as Honeycomb
+    ## events, proxied requests to the Honeycomb API, and OpenTelemetry data
+    ## using the `http` protocol. Incoming traffic is expected to be HTTP, so
+    ## if SSL is a requirement, put something like `nginx` in front to do the
+    ## decryption.
     ##
     ## Should be an ip:port like "0.0.0.0:8080".
     ## default: 0.0.0.0:8080
@@ -95,12 +98,11 @@ Network:
     ## Not eligible for live reload.
     {{ nonDefaultOnly .Data "PeerListenAddr" "PeerListenAddr" "0.0.0.0:8081" }}
 
-    ## HoneycombAPI is the URL of the Honeycomb API to which data will be
-    ## sent.
+    ## HoneycombAPI is the URL of the upstream Honeycomb API where the data
+    ## will be sent.
     ##
-    ## HoneycombAPI is the URL for the upstream Honeycomb API; this is the
-    ## destination to which refinery sends all events that it decides to
-    ## keep.
+    ## This setting is the destination to which Refinery sends all events
+    ## that it decides to keep.
     ##
     ## default: https://api.honeycomb.io
     ## Eligible for live reload.
@@ -125,12 +127,13 @@ AccessKeys:
     {{ renderStringarray .Data "ReceiveKeys" "ReceiveKeys" "your-key-goes-here" }}
 
     ## AcceptOnlyListedKeys is a boolean flag that causes events arriving
-    ## with API keys not in the ReceiveKeys list to be rejected.
+    ## with API keys not in the `ReceiveKeys` list to be rejected.
     ##
-    ## If true, only traffic using the keys listed in APIKeys is accepted.
-    ## Events arriving with API keys not in the ReceiveKeys list will be
-    ## rejected with an HTTP 401 error. If false, all traffic is accepted and
-    ## ReceiveKeys is ignored. Must be specified if APIKeys is specified.
+    ## If `true`, then only traffic using the keys listed in `APIKeys` is
+    ## accepted. Events arriving with API keys not in the `ReceiveKeys` list
+    ## will be rejected with an HTTP `401` error.
+    ## If `false`, then all traffic is accepted and `ReceiveKeys` is ignored.
+    ## Must be specified if `APIKeys` is specified.
     ##
     ## Eligible for live reload.
     {{ conditional .Data "AcceptOnlyListedKeys" "nostar APIKeys" }}
@@ -139,31 +142,31 @@ AccessKeys:
 ## Refinery Telemetry ##
 ########################
 RefineryTelemetry:
-  ## Configuration info for the telemetry that Refinery uses to record its
-  ## own operation.
+  ## contains configuration information for the telemetry that Refinery
+  ## uses to record its own operation.
   ####
-    ## AddRuleReasonToTrace controls whether to decorate traces with refinery
+    ## AddRuleReasonToTrace controls whether to decorate traces with Refinery
     ## rule evaluation results.
     ##
-    ## This causes traces that are sent to Honeycomb to include the field
-    ## `meta.refinery.reason`. This field contains text indicating which rule
-    ## was evaluated that caused the trace to be included. We recommend
-    ## enabling this field whenever a rules-based sampler is in use, as it is
-    ## useful for debugging and understanding the behavior of your refinery
-    ## installation.
+    ## When enabled, this setting causes traces that are sent to Honeycomb to
+    ## include the field `meta.refinery.reason`. This field contains text
+    ## indicating which rule was evaluated that caused the trace to be
+    ## included. We recommend enabling this setting whenever a rules-based
+    ## sampler is in use, as it is useful for debugging and understanding the
+    ## behavior of your Refinery installation.
     ##
     ## Eligible for live reload.
     {{ nonDefaultOnly .Data "AddRuleReasonToTrace" "AddRuleReasonToTrace" false }}
 
     ## AddSpanCountToRoot controls whether to add a metadata field to root
-    ## spans indicating the number of child spans.
+    ## spans that indicates the number of child spans.
     ##
-    ## Adds a new metadata field, `meta.span_count` to root spans to indicate
-    ## the number of child spans on the trace at the time the sampling
-    ## decision was made. This value is available to the rules-based sampler,
-    ## making it possible to write rules that are dependent upon the number
-    ## of spans in the trace. If true, Refinery will add meta.span_count to
-    ## the root span.
+    ## The added metadata field, `meta.span_count`, indicates the number of
+    ## child spans on the trace at the time the sampling decision was made.
+    ## This value is available to the rules-based sampler, making it possible
+    ## to write rules that are dependent upon the number of spans in the
+    ## trace. If `true`, then Refinery will add `meta. span_count` to the
+    ## root span.
     ##
     ## default: true
     ## Eligible for live reload.
@@ -172,10 +175,8 @@ RefineryTelemetry:
     ## AddHostMetadataToTrace specifies whether to add host metadata to
     ## traces.
     ##
-    ## AddHostMetadataToTrace specifies whether to add host metadata to
-    ## traces. If true, Refinery will add the following tags to all traces: -
-    ## meta.refinery.local_hostname: the hostname of the Refinery node (we
-    ## should consider adding more metadata here, like IP address, etc)
+    ## If `true`, then Refinery will add the following tag to all traces: -
+    ## `meta.refinery.local_hostname`: the hostname of the Refinery node
     ##
     ## default: true
     ## Eligible for live reload.
@@ -185,15 +186,15 @@ RefineryTelemetry:
 ## Traces ##
 ############
 Traces:
-  ## Configuration for how traces are managed.
+  ## contains configuration for how traces are managed.
   ####
     ## SendDelay is the duration to wait before sending a trace.
     ##
-    ## This is a short timer that will be triggered when a trace is complete.
-    ## Refinery will wait this duration before actually sending the trace.
-    ## The reason for this short delay is to allow for small network delays
-    ## or clock jitters to elapse and any final spans to arrive before
-    ## actually sending the trace. Set to 0 for immediate sends.
+    ## This setting is a short timer that is triggered when a trace is
+    ## complete. Refinery waits for this duration before sending the trace.
+    ## The reason for this setting is to allow for small network delays or
+    ## clock jitters to elapse and any final spans to arrive before sending
+    ## the trace. Set to "0" for immediate sending.
     ##
     ## Accepts a duration string with units, like "2s".
     ## default: 2s
@@ -202,9 +203,8 @@ Traces:
 
     ## BatchTimeout is how frequently Refinery sends unfulfilled batches.
     ##
-    ## Dictates how frequently to send unfulfilled batches. By default this
-    ## will use the DefaultBatchTimeout in libhoney as its value, which is
-    ## 100ms.
+    ## By default, this setting uses the `DefaultBatchTimeout` in `libhoney`
+    ## as its value, which is `100ms`.
     ##
     ## Accepts a duration string with units, like "500ms".
     ## Eligible for live reload.
@@ -214,13 +214,14 @@ Traces:
     ## on an incomplete trace.
     ##
     ## A long timer; it represents the outside boundary of how long to wait
-    ## before making the trace decision about an incomplete trace. Normally
-    ## trace decisions (send or drop) are made when the root span arrives.
-    ## Sometimes the root span never arrives (due to crashes or whatever),
-    ## and this timer will send a trace even without having received the root
-    ## span. If you have particularly long-lived traces you should increase
-    ## this timer. Note that this will also increase the memory requirements
-    ## for refinery.
+    ## before making the trace decision about an incomplete trace.
+    ## Normally trace decisions (send or drop) are made when the root span
+    ## arrives. Sometimes the root span never arrives (for example, due to
+    ## crashes) and this timer ensures sending a trace even without having
+    ## received the root span.
+    ## If particularly long-lived traces are present in your data, then you
+    ## should increase this timer. Note that this increase will also increase
+    ## the memory requirements for Refinery.
     ##
     ## Accepts a duration string with units, like "60s".
     ## default: 60s
@@ -230,10 +231,11 @@ Traces:
     ## MaxBatchSize is the maximum number of events to be included in each
     ## batch for sending.
     ##
-    ## This value is used to set the BatchSize field in the libhoney library
-    ## used to send data to Honeycomb. If you have particularly large traces
-    ## you should increase this value. Note that this will also increase the
-    ## memory requirements for refinery.
+    ## This value is used to set the `BatchSize` field in the `libhoney`
+    ## library used to send data to Honeycomb.
+    ## If you have particularly large traces, then you should increase this
+    ## value. Note that this will also increase the memory requirements for
+    ## Refinery.
     ##
     ## default: 500
     ## Eligible for live reload.
@@ -243,8 +245,9 @@ Traces:
     ##
     ## A short timer that determines the duration between trace cache review
     ## runs to send. Increasing this will spend more time processing incoming
-    ## events to reduce incoming_ or peer_router_dropped spikes. Decreasing
-    ## this will check the trace cache for timeouts more frequently.
+    ## events to reduce `incoming_` or `peer_router_dropped` spikes.
+    ## Decreasing this will check the trace cache for timeouts more
+    ## frequently.
     ##
     ## Accepts a duration string with units, like "100ms".
     ## default: 100ms
@@ -255,55 +258,55 @@ Traces:
 ## Debugging ##
 ###############
 Debugging:
-  ## Configuration values used when setting up and debugging Refinery.
+  ## contains configuration values used when setting up and debugging
+  ## Refinery.
   ####
-    ## DebugServiceAddr is the IP and port the debug service will run on.
+    ## DebugServiceAddr is the IP and port where the debug service runs.
     ##
-    ## Sets the IP and port for the debug service. The debug service is
-    ## generally only used when debugging Refinery itself, and will only run
-    ## if the command line flag -d is specified. If this value is not
-    ## specified, the debug service runs on the first open port between
-    ## localhost:6060 and :6069.
+    ## The debug service is generally only used when debugging Refinery
+    ## itself, and will only run if the command line option `-d` is
+    ## specified. If this value is not specified, then the debug service runs
+    ## on the first open port between `localhost:6060` and `localhost:6069`.
     ##
     ## Should be an ip:port like "localhost:6060".
     ## Not eligible for live reload.
     {{ nonEmptyString .Data "DebugServiceAddr" "DebugServiceAddr" "localhost:6060" }}
 
     ## QueryAuthToken is the token that must be specified to access the
-    ## /query endpoint.
+    ## `/query` endpoint.
     ##
-    ## Provides a token that must be specified with the header
-    ## "X-Honeycomb-Refinery-Query" in order for a /query request to succeed.
-    ## These /query requests are intended for debugging refinery during setup
-    ## and are not typically needed in normal operation. If not specified,
-    ## the /query endpoints are inaccessible.
+    ## This token must be specified with the header
+    ## "X-Honeycomb-Refinery-Query" in order for a `/query` request to
+    ## succeed. These `/query` requests are intended for debugging Refinery
+    ## during setup and are not typically needed in normal operation. If not
+    ## specified, then the `/query` endpoints are inaccessible.
     ##
     ## Not eligible for live reload.
     {{ nonEmptyString .Data "QueryAuthToken" "QueryAuthToken" "some-private-value" }}
 
     ## AdditionalErrorFields is a list of span fields to include when logging
-    ## errors.
+    ## errors happen during the ingestion of events.
     ##
-    ## A list of span fields that should be included when logging errors that
-    ## happen during ingestion of events (for example, the span too large
-    ## error). This is primarily useful in trying to track down misbehaving
-    ## senders in a large installation. The fields `dataset`, `apihost`, and
-    ## `environment` are always included. If a field is not present in the
-    ## span, it will not be present in the error log.
+    ## For example, the span too large error. This is primarily useful in
+    ## trying to track down misbehaving senders in a large installation. The
+    ## fields `dataset`, `apihost`, and `environment` are always included. If
+    ## a field is not present in the span, then it will not be present in the
+    ## error log.
     ##
     ## Eligible for live reload.
     {{ renderStringarray .Data "AdditionalErrorFields" "AdditionalErrorFields" "trace.span_id" }}
 
     ## DryRun controls whether sampling is applied to incoming traces.
     ##
-    ## If enabled, marks the traces that would be dropped given the current
-    ## sampling rules, and sends all traces regardless of the sampling
-    ## decision. This is useful for evaluating sampling rules. In DryRun
-    ## mode, traces will be decorated with meta.refinery.dryrun.kept set to
-    ## true or false based on whether the trace would be kept or dropped. In
-    ## addition, SampleRate will be set to the incoming rate for all traces,
-    ## and the field meta.refinery.dryrun.sample_rate will be set to the
-    ## sample rate that would have been used.
+    ## If enabled, then Refinery marks the traces that would be dropped given
+    ## the current sampling rules, and sends all traces regardless of the
+    ## sampling decision. This is useful for evaluating sampling rules.
+    ## When DryRun is enabled, traces is decorated with `meta.refinery.
+    ## dryrun.kept` that is set to `true` or `false`, based on whether the
+    ## trace would be kept or dropped. In addition, `SampleRate` will be set
+    ## to the incoming rate for all traces, and the field
+    ## `meta.refinery.dryrun.sample_rate` will be set to the sample rate that
+    ## would have been used.
     ##
     ## Eligible for live reload.
     # DryRun: true
@@ -312,25 +315,27 @@ Debugging:
 ## Refinery Logger ##
 #####################
 Logger:
-  ## Configuration for logging.
+  ## contains configuration for logging.
   ####
     ## Type is the type of logger to use.
     ##
-    ## Specifies where (and if) refinery sends logs. `none` means that logs
-    ## are discarded. `honeycomb` means that logs will be forwarded to
-    ## honeycomb as events according to the settings below. `stdout` means
-    ## that logs will be written to stdout.
+    ## The setting specifies where (and if) Refinery sends logs.
+    ## `none` means that logs are discarded.
+    ## `honeycomb` means that logs will be forwarded to Honeycomb as events
+    ## according to the set Logging settings.
+    ## `stdout` means that logs will be written to `stdout`.
     ##
     ## default: stdout
     ## Not eligible for live reload.
     ## Options: stdout honeycomb none
     {{ choice .Data "Type" "Type" (makeSlice "stdout" "honeycomb" "none") "stdout" }}
 
-    ## Level is the logging level above which refinery should send a log.
+    ## Level is the logging level above which Refinery should send a log to
+    ## the logger.
     ##
-    ## Sets the logging level above which refinery should send logs to the
-    ## logger. `debug` is very verbose, and should not be used in production
-    ## environments. `warn` is the recommended level for production.
+    ## `warn` is the recommended level for production.
+    ## `debug` is very verbose, and should not be used in production
+    ## environments.
     ##
     ## default: warn
     ## Not eligible for live reload.
@@ -341,39 +346,38 @@ Logger:
 ## Honeycomb Logger ##
 ######################
 HoneycombLogger:
-  ## Configuration for logging to Honeycomb. Only used if Logger.Type is
-  ## "honeycomb".
+  ## contains configuration for logging to Honeycomb. Only used if
+  ## `Logger.Type` is "honeycomb".
   ####
-    ## APIHost is the URL of the Honeycomb API to which logs will be sent.
+    ## APIHost is the URL of the Honeycomb API where Refinery sends its logs.
     ##
-    ## Sets the upstream Honeycomb API for logs; this is the destination to
-    ## which refinery sends its own logs.
+    ## Refinery's internal logs will be sent to this host using the standard
+    ## Honeycomb Events API.
     ##
     ## default: https://api.honeycomb.io
     ## Not eligible for live reload.
     {{ nonDefaultOnly .Data "APIHost" "HoneycombLogger.LoggerHoneycombAPI" "https://api.honeycomb.io" }}
 
-    ## APIKey is the API key to use when sending logs to Honeycomb.
+    ## APIKey is the API key used to send Refinery's logs to Honeycomb.
     ##
-    ## This is the API key to use for Refinery's logs when sending them to
-    ## Honeycomb. It is recommended that you create a separate team and key
-    ## for Refinery logs.
+    ## It is recommended that you create a separate team and key for Refinery
+    ## logs.
     ##
     ## Not eligible for live reload.
     {{ nonEmptyString .Data "APIKey" "HoneycombLogger.LoggerAPIKey" "SetThisToAHoneycombKey" }}
 
     ## Dataset is the dataset to which logs will be sent.
     ##
-    ## Specifies the Honeycomb dataset to which logs will be sent.
+    ## Only used if `APIKey` is specified.
     ##
     ## default: Refinery Logs
     ## Not eligible for live reload.
     {{ nonEmptyString .Data "Dataset" "HoneycombLogger.LoggerDataset" "" }}
 
-    ## SamplerEnabled controls whether to sample logs.
+    ## SamplerEnabled controls whether logs are sampled before sending to
+    ## Honeycomb.
     ##
-    ## Controls whether logs are sampled before sending to Honeycomb. The
-    ## sample rate is controlled by the SamplerThroughput setting.
+    ## The sample rate is controlled by the `SamplerThroughput` setting.
     ##
     ## default: true
     ## Not eligible for live reload.
@@ -382,11 +386,9 @@ HoneycombLogger:
     ## SamplerThroughput is the sampling throughput for logs in events per
     ## second.
     ##
-    ## SamplerThroughput is the sampling throughput for logs measured in
-    ## events per second. The sampling algorithm attempts to make sure that
-    ## the average throughput approximates this value, while also ensuring
-    ## that all unique logs arrive at Honeycomb at least once per sampling
-    ## period. TODO: THROUGHPUT FOR THE CLUSTER
+    ## The sampling algorithm attempts to make sure that the average
+    ## throughput approximates this value, while also ensuring that all
+    ## unique logs arrive at Honeycomb at least once per sampling period.
     ##
     ## default: 10
     ## Not eligible for live reload.
@@ -396,13 +398,13 @@ HoneycombLogger:
 ## Stdout Logger ##
 ###################
 StdoutLogger:
-  ## Configuration for logging to stdout. Only used if Logger.Type is
-  ## "stdout".
+  ## contains configuration for logging to `stdout`. Only used if
+  ## `Logger.Type` is "stdout".
   ####
-    ## Structured controls whether to used structured logging.
+    ## Structured controls whether to use structured logging.
     ##
-    ## Specifies whether the stdout logger generates structured logs (JSON)
-    ## or not (plain text).
+    ## `true` generates structured logs (JSON). `false` generates plain text
+    ## logs.
     ##
     ## default: true
     ## Not eligible for live reload.
@@ -412,24 +414,24 @@ StdoutLogger:
 ## Prometheus Metrics ##
 ########################
 PrometheusMetrics:
-  ## Configuration for Refinery's internally-generated metrics as made
-  ## available through Prometheus.
+  ## contains configuration for Refinery's internally-generated metrics as
+  ## made available through Prometheus.
   ####
-    ## Enabled controls whether to expose refinery metrics over
-    ## PromethusListenAddr
+    ## Enabled controls whether to expose Refinery metrics over the
+    ## `PrometheusListenAddr` port.
     ##
-    ## The flag specifies whether Refinery should expose its own metrics over
-    ## the PrometheusListenAddr port.
+    ## Each of the metrics providers can be enabled or disabled
+    ## independently. Metrics can be sent to multiple destinations.
     ##
     ## Not eligible for live reload.
     {{ conditional .Data "Enabled" "eq Metrics prometheus" }}
 
-    ## ListenAddr is the IP and port the prometheus metrics server will run
+    ## ListenAddr is the IP and port the Prometheus Metrics server will run
     ## on.
     ##
     ## Determines the interface and port on which Prometheus will listen for
-    ## requests for /metrics. Must be different from the main Refinery
-    ## listener. Only used if "Enabled" is true in PrometheusMetrics.
+    ## requests for `/metrics`. Must be different from the main Refinery
+    ## listener. Only used if `Enabled` is `true` in `PrometheusMetrics`.
     ##
     ## Should be an ip:port like "localhost:2112".
     ## default: localhost:2112
@@ -440,39 +442,43 @@ PrometheusMetrics:
 ## Legacy Metrics ##
 ####################
 LegacyMetrics:
-  ## Configuration for Refinery's legacy metrics. Version 1.x of Refinery
-  ## used this format for sending Metrics to Honeycomb. The metrics
-  ## generated that way are nonstandard and will be deprecated in a future
-  ## release. New installations should prefer OTelMetrics.
+  ## `LegacyMetrics` contains configuration for Refinery's legacy metrics.
+  ## Version 1.x of Refinery used this format for sending Metrics to
+  ## Honeycomb. The metrics generated that way are nonstandard and will be
+  ## deprecated in a future release. New installations should prefer
+  ## `OTelMetrics`.
   ##
   ####
-    ## Enabled controls whether to send metrics to Honeycomb.
+    ## Enabled controls whether to send legacy-formatted metrics to
+    ## Honeycomb.
     ##
-    ## This controls whether to send legacy-formatted metrics to Honeycomb.
+    ## Each of the metrics providers can be enabled or disabled
+    ## independently. Metrics can be sent to multiple destinations.
     ##
     ## Not eligible for live reload.
     {{ conditional .Data "Enabled" "eq Metrics honeycomb" }}
 
-    ## APIHost is the URL of the Honeycomb API to which metrics will be sent.
+    ## APIHost is the URL of the Honeycomb API where legacy metrics are sent.
     ##
-    ## Specifies the URL for the upstream Honeycomb API for legacy metrics.
+    ## Refinery's internal metrics will be sent to this host using the
+    ## standard Honeycomb Events API.
     ##
     ## default: https://api.honeycomb.io
     ## Not eligible for live reload.
     {{ nonDefaultOnly .Data "APIHost" "HoneycombMetrics.MetricsHoneycombAPI" "https://api.honeycomb.io" }}
 
-    ## APIKey is the API key used to send Honeycomb metrics.
+    ## APIKey is the API key used by Refinery to send its metrics to
+    ## Honeycomb.
     ##
-    ## Specifies the API key used when refinery sends its own metrics. It is
-    ## recommended that you create a separate team and key for Refinery
+    ## It is recommended that you create a separate team and key for Refinery
     ## metrics.
     ##
     ## Not eligible for live reload.
     {{ nonDefaultOnly .Data "APIKey" "HoneycombMetrics.MetricsAPIKey" "" }}
 
-    ## Dataset is the Honeycomb dataset to which metrics will be sent.
+    ## Dataset is the Honeycomb dataset where Refinery sends its metrics.
     ##
-    ## Specifies the dataset to which refinery sends its own metrics.
+    ## Only used if `APIKey` is specified.
     ##
     ## default: Refinery Metrics
     ## Not eligible for live reload.
@@ -481,8 +487,7 @@ LegacyMetrics:
     ## ReportingInterval is the interval between sending legacy metrics to
     ## Honeycomb.
     ##
-    ## The interval between sending metrics to Honeycomb. Between 1 and 60
-    ## seconds is typical.
+    ## Between 1 and 60 seconds is typical.
     ##
     ## Accepts a duration string with units, like "30s".
     ## default: 30s
@@ -493,62 +498,63 @@ LegacyMetrics:
 ## OpenTelemetry Metrics ##
 ###########################
 OTelMetrics:
-  ## Configuration for Refinery's OpenTelemetry metrics. This is the
-  ## preferred way to send metrics to Honeycomb. New installations should
-  ## prefer OTelMetrics.
+  ## `OTelMetrics` contains configuration for Refinery's OpenTelemetry
+  ## (OTel) metrics. This is the preferred way to send metrics to
+  ## Honeycomb. New installations should prefer `OTelMetrics`.
   ##
   ####
-    ## Enabled controls whether to send metrics via OTel.
+    ## Enabled controls whether to send metrics via OpenTelemetry.
     ##
-    ## Enabled controls whether to send OpenTelemetry metrics to Honeycomb.
+    ## Each of the metrics providers can be enabled or disabled
+    ## independently. Metrics can be sent to multiple destinations.
     ##
     ## Not eligible for live reload.
     {{ nonDefaultOnly .Data "Enabled" "Enabled" false }}
 
-    ## APIHost is the URL of the OTel API to which metrics will be sent.
+    ## APIHost is the URL of the OpenTelemetry API to which metrics will be
+    ## sent.
     ##
-    ## Specifies a URL for the upstream API to receive refinery's own OTel
-    ## metrics.
+    ## Refinery's internal metrics will be sent to the `/v1/metrics` endpoint
+    ## on this host.
     ##
     ## default: https://api.honeycomb.io
     ## Not eligible for live reload.
     {{ nonDefaultOnly .Data "APIHost" "APIHost" "https://api.honeycomb.io" }}
 
-    ## APIKey is the API key used to send Honeycomb metrics via OTel.
+    ## APIKey is the API key used to send Honeycomb metrics via
+    ## OpenTelemetry.
     ##
-    ## Specifies the API key used when refinery sends its own metrics. It is
-    ## recommended that you create a separate team and key for Refinery
-    ## metrics. If this is blank, Refinery will not set the
-    ## Honeycomb-specific headers for OTel, and your APIHost must be set to a
-    ## valid OTel endpoint.
+    ## It is recommended that you create a separate team and key for Refinery
+    ## metrics.
+    ## If this is blank, then Refinery will not set the Honeycomb-specific
+    ## headers for OpenTelemetry, and your `APIHost` must be set to a valid
+    ## OpenTelemetry endpoint.
     ##
     ## Not eligible for live reload.
     {{ nonDefaultOnly .Data "APIKey" "APIKey" "" }}
 
-    ## Dataset is the Honeycomb dataset to which OTel metrics will be sent.
+    ## Dataset is the Honeycomb dataset that Refinery sends its OpenTelemetry
+    ## metrics.
     ##
-    ## Specifies the dataset to which refinery sends its own OTel metrics.
-    ## Only used if APIKey is specified.
+    ## Only used if `APIKey` is specified.
     ##
     ## default: Refinery Metrics
     ## Not eligible for live reload.
     {{ nonDefaultOnly .Data "Dataset" "Dataset" "Refinery Metrics" }}
 
-    ## ReportingInterval is the interval between sending OTel metrics to
-    ## Honeycomb.
+    ## ReportingInterval is the interval between sending OpenTelemetry
+    ## metrics to Honeycomb.
     ##
-    ## The interval between sending metrics to Honeycomb. Between 1 and 60
-    ## seconds is typical.
+    ## Between `1` and `60` seconds is typical.
     ##
     ## Accepts a duration string with units, like "30s".
     ## default: 30s
     ## Not eligible for live reload.
     {{ secondsToDuration .Data "ReportingInterval" "ReportingInterval" "" }}
 
-    ## Compression is the compression algorithm to use when sending OTel
-    ## metrics.
+    ## Compression is the compression algorithm to use when sending
+    ## OpenTelemetry metrics to Honeycomb.
     ##
-    ## The compression algorithm to use when sending metrics to Honeycomb.
     ## `gzip` is the default and recommended value. In rare circumstances,
     ## compression costs may outweigh the benefits, in which case `none` may
     ## be used.
@@ -562,15 +568,15 @@ OTelMetrics:
 ## Peer Management ##
 #####################
 PeerManagement:
-  ## Controls how the Refinery cluster communicates between peers.
+  ## controls how the Refinery cluster communicates between peers.
   ####
     ## Type is the type of peer management to use.
     ##
-    ## Sets the type of peer management (the mechanism by which Refinery
-    ## locates its peers). `file` means that Refinery gets its peer list from
-    ## the Peers list in this config file. `redis` means that refinery
-    ## self-registers with a redis instance and gets its peer list from
-    ## there.
+    ## Peer management is the mechanism by which Refinery locates its peers.
+    ## `file` means that Refinery gets its peer list from the Peers list in
+    ## this config file.
+    ## `redis` means that Refinery self-registers with a Redis instance and
+    ## gets its peer list from there.
     ##
     ## default: redis
     ## Not eligible for live reload.
@@ -582,9 +588,10 @@ PeerManagement:
     ##
     ## By default, when using a peer registry, Refinery will use the local
     ## hostname to identify itself to other peers. If your environment
-    ## requires something else, (for example, if peers can't resolve each
-    ## other by name), you can specify the exact identifier (IP address, etc)
-    ## to use here. Overrides IdentifierInterfaceName, if both are set.
+    ## requires something else, (for example, if peers cannot resolve each
+    ## other by name), then you can specify the exact identifier, such as an
+    ## IP address, to use here. Overrides `IdentifierInterfaceName`, if both
+    ## are set.
     ##
     ## Not eligible for live reload.
     {{ nonEmptyString .Data "Identifier" "PeerManagement.RedisIdentifier" "192.168.1.1" }}
@@ -594,11 +601,11 @@ PeerManagement:
     ##
     ## By default, when using a peer registry, Refinery will use the local
     ## hostname to identify itself to other peers. If your environment
-    ## requires that you use IPs as identifiers (for example, if peers can't
-    ## resolve eachother by name), you can specify the network interface that
-    ## Refinery is listening on here. Refinery will use the first unicast
-    ## address that it finds on the specified network interface as its
-    ## identifier.
+    ## requires that you use IPs as identifiers (for example, if peers cannot
+    ## resolve each other by name), then you can specify the network
+    ## interface that Refinery is listening on here. Refinery will use the
+    ## first unicast address that it finds on the specified network interface
+    ## as its identifier.
     ##
     ## Not eligible for live reload.
     {{ nonEmptyString .Data "IdentifierInterfaceName" "PeerManagement.IdentifierInterfaceName" "eth0" }}
@@ -606,17 +613,16 @@ PeerManagement:
     ## UseIPV6Identifier specifies that Refinery should use an IPV6 address
     ## as its identifier.
     ##
-    ## If using IdentifierInterfaceName, Refinery will default to the first
+    ## If using `IdentifierInterfaceName`, Refinery will default to the first
     ## IPv4 unicast address it finds for the specified interface. If this
-    ## value is specified, Refinery will use the first IPV6 unicast address
-    ## found.
+    ## value is specified, then Refinery will use the first IPV6 unicast
+    ## address found.
     ##
     ## Not eligible for live reload.
     {{ nonDefaultOnly .Data "UseIPV6Identifier" "PeerManagement.UseIPV6Identifier" false }}
 
-    ## Peers is the list of peers to use when Type is "file".
+    ## Peers is the list of peers to use when Type is "file", excluding self.
     ##
-    ## Sets the list of peers to use when Type is "file", excluding self.
     ## This list is ignored when Type is "redis". The format is a list of
     ## strings of the form "host:port".
     ##
@@ -627,42 +633,42 @@ PeerManagement:
 ## Redis Peer Management ##
 ###########################
 RedisPeerManagement:
-  ## Controls how the Refinery cluster communicates between peers when
-  ## using Redis. Only applies when PeerManagement.Type is "redis".
+  ## `RedisPeerManagement` controls how the Refinery cluster communicates
+  ## between peers when using Redis. Only applies when
+  ## `PeerManagement.Type` is "redis".
   ##
   ####
-    ## Host is the host and port of the redis instance to use.
+    ## Host is the host and port of the Redis instance to use for peer
+    ## cluster membership management.
     ##
-    ## Sets the host and port of the redis instance to use for peer cluster
-    ## membership management.
+    ## Must be in the form `host:port`.
     ##
     ## Should be an ip:port like "localhost:6379".
     ## Not eligible for live reload.
     {{ nonEmptyString .Data "Host" "PeerManagement.RedisHost" "localhost:6379" }}
 
-    ## Username is the username used to connect to redis.
+    ## Username is the username used to connect to Redis for peer cluster
+    ## membership management.
     ##
-    ## The username used to connect to redis for peer cluster membership
-    ## management.
+    ## Many Redis installations do not use this field.
     ##
     ## Not eligible for live reload.
     {{ nonEmptyString .Data "Username" "PeerManagement.RedisUsername" "" }}
 
-    ## Password is the password used to connect to redis.
+    ## Password is the password used to connect to Redis for peer cluster
+    ## membership management.
     ##
-    ## Sets the password used to connect to redis for peer cluster membership
-    ## management.
+    ## Many Redis installations do not use this field.
     ##
     ## Not eligible for live reload.
     {{ nonEmptyString .Data "Password" "PeerManagement.Password" "" }}
 
-    ## Prefix is a string used as a prefix for the keys in redis.
+    ## Prefix is a string used as a prefix for the keys in Redis while
+    ## storing the peer membership.
     ##
-    ## Specifies a string to be used as a prefix for the keys in redis while
-    ## storing the peer membership. It might be useful to override this in
-    ## any situation where multiple refinery clusters or multiple
-    ## applications want to share a single Redis instance. It may not be
-    ## blank.
+    ## It might be useful to override this in any situation where multiple
+    ## Refinery clusters or multiple applications want to share a single
+    ## Redis instance. It may not be blank.
     ##
     ## default: refinery
     ## Not eligible for live reload.
@@ -673,32 +679,33 @@ RedisPeerManagement:
     ##
     ## An integer from 0-15 indicating the database number to use for the
     ## Redis instance storing the peer membership. It might be useful to set
-    ## this in any situation where multiple refinery clusters or multiple
+    ## this in any situation where multiple Refinery clusters or multiple
     ## applications want to share a single Redis instance.
     ##
     ## Not eligible for live reload.
     {{ nonDefaultOnly .Data "Database" "PeerManagement.Database" 0 }}
 
-    ## UseTLS enables TLS when connecting to redis.
+    ## UseTLS enables TLS when connecting to Redis for peer cluster
+    ## membership management.
     ##
-    ## Enables TLS when connecting to redis for peer cluster membership
-    ## management, and sets the MinVersion in the TLS configuration to 1.2.
+    ## When enabled, this setting sets the `MinVersion` in the TLS
+    ## configuration to `1.2`.
     ##
     ## Not eligible for live reload.
     {{ nonDefaultOnly .Data "UseTLS" "PeerManagement.UseTLS" false }}
 
-    ## UseTLSInsecure disables certificate checks when connecting to redis.
+    ## UseTLSInsecure disables certificate checks when connecting to Redis
+    ## for peer cluster membership management.
     ##
-    ## Disables certificate checks when connecting to redis for peer cluster
-    ## membership management.
+    ## This setting is intended for use with self-signed certificates and
+    ## sets the `InsecureSkipVerify` flag within Redis.
     ##
     ## Not eligible for live reload.
     {{ nonDefaultOnly .Data "UseTLSInsecure" "PeerManagement.UseTLSInsecure" false }}
 
     ## Timeout is the timeout to use when communicating with Redis.
     ##
-    ## Refinery will timeout after this duration when communicating with
-    ## Redis.
+    ## It is rarely necessary to adjust this value.
     ##
     ## Accepts a duration string with units, like "5s".
     ## default: 5s
@@ -709,11 +716,11 @@ RedisPeerManagement:
 ## Collection Settings ##
 #########################
 Collection:
-  ## Brings together the settings that are relevant to collecting spans
-  ## together to make traces. If none of the memory settings are used, then
-  ## Refinery will not attempt to limit its memory usage. This is not
-  ## recommended for production use since a burst of traffic could cause
-  ## Refinery to run out of memory and crash.
+  ## `Collection` contains the settings that are relevant to collecting
+  ## spans together to make traces. If none of the memory settings are
+  ## used, then Refinery will not attempt to limit its memory usage. This
+  ## is not recommended for production use since a burst of traffic could
+  ## cause Refinery to run out of memory and crash.
   ##
   ####
     ## CacheCapacity is the number of traces to keep in the cache's circular
@@ -731,15 +738,14 @@ Collection:
     {{ nonDefaultOnly .Data "CacheCapacity" "InMemCollector.CacheCapacity" 10000 }}
 
     ## AvailableMemory is the amount of system memory available to the
-    ## refinery process.
+    ## Refinery process.
     ##
-    ## The amount of system memory available to the refinery process. This
-    ## value will typically be set through an environment variable controlled
-    ## by the container or deploy script. If this value is zero or not set,
-    ## MaxMemory cannot be used to calculate the maximum allocation and
-    ## MaxAlloc will be used instead. If set, this must be a memory size.
-    ## 64-bit values are supported. Sizes with standard unit suffixes like
-    ## "MB" and "GiB" are also supported.
+    ## This value will typically be set through an environment variable
+    ## controlled by the container or deploy script. If this value is zero or
+    ## not set, then `MaxMemory` cannot be used to calculate the maximum
+    ## allocation and `MaxAlloc` will be used instead. If set, then this must
+    ## be a memory size. 64-bit values are supported. Sizes with standard
+    ## unit suffixes like "MB" and "GiB" are also supported.
     ##
     ## Eligible for live reload.
     {{ memorysize .Data "AvailableMemory" "AvailableMemory" "4Gb" }}
@@ -747,27 +753,27 @@ Collection:
     ## MaxMemoryPercentage is the maximum percentage of memory that should be
     ## allocated by the span collector.
     ##
-    ## If nonzero, it must be an integer value between 1 and 100,
+    ## If nonzero, then it must be an integer value between 1 and 100,
     ## representing the target maximum percentage of memory that should be
-    ## allocated by the span collector. If set to a non-zero value, once per
-    ## tick (see SendTicker) the collector will compare total allocated bytes
-    ## to this calculated value. If allocation is too high, traces will be
-    ## ejected from the cache early to reduce memory. Useful values for this
-    ## setting are generally in the range of 70-90. If this value is 0,
-    ## MaxAlloc will be used.
+    ## allocated by the span collector. If set to a non-zero value, then once
+    ## per tick (see `SendTicker`) the collector will compare total allocated
+    ## bytes to this calculated value. If allocation is too high, then traces
+    ## will be ejected from the cache early to reduce memory. Useful values
+    ## for this setting are generally in the range of 70-90. If this value is
+    ## `0`, then `MaxAlloc` will be used.
     ##
     ## default: 75
     ## Eligible for live reload.
     # MaxMemoryPercentage: 75
 
     ## MaxAlloc is the maximum number of bytes that should be allocated by
-    ## the collector.
+    ## the Collector.
     ##
-    ## If set, this must be a memory size. 64-bit values are supported. Sizes
-    ## with standard unit suffixes like "MB" and "GiB" are also supported.
-    ## The full list of supported values can be found at
+    ## If set, then this must be a memory size. 64-bit values are supported.
+    ## Sizes with standard unit suffixes like "MB" and "GiB" are also
+    ## supported. The full list of supported values can be found at
     ## https://pkg.go.dev/github.com/docker/go-units#pkg-constants. See
-    ## MaxMemory for more details.
+    ## `MaxMemory` for more details.
     ##
     ## Eligible for live reload.
     {{ memorysize .Data "MaxAlloc" "InMemCollector.MaxAlloc" "" }}
@@ -776,17 +782,17 @@ Collection:
 ## Buffer Sizes ##
 ##################
 BufferSizes:
-  ## Brings together the settings that are relevant to the sizes of
+  ## `BufferSizes` contains the settings that are relevant to the sizes of
   ## communications buffers.
   ##
   ####
     ## UpstreamBufferSize is the size of the queue used to buffer spans to
-    ## send to the upstream API.
+    ## send to the upstream Collector.
     ##
-    ## Sets the size of the buffer (measured in spans) used to send spans to
-    ## the upstream collector. If the buffer fills up, performance will
-    ## degrade because Refinery will block while waiting for space to become
-    ## available. If this happens, you should increase the buffer size.
+    ## The size of the buffer is measured in spans. If the buffer fills up,
+    ## then performance will degrade because Refinery will block while
+    ## waiting for space to become available. If this happens, then you
+    ## should increase the buffer size.
     ##
     ## default: 10000
     ## Eligible for live reload.
@@ -795,10 +801,10 @@ BufferSizes:
     ## PeerBufferSize is the size of the queue used to buffer spans to send
     ## to peer nodes.
     ##
-    ## Sets the size of the buffer (measured in spans) used to send spans to
-    ## peer nodes. If the buffer fills up, performance will degrade because
-    ## Refinery will block while waiting for space to become available. If
-    ## this happens, you should increase this buffer size.
+    ## The size of the buffer is measured in spans. If the buffer fills up,
+    ## then performance will degrade because Refinery will block while
+    ## waiting for space to become available. If this happens, then you
+    ## should increase this buffer size.
     ##
     ## default: 100000
     ## Eligible for live reload.
@@ -808,27 +814,28 @@ BufferSizes:
 ## Specialized Configuration ##
 ###############################
 Specialized:
-  ## Special-purpose configuration options that are not typically needed.
+  ## contains special-purpose configuration options that are not typically
+  ## needed.
   ####
     ## EnvironmentCacheTTL is the duration for which environment information
     ## is cached.
     ##
-    ## This is the amount of time for which refinery caches environment
+    ## This is the amount of time for which Refinery caches environment
     ## information, which it looks up from Honeycomb for each different
-    ## APIKey. This information is used when making sampling decisions. If
-    ## you have a very large number of environments, you may want to increase
-    ## this value.
+    ## `APIKey`. This information is used when making sampling decisions. If
+    ## you have a very large number of environments, then you may want to
+    ## increase this value.
     ##
     ## Accepts a duration string with units, like "1h".
     ## default: 1h
     ## Eligible for live reload.
     {{ nonDefaultOnly .Data "EnvironmentCacheTTL" "EnvironmentCacheTTL" "1h" }}
 
-    ## CompressPeerCommunication determines whether refinery will compress
+    ## CompressPeerCommunication determines whether Refinery will compress
     ## span data it forwards to peers.
     ##
-    ## If it costs money to transmit data between refinery instances (e.g.
-    ## they're spread across AWS availability zones), then you almost
+    ## If it costs money to transmit data between Refinery instances (for
+    ## example, when spread across AWS availability zones), then you almost
     ## certainly want compression enabled to reduce your bill. The option to
     ## disable it is provided as an escape hatch for deployments that value
     ## lower CPU utilization over data transfer costs.
@@ -838,11 +845,10 @@ Specialized:
     {{ nonDefaultOnly .Data "CompressPeerCommunication" "CompressPeerCommunication" true }}
 
     ## AdditionalAttributes is a map that can be used for injecting
-    ## user-defined attributes.
+    ## user-defined attributes into every span.
     ##
-    ## A map that can be used for injecting user-defined attributes into
-    ## every span. For example, it could be used for naming a refinery
-    ## cluster. Both keys and values must be strings.
+    ## For example, it could be used for naming a Refinery cluster. Both keys
+    ## and values must be strings.
     ##
     ## Eligible for live reload.
     {{ renderMap .Data "AdditionalAttributes" "AdditionalAttributes" "ClusterName:MyCluster,environment:production" }}
@@ -851,25 +857,26 @@ Specialized:
 ## ID Fields ##
 ###############
 IDFields:
-  ## Controls the field names to use for the event ID fields. These fields
-  ## are used to identify events that are part of the same trace.
+  ## `IDFields` controls the field names to use for the event ID fields.
+  ## These fields are used to identify events that are part of the same
+  ## trace.
   ##
   ####
     ## TraceNames is the list of field names to use for the trace ID.
     ##
-    ## The list of field names to use for the trace ID. The first field in
-    ## the list that is present in an incoming span will be used as the trace
-    ## ID. If none of the fields are present, refinery treats the span as not
-    ## being part of a trace and forwards it immediately to Honeycomb.
+    ## The first field in the list that is present in an incoming span will
+    ## be used as the trace ID. If none of the fields are present, then
+    ## Refinery treats the span as not being part of a trace and forwards it
+    ## immediately to Honeycomb.
     ##
     ## Eligible for live reload.
     {{ renderStringarray .Data "TraceNames" "TraceNames" "trace.trace_id,traceId" }}
 
     ## ParentNames is the list of field names to use for the parent ID.
     ##
-    ## The list of field names to use for the parent ID. The first field in
-    ## the list that is present in an event will be used as the parent ID. A
-    ## trace without a parent_id is assumed to be a root span.
+    ## The first field in the list that is present in an event will be used
+    ## as the parent ID. A trace without a `parent_id` is assumed to be a
+    ## root span.
     ##
     ## Eligible for live reload.
     {{ renderStringarray .Data "ParentNames" "ParentNames" "trace.parent_id,parentId" }}
@@ -878,24 +885,23 @@ IDFields:
 ## gRPC Server Parameters ##
 ############################
 GRPCServerParameters:
-  ## Controls the parameters of the gRPC server used to receive Open
-  ## Telemetry data in gRPC format.
+  ## `GRPCServerParameters` controls the parameters of the gRPC server used
+  ## to receive OpenTelemetry data in gRPC format.
   ##
   ####
     ## Enabled specifies whether the gRPC server is enabled.
     ##
-    ## Specifies whether the gRPC server is enabled. If false, the gRPC
-    ## server is not started and no gRPC traffic is accepted. TODO: WE NEED
-    ## TO DEFAULT THIS TO TRUE IF PREVIOUS CONFIG HAS A LISTEN ADDRESS
+    ## If `false`, then the gRPC server is not started and no gRPC traffic is
+    ## accepted.
     ##
     ## Not eligible for live reload.
     {{ nonDefaultOnly .Data "Enabled" "Enabled" false }}
 
-    ## ListenAddr is the address refinery listens to for incoming GRPC Open
-    ## Telemetry events.
+    ## ListenAddr is the address Refinery listens to for incoming GRPC
+    ## OpenTelemetry events.
     ##
-    ## Incoming traffic is expected to be unencrypted, so if using SSL put
-    ## something like nginx in front to do the decryption.
+    ## Incoming traffic is expected to be unencrypted, so if using SSL, then
+    ## put something like `nginx` in front to do the decryption.
     ##
     ## Should be an ip:port like "".
     ## Not eligible for live reload.
@@ -905,8 +911,8 @@ GRPCServerParameters:
     ##
     ## A duration for the amount of time after which an idle connection will
     ## be closed by sending a GoAway. "Idle" means that there are no active
-    ## RPCs. 0s sets duration to infinity, but this is not recommended for
-    ## refinery deployments behind a load balancer, because it will prevent
+    ## RPCs. "0s" sets duration to infinity, but this is not recommended for
+    ## Refinery deployments behind a load balancer, because it will prevent
     ## the load balancer from distributing load evenly among peers.
     ##
     ## Accepts a duration string with units, like "0s".
@@ -917,23 +923,22 @@ GRPCServerParameters:
     ## MaxConnectionAge is the maximum amount of time a gRPC connection may
     ## exist.
     ##
-    ## Sets a duration for the maximum amount of time a connection may exist
-    ## before it will be closed by sending a GoAway. A random jitter of
-    ## +/-10% will be added to MaxConnectionAge to spread out connection
-    ## storms. 0s sets duration to infinity; a value measured in low minutes
-    ## will help load balancers to distribute load among peers more evenly.
+    ## After this duration, the gRPC connection is closed by sending a
+    ## `GoAway`. A random jitter of +/-10% will be added to
+    ## `MaxConnectionAge` to spread out connection storms.
+    ## `0s` sets duration to infinity; a value measured in low minutes will
+    ## help load balancers to distribute load among peers more evenly.
     ##
     ## Accepts a duration string with units, like "3m".
     ## default: 3m
     ## Not eligible for live reload.
     {{ nonDefaultOnly .Data "MaxConnectionAge" "GRPCServerParameters.MaxConnectionAge" "3m" }}
 
-    ## MaxConnectionAgeGrace is the duration beyond MaxConnectionAge after
+    ## MaxConnectionAgeGrace is the duration beyond `MaxConnectionAge` after
     ## which the connection will be forcibly closed.
     ##
-    ## This is an additive period after MaxConnectionAge after which the
-    ## connection will be forcibly closed (in case the upstream node ignores
-    ## the GoAway request). 0s sets duration to infinity.
+    ## This setting is in case the upstream node ignores the `GoAway`
+    ## request. "0s" sets duration to infinity.
     ##
     ## Accepts a duration string with units, like "60s".
     ## default: 60s
@@ -942,9 +947,9 @@ GRPCServerParameters:
 
     ## KeepAlive is the duration between keep-alive pings.
     ##
-    ## Sets a duration for the amount of time after which if the client
-    ## doesn't see any activity it pings the server to see if the transport
-    ## is still alive. 0s sets duration to 2 hours.
+    ## After this amount of time, if the client does not see any activity,
+    ## then it pings the server to see if the transport is still alive. "0s"
+    ## sets duration to 2 hours.
     ##
     ## Accepts a duration string with units, like "1m".
     ## default: 1m
@@ -954,9 +959,9 @@ GRPCServerParameters:
     ## KeepAliveTimeout is the duration the server waits for activity on the
     ## connection.
     ##
-    ## This is the amount of time after which if the server doesn't see any
-    ## activity, it pings the client to see if the transport is still alive.
-    ## 0s sets duration to 20 seconds.
+    ## This is the amount of time after which if the server does not see any
+    ## activity, then it pings the client to see if the transport is still
+    ## alive. "0s" sets duration to 20 seconds.
     ##
     ## Accepts a duration string with units, like "20s".
     ## default: 20s
@@ -967,20 +972,19 @@ GRPCServerParameters:
 ## Sample Cache ##
 ##################
 SampleCache:
-  ## Controls the sample cache used to retain information about trace
-  ## status after the sampling decision has been made.
+  ## `SampleCache` controls the sample cache used to retain information
+  ## about trace status after the sampling decision has been made.
   ##
   ####
     ## KeptSize is the number of traces preserved in the cuckoo kept traces
     ## cache.
     ##
-    ## Controls the number of traces preserved in the cuckoo kept traces
-    ## cache. Refinery keeps a record of each trace that was kept and sent to
+    ## Refinery keeps a record of each trace that was kept and sent to
     ## Honeycomb, along with some statistical information. This is most
     ## useful in cases where the trace was sent before sending the root span,
     ## so that the root span can be decorated with accurate metadata. Default
-    ## is 10_000 traces (each trace in this cache consumes roughly 200
-    ## bytes).
+    ## is `10_000` traces. Each trace in this cache consumes roughly 200
+    ## bytes.
     ##
     ## default: 10000
     ## Eligible for live reload.
@@ -988,23 +992,19 @@ SampleCache:
 
     ## DroppedSize is the size of the cuckoo dropped traces cache.
     ##
-    ## Controls the size of the cuckoo dropped traces cache. This cache
-    ## consumes 4-6 bytes per trace at a scale of millions of traces.
-    ## Changing its size with live reload sets a future limit, but does not
-    ## have an immediate effect.
+    ## This cache consumes 4-6 bytes per trace at a scale of millions of
+    ## traces. Changing its size with live reload sets a future limit, but
+    ## does not have an immediate effect.
     ##
     ## default: 1000000
     ## Eligible for live reload.
     {{ nonDefaultOnly .Data "DroppedSize" "SampleCacheConfig/SampleCache.DroppedSize" 1000000 }}
 
     ## SizeCheckInterval controls how often the cuckoo cache re-evaluates its
-    ## capacity.
+    ## remaining capacity.
     ##
-    ## Controls the duration the cuckoo cache uses to determine how often it
-    ## re-evaluates the remaining capacity of its dropped traces cache and
-    ## possibly cycles it. This cache is quite resilient so it doesn't need
-    ## to happen very often, but the operation is also inexpensive. Default
-    ## is 10 seconds.
+    ## This cache is quite resilient so it does not need to happen very
+    ## often, but the operation is also inexpensive. Default is 10 seconds.
     ##
     ## Accepts a duration string with units, like "10s".
     ## default: 10s
@@ -1015,24 +1015,25 @@ SampleCache:
 ## Stress Relief ##
 ###################
 StressRelief:
-  ## Controls the stress relief mechanism, which is used to prevent
-  ## Refinery from being overwhelmed by a large number of traces.
-  ## There is a metric called stress_level that is emitted as part of
-  ## refinery metrics. It is a measure of refinery's throughput rate
+  ## `StressRelief` controls the Stress Relief mechanism, which is used to
+  ## prevent Refinery from being overwhelmed by a large number of traces.
+  ## There is a metric called `stress_level` that is emitted as part of
+  ## Refinery metrics. It is a measure of Refinery's throughput rate
   ## relative to its processing rate, combined with the amount of room in
-  ## its internal queues, and ranges from 0 to 100. It is generally
-  ## expected to be 0 except under heavy load. When stress levels reach
-  ## 100, there is an increased chance that refinery will become unstable.
+  ## its internal queues, and ranges from `0` to `100`. `stress_level` is
+  ## generally expected to be `0` except under heavy load. When stress
+  ## levels reach `100`, there is an increased chance that Refinery will
+  ## become unstable.
   ## To avoid this problem, the Stress Relief system can do deterministic
-  ## sampling on new trace traffic based solely on TraceID, without having
-  ## to store traces in the cache or take the time processing sampling
-  ## rules. Existing traces in flight will be processed normally, but when
-  ## Stress Relief is active, trace decisions are made deterministically on
-  ## a per-span basis; all spans will be sampled according to the
-  ## SamplingRate specified here.
-  ## Once Stress Relief activates (by exceeding the ActivationLevel), it
-  ## will not deactivate until stress_level falls below the
-  ## DeactivationLevel. When it deactivates, normal trace decisions are
+  ## sampling on new trace traffic based solely on `TraceID`, without
+  ## having to store traces in the cache or take the time processing
+  ## sampling rules. Existing traces in flight will be processed normally,
+  ## but when Stress Relief is active, trace decisions are made
+  ## deterministically on a per-span basis; all spans will be sampled
+  ## according to the `SamplingRate` specified here.
+  ## Once Stress Relief activates (by exceeding the `ActivationLevel`), it
+  ## will not deactivate until `stress_level` falls below the
+  ## `DeactivationLevel`. When it deactivates, normal trace decisions are
   ## made -- and any additional spans that arrive for traces that were
   ## active during Stress Relief will respect the decisions made during
   ## that time.
@@ -1047,32 +1048,33 @@ StressRelief:
   ####
     ## Mode is a string indicating how to use Stress Relief.
     ##
-    ## Sets the stress relief mode. "never" means that Stress Relief will
-    ## never activate "monitor" is the recommended setting, and means that
-    ## Stress Relief will monitor the status of refinery and activate
-    ## according to the levels set below. "always" means that Stress Relief
-    ## is always on, which may be useful in an emergency situation.
+    ## This setting sets the Stress Relief mode.
+    ## "never" means that Stress Relief will never activate.
+    ## "monitor" is the recommended setting, and means that Stress Relief
+    ## will monitor the status of Refinery and activate according to the
+    ## levels set by fields such as `ActivationLevel`.
+    ## "always" means that Stress Relief is always on, which may be useful in
+    ## an emergency situation.
     ##
     ## default: never
     ## Eligible for live reload.
     {{ nonDefaultOnly .Data "Mode" "StressRelief.Mode" "never" }}
 
-    ## ActivationLevel is the stress_level (from 0-100) at which Stress
+    ## ActivationLevel is the `stress_level` (from 0-100) at which Stress
     ## Relief is triggered.
     ##
-    ## Sets the stress_level (from 0-100) at which Stress Relief is
-    ## triggered.
+    ## This value must be greater than `DeactivationLevel` and should be high
+    ## enough that it is not reached in normal operation.
     ##
     ## default: 90
     ## Eligible for live reload.
     {{ nonDefaultOnly .Data "ActivationLevel" "StressRelief.ActivationLevel" 90 }}
 
-    ## DeactivationLevel is the stress_level (from 0-100) at which Stress
+    ## DeactivationLevel is the `stress_level` (from 0-100) at which Stress
     ## Relief is turned off.
     ##
-    ## Sets the stress_level (from 0-100) at which Stress Relief is turned
-    ## off (subject to MinimumActivationDuration). It must be less than
-    ## ActivationLevel.
+    ## This setting is subject to `MinimumActivationDuration`. The value must
+    ## be less than `ActivationLevel`.
     ##
     ## default: 70
     ## Eligible for live reload.
@@ -1081,38 +1083,38 @@ StressRelief:
     ## SamplingRate is the sampling rate to use when Stress Relief is
     ## activated.
     ##
-    ## Controls the sampling rate to use when Stress Relief is activated. All
-    ## new traces will be deterministically sampled at this rate based only
-    ## on the traceID. It should be chosen to be a rate that sends fewer
-    ## samples than the average sampling rate Refinery is expected to
-    ## generate. For example, if Refinery is configured to normally sample at
-    ## a rate of 1 in 10, then Stress Relief should be configured to sample
-    ## at a rate of at least 1 in 30.
+    ## All new traces will be deterministically sampled at this rate based
+    ## only on the `traceID`. It should be chosen to be a rate that sends
+    ## fewer samples than the average sampling rate Refinery is expected to
+    ## generate.
+    ## For example, if Refinery is configured to normally sample at a rate of
+    ## 1 in 10, then Stress Relief should be configured to sample at a rate
+    ## of at least 1 in 30.
     ##
     ## default: 100
     ## Eligible for live reload.
     {{ nonDefaultOnly .Data "SamplingRate" "StressRelief.StressSamplingRate" 100 }}
 
-    ## MinimumActivationDuration is the minimum time that stress relief will
-    ## stay enabled.
+    ## MinimumActivationDuration is the minimum time that Stress Relief will
+    ## stay enabled once activated.
     ##
-    ## Sets the minimum time that stress relief will stay enabled, once
-    ## activated. This helps to prevent oscillations.
+    ## This setting helps to prevent oscillations.
     ##
     ## Accepts a duration string with units, like "10s".
     ## default: 10s
     ## Eligible for live reload.
     {{ nonDefaultOnly .Data "MinimumActivationDuration" "StressRelief.MinimumActivationDuration" "10s" }}
 
-    ## MinimumStartupDuration is the minimum time that stress relief will
+    ## MinimumStartupDuration is the minimum time that Stress Relief will
     ## stay enabled.
     ##
-    ## Used when switching into Monitor mode. When stress monitoring is
-    ## enabled, it will start up in stressed mode for a at least this amount
-    ## of time to try to make sure that Refinery can handle the load before
-    ## it begins processing it in earnest. This is to help address the
-    ## problem of trying to bring a new node into an already-overloaded
-    ## cluster. If this duration is 0, Refinery will not start in stressed
+    ## This setting is used when switching into Monitor mode.
+    ## When Stress Relief is enabled, it will start up in stressed mode for
+    ## at least this set duration of time to try to make sure that Refinery
+    ## can handle the load before it begins processing it in earnest. This is
+    ## to help address the problem of trying to bring a new node into an
+    ## already-overloaded cluster.
+    ## If this duration is `0`, then Refinery will not start in stressed
     ## mode, which will provide faster startup at the possible cost of
     ## startup instability.
     ##


### PR DESCRIPTION
## Which problem is this PR solving?

- Cleans up the documentation and code around environment variables and command line.

## Short description of the changes

- Fix and add info about envvars and cmdlines in metadata
- Add the info to templates so they show up in the docs
- Regenerate all the things

Closes #727
