### PR TITLE
docs: Update docs to fix memory description

### DIFF
--- a/config.md
+++ b/config.md
@@ -1,7 +1,7 @@
 # Honeycomb Refinery Configuration Documentation
 
 This is the documentation for the configuration file for Honeycomb's Refinery.
-It was automatically generated on 2023-07-11 at 16:32:34 UTC.
+It was automatically generated on 2023-07-11 at 17:52:54 UTC.
 
 ## The Config file
 
@@ -745,9 +745,7 @@ This value will typically be set through an environment variable controlled by t
 If this value is zero or not set, then `MaxMemory` cannot be used to calculate the maximum allocation and `MaxAlloc` will be used instead.
 If set, then this must be a memory size.
 64-bit values are supported.
-Sizes with standard unit suffixes like "MB" and "GiB" are also supported.
-The full list of supported values can be found at https://pkg.go.dev/github.com/docker/go-units#pkg-constants.
-Kubernetes unit abbreviations are also supported.
+Sizes with standard unit suffixes (`MB`, `GiB`, etc) and Kubernetes units (`M`, `Gi`, etc) are also supported.
 
 - Eligible for live reload.
 - Type: `memorysize`
@@ -764,7 +762,6 @@ If set to a non-zero value, then once per tick (see `SendTicker`) the collector 
 If allocation is too high, then traces will be ejected from the cache early to reduce memory.
 Useful values for this setting are generally in the range of 70-90.
 If this value is `0`, then `MaxAlloc` will be used.
-Sizes with standard unit suffixes (`MB`, `GiB`, etc) and Kubernetes units (`M`, `Gi`, etc) are also supported.
 
 - Eligible for live reload.
 - Type: `percentage`

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -929,14 +929,12 @@ groups:
         summary: is the amount of system memory available to the Refinery process.
         description: >
           This value will typically be set through an environment variable
-          controlled by the container or deploy script. If this value is zero
-          or not set, then `MaxMemory` cannot be used to calculate the maximum
-          allocation and `MaxAlloc` will be used instead. If set, then this
-          must be a memory size. 64-bit values are supported. Sizes with
-          standard unit suffixes like "MB" and "GiB" are also supported.
-          The full list of supported values can be found at
-          https://pkg.go.dev/github.com/docker/go-units#pkg-constants.
-          Kubernetes unit abbreviations are also supported.
+          controlled by the container or deploy script. If this value is zero or
+          not set, then `MaxMemory` cannot be used to calculate the maximum
+          allocation and `MaxAlloc` will be used instead. If set, then this must
+          be a memory size. 64-bit values are supported. Sizes with standard
+          unit suffixes (`MB`, `GiB`, etc) and Kubernetes units (`M`, `Gi`, etc)
+          are also supported.
 
       - name: MaxMemoryPercentage
         type: percentage
@@ -958,9 +956,7 @@ groups:
           allocated bytes to this calculated value. If allocation is too high,
           then traces will be ejected from the cache early to reduce memory.
           Useful values for this setting are generally in the range of 70-90.
-          If this value is `0`, then `MaxAlloc` will be used. Sizes with standard
-          unit suffixes (`MB`, `GiB`, etc) and Kubernetes units (`M`, `Gi`, etc)
-          are also supported.
+          If this value is `0`, then `MaxAlloc` will be used.
 
       - name: MaxAlloc
         v1group: InMemCollector

--- a/refinery_config.md
+++ b/refinery_config.md
@@ -730,9 +730,7 @@ This value will typically be set through an environment variable controlled by t
 If this value is zero or not set, then `MaxMemory` cannot be used to calculate the maximum allocation and `MaxAlloc` will be used instead.
 If set, then this must be a memory size.
 64-bit values are supported.
-Sizes with standard unit suffixes like "MB" and "GiB" are also supported.
-The full list of supported values can be found at https://pkg.go.dev/github.com/docker/go-units#pkg-constants.
-Kubernetes unit abbreviations are also supported.
+Sizes with standard unit suffixes (`MB`, `GiB`, etc) and Kubernetes units (`M`, `Gi`, etc) are also supported.
 
 - Eligible for live reload.
 - Type: `memorysize`
@@ -749,7 +747,6 @@ If set to a non-zero value, then once per tick (see `SendTicker`) the collector 
 If allocation is too high, then traces will be ejected from the cache early to reduce memory.
 Useful values for this setting are generally in the range of 70-90.
 If this value is `0`, then `MaxAlloc` will be used.
-Sizes with standard unit suffixes (`MB`, `GiB`, etc) and Kubernetes units (`M`, `Gi`, etc) are also supported.
 
 - Eligible for live reload.
 - Type: `percentage`

--- a/tools/convert/templates/configV2.tmpl
+++ b/tools/convert/templates/configV2.tmpl
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created {{ now }} from {{ .Input }} using a template generated on 2023-07-11 at 16:32:33 UTC
+# created {{ now }} from {{ .Input }} using a template generated on 2023-07-11 at 17:52:53 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of
@@ -751,10 +751,8 @@ Collection:
     ## not set, then `MaxMemory` cannot be used to calculate the maximum
     ## allocation and `MaxAlloc` will be used instead. If set, then this must
     ## be a memory size. 64-bit values are supported. Sizes with standard
-    ## unit suffixes like "MB" and "GiB" are also supported. The full list of
-    ## supported values can be found at
-    ## https://pkg.go.dev/github.com/docker/go-units#pkg-constants.
-    ## Kubernetes unit abbreviations are also supported.
+    ## unit suffixes (`MB`, `GiB`, etc) and Kubernetes units (`M`, `Gi`, etc)
+    ## are also supported.
     ##
     ## Eligible for live reload.
     {{ memorysize .Data "AvailableMemory" "AvailableMemory" "4Gb" }}
@@ -769,9 +767,7 @@ Collection:
     ## bytes to this calculated value. If allocation is too high, then traces
     ## will be ejected from the cache early to reduce memory. Useful values
     ## for this setting are generally in the range of 70-90. If this value is
-    ## `0`, then `MaxAlloc` will be used. Sizes with standard unit suffixes
-    ## (`MB`, `GiB`, etc) and Kubernetes units (`M`, `Gi`, etc) are also
-    ## supported.
+    ## `0`, then `MaxAlloc` will be used.
     ##
     ## default: 75
     ## Eligible for live reload.


### PR DESCRIPTION
## Which problem is this PR solving?

- Docs had the right description in the wrong place, and the wrong description in the right place.

## Short description of the changes

- Convert two wrongs to a right.
- Regenerate the wrongness.

