### PR TITLE
fix: metrics injection startup issues

### DIFF
--- a/cmd/refinery/main.go
+++ b/cmd/refinery/main.go
@@ -104,7 +104,8 @@ func main() {
 	// get desired implementation for each dependency to inject
 	lgr := logger.GetLoggerImplementation(c)
 	collector := collect.GetCollectorImplementation(c)
-	metricsSingleton := metrics.GetMetricsImplementation(c)
+	metricsSingleton := &metrics.MultiMetrics{}
+	metricsList := metrics.GetMetricsImplementations(c)
 	shrdr := sharder.GetSharderImplementation(c)
 	samplerFactory := &sample.SamplerFactory{}
 
@@ -202,6 +203,7 @@ func main() {
 		{Value: peerTransmission, Name: "peerTransmission"},
 		{Value: shrdr},
 		{Value: collector},
+		{Value: metricsList, Name: "metricslist"},
 		{Value: metricsSingleton, Name: "metrics"},
 		{Value: genericMetricsRecorder, Name: "genericMetrics"},
 		{Value: upstreamMetricsRecorder, Name: "upstreamMetrics"},
@@ -212,7 +214,7 @@ func main() {
 		{Value: &a},
 	}
 	// we need to add the multimetrics children to the graph as well
-	for _, obj := range metricsSingleton.Children() {
+	for _, obj := range metricsList.Children() {
 		objects = append(objects, &inject.Object{Value: obj})
 	}
 	err = g.Provide(objects...)

--- a/metrics/multi_metrics.go
+++ b/metrics/multi_metrics.go
@@ -1,6 +1,8 @@
 package metrics
 
-import "sync"
+import (
+	"sync"
+)
 
 // MultiMetrics is a metrics provider that sends metrics to at least one
 // underlying metrics provider (StoreMetrics). It can be configured to send
@@ -10,30 +12,22 @@ import "sync"
 // which can then be retrieved with Get(). This is for use with StressRelief. It
 // does not track histograms or counters, which are reset after each scrape.
 type MultiMetrics struct {
-	children []Metrics
-	values   map[string]float64
-	lock     sync.RWMutex
+	MList  *MetricsList `inject:"metricslist"`
+	values map[string]float64
+	lock   sync.RWMutex
 }
 
-func NewMultiMetrics() *MultiMetrics {
-	return &MultiMetrics{
-		children: []Metrics{},
-		values:   make(map[string]float64),
-	}
+func (m *MultiMetrics) Start() error {
+	m.values = make(map[string]float64)
+	return nil
 }
 
-// This is not safe for concurrent use!
-func (m *MultiMetrics) AddChild(met Metrics) {
-	m.children = append(m.children, met)
-}
-
-// This is not safe for concurrent use!
 func (m *MultiMetrics) Children() []Metrics {
-	return m.children
+	return m.MList.Children()
 }
 
 func (m *MultiMetrics) Register(name string, metricType string) {
-	for _, ch := range m.children {
+	for _, ch := range m.Children() {
 		ch.Register(name, metricType)
 	}
 	m.lock.Lock()
@@ -42,13 +36,13 @@ func (m *MultiMetrics) Register(name string, metricType string) {
 }
 
 func (m *MultiMetrics) Increment(name string) { // for counters
-	for _, ch := range m.children {
+	for _, ch := range m.Children() {
 		ch.Increment(name)
 	}
 }
 
 func (m *MultiMetrics) Gauge(name string, val interface{}) { // for gauges
-	for _, ch := range m.children {
+	for _, ch := range m.Children() {
 		ch.Gauge(name, val)
 	}
 	m.lock.Lock()
@@ -57,19 +51,19 @@ func (m *MultiMetrics) Gauge(name string, val interface{}) { // for gauges
 }
 
 func (m *MultiMetrics) Count(name string, n interface{}) { // for counters
-	for _, ch := range m.children {
+	for _, ch := range m.Children() {
 		ch.Count(name, n)
 	}
 }
 
 func (m *MultiMetrics) Histogram(name string, obs interface{}) { // for histogram
-	for _, ch := range m.children {
+	for _, ch := range m.Children() {
 		ch.Histogram(name, obs)
 	}
 }
 
 func (m *MultiMetrics) Up(name string) { // for updown
-	for _, ch := range m.children {
+	for _, ch := range m.Children() {
 		ch.Up(name)
 	}
 	m.lock.Lock()
@@ -78,7 +72,7 @@ func (m *MultiMetrics) Up(name string) { // for updown
 }
 
 func (m *MultiMetrics) Down(name string) { // for updown
-	for _, ch := range m.children {
+	for _, ch := range m.Children() {
 		ch.Down(name)
 	}
 	m.lock.Lock()


### PR DESCRIPTION

## Which problem is this PR solving?

- Satisfying the injection system requires special magic which is neither special nor satisfying. But now, at least, refinery starts up reliably.

## Short description of the changes

- Make metrics objects behave the way that injection insists they must (must implement start, must not cause gaps in the injection graph)
- Fix tests

