### PR TITLE
fix: Improve drop cache performance

### DIFF
--- a/collect/cache/cuckoo_test.go
+++ b/collect/cache/cuckoo_test.go
@@ -1,0 +1,203 @@
+package cache
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/dgryski/go-wyhash"
+	"github.com/honeycombio/refinery/metrics"
+	"github.com/sourcegraph/conc/pool"
+)
+
+// genID returns a random hex string of length numChars
+func genID(numChars int) string {
+	seed := 3565269841805
+
+	const charset = "abcdef0123456789"
+
+	id := make([]byte, numChars)
+	for i := 0; i < numChars; i++ {
+		id[i] = charset[int(wyhash.Rng(seed))%len(charset)]
+	}
+	return string(id)
+}
+
+// Benchmark the Add function
+func BenchmarkCuckooTraceChecker_Add(b *testing.B) {
+	traceIDs := make([]string, b.N)
+	for i := 0; i < b.N; i++ {
+		traceIDs[i] = genID(32)
+	}
+
+	c := NewCuckooTraceChecker(1000000, &metrics.NullMetrics{})
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c.Add(traceIDs[i])
+	}
+}
+
+func BenchmarkCuckooTraceChecker_AddParallel(b *testing.B) {
+	traceIDs := make([]string, b.N)
+	for i := 0; i < b.N; i++ {
+		traceIDs[i] = genID(32)
+	}
+	const numGoroutines = 70
+
+	p := pool.New().WithMaxGoroutines(numGoroutines + 1)
+	stop := make(chan struct{})
+	p.Go(func() {
+		select {
+		case <-stop:
+			return
+		default:
+			rand.Intn(100)
+		}
+	})
+
+	c := NewCuckooTraceChecker(1000000, &metrics.NullMetrics{})
+	ch := make(chan int, numGoroutines)
+	for i := 0; i < numGoroutines; i++ {
+		p.Go(func() {
+			for n := range ch {
+				c.Add(traceIDs[n])
+			}
+		})
+	}
+	b.ResetTimer()
+	for j := 0; j < b.N; j++ {
+		ch <- j
+	}
+	close(ch)
+	close(stop)
+	p.Wait()
+}
+
+func BenchmarkCuckooTraceChecker_Check(b *testing.B) {
+	traceIDs := make([]string, b.N)
+	for i := 0; i < b.N; i++ {
+		traceIDs[i] = genID(32)
+	}
+
+	c := NewCuckooTraceChecker(1000000, &metrics.NullMetrics{})
+	// add every other one to the filter
+	for i := 0; i < b.N; i += 2 {
+		if i%10000 == 0 {
+			c.Maintain()
+		}
+		c.Add(traceIDs[i])
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c.Check(traceIDs[i])
+	}
+}
+
+func BenchmarkCuckooTraceChecker_CheckParallel(b *testing.B) {
+	traceIDs := make([]string, b.N)
+	for i := 0; i < b.N; i++ {
+		traceIDs[i] = genID(32)
+	}
+
+	c := NewCuckooTraceChecker(1000000, &metrics.NullMetrics{})
+	for i := 0; i < b.N; i += 2 {
+		if i%10000 == 0 {
+			c.Maintain()
+		}
+		c.Add(traceIDs[i])
+	}
+
+	const numGoroutines = 70
+
+	p := pool.New().WithMaxGoroutines(numGoroutines + 1)
+	stop := make(chan struct{})
+	p.Go(func() {
+		n := 0
+		select {
+		case <-stop:
+			return
+		default:
+			if n&1 == 0 {
+				c.Add(traceIDs[n])
+			}
+			n++
+			if n >= b.N {
+				n = 0
+			}
+		}
+	})
+
+	ch := make(chan int, numGoroutines)
+	for i := 0; i < numGoroutines; i++ {
+		p.Go(func() {
+			for n := range ch {
+				c.Check(traceIDs[n])
+			}
+		})
+	}
+	b.ResetTimer()
+	for j := 0; j < b.N; j++ {
+		ch <- j
+	}
+	close(ch)
+	close(stop)
+	p.Wait()
+}
+
+func BenchmarkCuckooTraceChecker_CheckAddParallel(b *testing.B) {
+	traceIDs := make([]string, b.N)
+	for i := 0; i < b.N; i++ {
+		traceIDs[i] = genID(32)
+	}
+
+	met := &metrics.MockMetrics{}
+	met.Start()
+	c := NewCuckooTraceChecker(1000000, met)
+	const numCheckers = 30
+	const numAdders = 30
+
+	p := pool.New().WithMaxGoroutines(numCheckers + numAdders + 1)
+	stop := make(chan struct{})
+	p.Go(func() {
+		select {
+		case <-stop:
+			return
+		default:
+			rand.Intn(100)
+		}
+	})
+
+	addch := make(chan int, numCheckers)
+	checkch := make(chan int, numCheckers)
+	for i := 0; i < numAdders; i++ {
+		p.Go(func() {
+			for n := range addch {
+				if n%10000 == 0 {
+					c.Maintain()
+				}
+				c.Add(traceIDs[n])
+			}
+		})
+	}
+	for i := 0; i < numCheckers; i++ {
+		p.Go(func() {
+			for n := range checkch {
+				c.Check(traceIDs[n])
+			}
+		})
+	}
+	b.ResetTimer()
+	for j := 0; j < b.N; j++ {
+		addch <- j
+	}
+	close(addch)
+	close(checkch)
+	close(stop)
+	p.Wait()
+	count, _ := met.Get(AddQueueFull)
+	if b.N >= 100 {
+		fmt.Printf("\n: Depth: %d Batchsize: %d Timing: %v QueueFull: %v \n", AddQueueDepth, AddQueueBatchSize, AddQueueSleepTime, count)
+		fmt.Print("BenchmarkCuckooTraceChecker_CheckParallel-10       	")
+	}
+}


### PR DESCRIPTION

## Which problem is this PR solving?

- The trace drop cache was causing cascading failures under high load when stress relief triggered. The problem was traced to the fact that the cuckoofilter library was internally locking the system random number generator repeatedly and the time spent locking and unlocking was significant. 

A test was done with a private fork of the library to remove this lock by using a different way to generate random values. This cut the time spent in the cuckoofilter by half, but this probably wouldn't have been enough to matter.

Instead, this change decouples the Add call for the drop cache; Add now simply puts an item into a large (10K item) channel that is monitored by a separate goroutine, which can in turn batch up to 5 calls to the cuckoo cache in one lock. This results in a serious performance improvement:

```
BenchmarkCuckooTraceChecker_Add-10                 	     100	      7057 ns/op
BenchmarkCuckooTraceChecker_AddParallel-10         	     100	      7385 ns/op
BenchmarkCuckooTraceChecker_Check-10               	     100	        15.83 ns/op
BenchmarkCuckooTraceChecker_CheckParallel-10       	     100	       172.9 ns/op
BenchmarkCuckooTraceChecker_CheckAddParallel-10    	     100	      7548 ns/op
```

## Short description of the changes

- 

