### PR TITLE
fix: Remove excess validation for api keys

### DIFF
--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -415,7 +415,6 @@ groups:
         envvar: REFINERY_HONEYCOMB_LOGGER_API_KEY, REFINERY_HONEYCOMB_API_KEY
         commandline: logger-api-key
         validations:
-          - type: requiredInGroup
           - type: format
             arg: apikey
         summary: is the API key used to send Refinery's logs to Honeycomb.
@@ -544,7 +543,6 @@ groups:
         example: "SetThisToAHoneycombKey"
         reload: false
         validations:
-          - type: requiredInGroup
           - type: format
             arg: apikey
         envvar: REFINERY_HONEYCOMB_METRICS_API_KEY, HONEYCOMB_API_KEY
@@ -614,6 +612,9 @@ groups:
         default: ""
         example: "SetThisToAHoneycombKey"
         reload: false
+        validations:
+          - type: format
+            arg: apikey
         envvar: REFINERY_METRICS_OTEL_API_KEY, HONEYCOMB_API_KEY
         commandline: otel-metrics-api-key
         firstversion: v2.0


### PR DESCRIPTION

## Which problem is this PR solving?

- API key validation was not allowing envvars to be properly validated, so we're removing it.

## Short description of the changes

- Rip it out.

