### PR TITLE
fix: Fix bugs with convert

### DIFF
--- a/tools/convert/helpers.go
+++ b/tools/convert/helpers.go
@@ -172,7 +172,7 @@ func memorysize(data map[string]any, key, oldkey string, example string) string 
 		case int:
 			i64 = int64(i)
 		}
-		return fmt.Sprintf(`# %s: %s`, key, units.HumanSize(float64(i64)))
+		return fmt.Sprintf(`%s: %s`, key, units.HumanSize(float64(i64)))
 	}
 	return fmt.Sprintf(`# %s: %v`, key, yamlf(example))
 }
@@ -275,7 +275,7 @@ func renderMap(data map[string]any, key, oldkey string, example string) string {
 func renderStringarray(data map[string]any, key, oldkey string, example string) string {
 	var sa []string
 	comment := ""
-	if v, ok := data[key]; ok {
+	if v, ok := _fetch(data, oldkey); ok {
 		switch value := v.(type) {
 		case []interface{}:
 			for _, s := range value {

--- a/tools/convert/templates/configV2.tmpl
+++ b/tools/convert/templates/configV2.tmpl
@@ -129,7 +129,7 @@ AccessKeys:
     ## keys.
     ##
     ## Not eligible for live reload.
-    {{ renderStringarray .Data "ReceiveKeys" "ReceiveKeys" "your-key-goes-here" }}
+    {{ renderStringarray .Data "ReceiveKeys" "APIKeys" "your-key-goes-here" }}
 
     ## AcceptOnlyListedKeys is a boolean flag that causes events arriving
     ## with API keys not in the `ReceiveKeys` list to be rejected.


### PR DESCRIPTION
## Which problem is this PR solving?

- An issue where `APIKeys` was not properly converted.
- An issue where `InMemCollector.MaxAlloc` was not properly converted.

## Short description of the changes

- Fix 2 template typos.


Input:

```
config:
  APIKeys: 
    - test-key
  InMemCollector:
    MaxAlloc: 3865470566
```

Command: `convert helm -i test.yaml -o result.yaml`

Before output:

```
config:
    AccessKeys:
        AcceptOnlyListedKeys: true
    General:
        ConfigurationVersion: 2
        MinRefineryVersion: v2.0
```

After output:

```
config:
    AccessKeys:
        AcceptOnlyListedKeys: true
        ReceiveKeys:
            - test-key
    Collection:
        MaxAlloc: 3.865GB
    General:
        ConfigurationVersion: 2
        MinRefineryVersion: v2.0
```

