### PR TITLE
docs: Update APIKeys reference in config

### DIFF
--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -150,12 +150,12 @@ groups:
             arg: ReceiveKeys
         summary: is a boolean flag that causes events arriving with API keys not in the `ReceiveKeys` list to be rejected.
         description: >
-          If `true`, then only traffic using the keys listed in `APIKeys` is
+          If `true`, then only traffic using the keys listed in `ReceiveKeys` is
           accepted. Events arriving with API keys not in the `ReceiveKeys` list
           will be rejected with an HTTP `401` error.
 
           If `false`, then all traffic is accepted and `ReceiveKeys` is
-          ignored. Must be specified if `APIKeys` is specified.
+          ignored. Must be specified if `ReceiveKeys` is specified.
 
   - name: RefineryTelemetry
     title: "Refinery Telemetry"


### PR DESCRIPTION
## Which problem is this PR solving?
This PR originally started as a result of customer feedback, which suggested updating the `APIKeys` description specifically to include the word "allowlist". Upon investigation, I realized `APIKeys` is no longer in use, but `ReceiveKeys` still is. I updated the config here, but please feel free to make further related changes.

## Short description of the changes

- This PR updates two outdated `APIKeys` references in Refinery's config documentation to `ReceiveKeys`.

