### PR TITLE
fix: The peer management default value was wrong.

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -7,3 +7,4 @@
 5. Push the tag upstream (this will kick off the release pipeline in CI)
 6. Copy change log entry for newest version into draft GitHub release created as part of CI publish steps
 7. Update the `appVersion` and any relevant chart changes in [helm-charts](https://github.com/honeycombio/helm-charts/tree/main/charts/refinery)
+8. If either `refinery_config.md` or `refinery_rules.md` were modified in this release, you must also copy these files to docs and do a docs PR.

--- a/config.md
+++ b/config.md
@@ -1,7 +1,7 @@
 # Honeycomb Refinery Configuration Documentation
 
 This is the documentation for the configuration file for Honeycomb's Refinery.
-It was automatically generated on 2023-07-10 at 20:11:38 UTC.
+It was automatically generated on 2023-07-11 at 15:26:09 UTC.
 
 ## The Config file
 
@@ -585,7 +585,7 @@ Peer management is the mechanism by which Refinery locates its peers.
 
 - Not eligible for live reload.
 - Type: `string`
-- Default: `redis`
+- Default: `file`
 - Options: `redis file`
 
 ### `Identifier`
@@ -746,7 +746,7 @@ If this value is zero or not set, then `MaxMemory` cannot be used to calculate t
 If set, then this must be a memory size.
 64-bit values are supported.
 Sizes with standard unit suffixes like "MB" and "GiB" are also supported.
-The full list of supported values can be found at  https://pkg.go.dev/github.com/docker/go-units#pkg-constants.
+The full list of supported values can be found at https://pkg.go.dev/github.com/docker/go-units#pkg-constants.
 Kubernetes unit abbreviations are also supported.
 
 - Eligible for live reload.
@@ -764,7 +764,7 @@ If set to a non-zero value, then once per tick (see `SendTicker`) the collector 
 If allocation is too high, then traces will be ejected from the cache early to reduce memory.
 Useful values for this setting are generally in the range of 70-90.
 If this value is `0`, then `MaxAlloc` will be used.
-Kubernetes unit  abbreviations are also supported.
+Kubernetes unit abbreviations are also supported.
 
 - Eligible for live reload.
 - Type: `percentage`

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -1,4 +1,9 @@
-# this contains a list of all of the config items supported by Refinery
+# This contains a list of all of the config items supported by Refinery.
+#
+# This file is a YAML file containing configuration information for all of the values in Refinery.
+# If you modify this file, you must `cd tools/convert` and run `make all` to regenerate the
+# dependent files. Note that refinery_config.md and refinery_rules.md are used by the documentation
+# system, so you must also copy them to the docs directory and create a PR there.
 groups:
   - name: "General"
     title: "General Configuration"

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -666,7 +666,7 @@ groups:
         type: string
         valuetype: choice
         choices: ["redis", "file"]
-        default: "redis"
+        default: "file"
         reload: false
         validations:
           - type: choice
@@ -929,7 +929,7 @@ groups:
           allocation and `MaxAlloc` will be used instead. If set, then this
           must be a memory size. 64-bit values are supported. Sizes with
           standard unit suffixes like "MB" and "GiB" are also supported.
-          The full list of supported values can be found at 
+          The full list of supported values can be found at
           https://pkg.go.dev/github.com/docker/go-units#pkg-constants.
           Kubernetes unit abbreviations are also supported.
 
@@ -953,7 +953,7 @@ groups:
           allocated bytes to this calculated value. If allocation is too high,
           then traces will be ejected from the cache early to reduce memory.
           Useful values for this setting are generally in the range of 70-90.
-          If this value is `0`, then `MaxAlloc` will be used. Kubernetes unit 
+          If this value is `0`, then `MaxAlloc` will be used. Kubernetes unit
           abbreviations are also supported.
 
       - name: MaxAlloc

--- a/refinery_config.md
+++ b/refinery_config.md
@@ -570,7 +570,7 @@ Peer management is the mechanism by which Refinery locates its peers.
 
 - Not eligible for live reload.
 - Type: `string`
-- Default: `redis`
+- Default: `file`
 - Options: `redis file`
 
 ### `Identifier`
@@ -731,7 +731,7 @@ If this value is zero or not set, then `MaxMemory` cannot be used to calculate t
 If set, then this must be a memory size.
 64-bit values are supported.
 Sizes with standard unit suffixes like "MB" and "GiB" are also supported.
-The full list of supported values can be found at  https://pkg.go.dev/github.com/docker/go-units#pkg-constants.
+The full list of supported values can be found at https://pkg.go.dev/github.com/docker/go-units#pkg-constants.
 Kubernetes unit abbreviations are also supported.
 
 - Eligible for live reload.
@@ -749,7 +749,7 @@ If set to a non-zero value, then once per tick (see `SendTicker`) the collector 
 If allocation is too high, then traces will be ejected from the cache early to reduce memory.
 Useful values for this setting are generally in the range of 70-90.
 If this value is `0`, then `MaxAlloc` will be used.
-Kubernetes unit  abbreviations are also supported.
+Kubernetes unit abbreviations are also supported.
 
 - Eligible for live reload.
 - Type: `percentage`

--- a/tools/convert/templates/configV2.tmpl
+++ b/tools/convert/templates/configV2.tmpl
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created {{ now }} from {{ .Input }} using a template generated on 2023-07-10 at 20:11:37 UTC
+# created {{ now }} from {{ .Input }} using a template generated on 2023-07-11 at 15:26:08 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of
@@ -584,10 +584,10 @@ PeerManagement:
     ## `redis` means that Refinery self-registers with a Redis instance and
     ## gets its peer list from there.
     ##
-    ## default: redis
+    ## default: file
     ## Not eligible for live reload.
     ## Options: redis file
-    {{ choice .Data "Type" "PeerManagement.Type" (makeSlice "redis" "file") "redis" }}
+    {{ choice .Data "Type" "PeerManagement.Type" (makeSlice "redis" "file") "file" }}
 
     ## Identifier specifies the identifier to use when registering itself
     ## with peers.
@@ -769,7 +769,7 @@ Collection:
     ## bytes to this calculated value. If allocation is too high, then traces
     ## will be ejected from the cache early to reduce memory. Useful values
     ## for this setting are generally in the range of 70-90. If this value is
-    ## `0`, then `MaxAlloc` will be used. Kubernetes unit  abbreviations are
+    ## `0`, then `MaxAlloc` will be used. Kubernetes unit abbreviations are
     ## also supported.
     ##
     ## default: 75


### PR DESCRIPTION
## Which problem is this PR solving?

- Peer management default was documented as `redis` but it can't be, because then a single-node cluster won't work right.

## Short description of the changes

- Change default in metadata
- Regenerate the appropriate files

