### PR TITLE
docs: Generated Refinery docs for docs site improvements

### DIFF
--- a/config.md
+++ b/config.md
@@ -1,7 +1,7 @@
 # Honeycomb Refinery Configuration Documentation
 
 This is the documentation for the configuration file for Honeycomb's Refinery.
-It was automatically generated on 2023-06-27 at 22:07:32 UTC.
+It was automatically generated on 2023-06-28 at 21:40:58 UTC.
 
 ## The Config file
 
@@ -139,7 +139,7 @@ This setting is the destination to which Refinery sends all events that it decid
 
 ## Access Key Configuration
 
-`AccessKeys` Contains access keys -- API keys that the proxy will treat specially, and other flags that control how the proxy handles API keys.
+`AccessKeys` contains access keys -- API keys that the proxy will treat specially, and other flags that control how the proxy handles API keys.
 
 ### `ReceiveKeys`
 
@@ -446,7 +446,7 @@ Only used if `Enabled` is `true` in `PrometheusMetrics`.
 
 ## Legacy Metrics
 
-`LegacyMetrics` `LegacyMetrics` contains configuration for Refinery's legacy metrics.
+`LegacyMetrics` contains configuration for Refinery's legacy metrics.
 Version 1.x of Refinery used this format for sending Metrics to Honeycomb.
 The metrics generated that way are nonstandard and will be deprecated in a future release.
 New installations should prefer `OTelMetrics`.
@@ -504,7 +504,7 @@ Between 1 and 60 seconds is typical.
 
 ## OpenTelemetry Metrics
 
-`OTelMetrics` `OTelMetrics` contains configuration for Refinery's OpenTelemetry (OTel) metrics.
+`OTelMetrics` contains configuration for Refinery's OpenTelemetry (OTel) metrics.
 This is the preferred way to send metrics to Honeycomb.
 New installations should prefer `OTelMetrics`.
 
@@ -635,7 +635,7 @@ The format is a list of strings of the form "host:port".
 
 ## Redis Peer Management
 
-`RedisPeerManagement` `RedisPeerManagement` controls how the Refinery cluster communicates between peers when using Redis.
+`RedisPeerManagement` controls how the Refinery cluster communicates between peers when using Redis.
 Only applies when `PeerManagement.Type` is "redis".
 
 ### `Host`
@@ -722,7 +722,7 @@ It is rarely necessary to adjust this value.
 
 ## Collection Settings
 
-`Collection` `Collection` contains the settings that are relevant to collecting spans together to make traces.
+`Collection` contains the settings that are relevant to collecting spans together to make traces.
 If none of the memory settings are used, then Refinery will not attempt to limit its memory usage.
 This is not recommended for production use since a burst of traffic could cause Refinery to run out of memory and crash.
 
@@ -783,7 +783,7 @@ See `MaxMemory` for more details.
 
 ## Buffer Sizes
 
-`BufferSizes` `BufferSizes` contains the settings that are relevant to the sizes of communications buffers.
+`BufferSizes` contains the settings that are relevant to the sizes of communications buffers.
 
 ### `UpstreamBufferSize`
 
@@ -848,7 +848,7 @@ Both keys and values must be strings.
 
 ## ID Fields
 
-`IDFields` `IDFields` controls the field names to use for the event ID fields.
+`IDFields` controls the field names to use for the event ID fields.
 These fields are used to identify events that are part of the same trace.
 
 ### `TraceNames`
@@ -875,7 +875,7 @@ A trace without a `parent_id` is assumed to be a root span.
 
 ## gRPC Server Parameters
 
-`GRPCServerParameters` `GRPCServerParameters` controls the parameters of the gRPC server used to receive OpenTelemetry data in gRPC format.
+`GRPCServerParameters` controls the parameters of the gRPC server used to receive OpenTelemetry data in gRPC format.
 
 ### `Enabled`
 
@@ -957,7 +957,7 @@ This is the amount of time after which if the server does not see any activity, 
 
 ## Sample Cache
 
-`SampleCache` `SampleCache` controls the sample cache used to retain information about trace status after the sampling decision has been made.
+`SampleCache` controls the sample cache used to retain information about trace status after the sampling decision has been made.
 
 ### `KeptSize`
 
@@ -996,7 +996,7 @@ Default is 10 seconds.
 
 ## Stress Relief
 
-`StressRelief` `StressRelief` controls the Stress Relief mechanism, which is used to prevent Refinery from being overwhelmed by a large number of traces.
+`StressRelief` controls the Stress Relief mechanism, which is used to prevent Refinery from being overwhelmed by a large number of traces.
 There is a metric called `stress_level` that is emitted as part of Refinery metrics.
 It is a measure of Refinery's throughput rate relative to its processing rate, combined with the amount of room in its internal queues, and ranges from `0` to `100`.
 `stress_level` is generally expected to be `0` except under heavy load.

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -499,7 +499,7 @@ groups:
   - name: LegacyMetrics
     title: "Legacy Metrics"
     description: >
-      `LegacyMetrics` contains configuration for Refinery's legacy metrics.
+      contains configuration for Refinery's legacy metrics.
       Version 1.x of Refinery used this format for sending Metrics to
       Honeycomb. The metrics generated that way are nonstandard and will be
       deprecated in a future release. New installations should prefer
@@ -573,7 +573,7 @@ groups:
   - name: OTelMetrics
     title: "OpenTelemetry Metrics"
     description: >
-      `OTelMetrics` contains configuration for Refinery's OpenTelemetry (OTel)
+      contains configuration for Refinery's OpenTelemetry (OTel)
       metrics. This is the preferred way to send metrics to Honeycomb. New
       installations should prefer `OTelMetrics`.
     fields:
@@ -742,7 +742,7 @@ groups:
   - name: RedisPeerManagement
     title: "Redis Peer Management"
     description: >
-      `RedisPeerManagement` controls how the Refinery cluster communicates
+      controls how the Refinery cluster communicates
       between peers when using Redis. Only applies when `PeerManagement.Type`
       is "redis".
 
@@ -886,7 +886,7 @@ groups:
   - name: Collection
     title: "Collection Settings"
     description: >
-      `Collection` contains the settings that are relevant to collecting spans
+      contains the settings that are relevant to collecting spans
       together to make traces. If none of the memory settings are used, then
       Refinery will not attempt to limit its memory usage. This is not
       recommended for production use since a burst of traffic could cause
@@ -967,7 +967,7 @@ groups:
   - name: BufferSizes
     title: "Buffer Sizes"
     description: >
-      `BufferSizes` contains the settings that are relevant to
+      contains the settings that are relevant to
       the sizes of communications buffers.
     fields:
       - name: UpstreamBufferSize
@@ -1087,7 +1087,7 @@ groups:
   - name: IDFields
     title: "ID Fields"
     description: >
-      `IDFields` controls the field names to use for the event ID fields. These
+      controls the field names to use for the event ID fields. These
       fields are used to identify events that are part of the same trace.
     fields:
       - name: TraceNames
@@ -1122,7 +1122,7 @@ groups:
   - name: GRPCServerParameters
     title: "gRPC Server Parameters"
     description: >
-      `GRPCServerParameters` controls the parameters of the gRPC server used to
+      controls the parameters of the gRPC server used to
       receive OpenTelemetry data in gRPC format.
     fields:
       - name: Enabled
@@ -1233,7 +1233,7 @@ groups:
   - name: SampleCache
     title: "Sample Cache"
     description: >
-      `SampleCache` controls the sample cache used to retain information about trace status after the sampling decision has been made.
+      controls the sample cache used to retain information about trace status after the sampling decision has been made.
     fields:
       - name: Type
         # we had a bug in the v1 config where this was implemented as `SampleCache` but documented as `SampleCacheConfig`;
@@ -1307,7 +1307,7 @@ groups:
   - name: StressRelief
     title: "Stress Relief"
     description: >
-      `StressRelief` controls the Stress Relief mechanism, which is used to
+      controls the Stress Relief mechanism, which is used to
       prevent Refinery from being overwhelmed by a large number of traces.
 
       There is a metric called `stress_level` that is emitted as part of

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -122,7 +122,7 @@ groups:
   - name: AccessKeys
     title: "Access Key Configuration"
     description: >
-      Contains access keys -- API keys that the proxy will treat specially, and
+      contains access keys -- API keys that the proxy will treat specially, and
       other flags that control how the proxy handles API keys.
     fields:
       - name: ReceiveKeys

--- a/config/metadata/rulesMeta.yaml
+++ b/config/metadata/rulesMeta.yaml
@@ -4,26 +4,26 @@ groups:
     sortorder: 0
     summary: is the list of samplers to use.
     description: >
-      `Samplers` maps targets to sampler configurations. Each target is a 
+      `Samplers` maps targets to sampler configurations. Each target is a
       Honeycomb environment, (or a dataset for Honeycomb Classic keys).
-      The value is the sampler to use for that target. A `__default__` 
+      The value is the sampler to use for that target. A `__default__`
       target is required. The target called `__default__` will be used 
       for any target that is not explicitly listed.
 
       The targets are determined by examining the API key used to send the
       trace. If the API key is a Honeycomb Classic key with a 32-character
-      hexadecimal value, then the specified dataset name is used as the target. 
-      If the API key is a key with 20-23 alphanumeric characters, then 
+      hexadecimal value, then the specified dataset name is used as the target.
+      If the API key is a key with 20-23 alphanumeric characters, then
       the key's environment name is used as the target.
 
   - name: DeterministicSampler
     title: Deterministic Sampler
     sortorder: 10
     description: >
-      The Deterministic Sampler (`DeterministicSampler`) uses a fixed sample 
-      rate to sample traces based on their trace ID. This is the simplest 
-      sampling algorithm - it is a static sample rate, choosing traces randomly 
-      to either keep or send (at the appropriate rate). It is not influenced by 
+      The Deterministic Sampler (`DeterministicSampler`) uses a fixed sample
+      rate to sample traces based on their trace ID. This is the simplest
+      sampling algorithm - it is a static sample rate, choosing traces randomly
+      to either keep or send (at the appropriate rate). It is not influenced by
       the contents of the trace other than the trace ID.
     fields:
       - name: SampleRate
@@ -44,15 +44,15 @@ groups:
     title: Dynamic Sampler
     sortorder: 20
     description: >
-      The Dynamic Sampler (`DynamicSampler`) is the basic Dynamic Sampler 
-      implementation. Most installations will find the EMA Dynamic Sampler to 
-      be a better choice. This sampler collects the values of a number of 
-      fields from a trace and uses them to form a key. This key is handed to 
-      the standard dynamic sampler algorithm, which generates a sample rate 
-      based on the frequency with which that key has appeared during the 
-      previous `ClearFrequency`. See 
-      https://github.com/honeycombio/dynsampler-go for more detail on the 
-      mechanics of the Dynamic Sampler. This sampler uses the `AvgSampleRate` 
+      The Dynamic Sampler (`DynamicSampler`) is the basic Dynamic Sampler
+      implementation. Most installations will find the EMA Dynamic Sampler to
+      be a better choice. This sampler collects the values of a number of
+      fields from a trace and uses them to form a key. This key is handed to
+      the standard dynamic sampler algorithm, which generates a sample rate
+      based on the frequency with which that key has appeared during the
+      previous `ClearFrequency`. See
+      https://github.com/honeycombio/dynsampler-go for more detail on the
+      mechanics of the Dynamic Sampler. This sampler uses the `AvgSampleRate`
       algorithm from that package.
     fields:
       - name: SampleRate
@@ -66,7 +66,7 @@ groups:
         summary: is the duration over which the sampler will calculate the sample rate.
         description: >
           The duration after which the Dynamic Sampler should reset its internal
-          counters. It should be specified as a duration string. For example, "30s" or "1m".
+          counters. It should be specified as a duration string. For example,"30s" or "1m".
       - name: FieldList
         type: stringarray
         validations:
@@ -79,16 +79,16 @@ groups:
           all of these fields should reflect how interesting the trace is
           compared to another.
           
-          When choosing field names for `FieldList`, a good field selection 
+          When choosing field names for `FieldList`, a good field selection
           has consistent values for high-frequency, boring traffic, and
           unique values for outliers and interesting traffic. Including
-          an error field, or something like `HTTP status code`, is an 
+          an error field, or something like `HTTP status code`, is an
           excellent choice. Using fields with very high cardinality,
           like `k8s.pod.id`, is a bad choice.
           
-          If the combination of fields essentially makes each trace unique, 
-          then the Dynamic Sampler will sample everything. If the combination 
-          of fields is not unique enough, then you will not be guaranteed 
+          If the combination of fields essentially makes each trace unique,
+          then the Dynamic Sampler will sample everything. If the combination
+          of fields is not unique enough, then you will not be guaranteed
           samples of the most interesting traces.
           
           As an example, consider as a good set of fields: the combination of
@@ -98,16 +98,16 @@ groups:
           all endpoints under normal traffic and call out when there is
           failing traffic to any endpoint.
 
-          In contrast, for example, consider as a bad set of fields: a 
-          combination of `HTTP endpoint`, `status code`, and `pod id`, since it 
-          would result in keys that are all unique, and therefore result in 
-          sampling 100% of traces. 
+          In contrast, for example, consider as a bad set of fields: a
+          combination of `HTTP endpoint`, `status code`, and `pod id`, since it
+          would result in keys that are all unique, and therefore result in
+          sampling 100% of traces.
           
-          For example, rather than a set of fields, using only the `HTTP 
-          endpoint` field is a **bad** choice, as it is not unique enough, and 
-          therefore interesting traces, like traces that experienced a `500`, 
-          might not be sampled. Field names may come from any span in the 
-          trace; if they occur on multiple spans, then all unique values will 
+          For example, rather than a set of fields, using only the `HTTP
+          endpoint` field is a **bad** choice, as it is not unique enough, and
+          therefore interesting traces, like traces that experienced a `500`,
+          might not be sampled. Field names may come from any span in the
+          trace; if they occur on multiple spans, then all unique values will
           be included in the key.
       - name: MaxKeys
         type: int
@@ -116,8 +116,8 @@ groups:
           Limits the number of distinct keys tracked by the sampler.
           Once `MaxKeys` is reached, new keys will not be included in the sample
           rate map, but existing keys will continue to be be counted. Use this
-          field to keep the sample rate map size under control. Defaults to 
-          `500`; Dynamic Samplers will rarely achieve their sampling goals with 
+          field to keep the sample rate map size under control. Defaults to
+          `500`; Dynamic Samplers will rarely achieve their sampling goals with
           more keys than this.
       - name: UseTraceLength
         type: bool
@@ -125,7 +125,7 @@ groups:
         description: >
           Indicates whether to include the trace length (number of spans in the
           trace) as part of the key. The number of spans is exact, so if there
-          are normally small variations in trace length, we recommend setting 
+          are normally small variations in trace length, we recommend setting
           this field to `false`. If your traces are consistent lengths and
           changes in trace length is a useful indicator to view in Honeycomb,
           then set this field to `true`.
@@ -134,12 +134,12 @@ groups:
     title: EMA Dynamic Sampler
     sortorder: 30
     description: >
-      The Exponential Moving Average (EMA) Dynamic Sampler 
-      (`EMADynamicSampler`) attempts to average a given sample rate, weighting 
-      rare traffic and frequent traffic differently so as to end up with the 
+      The Exponential Moving Average (EMA) Dynamic Sampler
+      (`EMADynamicSampler`) attempts to average a given sample rate, weighting
+      rare traffic and frequent traffic differently so as to end up with the
       correct average.
 
-      `EMADynamicSampler` is an improvement upon the simple `DynamicSampler` 
+      `EMADynamicSampler` is an improvement upon the simple `DynamicSampler`
       and is recommended for many use cases. Based on the `DynamicSampler`,
       `EMADynamicSampler` differs in that rather than compute rate based on a
       periodic sample of traffic, it maintains an Exponential Moving Average of
@@ -180,10 +180,10 @@ groups:
         summary: is the weight to use when calculating the EMA.
         description: >
           The weight to use when calculating the EMA. It should be a number
-          between `0` and `1`. Larger values weight the average more toward 
-          recent observations. In other words, a larger weight will cause 
-          sample rates more quickly adapt to traffic patterns, while a smaller 
-          weight will result in sample rates that are less sensitive to bursts 
+          between `0` and `1`. Larger values weight the average more toward
+          recent observations. In other words, a larger weight will cause
+          sample rates more quickly adapt to traffic patterns, while a smaller
+          weight will result in sample rates that are less sensitive to bursts
           or drops in traffic and thus more consistent over time.
       - name: AgeOutValue
         type: float
@@ -196,22 +196,22 @@ groups:
         description: >
           Indicates the threshold for removing keys from the EMA.
           The EMA of any key will approach `0` if it is not repeatedly observed,
-          but will never truly reach it, so this field determines what 
-          constitutes "zero". Keys with averages below this threshold will be 
-          removed from the EMA. Default is the same as `Weight`, as this 
-          prevents a key with the smallest integer value (1) from being aged 
-          out immediately. This value should generally be less than (<=) 
+          but will never truly reach it, so this field determines what
+          constitutes "zero". Keys with averages below this threshold will be
+          removed from the EMA. Default is the same as `Weight`, as this
+          prevents a key with the smallest integer value (1) from being aged
+          out immediately. This value should generally be less than (<=)
           `Weight`, unless you have very specific reasons to set it higher.
       - name: BurstMultiple
         type: float
         summary: is the multiple of the sample rate to use when detecting bursts.
         description: >
-          If set, then this value is multiplied by the sum of the running 
-          average of counts to dynamically define the burst detection 
-          threshold. If total counts observed for a given interval exceed this 
-          threshold, then EMA is updated immediately, rather than waiting on 
-          the `AdjustmentInterval`. Defaults to `2`; a negative value disables. 
-          With the default of `2`, if your traffic suddenly doubles, then burst 
+          If set, then this value is multiplied by the sum of the running
+          average of counts to dynamically define the burst detection
+          threshold. If total counts observed for a given interval exceed this
+          threshold, then EMA is updated immediately, rather than waiting on
+          the `AdjustmentInterval`. Defaults to `2`; a negative value disables.
+          With the default of `2`, if your traffic suddenly doubles, then burst
           detection will kick in.
       - name: BurstDetectionDelay
         type: int
@@ -239,19 +239,19 @@ groups:
     title: EMA Throughput Sampler
     sortorder: 40
     description: >
-      The Exponential Moving Average (EMA) Throughput Sampler 
-      (`EMAThroughputSampler`) attempts to achieve a given throughput -- number 
-      of spans per second -- weighting rare traffic and frequent traffic 
+      The Exponential Moving Average (EMA) Throughput Sampler
+      (`EMAThroughputSampler`) attempts to achieve a given throughput -- number
+      of spans per second -- weighting rare traffic and frequent traffic
       differently so as to end up with the correct rate.
 
       The `EMAThroughputSampler` is an improvement upon the Total Throughput
       Sampler and is recommended for most throughput-based use cases. Because it
-      like the `EMADynamicSampler`, `EMAThroughputSampler` maintains an 
+      like the `EMADynamicSampler`, `EMAThroughputSampler` maintains an
       Exponential Moving Average of counts seen per key, and adjusts this
       average at regular intervals. The weight applied to more recent intervals
       is defined by `weight`, a number between (0, 1) - larger values weight
-      the average more toward recent observations. In other words, a larger 
-      weight will cause sample rates more quickly adapt to traffic patterns, 
+      the average more toward recent observations. In other words, a larger
+      weight will cause sample rates more quickly adapt to traffic patterns,
       while a smaller weight will result in sample rates that are less sensitive
       to bursts or drops in traffic and thus more consistent over time.
 
@@ -267,18 +267,18 @@ groups:
           - type: requiredInGroup
         summary: is the desired throughput per second of events sent to Honeycomb.
         description: >
-          The desired throughput **per second**. This is the number of events 
-          per second you want to send to Honeycomb. The sampler will adjust 
+          The desired throughput **per second**. This is the number of events
+          per second you want to send to Honeycomb. The sampler will adjust
           sample rates to try to achieve this desired throughput. This value is
           calculated for the individual instance, not for the cluster; if your
-          cluster has multiple instances, then you will need to divide your 
-          total desired sample rate by the number of instances to get this 
+          cluster has multiple instances, then you will need to divide your
+          total desired sample rate by the number of instances to get this
           value.
       - name: InitialSampleRate
         type: int
         summary: is the sample rate to use.
         description: >
-          `InitialSampleRate` is the sample rate to use during startup, before 
+          `InitialSampleRate` is the sample rate to use during startup, before
           the sampler has accumulated enough data to calculate a reasonable
           throughput. This is mainly useful in situations where unsampled
           throughput is high enough to cause problems.
@@ -332,9 +332,9 @@ groups:
     title: Windowed Throughput Sampler
     sortorder: 50
     description: >
-      Windowed Throughput Sampler (`WindowedThroughputSampler`) is an enhanced 
-      version of total throughput sampling. Just like the `TotalThroughput` 
-      Sampler, `WindowedThroughputSampler` attempts to meet the goal of fixed 
+      Windowed Throughput Sampler (`WindowedThroughputSampler`) is an enhanced
+      version of total throughput sampling. Just like the `TotalThroughput`
+      Sampler, `WindowedThroughputSampler` attempts to meet the goal of fixed
       number of events per second sent to Honeycomb.
 
       The original throughput sampler updates the sampling rate every
@@ -342,20 +342,20 @@ groups:
       from the following tradeoff:
         - Decreasing it is more responsive to load spikes, but with the
         cost of making the sampling decision on less data.
-        - Increasing it is less responsive to load spikes, but sample rates 
+        - Increasing it is less responsive to load spikes, but sample rates
         will be more stable because they are made with more data.
 
       The Windowed Throughput Sampler resolves this by introducing two
       different, tunable parameters:
         - `UpdateFrequency`: how often the sampling rate is recomputed
-        - `LookbackFrequency`: how much total time is considered when 
+        - `LookbackFrequency`: how much total time is considered when
         recomputing sampling rate.
 
       A standard configuration would be to set `UpdateFrequency` to `1s` and
-      `LookbackFrequency` to `30s`. In this configuration, for every second, we 
-      lookback at the last 30 seconds of data in order to compute the new 
-      sampling rate. The actual sampling rate computation is nearly identical 
-      to the original Throughput Sampler, but this variant has better support 
+      `LookbackFrequency` to `30s`. In this configuration, for every second, we
+      lookback at the last 30 seconds of data in order to compute the new
+      sampling rate. The actual sampling rate computation is nearly identical
+      to the original Throughput Sampler, but this variant has better support
       for floating point numbers.
 
     fields:
@@ -365,12 +365,12 @@ groups:
           - type: requiredInGroup
         summary: is the desired throughput per second of events sent to Honeycomb.
         description: >
-          The desired throughput **per second**. This is the number of events 
-          per second you want to send to Honeycomb. The sampler will adjust 
+          The desired throughput **per second**. This is the number of events
+          per second you want to send to Honeycomb. The sampler will adjust
           sample rates to try to achieve this desired throughput. This value is
           calculated for the individual instance, not for the cluster; if your
-          cluster has multiple instances, then you will need to divide your 
-          total desired sample rate by the number of instances to get this 
+          cluster has multiple instances, then you will need to divide your
+          total desired sample rate by the number of instances to get this
           value.
       - name: UpdateFrequency
         type: duration
@@ -382,9 +382,9 @@ groups:
         type: duration
         summary: how far back in time to look when computing the sampling rate.
         description: >
-          This controls how far back in time to lookback to dynamically adjust 
+          This controls how far back in time to lookback to dynamically adjust
           the sampling rate. Default is `30 * UpdateFrequencyDuration`.
-          This field is forced to be an **integer multiple** of 
+          This field is forced to be an **integer multiple** of
           `UpdateFrequencyDuration`.
       - name: FieldList
         type: stringarray
@@ -406,10 +406,11 @@ groups:
     title: Total Throughput Sampler
     sortorder: 80
     description: >
-      Total Throughput Sampler (`TotalThroughputSampler`) attempts to meet a 
-      goal of a fixed number of events per second sent to Honeycomb. This 
-      sampler is **deprecated** and present mainly for compatibility. Consider 
-      using either `EMAThroughputSampler` or `WindowedThroughputSampler` instead.
+      Total Throughput Sampler (`TotalThroughputSampler`) attempts to meet a
+      goal of a fixed number of events per second sent to Honeycomb. This
+      sampler is **deprecated** and present mainly for compatibility. Consider
+      using either `EMAThroughputSampler` or `WindowedThroughputSampler`
+      instead.
 
       If your key space is sharded across different servers, then this is a good
       method for making sure each server sends roughly the same volume of
@@ -419,7 +420,7 @@ groups:
       `GoalThroughputPerSec` * `ClearFrequency` defines the upper
       limit of the number of keys that can be reported and stay under the goal,
       but with that many keys, you'll only get one event per key per
-      `ClearFrequencySec`, which is very coarse. Aim for at least 1 event per 
+      `ClearFrequencySec`, which is very coarse. Aim for at least 1 event per
       key per sec to 1 event per key per 10sec to get reasonable data.
       In other words, the number of active keys should be less than
       10 * `GoalThroughputPerSec`.
@@ -460,7 +461,7 @@ groups:
       The Rules-based sampler allows you to specify a set of rules that will
       determine whether a trace should be sampled or not. Rules are evaluated in
       order, and the first rule that matches will be used to determine the
-      sample rate. If no rules match, then the `SampleRate` defaults to `1` and 
+      sample rate. If no rules match, then the `SampleRate` defaults to `1` and
       all traces will be kept.
 
       Rules-based samplers will usually be configured to have the last rule be a
@@ -491,20 +492,20 @@ groups:
     sortorder: 75
     description: >
       Rules are evaluated in order, and the first rule that matches will be used
-      to determine the sample rate. If no rules match, then the `SampleRate` 
+      to determine the sample rate. If no rules match, then the `SampleRate`
       will be `1` and all traces will be kept.
 
       If a rule matches, one of three things happens, and they are evaluated in
       this order: a) if the rule specifies a downstream Sampler, that sampler is
-      used to determine the sample rate; b) if the rule has the `Drop` flag set 
+      used to determine the sample rate; b) if the rule has the `Drop` flag set
       to `true`, the trace is dropped; c) the rule's sample rate is used.
     fields:
       - name: Name
         type: string
         summary: is the name of the rule.
         description: >
-          The name of the rule. This field is used for debugging and will 
-          appear in the trace metadata if `AddRuleReasonToTrace` is set to 
+          The name of the rule. This field is used for debugging and will
+          appear in the trace metadata if `AddRuleReasonToTrace` is set to
           `true`.
       - name: Sampler
         type: object
@@ -519,15 +520,15 @@ groups:
         summary: is the Dynamic Sampler to use if the rule matches.
         description: >
           The sampler to use if the rule matches. If this is set, the sample
-          rate will be determined by this downstream sampler. If this is not 
-          set, the sample rate will be determined by the `Drop` flag or the 
+          rate will be determined by this downstream sampler. If this is not
+          set, the sample rate will be determined by the `Drop` flag or the
           `SampleRate` field.
       - name: Drop
         type: bool
         summary: indicates whether to drop the trace.
         description: >
-          Indicates whether to drop the trace if it matches this rule. If 
-          `true`, then the trace will be dropped. If `false`, then the trace 
+          Indicates whether to drop the trace if it matches this rule. If
+          `true`, then the trace will be dropped. If `false`, then the trace
           will be kept.
       - name: SampleRate
         type: int
@@ -541,8 +542,8 @@ groups:
         description: >
           Conditions is a list of conditions to use to determine whether the
           rule matches. All conditions must be met for the rule to match. If
-          there are no conditions, then the rule will always match. A 
-          no-condition rule is typically used for the last rule to provide a 
+          there are no conditions, then the rule will always match. A
+          no-condition rule is typically used for the last rule to provide a
           default behavior.
       - name: Scope
         type: string
@@ -555,9 +556,9 @@ groups:
         description: >
           Controls the scope of the rule evaluation. If set to "trace" (the
           default), then each condition can apply to any span in the trace
-          independently. If set to "span", then all of the conditions in the 
-          rule will be evaluated against each span in the trace and the rule 
-          only succeeds if all of the conditions match on a single span 
+          independently. If set to "span", then all of the conditions in the
+          rule will be evaluated against each span in the trace and the rule
+          only succeeds if all of the conditions match on a single span
           together.
 
   - name: Conditions
@@ -565,8 +566,8 @@ groups:
     sortorder: 78
     description: >
       Conditions are evaluated in order, and the first condition that does not
-      match will cause the rule to not match. If all conditions match, then the 
-      rule will match. If there are no conditions, then the rule will always 
+      match will cause the rule to not match. If all conditions match, then the
+      rule will match. If there are no conditions, then the rule will always
       match.
     fields:
       - name: Field
@@ -615,8 +616,8 @@ groups:
         description: >
           The datatype to use when comparing the value and the field. If
           `Datatype` is specified, then both values will be converted
-          (best-effort) to that type and then compared. Errors in conversion 
-          will result in the comparison evaluating to `false`. This is 
-          especially useful when a field like `http status code` may be 
-          rendered as strings by some environments and as numbers or booleans 
+          (best-effort) to that type and then compared. Errors in conversion
+          will result in the comparison evaluating to `false`. This is
+          especially useful when a field like `http status code` may be
+          rendered as strings by some environments and as numbers or booleans
           by others.

--- a/config/metadata/rulesMeta.yaml
+++ b/config/metadata/rulesMeta.yaml
@@ -5,7 +5,7 @@ groups:
     summary: is the list of samplers to use.
     description: >
       `Samplers` maps targets to sampler configurations. Each target is a
-      Honeycomb environment, (or a dataset for Honeycomb Classic keys).
+      Honeycomb environment (or a dataset for Honeycomb Classic keys).
       The value is the sampler to use for that target. A `__default__`
       target is required. The target called `__default__` will be used 
       for any target that is not explicitly listed.

--- a/refinery_config.md
+++ b/refinery_config.md
@@ -1,11 +1,13 @@
-## The Config file
+## Refinery Config File
 
-The config file is a YAML file.
+The Refinery `config` file is a YAML file.
 The file is split into sections; each section is a group of related configuration options.
 Each section has a name, and the name is used to refer to the section in other parts of the config file.
 
-## Sample
-This is a sample config file:
+## Example
+
+This is an example `config` file:
+
 ```yaml
 General:
   ConfigurationVersion: 2
@@ -17,7 +19,7 @@ OTelMetrics:
   APIKey: SetThisToAHoneycombKey
 ```
 
-The remainder of this document describes the sections within the file and the fields in each.
+The remainder of this page describes the sections within the file and the fields in each.
 
 ## General Configuration
 
@@ -114,7 +116,7 @@ This setting is the destination to which Refinery sends all events that it decid
 
 ## Access Key Configuration
 
-`AccessKeys` Contains access keys -- API keys that the proxy will treat specially, and other flags that control how the proxy handles API keys.
+`AccessKeys` contains access keys -- API keys that the proxy will treat specially, and other flags that control how the proxy handles API keys.
 
 ### `ReceiveKeys`
 
@@ -428,7 +430,7 @@ Only used if `Enabled` is `true` in `PrometheusMetrics`.
 
 ## Legacy Metrics
 
-`LegacyMetrics` `LegacyMetrics` contains configuration for Refinery's legacy metrics.
+`LegacyMetrics` contains configuration for Refinery's legacy metrics.
 Version 1.x of Refinery used this format for sending Metrics to Honeycomb.
 The metrics generated that way are nonstandard and will be deprecated in a future release.
 New installations should prefer `OTelMetrics`.
@@ -486,7 +488,7 @@ Between 1 and 60 seconds is typical.
 
 ## OpenTelemetry Metrics
 
-`OTelMetrics` `OTelMetrics` contains configuration for Refinery's OpenTelemetry (OTel) metrics.
+`OTelMetrics` contains configuration for Refinery's OpenTelemetry (OTel) metrics.
 This is the preferred way to send metrics to Honeycomb.
 New installations should prefer `OTelMetrics`.
 
@@ -618,7 +620,7 @@ The format is a list of strings of the form "host:port".
 
 ## Redis Peer Management
 
-`RedisPeerManagement` `RedisPeerManagement` controls how the Refinery cluster communicates between peers when using Redis.
+`RedisPeerManagement` controls how the Refinery cluster communicates between peers when using Redis.
 Only applies when `PeerManagement.Type` is "redis".
 
 ### `Host`
@@ -705,7 +707,7 @@ It is rarely necessary to adjust this value.
 
 ## Collection Settings
 
-`Collection` `Collection` contains the settings that are relevant to collecting spans together to make traces.
+`Collection` contains the settings that are relevant to collecting spans together to make traces.
 If none of the memory settings are used, then Refinery will not attempt to limit its memory usage.
 This is not recommended for production use since a burst of traffic could cause Refinery to run out of memory and crash.
 
@@ -766,7 +768,7 @@ See `MaxMemory` for more details.
 
 ## Buffer Sizes
 
-`BufferSizes` `BufferSizes` contains the settings that are relevant to the sizes of communications buffers.
+`BufferSizes` contains the settings that are relevant to the sizes of communications buffers.
 
 ### `UpstreamBufferSize`
 
@@ -832,7 +834,7 @@ Both keys and values must be strings.
 
 ## ID Fields
 
-`IDFields` `IDFields` controls the field names to use for the event ID fields.
+`IDFields` controls the field names to use for the event ID fields.
 These fields are used to identify events that are part of the same trace.
 
 ### `TraceNames`
@@ -859,7 +861,7 @@ A trace without a `parent_id` is assumed to be a root span.
 
 ## gRPC Server Parameters
 
-`GRPCServerParameters` `GRPCServerParameters` controls the parameters of the gRPC server used to receive OpenTelemetry data in gRPC format.
+`GRPCServerParameters` controls the parameters of the gRPC server used to receive OpenTelemetry data in gRPC format.
 
 ### `Enabled`
 
@@ -941,7 +943,7 @@ This is the amount of time after which if the server does not see any activity, 
 
 ## Sample Cache
 
-`SampleCache` `SampleCache` controls the sample cache used to retain information about trace status after the sampling decision has been made.
+`SampleCache` controls the sample cache used to retain information about trace status after the sampling decision has been made.
 
 ### `KeptSize`
 
@@ -980,7 +982,7 @@ Default is 10 seconds.
 
 ## Stress Relief
 
-`StressRelief` `StressRelief` controls the Stress Relief mechanism, which is used to prevent Refinery from being overwhelmed by a large number of traces.
+`StressRelief` controls the Stress Relief mechanism, which is used to prevent Refinery from being overwhelmed by a large number of traces.
 There is a metric called `stress_level` that is emitted as part of Refinery metrics.
 It is a measure of Refinery's throughput rate relative to its processing rate, combined with the amount of room in its internal queues, and ranges from `0` to `100`.
 `stress_level` is generally expected to be `0` except under heavy load.

--- a/refinery_rules.md
+++ b/refinery_rules.md
@@ -1,7 +1,10 @@
-## The Rules file
+## Refinery Rules file
 
-The rules file is a YAML file.
-Here is a simple example of a rules file:
+The Refinery `rules` file is a YAML file.
+
+## Example
+
+Here is a simple example of a `rules` file:
 
 ```yaml
 RulesVersion: 2
@@ -19,31 +22,27 @@ Samplers:
                 - response.status_code
 ```
 
-Name: `RulesVersion`
+where:
 
-This is a required parameter used to verify the version of the rules file.
-It must be set to 2.
+`RulesVersion` is a required parameter used to verify the version of the rules file.
+It must be set to `2`.
 
-Name: `Samplers`
-
-Samplers is a mapping of targets to samplers.
-Each target is a Honeycomb environment (or, for classic keys, a dataset).
+`Samplers` maps targets to sampler configurations. Each target is a Honeycomb environment (or a dataset for Honeycomb Classic keys).
 The value is the sampler to use for that target.
-The target called `__default__` will be used for any target that is not explicitly listed.
 A `__default__` target is required.
-The targets are determined by examining the API key used to send the trace.
-If the API key is a 'classic' key (which is a 32-character hexadecimal value), the specified dataset name is used as the target.
-If the API key is a new-style key (20-23 alphanumeric characters), the key's environment name is used as the target.
+The target called `__default__` will be used for any target that is not explicitly listed.
 
-The remainder of this document describes the samplers that can be used within the `Samplers` section and the fields that control their behavior.
+The targets are determined by examining the API key used to send the trace.
+If the API key is a Honeycomb Classic key with a 32-character hexadecimal value, then the specified dataset name is used as the target.
+If the API key is a key with 20-23 alphanumeric characters, then the key's environment name is used as the target.
+
+The remainder of this page describes the samplers that can be used within the `Samplers` section and the fields that control their behavior.
 
 ## Deterministic Sampler
 
-### Name: `DeterministicSampler`
-
-The Deterministic Sampler (`DeterministicSampler`) uses a fixed sample  rate to sample traces based on their trace ID.
-This is the simplest  sampling algorithm - it is a static sample rate, choosing traces randomly  to either keep or send (at the appropriate rate).
-It is not influenced by  the contents of the trace other than the trace ID.
+The Deterministic Sampler (`DeterministicSampler`) uses a fixed sample rate to sample traces based on their trace ID.
+This is the simplest sampling algorithm - it is a static sample rate, choosing traces randomly to either keep or send (at the appropriate rate).
+It is not influenced by the contents of the trace other than the trace ID.
 
 ### `SampleRate`
 
@@ -57,14 +56,12 @@ The sample rate is calculated from the trace ID, so all spans with the same trac
 
 ## Dynamic Sampler
 
-### Name: `DynamicSampler`
-
-The Dynamic Sampler (`DynamicSampler`) is the basic Dynamic Sampler  implementation.
-Most installations will find the EMA Dynamic Sampler to  be a better choice.
-This sampler collects the values of a number of  fields from a trace and uses them to form a key.
-This key is handed to  the standard dynamic sampler algorithm, which generates a sample rate  based on the frequency with which that key has appeared during the  previous `ClearFrequency`.
-See  https://github.com/honeycombio/dynsampler-go for more detail on the  mechanics of the Dynamic Sampler.
-This sampler uses the `AvgSampleRate`  algorithm from that package.
+The Dynamic Sampler (`DynamicSampler`) is the basic Dynamic Sampler implementation.
+Most installations will find the EMA Dynamic Sampler to be a better choice.
+This sampler collects the values of a number of fields from a trace and uses them to form a key.
+This key is handed to the standard dynamic sampler algorithm, which generates a sample rate based on the frequency with which that key has appeared during the previous `ClearFrequency`.
+See https://github.com/honeycombio/dynsampler-go for more detail on the mechanics of the Dynamic Sampler.
+This sampler uses the `AvgSampleRate` algorithm from that package.
 
 ### `SampleRate`
 
@@ -88,15 +85,15 @@ For example, "30s" or "1m".
 
 A list of all the field names to use to form the key that will be handed to the Dynamic Sampler.
 The combination of values from all of these fields should reflect how interesting the trace is compared to another.
-When choosing field names for `FieldList`, a good field selection  has consistent values for high-frequency, boring traffic, and unique values for outliers and interesting traffic.
-Including an error field, or something like `HTTP status code`, is an  excellent choice.
+When choosing field names for `FieldList`, a good field selection has consistent values for high-frequency, boring traffic, and unique values for outliers and interesting traffic.
+Including an error field, or something like `HTTP status code`, is an excellent choice.
 Using fields with very high cardinality, like `k8s.pod.id`, is a bad choice.
-If the combination of fields essentially makes each trace unique,  then the Dynamic Sampler will sample everything.
-If the combination  of fields is not unique enough, then you will not be guaranteed  samples of the most interesting traces.
+If the combination of fields essentially makes each trace unique, then the Dynamic Sampler will sample everything.
+If the combination of fields is not unique enough, then you will not be guaranteed samples of the most interesting traces.
 As an example, consider as a good set of fields: the combination of `HTTP endpoint` (high-frequency and boring), `HTTP method`, and `status code` (normally boring but can become interesting when indicating an error) since it will allowing proper sampling of all endpoints under normal traffic and call out when there is failing traffic to any endpoint.
-In contrast, for example, consider as a bad set of fields: a  combination of `HTTP endpoint`, `status code`, and `pod id`, since it  would result in keys that are all unique, and therefore result in  sampling 100% of traces.
-For example, rather than a set of fields, using only the `HTTP  endpoint` field is a **bad** choice, as it is not unique enough, and  therefore interesting traces, like traces that experienced a `500`,  might not be sampled.
-Field names may come from any span in the  trace; if they occur on multiple spans, then all unique values will  be included in the key.
+In contrast, for example, consider as a bad set of fields: a combination of `HTTP endpoint`, `status code`, and `pod id`, since it would result in keys that are all unique, and therefore result in sampling 100% of traces.
+For example, rather than a set of fields, using only the `HTTP endpoint` field is a **bad** choice, as it is not unique enough, and therefore interesting traces, like traces that experienced a `500`, might not be sampled.
+Field names may come from any span in the trace; if they occur on multiple spans, then all unique values will be included in the key.
 
 - Type: `stringarray`
 
@@ -105,24 +102,22 @@ Field names may come from any span in the  trace; if they occur on multiple span
 Limits the number of distinct keys tracked by the sampler.
 Once `MaxKeys` is reached, new keys will not be included in the sample rate map, but existing keys will continue to be be counted.
 Use this field to keep the sample rate map size under control.
-Defaults to  `500`; Dynamic Samplers will rarely achieve their sampling goals with  more keys than this.
+Defaults to `500`; Dynamic Samplers will rarely achieve their sampling goals with more keys than this.
 
 - Type: `int`
 
 ### `UseTraceLength`
 
 Indicates whether to include the trace length (number of spans in the trace) as part of the key.
-The number of spans is exact, so if there are normally small variations in trace length, we recommend setting  this field to `false`.
+The number of spans is exact, so if there are normally small variations in trace length, we recommend setting this field to `false`.
 If your traces are consistent lengths and changes in trace length is a useful indicator to view in Honeycomb, then set this field to `true`.
 
 - Type: `bool`
 
 ## EMA Dynamic Sampler
 
-### Name: `EMADynamicSampler`
-
-The Exponential Moving Average (EMA) Dynamic Sampler  (`EMADynamicSampler`) attempts to average a given sample rate, weighting  rare traffic and frequent traffic differently so as to end up with the  correct average.
-`EMADynamicSampler` is an improvement upon the simple `DynamicSampler`  and is recommended for many use cases.
+The Exponential Moving Average (EMA) Dynamic Sampler (`EMADynamicSampler`) attempts to average a given sample rate, weighting rare traffic and frequent traffic differently so as to end up with the correct average.
+`EMADynamicSampler` is an improvement upon the simple `DynamicSampler` and is recommended for many use cases.
 Based on the `DynamicSampler`, `EMADynamicSampler` differs in that rather than compute rate based on a periodic sample of traffic, it maintains an Exponential Moving Average of counts seen per key, and adjusts this average at regular intervals.
 The weight applied to more recent intervals is defined by `weight`, a number between (0, 1).
 Larger values weight the average more toward recent observations.
@@ -153,27 +148,27 @@ For example, "30s" or "1m".
 
 The weight to use when calculating the EMA.
 It should be a number between `0` and `1`.
-Larger values weight the average more toward  recent observations.
-In other words, a larger weight will cause  sample rates more quickly adapt to traffic patterns, while a smaller  weight will result in sample rates that are less sensitive to bursts  or drops in traffic and thus more consistent over time.
+Larger values weight the average more toward recent observations.
+In other words, a larger weight will cause sample rates more quickly adapt to traffic patterns, while a smaller weight will result in sample rates that are less sensitive to bursts or drops in traffic and thus more consistent over time.
 
 - Type: `float`
 
 ### `AgeOutValue`
 
 Indicates the threshold for removing keys from the EMA.
-The EMA of any key will approach `0` if it is not repeatedly observed, but will never truly reach it, so this field determines what  constitutes "zero".
-Keys with averages below this threshold will be  removed from the EMA.
-Default is the same as `Weight`, as this  prevents a key with the smallest integer value (1) from being aged  out immediately.
-This value should generally be less than (<=)  `Weight`, unless you have very specific reasons to set it higher.
+The EMA of any key will approach `0` if it is not repeatedly observed, but will never truly reach it, so this field determines what constitutes "zero".
+Keys with averages below this threshold will be removed from the EMA.
+Default is the same as `Weight`, as this prevents a key with the smallest integer value (1) from being aged out immediately.
+This value should generally be less than (<=) `Weight`, unless you have very specific reasons to set it higher.
 
 - Type: `float`
 
 ### `BurstMultiple`
 
-If set, then this value is multiplied by the sum of the running  average of counts to dynamically define the burst detection  threshold.
-If total counts observed for a given interval exceed this  threshold, then EMA is updated immediately, rather than waiting on  the `AdjustmentInterval`.
+If set, then this value is multiplied by the sum of the running average of counts to dynamically define the burst detection threshold.
+If total counts observed for a given interval exceed this threshold, then EMA is updated immediately, rather than waiting on the `AdjustmentInterval`.
 Defaults to `2`; a negative value disables.
-With the default of `2`, if your traffic suddenly doubles, then burst  detection will kick in.
+With the default of `2`, if your traffic suddenly doubles, then burst detection will kick in.
 
 - Type: `float`
 
@@ -188,15 +183,15 @@ Defaults to `3`.
 
 A list of all the field names to use to form the key that will be handed to the Dynamic Sampler.
 The combination of values from all of these fields should reflect how interesting the trace is compared to another.
-When choosing field names for `FieldList`, a good field selection  has consistent values for high-frequency, boring traffic, and unique values for outliers and interesting traffic.
-Including an error field, or something like `HTTP status code`, is an  excellent choice.
+When choosing field names for `FieldList`, a good field selection has consistent values for high-frequency, boring traffic, and unique values for outliers and interesting traffic.
+Including an error field, or something like `HTTP status code`, is an excellent choice.
 Using fields with very high cardinality, like `k8s.pod.id`, is a bad choice.
-If the combination of fields essentially makes each trace unique,  then the Dynamic Sampler will sample everything.
-If the combination  of fields is not unique enough, then you will not be guaranteed  samples of the most interesting traces.
+If the combination of fields essentially makes each trace unique, then the Dynamic Sampler will sample everything.
+If the combination of fields is not unique enough, then you will not be guaranteed samples of the most interesting traces.
 As an example, consider as a good set of fields: the combination of `HTTP endpoint` (high-frequency and boring), `HTTP method`, and `status code` (normally boring but can become interesting when indicating an error) since it will allowing proper sampling of all endpoints under normal traffic and call out when there is failing traffic to any endpoint.
-In contrast, for example, consider as a bad set of fields: a  combination of `HTTP endpoint`, `status code`, and `pod id`, since it  would result in keys that are all unique, and therefore result in  sampling 100% of traces.
-For example, rather than a set of fields, using only the `HTTP  endpoint` field is a **bad** choice, as it is not unique enough, and  therefore interesting traces, like traces that experienced a `500`,  might not be sampled.
-Field names may come from any span in the  trace; if they occur on multiple spans, then all unique values will  be included in the key.
+In contrast, for example, consider as a bad set of fields: a combination of `HTTP endpoint`, `status code`, and `pod id`, since it would result in keys that are all unique, and therefore result in sampling 100% of traces.
+For example, rather than a set of fields, using only the `HTTP endpoint` field is a **bad** choice, as it is not unique enough, and therefore interesting traces, like traces that experienced a `500`, might not be sampled.
+Field names may come from any span in the trace; if they occur on multiple spans, then all unique values will be included in the key.
 
 - Type: `stringarray`
 
@@ -205,27 +200,25 @@ Field names may come from any span in the  trace; if they occur on multiple span
 Limits the number of distinct keys tracked by the sampler.
 Once `MaxKeys` is reached, new keys will not be included in the sample rate map, but existing keys will continue to be be counted.
 Use this field to keep the sample rate map size under control.
-Defaults to  `500`; Dynamic Samplers will rarely achieve their sampling goals with  more keys than this.
+Defaults to `500`; Dynamic Samplers will rarely achieve their sampling goals with more keys than this.
 
 - Type: `int`
 
 ### `UseTraceLength`
 
 Indicates whether to include the trace length (number of spans in the trace) as part of the key.
-The number of spans is exact, so if there are normally small variations in trace length, we recommend setting  this field to `false`.
+The number of spans is exact, so if there are normally small variations in trace length, we recommend setting this field to `false`.
 If your traces are consistent lengths and changes in trace length is a useful indicator to view in Honeycomb, then set this field to `true`.
 
 - Type: `bool`
 
 ## EMA Throughput Sampler
 
-### Name: `EMAThroughputSampler`
-
-The Exponential Moving Average (EMA) Throughput Sampler  (`EMAThroughputSampler`) attempts to achieve a given throughput -- number  of spans per second -- weighting rare traffic and frequent traffic  differently so as to end up with the correct rate.
+The Exponential Moving Average (EMA) Throughput Sampler (`EMAThroughputSampler`) attempts to achieve a given throughput -- number of spans per second -- weighting rare traffic and frequent traffic differently so as to end up with the correct rate.
 The `EMAThroughputSampler` is an improvement upon the Total Throughput Sampler and is recommended for most throughput-based use cases.
-Because it like the `EMADynamicSampler`, `EMAThroughputSampler` maintains an  Exponential Moving Average of counts seen per key, and adjusts this average at regular intervals.
+Because it like the `EMADynamicSampler`, `EMAThroughputSampler` maintains an Exponential Moving Average of counts seen per key, and adjusts this average at regular intervals.
 The weight applied to more recent intervals is defined by `weight`, a number between (0, 1) - larger values weight the average more toward recent observations.
-In other words, a larger  weight will cause sample rates more quickly adapt to traffic patterns,  while a smaller weight will result in sample rates that are less sensitive to bursts or drops in traffic and thus more consistent over time.
+In other words, a larger weight will cause sample rates more quickly adapt to traffic patterns, while a smaller weight will result in sample rates that are less sensitive to bursts or drops in traffic and thus more consistent over time.
 New keys that are not already present in the EMA will always have a sample rate of `1`.
 Keys that occur more frequently will be sampled on a logarithmic curve.
 Every key will be represented at least once in any given window and more frequent keys will have their sample rate increased proportionally to trend towards the goal throughput.
@@ -233,15 +226,15 @@ Every key will be represented at least once in any given window and more frequen
 ### `GoalThroughputPerSec`
 
 The desired throughput **per second**.
-This is the number of events  per second you want to send to Honeycomb.
-The sampler will adjust  sample rates to try to achieve this desired throughput.
-This value is calculated for the individual instance, not for the cluster; if your cluster has multiple instances, then you will need to divide your  total desired sample rate by the number of instances to get this  value.
+This is the number of events per second you want to send to Honeycomb.
+The sampler will adjust sample rates to try to achieve this desired throughput.
+This value is calculated for the individual instance, not for the cluster; if your cluster has multiple instances, then you will need to divide your total desired sample rate by the number of instances to get this value.
 
 - Type: `int`
 
 ### `InitialSampleRate`
 
-`InitialSampleRate` is the sample rate to use during startup, before  the sampler has accumulated enough data to calculate a reasonable throughput.
+`InitialSampleRate` is the sample rate to use during startup, before the sampler has accumulated enough data to calculate a reasonable throughput.
 This is mainly useful in situations where unsampled throughput is high enough to cause problems.
 
 - Type: `int`
@@ -258,27 +251,27 @@ For example, "30s" or "1m".
 
 The weight to use when calculating the EMA.
 It should be a number between `0` and `1`.
-Larger values weight the average more toward  recent observations.
-In other words, a larger weight will cause  sample rates more quickly adapt to traffic patterns, while a smaller  weight will result in sample rates that are less sensitive to bursts  or drops in traffic and thus more consistent over time.
+Larger values weight the average more toward recent observations.
+In other words, a larger weight will cause sample rates more quickly adapt to traffic patterns, while a smaller weight will result in sample rates that are less sensitive to bursts or drops in traffic and thus more consistent over time.
 
 - Type: `float`
 
 ### `AgeOutValue`
 
 Indicates the threshold for removing keys from the EMA.
-The EMA of any key will approach `0` if it is not repeatedly observed, but will never truly reach it, so this field determines what  constitutes "zero".
-Keys with averages below this threshold will be  removed from the EMA.
-Default is the same as `Weight`, as this  prevents a key with the smallest integer value (1) from being aged  out immediately.
-This value should generally be less than (<=)  `Weight`, unless you have very specific reasons to set it higher.
+The EMA of any key will approach `0` if it is not repeatedly observed, but will never truly reach it, so this field determines what constitutes "zero".
+Keys with averages below this threshold will be removed from the EMA.
+Default is the same as `Weight`, as this prevents a key with the smallest integer value (1) from being aged out immediately.
+This value should generally be less than (<=) `Weight`, unless you have very specific reasons to set it higher.
 
 - Type: `float`
 
 ### `BurstMultiple`
 
-If set, then this value is multiplied by the sum of the running  average of counts to dynamically define the burst detection  threshold.
-If total counts observed for a given interval exceed this  threshold, then EMA is updated immediately, rather than waiting on  the `AdjustmentInterval`.
+If set, then this value is multiplied by the sum of the running average of counts to dynamically define the burst detection threshold.
+If total counts observed for a given interval exceed this threshold, then EMA is updated immediately, rather than waiting on the `AdjustmentInterval`.
 Defaults to `2`; a negative value disables.
-With the default of `2`, if your traffic suddenly doubles, then burst  detection will kick in.
+With the default of `2`, if your traffic suddenly doubles, then burst detection will kick in.
 
 - Type: `float`
 
@@ -293,15 +286,15 @@ Defaults to `3`.
 
 A list of all the field names to use to form the key that will be handed to the Dynamic Sampler.
 The combination of values from all of these fields should reflect how interesting the trace is compared to another.
-When choosing field names for `FieldList`, a good field selection  has consistent values for high-frequency, boring traffic, and unique values for outliers and interesting traffic.
-Including an error field, or something like `HTTP status code`, is an  excellent choice.
+When choosing field names for `FieldList`, a good field selection has consistent values for high-frequency, boring traffic, and unique values for outliers and interesting traffic.
+Including an error field, or something like `HTTP status code`, is an excellent choice.
 Using fields with very high cardinality, like `k8s.pod.id`, is a bad choice.
-If the combination of fields essentially makes each trace unique,  then the Dynamic Sampler will sample everything.
-If the combination  of fields is not unique enough, then you will not be guaranteed  samples of the most interesting traces.
+If the combination of fields essentially makes each trace unique, then the Dynamic Sampler will sample everything.
+If the combination of fields is not unique enough, then you will not be guaranteed samples of the most interesting traces.
 As an example, consider as a good set of fields: the combination of `HTTP endpoint` (high-frequency and boring), `HTTP method`, and `status code` (normally boring but can become interesting when indicating an error) since it will allowing proper sampling of all endpoints under normal traffic and call out when there is failing traffic to any endpoint.
-In contrast, for example, consider as a bad set of fields: a  combination of `HTTP endpoint`, `status code`, and `pod id`, since it  would result in keys that are all unique, and therefore result in  sampling 100% of traces.
-For example, rather than a set of fields, using only the `HTTP  endpoint` field is a **bad** choice, as it is not unique enough, and  therefore interesting traces, like traces that experienced a `500`,  might not be sampled.
-Field names may come from any span in the  trace; if they occur on multiple spans, then all unique values will  be included in the key.
+In contrast, for example, consider as a bad set of fields: a combination of `HTTP endpoint`, `status code`, and `pod id`, since it would result in keys that are all unique, and therefore result in sampling 100% of traces.
+For example, rather than a set of fields, using only the `HTTP endpoint` field is a **bad** choice, as it is not unique enough, and therefore interesting traces, like traces that experienced a `500`, might not be sampled.
+Field names may come from any span in the trace; if they occur on multiple spans, then all unique values will be included in the key.
 
 - Type: `stringarray`
 
@@ -310,44 +303,42 @@ Field names may come from any span in the  trace; if they occur on multiple span
 Limits the number of distinct keys tracked by the sampler.
 Once `MaxKeys` is reached, new keys will not be included in the sample rate map, but existing keys will continue to be be counted.
 Use this field to keep the sample rate map size under control.
-Defaults to  `500`; Dynamic Samplers will rarely achieve their sampling goals with  more keys than this.
+Defaults to `500`; Dynamic Samplers will rarely achieve their sampling goals with more keys than this.
 
 - Type: `int`
 
 ### `UseTraceLength`
 
 Indicates whether to include the trace length (number of spans in the trace) as part of the key.
-The number of spans is exact, so if there are normally small variations in trace length, we recommend setting  this field to `false`.
+The number of spans is exact, so if there are normally small variations in trace length, we recommend setting this field to `false`.
 If your traces are consistent lengths and changes in trace length is a useful indicator to view in Honeycomb, then set this field to `true`.
 
 - Type: `bool`
 
 ## Windowed Throughput Sampler
 
-### Name: `WindowedThroughputSampler`
-
-Windowed Throughput Sampler (`WindowedThroughputSampler`) is an enhanced  version of total throughput sampling.
-Just like the `TotalThroughput`  Sampler, `WindowedThroughputSampler` attempts to meet the goal of fixed  number of events per second sent to Honeycomb.
+Windowed Throughput Sampler (`WindowedThroughputSampler`) is an enhanced version of total throughput sampling.
+Just like the `TotalThroughput` Sampler, `WindowedThroughputSampler` attempts to meet the goal of fixed number of events per second sent to Honeycomb.
 The original throughput sampler updates the sampling rate every "ClearFrequency" seconds.
 While this parameter is configurable, it suffers from the following tradeoff:
   - Decreasing it is more responsive to load spikes, but with the
   cost of making the sampling decision on less data.
-- Increasing it is less responsive to load spikes, but sample rates 
+- Increasing it is less responsive to load spikes, but sample rates
   will be more stable because they are made with more data.
 The Windowed Throughput Sampler resolves this by introducing two different, tunable parameters:
   - `UpdateFrequency`: how often the sampling rate is recomputed
-  - `LookbackFrequency`: how much total time is considered when 
+  - `LookbackFrequency`: how much total time is considered when
   recomputing sampling rate.
 A standard configuration would be to set `UpdateFrequency` to `1s` and `LookbackFrequency` to `30s`.
-In this configuration, for every second, we  lookback at the last 30 seconds of data in order to compute the new  sampling rate.
-The actual sampling rate computation is nearly identical  to the original Throughput Sampler, but this variant has better support  for floating point numbers.
+In this configuration, for every second, we lookback at the last 30 seconds of data in order to compute the new sampling rate.
+The actual sampling rate computation is nearly identical to the original Throughput Sampler, but this variant has better support for floating point numbers.
 
 ### `GoalThroughputPerSec`
 
 The desired throughput **per second**.
-This is the number of events  per second you want to send to Honeycomb.
-The sampler will adjust  sample rates to try to achieve this desired throughput.
-This value is calculated for the individual instance, not for the cluster; if your cluster has multiple instances, then you will need to divide your  total desired sample rate by the number of instances to get this  value.
+This is the number of events per second you want to send to Honeycomb.
+The sampler will adjust sample rates to try to achieve this desired throughput.
+This value is calculated for the individual instance, not for the cluster; if your cluster has multiple instances, then you will need to divide your total desired sample rate by the number of instances to get this value.
 
 - Type: `int`
 
@@ -361,9 +352,9 @@ For example, "30s" or "1m".
 
 ### `LookbackFrequency`
 
-This controls how far back in time to lookback to dynamically adjust  the sampling rate.
+This controls how far back in time to lookback to dynamically adjust the sampling rate.
 Default is `30 * UpdateFrequencyDuration`.
-This field is forced to be an **integer multiple** of  `UpdateFrequencyDuration`.
+This field is forced to be an **integer multiple** of `UpdateFrequencyDuration`.
 
 - Type: `duration`
 
@@ -371,15 +362,15 @@ This field is forced to be an **integer multiple** of  `UpdateFrequencyDuration`
 
 A list of all the field names to use to form the key that will be handed to the Dynamic Sampler.
 The combination of values from all of these fields should reflect how interesting the trace is compared to another.
-When choosing field names for `FieldList`, a good field selection  has consistent values for high-frequency, boring traffic, and unique values for outliers and interesting traffic.
-Including an error field, or something like `HTTP status code`, is an  excellent choice.
+When choosing field names for `FieldList`, a good field selection has consistent values for high-frequency, boring traffic, and unique values for outliers and interesting traffic.
+Including an error field, or something like `HTTP status code`, is an excellent choice.
 Using fields with very high cardinality, like `k8s.pod.id`, is a bad choice.
-If the combination of fields essentially makes each trace unique,  then the Dynamic Sampler will sample everything.
-If the combination  of fields is not unique enough, then you will not be guaranteed  samples of the most interesting traces.
+If the combination of fields essentially makes each trace unique, then the Dynamic Sampler will sample everything.
+If the combination of fields is not unique enough, then you will not be guaranteed samples of the most interesting traces.
 As an example, consider as a good set of fields: the combination of `HTTP endpoint` (high-frequency and boring), `HTTP method`, and `status code` (normally boring but can become interesting when indicating an error) since it will allowing proper sampling of all endpoints under normal traffic and call out when there is failing traffic to any endpoint.
-In contrast, for example, consider as a bad set of fields: a  combination of `HTTP endpoint`, `status code`, and `pod id`, since it  would result in keys that are all unique, and therefore result in  sampling 100% of traces.
-For example, rather than a set of fields, using only the `HTTP  endpoint` field is a **bad** choice, as it is not unique enough, and  therefore interesting traces, like traces that experienced a `500`,  might not be sampled.
-Field names may come from any span in the  trace; if they occur on multiple spans, then all unique values will  be included in the key.
+In contrast, for example, consider as a bad set of fields: a combination of `HTTP endpoint`, `status code`, and `pod id`, since it would result in keys that are all unique, and therefore result in sampling 100% of traces.
+For example, rather than a set of fields, using only the `HTTP endpoint` field is a **bad** choice, as it is not unique enough, and therefore interesting traces, like traces that experienced a `500`, might not be sampled.
+Field names may come from any span in the trace; if they occur on multiple spans, then all unique values will be included in the key.
 
 - Type: `stringarray`
 
@@ -388,25 +379,23 @@ Field names may come from any span in the  trace; if they occur on multiple span
 Limits the number of distinct keys tracked by the sampler.
 Once `MaxKeys` is reached, new keys will not be included in the sample rate map, but existing keys will continue to be be counted.
 Use this field to keep the sample rate map size under control.
-Defaults to  `500`; Dynamic Samplers will rarely achieve their sampling goals with  more keys than this.
+Defaults to `500`; Dynamic Samplers will rarely achieve their sampling goals with more keys than this.
 
 - Type: `int`
 
 ### `UseTraceLength`
 
 Indicates whether to include the trace length (number of spans in the trace) as part of the key.
-The number of spans is exact, so if there are normally small variations in trace length, we recommend setting  this field to `false`.
+The number of spans is exact, so if there are normally small variations in trace length, we recommend setting this field to `false`.
 If your traces are consistent lengths and changes in trace length is a useful indicator to view in Honeycomb, then set this field to `true`.
 
 - Type: `bool`
 
 ## Rules-based Sampler
 
-### Name: `RulesBasedSampler`
-
 The Rules-based sampler allows you to specify a set of rules that will determine whether a trace should be sampled or not.
 Rules are evaluated in order, and the first rule that matches will be used to determine the sample rate.
-If no rules match, then the `SampleRate` defaults to `1` and  all traces will be kept.
+If no rules match, then the `SampleRate` defaults to `1` and all traces will be kept.
 Rules-based samplers will usually be configured to have the last rule be a default rule with no conditions that uses a downstream Dynamic Sampler to keep overall sample rate under control.
 
 ### `Rules`
@@ -427,16 +416,14 @@ This is a computationally expensive option and may cause performance problems if
 
 ## Rules for Rules-based Samplers
 
-### Name: `Rules`
-
 Rules are evaluated in order, and the first rule that matches will be used to determine the sample rate.
-If no rules match, then the `SampleRate`  will be `1` and all traces will be kept.
-If a rule matches, one of three things happens, and they are evaluated in this order: a) if the rule specifies a downstream Sampler, that sampler is used to determine the sample rate; b) if the rule has the `Drop` flag set  to `true`, the trace is dropped; c) the rule's sample rate is used.
+If no rules match, then the `SampleRate` will be `1` and all traces will be kept.
+If a rule matches, one of three things happens, and they are evaluated in this order: a) if the rule specifies a downstream Sampler, that sampler is used to determine the sample rate; b) if the rule has the `Drop` flag set to `true`, the trace is dropped; c) the rule's sample rate is used.
 
 ### `Name`
 
 The name of the rule.
-This field is used for debugging and will  appear in the trace metadata if `AddRuleReasonToTrace` is set to  `true`.
+This field is used for debugging and will appear in the trace metadata if `AddRuleReasonToTrace` is set to `true`.
 
 - Type: `string`
 
@@ -444,15 +431,15 @@ This field is used for debugging and will  appear in the trace metadata if `AddR
 
 The sampler to use if the rule matches.
 If this is set, the sample rate will be determined by this downstream sampler.
-If this is not  set, the sample rate will be determined by the `Drop` flag or the  `SampleRate` field.
+If this is not set, the sample rate will be determined by the `Drop` flag or the `SampleRate` field.
 
 - Type: `object`
 
 ### `Drop`
 
 Indicates whether to drop the trace if it matches this rule.
-If  `true`, then the trace will be dropped.
-If `false`, then the trace  will be kept.
+If `true`, then the trace will be dropped.
+If `false`, then the trace will be kept.
 
 - Type: `bool`
 
@@ -467,7 +454,7 @@ If the rule is matched, there is no Sampler specified, and the `Drop` flag is `f
 Conditions is a list of conditions to use to determine whether the rule matches.
 All conditions must be met for the rule to match.
 If there are no conditions, then the rule will always match.
-A  no-condition rule is typically used for the last rule to provide a  default behavior.
+A no-condition rule is typically used for the last rule to provide a default behavior.
 
 - Type: `objectarray`
 
@@ -475,17 +462,15 @@ A  no-condition rule is typically used for the last rule to provide a  default b
 
 Controls the scope of the rule evaluation.
 If set to "trace" (the default), then each condition can apply to any span in the trace independently.
-If set to "span", then all of the conditions in the  rule will be evaluated against each span in the trace and the rule  only succeeds if all of the conditions match on a single span  together.
+If set to "span", then all of the conditions in the rule will be evaluated against each span in the trace and the rule only succeeds if all of the conditions match on a single span together.
 
 - Type: `string`
 
 ## Conditions for the Rules in Rules-based Samplers
 
-### Name: `Conditions`
-
 Conditions are evaluated in order, and the first condition that does not match will cause the rule to not match.
-If all conditions match, then the  rule will match.
-If there are no conditions, then the rule will always  match.
+If all conditions match, then the rule will match.
+If there are no conditions, then the rule will always match.
 
 ### `Field`
 
@@ -514,22 +499,20 @@ If `Datatype` is not specified, then the value and the field will be compared ba
 
 The datatype to use when comparing the value and the field.
 If `Datatype` is specified, then both values will be converted (best-effort) to that type and then compared.
-Errors in conversion  will result in the comparison evaluating to `false`.
-This is  especially useful when a field like `http status code` may be  rendered as strings by some environments and as numbers or booleans  by others.
+Errors in conversion will result in the comparison evaluating to `false`.
+This is especially useful when a field like `http status code` may be rendered as strings by some environments and as numbers or booleans by others.
 
 - Type: `string`
 
 ## Total Throughput Sampler
 
-### Name: `TotalThroughputSampler`
-
-Total Throughput Sampler (`TotalThroughputSampler`) attempts to meet a  goal of a fixed number of events per second sent to Honeycomb.
-This  sampler is **deprecated** and present mainly for compatibility.
-Consider  using either `EMAThroughputSampler` or `WindowedThroughputSampler` instead.
+Total Throughput Sampler (`TotalThroughputSampler`) attempts to meet a goal of a fixed number of events per second sent to Honeycomb.
+This sampler is **deprecated** and present mainly for compatibility.
+Consider using either `EMAThroughputSampler` or `WindowedThroughputSampler` instead.
 If your key space is sharded across different servers, then this is a good method for making sure each server sends roughly the same volume of content to Honeycomb.
 It performs poorly when the active keyspace is very large.
 `GoalThroughputPerSec` * `ClearFrequency` defines the upper limit of the number of keys that can be reported and stay under the goal, but with that many keys, you'll only get one event per key per `ClearFrequencySec`, which is very coarse.
-Aim for at least 1 event per  key per sec to 1 event per key per 10sec to get reasonable data.
+Aim for at least 1 event per key per sec to 1 event per key per 10sec to get reasonable data.
 In other words, the number of active keys should be less than 10 * `GoalThroughputPerSec`.
 
 ### `GoalThroughputPerSec`
@@ -544,7 +527,7 @@ This is not the same as the Sample Rate.
 
 The duration after which the Dynamic Sampler should reset its internal counters.
 It should be specified as a duration string.
-For example, "30s" or "1m".
+For example,"30s" or "1m".
 
 - Type: `duration`
 
@@ -552,15 +535,15 @@ For example, "30s" or "1m".
 
 A list of all the field names to use to form the key that will be handed to the Dynamic Sampler.
 The combination of values from all of these fields should reflect how interesting the trace is compared to another.
-When choosing field names for `FieldList`, a good field selection  has consistent values for high-frequency, boring traffic, and unique values for outliers and interesting traffic.
-Including an error field, or something like `HTTP status code`, is an  excellent choice.
+When choosing field names for `FieldList`, a good field selection has consistent values for high-frequency, boring traffic, and unique values for outliers and interesting traffic.
+Including an error field, or something like `HTTP status code`, is an excellent choice.
 Using fields with very high cardinality, like `k8s.pod.id`, is a bad choice.
-If the combination of fields essentially makes each trace unique,  then the Dynamic Sampler will sample everything.
-If the combination  of fields is not unique enough, then you will not be guaranteed  samples of the most interesting traces.
+If the combination of fields essentially makes each trace unique, then the Dynamic Sampler will sample everything.
+If the combination of fields is not unique enough, then you will not be guaranteed samples of the most interesting traces.
 As an example, consider as a good set of fields: the combination of `HTTP endpoint` (high-frequency and boring), `HTTP method`, and `status code` (normally boring but can become interesting when indicating an error) since it will allowing proper sampling of all endpoints under normal traffic and call out when there is failing traffic to any endpoint.
-In contrast, for example, consider as a bad set of fields: a  combination of `HTTP endpoint`, `status code`, and `pod id`, since it  would result in keys that are all unique, and therefore result in  sampling 100% of traces.
-For example, rather than a set of fields, using only the `HTTP  endpoint` field is a **bad** choice, as it is not unique enough, and  therefore interesting traces, like traces that experienced a `500`,  might not be sampled.
-Field names may come from any span in the  trace; if they occur on multiple spans, then all unique values will  be included in the key.
+In contrast, for example, consider as a bad set of fields: a combination of `HTTP endpoint`, `status code`, and `pod id`, since it would result in keys that are all unique, and therefore result in sampling 100% of traces.
+For example, rather than a set of fields, using only the `HTTP endpoint` field is a **bad** choice, as it is not unique enough, and therefore interesting traces, like traces that experienced a `500`, might not be sampled.
+Field names may come from any span in the trace; if they occur on multiple spans, then all unique values will be included in the key.
 
 - Type: `stringarray`
 
@@ -569,14 +552,14 @@ Field names may come from any span in the  trace; if they occur on multiple span
 Limits the number of distinct keys tracked by the sampler.
 Once `MaxKeys` is reached, new keys will not be included in the sample rate map, but existing keys will continue to be be counted.
 Use this field to keep the sample rate map size under control.
-Defaults to  `500`; Dynamic Samplers will rarely achieve their sampling goals with  more keys than this.
+Defaults to `500`; Dynamic Samplers will rarely achieve their sampling goals with more keys than this.
 
 - Type: `int`
 
 ### `UseTraceLength`
 
 Indicates whether to include the trace length (number of spans in the trace) as part of the key.
-The number of spans is exact, so if there are normally small variations in trace length, we recommend setting  this field to `false`.
+The number of spans is exact, so if there are normally small variations in trace length, we recommend setting this field to `false`.
 If your traces are consistent lengths and changes in trace length is a useful indicator to view in Honeycomb, then set this field to `true`.
 
 - Type: `bool`

--- a/rules.md
+++ b/rules.md
@@ -1,7 +1,7 @@
 # Honeycomb Refinery Rules Documentation
 
 This is the documentation for the rules configuration for Honeycomb's Refinery.
-It was automatically generated on 2023-06-22 at 23:17:31 UTC.
+It was automatically generated on 2023-06-28 at 21:40:58 UTC.
 
 ## The Rules file
 
@@ -58,9 +58,9 @@ The remainder of this document describes the samplers that can be used within th
 
 ### Name: `DeterministicSampler`
 
-The Deterministic Sampler (`DeterministicSampler`) uses a fixed sample  rate to sample traces based on their trace ID.
-This is the simplest  sampling algorithm - it is a static sample rate, choosing traces randomly  to either keep or send (at the appropriate rate).
-It is not influenced by  the contents of the trace other than the trace ID.
+The Deterministic Sampler (`DeterministicSampler`) uses a fixed sample rate to sample traces based on their trace ID.
+This is the simplest sampling algorithm - it is a static sample rate, choosing traces randomly to either keep or send (at the appropriate rate).
+It is not influenced by the contents of the trace other than the trace ID.
 
 ### `SampleRate`
 
@@ -77,12 +77,12 @@ Type: `int`
 
 ### Name: `DynamicSampler`
 
-The Dynamic Sampler (`DynamicSampler`) is the basic Dynamic Sampler  implementation.
-Most installations will find the EMA Dynamic Sampler to  be a better choice.
-This sampler collects the values of a number of  fields from a trace and uses them to form a key.
-This key is handed to  the standard dynamic sampler algorithm, which generates a sample rate  based on the frequency with which that key has appeared during the  previous `ClearFrequency`.
-See  https://github.com/honeycombio/dynsampler-go for more detail on the  mechanics of the Dynamic Sampler.
-This sampler uses the `AvgSampleRate`  algorithm from that package.
+The Dynamic Sampler (`DynamicSampler`) is the basic Dynamic Sampler implementation.
+Most installations will find the EMA Dynamic Sampler to be a better choice.
+This sampler collects the values of a number of fields from a trace and uses them to form a key.
+This key is handed to the standard dynamic sampler algorithm, which generates a sample rate based on the frequency with which that key has appeared during the previous `ClearFrequency`.
+See https://github.com/honeycombio/dynsampler-go for more detail on the mechanics of the Dynamic Sampler.
+This sampler uses the `AvgSampleRate` algorithm from that package.
 
 ### `SampleRate`
 
@@ -98,7 +98,7 @@ Type: `int`
 
 The duration after which the Dynamic Sampler should reset its internal counters.
 It should be specified as a duration string.
-For example, "30s" or "1m".
+For example,"30s" or "1m".
 
 Type: `duration`
 
@@ -106,15 +106,15 @@ Type: `duration`
 
 A list of all the field names to use to form the key that will be handed to the Dynamic Sampler.
 The combination of values from all of these fields should reflect how interesting the trace is compared to another.
-When choosing field names for `FieldList`, a good field selection  has consistent values for high-frequency, boring traffic, and unique values for outliers and interesting traffic.
-Including an error field, or something like `HTTP status code`, is an  excellent choice.
+When choosing field names for `FieldList`, a good field selection has consistent values for high-frequency, boring traffic, and unique values for outliers and interesting traffic.
+Including an error field, or something like `HTTP status code`, is an excellent choice.
 Using fields with very high cardinality, like `k8s.pod.id`, is a bad choice.
-If the combination of fields essentially makes each trace unique,  then the Dynamic Sampler will sample everything.
-If the combination  of fields is not unique enough, then you will not be guaranteed  samples of the most interesting traces.
+If the combination of fields essentially makes each trace unique, then the Dynamic Sampler will sample everything.
+If the combination of fields is not unique enough, then you will not be guaranteed samples of the most interesting traces.
 As an example, consider as a good set of fields: the combination of `HTTP endpoint` (high-frequency and boring), `HTTP method`, and `status code` (normally boring but can become interesting when indicating an error) since it will allowing proper sampling of all endpoints under normal traffic and call out when there is failing traffic to any endpoint.
-In contrast, for example, consider as a bad set of fields: a  combination of `HTTP endpoint`, `status code`, and `pod id`, since it  would result in keys that are all unique, and therefore result in  sampling 100% of traces.
-For example, rather than a set of fields, using only the `HTTP  endpoint` field is a **bad** choice, as it is not unique enough, and  therefore interesting traces, like traces that experienced a `500`,  might not be sampled.
-Field names may come from any span in the  trace; if they occur on multiple spans, then all unique values will  be included in the key.
+In contrast, for example, consider as a bad set of fields: a combination of `HTTP endpoint`, `status code`, and `pod id`, since it would result in keys that are all unique, and therefore result in sampling 100% of traces.
+For example, rather than a set of fields, using only the `HTTP endpoint` field is a **bad** choice, as it is not unique enough, and therefore interesting traces, like traces that experienced a `500`, might not be sampled.
+Field names may come from any span in the trace; if they occur on multiple spans, then all unique values will be included in the key.
 
 Type: `stringarray`
 
@@ -123,14 +123,14 @@ Type: `stringarray`
 Limits the number of distinct keys tracked by the sampler.
 Once `MaxKeys` is reached, new keys will not be included in the sample rate map, but existing keys will continue to be be counted.
 Use this field to keep the sample rate map size under control.
-Defaults to  `500`; Dynamic Samplers will rarely achieve their sampling goals with  more keys than this.
+Defaults to `500`; Dynamic Samplers will rarely achieve their sampling goals with more keys than this.
 
 Type: `int`
 
 ### `UseTraceLength`
 
 Indicates whether to include the trace length (number of spans in the trace) as part of the key.
-The number of spans is exact, so if there are normally small variations in trace length, we recommend setting  this field to `false`.
+The number of spans is exact, so if there are normally small variations in trace length, we recommend setting this field to `false`.
 If your traces are consistent lengths and changes in trace length is a useful indicator to view in Honeycomb, then set this field to `true`.
 
 Type: `bool`
@@ -140,8 +140,8 @@ Type: `bool`
 
 ### Name: `EMADynamicSampler`
 
-The Exponential Moving Average (EMA) Dynamic Sampler  (`EMADynamicSampler`) attempts to average a given sample rate, weighting  rare traffic and frequent traffic differently so as to end up with the  correct average.
-`EMADynamicSampler` is an improvement upon the simple `DynamicSampler`  and is recommended for many use cases.
+The Exponential Moving Average (EMA) Dynamic Sampler (`EMADynamicSampler`) attempts to average a given sample rate, weighting rare traffic and frequent traffic differently so as to end up with the correct average.
+`EMADynamicSampler` is an improvement upon the simple `DynamicSampler` and is recommended for many use cases.
 Based on the `DynamicSampler`, `EMADynamicSampler` differs in that rather than compute rate based on a periodic sample of traffic, it maintains an Exponential Moving Average of counts seen per key, and adjusts this average at regular intervals.
 The weight applied to more recent intervals is defined by `weight`, a number between (0, 1).
 Larger values weight the average more toward recent observations.
@@ -172,27 +172,27 @@ Type: `duration`
 
 The weight to use when calculating the EMA.
 It should be a number between `0` and `1`.
-Larger values weight the average more toward  recent observations.
-In other words, a larger weight will cause  sample rates more quickly adapt to traffic patterns, while a smaller  weight will result in sample rates that are less sensitive to bursts  or drops in traffic and thus more consistent over time.
+Larger values weight the average more toward recent observations.
+In other words, a larger weight will cause sample rates more quickly adapt to traffic patterns, while a smaller weight will result in sample rates that are less sensitive to bursts or drops in traffic and thus more consistent over time.
 
 Type: `float`
 
 ### `AgeOutValue`
 
 Indicates the threshold for removing keys from the EMA.
-The EMA of any key will approach `0` if it is not repeatedly observed, but will never truly reach it, so this field determines what  constitutes "zero".
-Keys with averages below this threshold will be  removed from the EMA.
-Default is the same as `Weight`, as this  prevents a key with the smallest integer value (1) from being aged  out immediately.
-This value should generally be less than (<=)  `Weight`, unless you have very specific reasons to set it higher.
+The EMA of any key will approach `0` if it is not repeatedly observed, but will never truly reach it, so this field determines what constitutes "zero".
+Keys with averages below this threshold will be removed from the EMA.
+Default is the same as `Weight`, as this prevents a key with the smallest integer value (1) from being aged out immediately.
+This value should generally be less than (<=) `Weight`, unless you have very specific reasons to set it higher.
 
 Type: `float`
 
 ### `BurstMultiple`
 
-If set, then this value is multiplied by the sum of the running  average of counts to dynamically define the burst detection  threshold.
-If total counts observed for a given interval exceed this  threshold, then EMA is updated immediately, rather than waiting on  the `AdjustmentInterval`.
+If set, then this value is multiplied by the sum of the running average of counts to dynamically define the burst detection threshold.
+If total counts observed for a given interval exceed this threshold, then EMA is updated immediately, rather than waiting on the `AdjustmentInterval`.
 Defaults to `2`; a negative value disables.
-With the default of `2`, if your traffic suddenly doubles, then burst  detection will kick in.
+With the default of `2`, if your traffic suddenly doubles, then burst detection will kick in.
 
 Type: `float`
 
@@ -207,15 +207,15 @@ Type: `int`
 
 A list of all the field names to use to form the key that will be handed to the Dynamic Sampler.
 The combination of values from all of these fields should reflect how interesting the trace is compared to another.
-When choosing field names for `FieldList`, a good field selection  has consistent values for high-frequency, boring traffic, and unique values for outliers and interesting traffic.
-Including an error field, or something like `HTTP status code`, is an  excellent choice.
+When choosing field names for `FieldList`, a good field selection has consistent values for high-frequency, boring traffic, and unique values for outliers and interesting traffic.
+Including an error field, or something like `HTTP status code`, is an excellent choice.
 Using fields with very high cardinality, like `k8s.pod.id`, is a bad choice.
-If the combination of fields essentially makes each trace unique,  then the Dynamic Sampler will sample everything.
-If the combination  of fields is not unique enough, then you will not be guaranteed  samples of the most interesting traces.
+If the combination of fields essentially makes each trace unique, then the Dynamic Sampler will sample everything.
+If the combination of fields is not unique enough, then you will not be guaranteed samples of the most interesting traces.
 As an example, consider as a good set of fields: the combination of `HTTP endpoint` (high-frequency and boring), `HTTP method`, and `status code` (normally boring but can become interesting when indicating an error) since it will allowing proper sampling of all endpoints under normal traffic and call out when there is failing traffic to any endpoint.
-In contrast, for example, consider as a bad set of fields: a  combination of `HTTP endpoint`, `status code`, and `pod id`, since it  would result in keys that are all unique, and therefore result in  sampling 100% of traces.
-For example, rather than a set of fields, using only the `HTTP  endpoint` field is a **bad** choice, as it is not unique enough, and  therefore interesting traces, like traces that experienced a `500`,  might not be sampled.
-Field names may come from any span in the  trace; if they occur on multiple spans, then all unique values will  be included in the key.
+In contrast, for example, consider as a bad set of fields: a combination of `HTTP endpoint`, `status code`, and `pod id`, since it would result in keys that are all unique, and therefore result in sampling 100% of traces.
+For example, rather than a set of fields, using only the `HTTP endpoint` field is a **bad** choice, as it is not unique enough, and therefore interesting traces, like traces that experienced a `500`, might not be sampled.
+Field names may come from any span in the trace; if they occur on multiple spans, then all unique values will be included in the key.
 
 Type: `stringarray`
 
@@ -224,14 +224,14 @@ Type: `stringarray`
 Limits the number of distinct keys tracked by the sampler.
 Once `MaxKeys` is reached, new keys will not be included in the sample rate map, but existing keys will continue to be be counted.
 Use this field to keep the sample rate map size under control.
-Defaults to  `500`; Dynamic Samplers will rarely achieve their sampling goals with  more keys than this.
+Defaults to `500`; Dynamic Samplers will rarely achieve their sampling goals with more keys than this.
 
 Type: `int`
 
 ### `UseTraceLength`
 
 Indicates whether to include the trace length (number of spans in the trace) as part of the key.
-The number of spans is exact, so if there are normally small variations in trace length, we recommend setting  this field to `false`.
+The number of spans is exact, so if there are normally small variations in trace length, we recommend setting this field to `false`.
 If your traces are consistent lengths and changes in trace length is a useful indicator to view in Honeycomb, then set this field to `true`.
 
 Type: `bool`
@@ -241,11 +241,11 @@ Type: `bool`
 
 ### Name: `EMAThroughputSampler`
 
-The Exponential Moving Average (EMA) Throughput Sampler  (`EMAThroughputSampler`) attempts to achieve a given throughput -- number  of spans per second -- weighting rare traffic and frequent traffic  differently so as to end up with the correct rate.
+The Exponential Moving Average (EMA) Throughput Sampler (`EMAThroughputSampler`) attempts to achieve a given throughput -- number of spans per second -- weighting rare traffic and frequent traffic differently so as to end up with the correct rate.
 The `EMAThroughputSampler` is an improvement upon the Total Throughput Sampler and is recommended for most throughput-based use cases.
-Because it like the `EMADynamicSampler`, `EMAThroughputSampler` maintains an  Exponential Moving Average of counts seen per key, and adjusts this average at regular intervals.
+Because it like the `EMADynamicSampler`, `EMAThroughputSampler` maintains an Exponential Moving Average of counts seen per key, and adjusts this average at regular intervals.
 The weight applied to more recent intervals is defined by `weight`, a number between (0, 1) - larger values weight the average more toward recent observations.
-In other words, a larger  weight will cause sample rates more quickly adapt to traffic patterns,  while a smaller weight will result in sample rates that are less sensitive to bursts or drops in traffic and thus more consistent over time.
+In other words, a larger weight will cause sample rates more quickly adapt to traffic patterns, while a smaller weight will result in sample rates that are less sensitive to bursts or drops in traffic and thus more consistent over time.
 New keys that are not already present in the EMA will always have a sample rate of `1`.
 Keys that occur more frequently will be sampled on a logarithmic curve.
 Every key will be represented at least once in any given window and more frequent keys will have their sample rate increased proportionally to trend towards the goal throughput.
@@ -253,15 +253,15 @@ Every key will be represented at least once in any given window and more frequen
 ### `GoalThroughputPerSec`
 
 The desired throughput **per second**.
-This is the number of events  per second you want to send to Honeycomb.
-The sampler will adjust  sample rates to try to achieve this desired throughput.
-This value is calculated for the individual instance, not for the cluster; if your cluster has multiple instances, then you will need to divide your  total desired sample rate by the number of instances to get this  value.
+This is the number of events per second you want to send to Honeycomb.
+The sampler will adjust sample rates to try to achieve this desired throughput.
+This value is calculated for the individual instance, not for the cluster; if your cluster has multiple instances, then you will need to divide your total desired sample rate by the number of instances to get this value.
 
 Type: `int`
 
 ### `InitialSampleRate`
 
-`InitialSampleRate` is the sample rate to use during startup, before  the sampler has accumulated enough data to calculate a reasonable throughput.
+`InitialSampleRate` is the sample rate to use during startup, before the sampler has accumulated enough data to calculate a reasonable throughput.
 This is mainly useful in situations where unsampled throughput is high enough to cause problems.
 
 Type: `int`
@@ -278,27 +278,27 @@ Type: `duration`
 
 The weight to use when calculating the EMA.
 It should be a number between `0` and `1`.
-Larger values weight the average more toward  recent observations.
-In other words, a larger weight will cause  sample rates more quickly adapt to traffic patterns, while a smaller  weight will result in sample rates that are less sensitive to bursts  or drops in traffic and thus more consistent over time.
+Larger values weight the average more toward recent observations.
+In other words, a larger weight will cause sample rates more quickly adapt to traffic patterns, while a smaller weight will result in sample rates that are less sensitive to bursts or drops in traffic and thus more consistent over time.
 
 Type: `float`
 
 ### `AgeOutValue`
 
 Indicates the threshold for removing keys from the EMA.
-The EMA of any key will approach `0` if it is not repeatedly observed, but will never truly reach it, so this field determines what  constitutes "zero".
-Keys with averages below this threshold will be  removed from the EMA.
-Default is the same as `Weight`, as this  prevents a key with the smallest integer value (1) from being aged  out immediately.
-This value should generally be less than (<=)  `Weight`, unless you have very specific reasons to set it higher.
+The EMA of any key will approach `0` if it is not repeatedly observed, but will never truly reach it, so this field determines what constitutes "zero".
+Keys with averages below this threshold will be removed from the EMA.
+Default is the same as `Weight`, as this prevents a key with the smallest integer value (1) from being aged out immediately.
+This value should generally be less than (<=) `Weight`, unless you have very specific reasons to set it higher.
 
 Type: `float`
 
 ### `BurstMultiple`
 
-If set, then this value is multiplied by the sum of the running  average of counts to dynamically define the burst detection  threshold.
-If total counts observed for a given interval exceed this  threshold, then EMA is updated immediately, rather than waiting on  the `AdjustmentInterval`.
+If set, then this value is multiplied by the sum of the running average of counts to dynamically define the burst detection threshold.
+If total counts observed for a given interval exceed this threshold, then EMA is updated immediately, rather than waiting on the `AdjustmentInterval`.
 Defaults to `2`; a negative value disables.
-With the default of `2`, if your traffic suddenly doubles, then burst  detection will kick in.
+With the default of `2`, if your traffic suddenly doubles, then burst detection will kick in.
 
 Type: `float`
 
@@ -313,15 +313,15 @@ Type: `int`
 
 A list of all the field names to use to form the key that will be handed to the Dynamic Sampler.
 The combination of values from all of these fields should reflect how interesting the trace is compared to another.
-When choosing field names for `FieldList`, a good field selection  has consistent values for high-frequency, boring traffic, and unique values for outliers and interesting traffic.
-Including an error field, or something like `HTTP status code`, is an  excellent choice.
+When choosing field names for `FieldList`, a good field selection has consistent values for high-frequency, boring traffic, and unique values for outliers and interesting traffic.
+Including an error field, or something like `HTTP status code`, is an excellent choice.
 Using fields with very high cardinality, like `k8s.pod.id`, is a bad choice.
-If the combination of fields essentially makes each trace unique,  then the Dynamic Sampler will sample everything.
-If the combination  of fields is not unique enough, then you will not be guaranteed  samples of the most interesting traces.
+If the combination of fields essentially makes each trace unique, then the Dynamic Sampler will sample everything.
+If the combination of fields is not unique enough, then you will not be guaranteed samples of the most interesting traces.
 As an example, consider as a good set of fields: the combination of `HTTP endpoint` (high-frequency and boring), `HTTP method`, and `status code` (normally boring but can become interesting when indicating an error) since it will allowing proper sampling of all endpoints under normal traffic and call out when there is failing traffic to any endpoint.
-In contrast, for example, consider as a bad set of fields: a  combination of `HTTP endpoint`, `status code`, and `pod id`, since it  would result in keys that are all unique, and therefore result in  sampling 100% of traces.
-For example, rather than a set of fields, using only the `HTTP  endpoint` field is a **bad** choice, as it is not unique enough, and  therefore interesting traces, like traces that experienced a `500`,  might not be sampled.
-Field names may come from any span in the  trace; if they occur on multiple spans, then all unique values will  be included in the key.
+In contrast, for example, consider as a bad set of fields: a combination of `HTTP endpoint`, `status code`, and `pod id`, since it would result in keys that are all unique, and therefore result in sampling 100% of traces.
+For example, rather than a set of fields, using only the `HTTP endpoint` field is a **bad** choice, as it is not unique enough, and therefore interesting traces, like traces that experienced a `500`, might not be sampled.
+Field names may come from any span in the trace; if they occur on multiple spans, then all unique values will be included in the key.
 
 Type: `stringarray`
 
@@ -330,14 +330,14 @@ Type: `stringarray`
 Limits the number of distinct keys tracked by the sampler.
 Once `MaxKeys` is reached, new keys will not be included in the sample rate map, but existing keys will continue to be be counted.
 Use this field to keep the sample rate map size under control.
-Defaults to  `500`; Dynamic Samplers will rarely achieve their sampling goals with  more keys than this.
+Defaults to `500`; Dynamic Samplers will rarely achieve their sampling goals with more keys than this.
 
 Type: `int`
 
 ### `UseTraceLength`
 
 Indicates whether to include the trace length (number of spans in the trace) as part of the key.
-The number of spans is exact, so if there are normally small variations in trace length, we recommend setting  this field to `false`.
+The number of spans is exact, so if there are normally small variations in trace length, we recommend setting this field to `false`.
 If your traces are consistent lengths and changes in trace length is a useful indicator to view in Honeycomb, then set this field to `true`.
 
 Type: `bool`
@@ -347,28 +347,28 @@ Type: `bool`
 
 ### Name: `WindowedThroughputSampler`
 
-Windowed Throughput Sampler (`WindowedThroughputSampler`) is an enhanced  version of total throughput sampling.
-Just like the `TotalThroughput`  Sampler, `WindowedThroughputSampler` attempts to meet the goal of fixed  number of events per second sent to Honeycomb.
+Windowed Throughput Sampler (`WindowedThroughputSampler`) is an enhanced version of total throughput sampling.
+Just like the `TotalThroughput` Sampler, `WindowedThroughputSampler` attempts to meet the goal of fixed number of events per second sent to Honeycomb.
 The original throughput sampler updates the sampling rate every "ClearFrequency" seconds.
 While this parameter is configurable, it suffers from the following tradeoff:
   - Decreasing it is more responsive to load spikes, but with the
   cost of making the sampling decision on less data.
-- Increasing it is less responsive to load spikes, but sample rates 
+- Increasing it is less responsive to load spikes, but sample rates
   will be more stable because they are made with more data.
 The Windowed Throughput Sampler resolves this by introducing two different, tunable parameters:
   - `UpdateFrequency`: how often the sampling rate is recomputed
-  - `LookbackFrequency`: how much total time is considered when 
+  - `LookbackFrequency`: how much total time is considered when
   recomputing sampling rate.
 A standard configuration would be to set `UpdateFrequency` to `1s` and `LookbackFrequency` to `30s`.
-In this configuration, for every second, we  lookback at the last 30 seconds of data in order to compute the new  sampling rate.
-The actual sampling rate computation is nearly identical  to the original Throughput Sampler, but this variant has better support  for floating point numbers.
+In this configuration, for every second, we lookback at the last 30 seconds of data in order to compute the new sampling rate.
+The actual sampling rate computation is nearly identical to the original Throughput Sampler, but this variant has better support for floating point numbers.
 
 ### `GoalThroughputPerSec`
 
 The desired throughput **per second**.
-This is the number of events  per second you want to send to Honeycomb.
-The sampler will adjust  sample rates to try to achieve this desired throughput.
-This value is calculated for the individual instance, not for the cluster; if your cluster has multiple instances, then you will need to divide your  total desired sample rate by the number of instances to get this  value.
+This is the number of events per second you want to send to Honeycomb.
+The sampler will adjust sample rates to try to achieve this desired throughput.
+This value is calculated for the individual instance, not for the cluster; if your cluster has multiple instances, then you will need to divide your total desired sample rate by the number of instances to get this value.
 
 Type: `int`
 
@@ -382,9 +382,9 @@ Type: `duration`
 
 ### `LookbackFrequency`
 
-This controls how far back in time to lookback to dynamically adjust  the sampling rate.
+This controls how far back in time to lookback to dynamically adjust the sampling rate.
 Default is `30 * UpdateFrequencyDuration`.
-This field is forced to be an **integer multiple** of  `UpdateFrequencyDuration`.
+This field is forced to be an **integer multiple** of `UpdateFrequencyDuration`.
 
 Type: `duration`
 
@@ -392,15 +392,15 @@ Type: `duration`
 
 A list of all the field names to use to form the key that will be handed to the Dynamic Sampler.
 The combination of values from all of these fields should reflect how interesting the trace is compared to another.
-When choosing field names for `FieldList`, a good field selection  has consistent values for high-frequency, boring traffic, and unique values for outliers and interesting traffic.
-Including an error field, or something like `HTTP status code`, is an  excellent choice.
+When choosing field names for `FieldList`, a good field selection has consistent values for high-frequency, boring traffic, and unique values for outliers and interesting traffic.
+Including an error field, or something like `HTTP status code`, is an excellent choice.
 Using fields with very high cardinality, like `k8s.pod.id`, is a bad choice.
-If the combination of fields essentially makes each trace unique,  then the Dynamic Sampler will sample everything.
-If the combination  of fields is not unique enough, then you will not be guaranteed  samples of the most interesting traces.
+If the combination of fields essentially makes each trace unique, then the Dynamic Sampler will sample everything.
+If the combination of fields is not unique enough, then you will not be guaranteed samples of the most interesting traces.
 As an example, consider as a good set of fields: the combination of `HTTP endpoint` (high-frequency and boring), `HTTP method`, and `status code` (normally boring but can become interesting when indicating an error) since it will allowing proper sampling of all endpoints under normal traffic and call out when there is failing traffic to any endpoint.
-In contrast, for example, consider as a bad set of fields: a  combination of `HTTP endpoint`, `status code`, and `pod id`, since it  would result in keys that are all unique, and therefore result in  sampling 100% of traces.
-For example, rather than a set of fields, using only the `HTTP  endpoint` field is a **bad** choice, as it is not unique enough, and  therefore interesting traces, like traces that experienced a `500`,  might not be sampled.
-Field names may come from any span in the  trace; if they occur on multiple spans, then all unique values will  be included in the key.
+In contrast, for example, consider as a bad set of fields: a combination of `HTTP endpoint`, `status code`, and `pod id`, since it would result in keys that are all unique, and therefore result in sampling 100% of traces.
+For example, rather than a set of fields, using only the `HTTP endpoint` field is a **bad** choice, as it is not unique enough, and therefore interesting traces, like traces that experienced a `500`, might not be sampled.
+Field names may come from any span in the trace; if they occur on multiple spans, then all unique values will be included in the key.
 
 Type: `stringarray`
 
@@ -409,14 +409,14 @@ Type: `stringarray`
 Limits the number of distinct keys tracked by the sampler.
 Once `MaxKeys` is reached, new keys will not be included in the sample rate map, but existing keys will continue to be be counted.
 Use this field to keep the sample rate map size under control.
-Defaults to  `500`; Dynamic Samplers will rarely achieve their sampling goals with  more keys than this.
+Defaults to `500`; Dynamic Samplers will rarely achieve their sampling goals with more keys than this.
 
 Type: `int`
 
 ### `UseTraceLength`
 
 Indicates whether to include the trace length (number of spans in the trace) as part of the key.
-The number of spans is exact, so if there are normally small variations in trace length, we recommend setting  this field to `false`.
+The number of spans is exact, so if there are normally small variations in trace length, we recommend setting this field to `false`.
 If your traces are consistent lengths and changes in trace length is a useful indicator to view in Honeycomb, then set this field to `true`.
 
 Type: `bool`
@@ -428,7 +428,7 @@ Type: `bool`
 
 The Rules-based sampler allows you to specify a set of rules that will determine whether a trace should be sampled or not.
 Rules are evaluated in order, and the first rule that matches will be used to determine the sample rate.
-If no rules match, then the `SampleRate` defaults to `1` and  all traces will be kept.
+If no rules match, then the `SampleRate` defaults to `1` and all traces will be kept.
 Rules-based samplers will usually be configured to have the last rule be a default rule with no conditions that uses a downstream Dynamic Sampler to keep overall sample rate under control.
 
 ### `Rules`
@@ -453,13 +453,13 @@ Type: `bool`
 ### Name: `Rules`
 
 Rules are evaluated in order, and the first rule that matches will be used to determine the sample rate.
-If no rules match, then the `SampleRate`  will be `1` and all traces will be kept.
-If a rule matches, one of three things happens, and they are evaluated in this order: a) if the rule specifies a downstream Sampler, that sampler is used to determine the sample rate; b) if the rule has the `Drop` flag set  to `true`, the trace is dropped; c) the rule's sample rate is used.
+If no rules match, then the `SampleRate` will be `1` and all traces will be kept.
+If a rule matches, one of three things happens, and they are evaluated in this order: a) if the rule specifies a downstream Sampler, that sampler is used to determine the sample rate; b) if the rule has the `Drop` flag set to `true`, the trace is dropped; c) the rule's sample rate is used.
 
 ### `Name`
 
 The name of the rule.
-This field is used for debugging and will  appear in the trace metadata if `AddRuleReasonToTrace` is set to  `true`.
+This field is used for debugging and will appear in the trace metadata if `AddRuleReasonToTrace` is set to `true`.
 
 Type: `string`
 
@@ -467,15 +467,15 @@ Type: `string`
 
 The sampler to use if the rule matches.
 If this is set, the sample rate will be determined by this downstream sampler.
-If this is not  set, the sample rate will be determined by the `Drop` flag or the  `SampleRate` field.
+If this is not set, the sample rate will be determined by the `Drop` flag or the `SampleRate` field.
 
 Type: `object`
 
 ### `Drop`
 
 Indicates whether to drop the trace if it matches this rule.
-If  `true`, then the trace will be dropped.
-If `false`, then the trace  will be kept.
+If `true`, then the trace will be dropped.
+If `false`, then the trace will be kept.
 
 Type: `bool`
 
@@ -490,7 +490,7 @@ Type: `int`
 Conditions is a list of conditions to use to determine whether the rule matches.
 All conditions must be met for the rule to match.
 If there are no conditions, then the rule will always match.
-A  no-condition rule is typically used for the last rule to provide a  default behavior.
+A no-condition rule is typically used for the last rule to provide a default behavior.
 
 Type: `objectarray`
 
@@ -498,7 +498,7 @@ Type: `objectarray`
 
 Controls the scope of the rule evaluation.
 If set to "trace" (the default), then each condition can apply to any span in the trace independently.
-If set to "span", then all of the conditions in the  rule will be evaluated against each span in the trace and the rule  only succeeds if all of the conditions match on a single span  together.
+If set to "span", then all of the conditions in the rule will be evaluated against each span in the trace and the rule only succeeds if all of the conditions match on a single span together.
 
 Type: `string`
 
@@ -508,8 +508,8 @@ Type: `string`
 ### Name: `Conditions`
 
 Conditions are evaluated in order, and the first condition that does not match will cause the rule to not match.
-If all conditions match, then the  rule will match.
-If there are no conditions, then the rule will always  match.
+If all conditions match, then the rule will match.
+If there are no conditions, then the rule will always match.
 
 ### `Field`
 
@@ -538,8 +538,8 @@ Type: `anyscalar`
 
 The datatype to use when comparing the value and the field.
 If `Datatype` is specified, then both values will be converted (best-effort) to that type and then compared.
-Errors in conversion  will result in the comparison evaluating to `false`.
-This is  especially useful when a field like `http status code` may be  rendered as strings by some environments and as numbers or booleans  by others.
+Errors in conversion will result in the comparison evaluating to `false`.
+This is especially useful when a field like `http status code` may be rendered as strings by some environments and as numbers or booleans by others.
 
 Type: `string`
 
@@ -548,13 +548,13 @@ Type: `string`
 
 ### Name: `TotalThroughputSampler`
 
-Total Throughput Sampler (`TotalThroughputSampler`) attempts to meet a  goal of a fixed number of events per second sent to Honeycomb.
-This  sampler is **deprecated** and present mainly for compatibility.
-Consider  using either `EMAThroughputSampler` or `WindowedThroughputSampler` instead.
+Total Throughput Sampler (`TotalThroughputSampler`) attempts to meet a goal of a fixed number of events per second sent to Honeycomb.
+This sampler is **deprecated** and present mainly for compatibility.
+Consider using either `EMAThroughputSampler` or `WindowedThroughputSampler` instead.
 If your key space is sharded across different servers, then this is a good method for making sure each server sends roughly the same volume of content to Honeycomb.
 It performs poorly when the active keyspace is very large.
 `GoalThroughputPerSec` * `ClearFrequency` defines the upper limit of the number of keys that can be reported and stay under the goal, but with that many keys, you'll only get one event per key per `ClearFrequencySec`, which is very coarse.
-Aim for at least 1 event per  key per sec to 1 event per key per 10sec to get reasonable data.
+Aim for at least 1 event per key per sec to 1 event per key per 10sec to get reasonable data.
 In other words, the number of active keys should be less than 10 * `GoalThroughputPerSec`.
 
 ### `GoalThroughputPerSec`
@@ -569,7 +569,7 @@ Type: `int`
 
 The duration after which the Dynamic Sampler should reset its internal counters.
 It should be specified as a duration string.
-For example, "30s" or "1m".
+For example,"30s" or "1m".
 
 Type: `duration`
 
@@ -577,15 +577,15 @@ Type: `duration`
 
 A list of all the field names to use to form the key that will be handed to the Dynamic Sampler.
 The combination of values from all of these fields should reflect how interesting the trace is compared to another.
-When choosing field names for `FieldList`, a good field selection  has consistent values for high-frequency, boring traffic, and unique values for outliers and interesting traffic.
-Including an error field, or something like `HTTP status code`, is an  excellent choice.
+When choosing field names for `FieldList`, a good field selection has consistent values for high-frequency, boring traffic, and unique values for outliers and interesting traffic.
+Including an error field, or something like `HTTP status code`, is an excellent choice.
 Using fields with very high cardinality, like `k8s.pod.id`, is a bad choice.
-If the combination of fields essentially makes each trace unique,  then the Dynamic Sampler will sample everything.
-If the combination  of fields is not unique enough, then you will not be guaranteed  samples of the most interesting traces.
+If the combination of fields essentially makes each trace unique, then the Dynamic Sampler will sample everything.
+If the combination of fields is not unique enough, then you will not be guaranteed samples of the most interesting traces.
 As an example, consider as a good set of fields: the combination of `HTTP endpoint` (high-frequency and boring), `HTTP method`, and `status code` (normally boring but can become interesting when indicating an error) since it will allowing proper sampling of all endpoints under normal traffic and call out when there is failing traffic to any endpoint.
-In contrast, for example, consider as a bad set of fields: a  combination of `HTTP endpoint`, `status code`, and `pod id`, since it  would result in keys that are all unique, and therefore result in  sampling 100% of traces.
-For example, rather than a set of fields, using only the `HTTP  endpoint` field is a **bad** choice, as it is not unique enough, and  therefore interesting traces, like traces that experienced a `500`,  might not be sampled.
-Field names may come from any span in the  trace; if they occur on multiple spans, then all unique values will  be included in the key.
+In contrast, for example, consider as a bad set of fields: a combination of `HTTP endpoint`, `status code`, and `pod id`, since it would result in keys that are all unique, and therefore result in sampling 100% of traces.
+For example, rather than a set of fields, using only the `HTTP endpoint` field is a **bad** choice, as it is not unique enough, and therefore interesting traces, like traces that experienced a `500`, might not be sampled.
+Field names may come from any span in the trace; if they occur on multiple spans, then all unique values will be included in the key.
 
 Type: `stringarray`
 
@@ -594,14 +594,14 @@ Type: `stringarray`
 Limits the number of distinct keys tracked by the sampler.
 Once `MaxKeys` is reached, new keys will not be included in the sample rate map, but existing keys will continue to be be counted.
 Use this field to keep the sample rate map size under control.
-Defaults to  `500`; Dynamic Samplers will rarely achieve their sampling goals with  more keys than this.
+Defaults to `500`; Dynamic Samplers will rarely achieve their sampling goals with more keys than this.
 
 Type: `int`
 
 ### `UseTraceLength`
 
 Indicates whether to include the trace length (number of spans in the trace) as part of the key.
-The number of spans is exact, so if there are normally small variations in trace length, we recommend setting  this field to `false`.
+The number of spans is exact, so if there are normally small variations in trace length, we recommend setting this field to `false`.
 If your traces are consistent lengths and changes in trace length is a useful indicator to view in Honeycomb, then set this field to `true`.
 
 Type: `bool`

--- a/tools/convert/templates/cfg_docsite.tmpl
+++ b/tools/convert/templates/cfg_docsite.tmpl
@@ -1,12 +1,14 @@
 {{- $file := . -}}
-## The Config file
+## Refinery Config File
 
-The config file is a YAML file.
+The Refinery `config` file is a YAML file.
 The file is split into sections; each section is a group of related configuration options.
 Each section has a name, and the name is used to refer to the section in other parts of the config file.
 
-## Sample
-This is a sample config file:
+## Example
+
+This is an example `config` file:
+
 ```yaml
 General:
   ConfigurationVersion: 2
@@ -18,7 +20,7 @@ OTelMetrics:
   APIKey: SetThisToAHoneycombKey
 ```
 
-The remainder of this document describes the sections within the file and the fields in each.
+The remainder of this page describes the sections within the file and the fields in each.
 
 {{ range $file.Groups -}}
 {{- template "docsite_group" . -}}

--- a/tools/convert/templates/configV2.tmpl
+++ b/tools/convert/templates/configV2.tmpl
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created {{ now }} from {{ .Input }} using a template generated on 2023-06-28 at 13:29:01 UTC
+# created {{ now }} from {{ .Input }} using a template generated on 2023-06-28 at 21:40:56 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of
@@ -116,7 +116,7 @@ Network:
 ## Access Key Configuration ##
 ##############################
 AccessKeys:
-  ## AccessKeys Contains access keys -- API keys that the proxy will treat
+  ## AccessKeys contains access keys -- API keys that the proxy will treat
   ## specially, and other flags that control how the proxy handles API
   ## keys.
   ##
@@ -447,11 +447,11 @@ PrometheusMetrics:
 ## Legacy Metrics ##
 ####################
 LegacyMetrics:
-  ## LegacyMetrics `LegacyMetrics` contains configuration for Refinery's
-  ## legacy metrics. Version 1.x of Refinery used this format for sending
-  ## Metrics to Honeycomb. The metrics generated that way are nonstandard
-  ## and will be deprecated in a future release. New installations should
-  ## prefer `OTelMetrics`.
+  ## LegacyMetrics contains configuration for Refinery's legacy metrics.
+  ## Version 1.x of Refinery used this format for sending Metrics to
+  ## Honeycomb. The metrics generated that way are nonstandard and will be
+  ## deprecated in a future release. New installations should prefer
+  ## `OTelMetrics`.
   ##
   ####
     ## Enabled controls whether to send legacy-formatted metrics to
@@ -503,9 +503,9 @@ LegacyMetrics:
 ## OpenTelemetry Metrics ##
 ###########################
 OTelMetrics:
-  ## OTelMetrics `OTelMetrics` contains configuration for Refinery's
-  ## OpenTelemetry (OTel) metrics. This is the preferred way to send
-  ## metrics to Honeycomb. New installations should prefer `OTelMetrics`.
+  ## OTelMetrics contains configuration for Refinery's OpenTelemetry (OTel)
+  ## metrics. This is the preferred way to send metrics to Honeycomb. New
+  ## installations should prefer `OTelMetrics`.
   ##
   ####
     ## Enabled controls whether to send metrics via OpenTelemetry.
@@ -639,8 +639,8 @@ PeerManagement:
 ## Redis Peer Management ##
 ###########################
 RedisPeerManagement:
-  ## RedisPeerManagement `RedisPeerManagement` controls how the Refinery
-  ## cluster communicates between peers when using Redis. Only applies when
+  ## RedisPeerManagement controls how the Refinery cluster communicates
+  ## between peers when using Redis. Only applies when
   ## `PeerManagement.Type` is "redis".
   ##
   ####
@@ -722,11 +722,11 @@ RedisPeerManagement:
 ## Collection Settings ##
 #########################
 Collection:
-  ## Collection `Collection` contains the settings that are relevant to
-  ## collecting spans together to make traces. If none of the memory
-  ## settings are used, then Refinery will not attempt to limit its memory
-  ## usage. This is not recommended for production use since a burst of
-  ## traffic could cause Refinery to run out of memory and crash.
+  ## Collection contains the settings that are relevant to collecting spans
+  ## together to make traces. If none of the memory settings are used, then
+  ## Refinery will not attempt to limit its memory usage. This is not
+  ## recommended for production use since a burst of traffic could cause
+  ## Refinery to run out of memory and crash.
   ##
   ####
     ## CacheCapacity is the number of traces to keep in the cache's circular
@@ -788,8 +788,8 @@ Collection:
 ## Buffer Sizes ##
 ##################
 BufferSizes:
-  ## BufferSizes `BufferSizes` contains the settings that are relevant to
-  ## the sizes of communications buffers.
+  ## BufferSizes contains the settings that are relevant to the sizes of
+  ## communications buffers.
   ##
   ####
     ## UpstreamBufferSize is the size of the queue used to buffer spans to
@@ -863,9 +863,9 @@ Specialized:
 ## ID Fields ##
 ###############
 IDFields:
-  ## IDFields `IDFields` controls the field names to use for the event ID
-  ## fields. These fields are used to identify events that are part of the
-  ## same trace.
+  ## IDFields controls the field names to use for the event ID fields.
+  ## These fields are used to identify events that are part of the same
+  ## trace.
   ##
   ####
     ## TraceNames is the list of field names to use for the trace ID.
@@ -891,8 +891,8 @@ IDFields:
 ## gRPC Server Parameters ##
 ############################
 GRPCServerParameters:
-  ## GRPCServerParameters `GRPCServerParameters` controls the parameters of
-  ## the gRPC server used to receive OpenTelemetry data in gRPC format.
+  ## GRPCServerParameters controls the parameters of the gRPC server used
+  ## to receive OpenTelemetry data in gRPC format.
   ##
   ####
     ## Enabled specifies whether the gRPC server is enabled.
@@ -978,9 +978,8 @@ GRPCServerParameters:
 ## Sample Cache ##
 ##################
 SampleCache:
-  ## SampleCache `SampleCache` controls the sample cache used to retain
-  ## information about trace status after the sampling decision has been
-  ## made.
+  ## SampleCache controls the sample cache used to retain information about
+  ## trace status after the sampling decision has been made.
   ##
   ####
     ## KeptSize is the number of traces preserved in the cuckoo kept traces
@@ -1022,9 +1021,8 @@ SampleCache:
 ## Stress Relief ##
 ###################
 StressRelief:
-  ## StressRelief `StressRelief` controls the Stress Relief mechanism,
-  ## which is used to prevent Refinery from being overwhelmed by a large
-  ## number of traces.
+  ## StressRelief controls the Stress Relief mechanism, which is used to
+  ## prevent Refinery from being overwhelmed by a large number of traces.
   ## There is a metric called `stress_level` that is emitted as part of
   ## Refinery metrics. It is a measure of Refinery's throughput rate
   ## relative to its processing rate, combined with the amount of room in

--- a/tools/convert/templates/rules_docsite.tmpl
+++ b/tools/convert/templates/rules_docsite.tmpl
@@ -25,11 +25,17 @@ Samplers:
 
 where:
 
-`RulesVersion` is a required parameter used to verify the version of the rules file. It must be set to `2`.
+`RulesVersion` is a required parameter used to verify the version of the rules file.
+It must be set to `2`.
 
-`Samplers` maps targets to sampler configurations. Each target is a Honeycomb environment (or a dataset for Honeycomb Classic keys). The value is the sampler to use for that target. A `__default__` target is required. The target called `__default__` will be used for any target that is not explicitly listed.
+`Samplers` maps targets to sampler configurations. Each target is a Honeycomb environment (or a dataset for Honeycomb Classic keys).
+The value is the sampler to use for that target.
+A `__default__` target is required.
+The target called `__default__` will be used for any target that is not explicitly listed.
 
-The targets are determined by examining the API key used to send the trace. If the API key is a Honeycomb Classic key with a 32-character hexadecimal value, then the specified dataset name is used as the target. If the API key is a key with 20-23 alphanumeric characters, then the key's environment name is used as the target.
+The targets are determined by examining the API key used to send the trace.
+If the API key is a Honeycomb Classic key with a 32-character hexadecimal value, then the specified dataset name is used as the target.
+If the API key is a key with 20-23 alphanumeric characters, then the key's environment name is used as the target.
 
 The remainder of this page describes the samplers that can be used within the `Samplers` section and the fields that control their behavior.
 

--- a/tools/convert/templates/rules_docsite.tmpl
+++ b/tools/convert/templates/rules_docsite.tmpl
@@ -1,8 +1,11 @@
 {{- $file := . -}}
-## The Rules file
+## Refinery Rules file
 
-The rules file is a YAML file.
-Here is a simple example of a rules file:
+The Refinery `rules` file is a YAML file.
+
+## Example
+
+Here is a simple example of a `rules` file:
 
 ```yaml
 RulesVersion: 2
@@ -20,23 +23,15 @@ Samplers:
                 - response.status_code
 ```
 
-Name: `RulesVersion`
+where:
 
-This is a required parameter used to verify the version of the rules file.
-It must be set to 2.
+`RulesVersion` is a required parameter used to verify the version of the rules file. It must be set to `2`.
 
-Name: `Samplers`
+`Samplers` maps targets to sampler configurations. Each target is a Honeycomb environment (or a dataset for Honeycomb Classic keys). The value is the sampler to use for that target. A `__default__` target is required. The target called `__default__` will be used for any target that is not explicitly listed.
 
-Samplers is a mapping of targets to samplers.
-Each target is a Honeycomb environment (or, for classic keys, a dataset).
-The value is the sampler to use for that target.
-The target called `__default__` will be used for any target that is not explicitly listed.
-A `__default__` target is required.
-The targets are determined by examining the API key used to send the trace.
-If the API key is a 'classic' key (which is a 32-character hexadecimal value), the specified dataset name is used as the target.
-If the API key is a new-style key (20-23 alphanumeric characters), the key's environment name is used as the target.
+The targets are determined by examining the API key used to send the trace. If the API key is a Honeycomb Classic key with a 32-character hexadecimal value, then the specified dataset name is used as the target. If the API key is a key with 20-23 alphanumeric characters, then the key's environment name is used as the target.
 
-The remainder of this document describes the samplers that can be used within the `Samplers` section and the fields that control their behavior.
+The remainder of this page describes the samplers that can be used within the `Samplers` section and the fields that control their behavior.
 
 {{ range $file.Groups -}}
 {{- if gt .SortOrder 0 -}}

--- a/tools/convert/templates/rules_docsite.tmpl
+++ b/tools/convert/templates/rules_docsite.tmpl
@@ -44,8 +44,6 @@ The remainder of this page describes the samplers that can be used within the `S
 
 ## {{ $group.Title }}
 
-### Name: `{{ $group.Name }}`
-
 {{ $group.Description | wrapForDocs }}
 {{- println -}}
 


### PR DESCRIPTION
**Please do not merge until @kentquirk is able to advise and re-generate the Refinery docs. Thank you!**

## Which problem is this PR solving?

This PR fixes noticed issues and adds improvements to the generated Refinery docs.

## Short description of the changes

Improvements include:

- [x] fixing "random" double spaces in `rules.yaml`
- [x] reformatting of the intros for the `rules` and `config` docs site files
- [x] removing the double "`groupName` `groupName`" for multiple Group Names in generated `config` file - 
    - refer to double `LegacyMetrics` example: https://github.com/honeycombio/refinery/blob/main/refinery_config.md#legacy-metrics 
- [x] removing the "Name: `SAMPLER`" headers from generated `rules` file
    - refer to example in:  https://github.com/honeycombio/refinery/blob/main/refinery_rules.md#name-deterministicsampler

