### PR TITLE
fix: Add ability to handle k8s unit format

### DIFF
--- a/config.md
+++ b/config.md
@@ -1,7 +1,7 @@
 # Honeycomb Refinery Configuration Documentation
 
 This is the documentation for the configuration file for Honeycomb's Refinery.
-It was automatically generated on 2023-07-06 at 19:51:06 UTC.
+It was automatically generated on 2023-07-10 at 15:15:58 UTC.
 
 ## The Config file
 
@@ -746,6 +746,8 @@ If this value is zero or not set, then `MaxMemory` cannot be used to calculate t
 If set, then this must be a memory size.
 64-bit values are supported.
 Sizes with standard unit suffixes like "MB" and "GiB" are also supported.
+The full list of supported values can be found at  https://pkg.go.dev/github.com/docker/go-units#pkg-constants.
+Kubernetes unit abbreviations are also supported.
 
 - Eligible for live reload.
 - Type: `memorysize`
@@ -762,6 +764,7 @@ If set to a non-zero value, then once per tick (see `SendTicker`) the collector 
 If allocation is too high, then traces will be ejected from the cache early to reduce memory.
 Useful values for this setting are generally in the range of 70-90.
 If this value is `0`, then `MaxAlloc` will be used.
+Kubernetes unit  abbreviations are also supported.
 
 - Eligible for live reload.
 - Type: `percentage`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -723,3 +723,42 @@ func TestHoneycombIdFieldsConfigDefault(t *testing.T) {
 	assert.Equal(t, []string{"trace.trace_id", "traceId"}, c.GetTraceIdFieldNames())
 	assert.Equal(t, []string{"trace.parent_id", "parentId"}, c.GetParentIdFieldNames())
 }
+
+func TestMemorySizeUnmarshal(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected MemorySize
+	}{
+		{
+			name:     "single letter",
+			input:    "1G",
+			expected: 1024 * 1024 * 1024,
+		},
+		{
+			name:     "B included",
+			input:    "1GB",
+			expected: 1024 * 1024 * 1024,
+		},
+		{
+			name:     "iB included",
+			input:    "1GiB",
+			expected: 1024 * 1024 * 1024,
+		},
+		{
+			name:     "k8s format",
+			input:    "1Gi",
+			expected: 1024 * 1024 * 1024,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var m MemorySize
+			err := m.UnmarshalText([]byte(tt.input))
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, m)
+
+		})
+	}
+
+}

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -38,7 +38,14 @@ func (m MemorySize) MarshalText() ([]byte, error) {
 }
 
 func (m *MemorySize) UnmarshalText(text []byte) error {
-	size, err := units.RAMInBytes(string(text))
+	txt := string(text)
+	// Kubernetes uses 2 digit representation for power-of-two representation
+	// (Ki, Mi, Gi, etc), but our package expects a `B` as a third character
+	s := txt[len(txt)-1:]
+	if s == "i" {
+		txt += "B"
+	}
+	size, err := units.RAMInBytes(txt)
 	if err != nil {
 		return err
 	}

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -927,6 +927,9 @@ groups:
           allocation and `MaxAlloc` will be used instead. If set, then this
           must be a memory size. 64-bit values are supported. Sizes with
           standard unit suffixes like "MB" and "GiB" are also supported.
+          The full list of supported values can be found at 
+          https://pkg.go.dev/github.com/docker/go-units#pkg-constants.
+          Kubernetes unit abbreviations are also supported.
 
       - name: MaxMemoryPercentage
         type: percentage
@@ -948,7 +951,8 @@ groups:
           allocated bytes to this calculated value. If allocation is too high,
           then traces will be ejected from the cache early to reduce memory.
           Useful values for this setting are generally in the range of 70-90.
-          If this value is `0`, then `MaxAlloc` will be used.
+          If this value is `0`, then `MaxAlloc` will be used. Kubernetes unit 
+          abbreviations are also supported.
 
       - name: MaxAlloc
         v1group: InMemCollector

--- a/refinery_config.md
+++ b/refinery_config.md
@@ -731,6 +731,8 @@ If this value is zero or not set, then `MaxMemory` cannot be used to calculate t
 If set, then this must be a memory size.
 64-bit values are supported.
 Sizes with standard unit suffixes like "MB" and "GiB" are also supported.
+The full list of supported values can be found at  https://pkg.go.dev/github.com/docker/go-units#pkg-constants.
+Kubernetes unit abbreviations are also supported.
 
 - Eligible for live reload.
 - Type: `memorysize`
@@ -747,6 +749,7 @@ If set to a non-zero value, then once per tick (see `SendTicker`) the collector 
 If allocation is too high, then traces will be ejected from the cache early to reduce memory.
 Useful values for this setting are generally in the range of 70-90.
 If this value is `0`, then `MaxAlloc` will be used.
+Kubernetes unit  abbreviations are also supported.
 
 - Eligible for live reload.
 - Type: `percentage`

--- a/rules.md
+++ b/rules.md
@@ -1,7 +1,7 @@
 # Honeycomb Refinery Rules Documentation
 
 This is the documentation for the rules configuration for Honeycomb's Refinery.
-It was automatically generated on 2023-07-06 at 19:51:07 UTC.
+It was automatically generated on 2023-07-10 at 15:15:58 UTC.
 
 ## The Rules file
 

--- a/tools/convert/templates/configV2.tmpl
+++ b/tools/convert/templates/configV2.tmpl
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created {{ now }} from {{ .Input }} using a template generated on 2023-07-06 at 19:51:05 UTC
+# created {{ now }} from {{ .Input }} using a template generated on 2023-07-10 at 15:15:57 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of
@@ -751,7 +751,10 @@ Collection:
     ## not set, then `MaxMemory` cannot be used to calculate the maximum
     ## allocation and `MaxAlloc` will be used instead. If set, then this must
     ## be a memory size. 64-bit values are supported. Sizes with standard
-    ## unit suffixes like "MB" and "GiB" are also supported.
+    ## unit suffixes like "MB" and "GiB" are also supported. The full list of
+    ## supported values can be found at
+    ## https://pkg.go.dev/github.com/docker/go-units#pkg-constants.
+    ## Kubernetes unit abbreviations are also supported.
     ##
     ## Eligible for live reload.
     {{ memorysize .Data "AvailableMemory" "AvailableMemory" "4Gb" }}
@@ -766,7 +769,8 @@ Collection:
     ## bytes to this calculated value. If allocation is too high, then traces
     ## will be ejected from the cache early to reduce memory. Useful values
     ## for this setting are generally in the range of 70-90. If this value is
-    ## `0`, then `MaxAlloc` will be used.
+    ## `0`, then `MaxAlloc` will be used. Kubernetes unit  abbreviations are
+    ## also supported.
     ##
     ## default: 75
     ## Eligible for live reload.


### PR DESCRIPTION
## Which problem is this PR solving?

- https://github.com/honeycombio/refinery/issues/773

## Short description of the changes

- Updates `MemorySize.UnmarshalText` to be able to handle k8s memory format.
- Add unit tests

