### PR TITLE
fix: Move Unknown log level to zero position

### DIFF
--- a/config/level.go
+++ b/config/level.go
@@ -8,12 +8,12 @@ import (
 type Level int
 
 const (
-	DebugLevel Level = iota
+	UnknownLevel Level = iota
+	DebugLevel
 	InfoLevel
 	WarnLevel
 	ErrorLevel
 	PanicLevel
-	UnknownLevel // unknown should be higher than everything
 )
 
 func ParseLevel(s string) Level {


### PR DESCRIPTION
## Which problem is this PR solving?

- closes https://github.com/honeycombio/refinery/pull/769

## Short description of the changes

- Moves `Unknown` log level to the 0 position. This is necessary to ensure that https://github.com/honeycombio/refinery/blob/5c30fbf2e2d3a2cd673fd9414f09c7537fe2a505/config/configLoadHelpers.go#L175 doesn't view `Debug` log level as a zero value and overwrite it with `warn`.

