### PR TITLE
fix: Inject all metrics and config later

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -46,21 +46,7 @@ type Metrics interface {
 }
 
 func GetMetricsImplementation(c config.Config) *MultiMetrics {
-	multi := NewMultiMetrics()
-
-	if c.GetLegacyMetricsConfig().Enabled {
-		multi.AddChild(&LegacyMetrics{})
-	}
-
-	if c.GetPrometheusMetricsConfig().Enabled {
-		multi.AddChild(&PromMetrics{})
-	}
-
-	if c.GetOTelMetricsConfig().Enabled {
-		multi.AddChild(&OTelMetrics{})
-	}
-
-	return multi
+	return NewMultiMetrics()
 }
 
 func ConvertNumeric(val interface{}) float64 {


### PR DESCRIPTION
## Which problem is this PR solving?

- We had missing metrics because the metrics objects that were loaded from config were not being Start()ed.

## Short description of the changes

- Rework MultiMetrics to inject all the internal implementations even if they're not being used.
- On Start(), copy the enabled ones to the children list so that the rest of metrics works right.
- Remove the previous attempt to avoid doing this.
- Also inject All The Things into a test that needs injection.

Fixes #776.

