### PR TITLE
docs: General Improvements

### DIFF
--- a/config.md
+++ b/config.md
@@ -1,7 +1,7 @@
 # Honeycomb Refinery Configuration Documentation
 
 This is the documentation for the configuration file for Honeycomb's Refinery.
-It was automatically generated on 2023-07-11 at 17:52:54 UTC.
+It was automatically generated on 2023-07-11 at 21:19:53 UTC.
 
 ## The Config file
 
@@ -334,7 +334,7 @@ The setting specifies where (and if) Refinery sends logs.
 - Not eligible for live reload.
 - Type: `string`
 - Default: `stdout`
-- Options: `stdout honeycomb none`
+- Options: `stdout`, `honeycomb`, `none`
 
 ### `Level`
 
@@ -346,7 +346,7 @@ Level is the logging level above which Refinery should send a log to the logger.
 - Not eligible for live reload.
 - Type: `string`
 - Default: `warn`
-- Options: `debug info warn error panic`
+- Options: `debug`, `info`, `warn`, `error`, `panic`
 
 ## Honeycomb Logger
 
@@ -570,7 +570,7 @@ In rare circumstances, compression costs may outweigh the benefits, in which cas
 - Not eligible for live reload.
 - Type: `string`
 - Default: `gzip`
-- Options: `none gzip`
+- Options: `none`, `gzip`
 
 ## Peer Management
 
@@ -586,7 +586,7 @@ Peer management is the mechanism by which Refinery locates its peers.
 - Not eligible for live reload.
 - Type: `string`
 - Default: `file`
-- Options: `redis file`
+- Options: `redis`, `file`
 
 ### `Identifier`
 

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -934,8 +934,8 @@ groups:
           not set, then `MaxMemory` cannot be used to calculate the maximum
           allocation and `MaxAlloc` will be used instead. If set, then this must
           be a memory size. 64-bit values are supported. Sizes with standard
-          unit suffixes (`MB`, `GiB`, etc) and Kubernetes units (`M`, `Gi`, etc)
-          are also supported.
+          unit suffixes (`MB`, `GiB`, etc.) and Kubernetes units (`M`, `Gi`, 
+          etc.) are also supported.
 
       - name: MaxMemoryPercentage
         type: percentage

--- a/refinery_config.md
+++ b/refinery_config.md
@@ -315,7 +315,7 @@ The setting specifies where (and if) Refinery sends logs.
 - Not eligible for live reload.
 - Type: `string`
 - Default: `stdout`
-- Options: `stdout honeycomb none`
+- Options: `stdout`, `honeycomb`, `none`
 
 ### `Level`
 
@@ -327,7 +327,7 @@ The setting specifies where (and if) Refinery sends logs.
 - Not eligible for live reload.
 - Type: `string`
 - Default: `warn`
-- Options: `debug info warn error panic`
+- Options: `debug`, `info`, `warn`, `error`, `panic`
 
 ## Honeycomb Logger
 
@@ -554,7 +554,7 @@ In rare circumstances, compression costs may outweigh the benefits, in which cas
 - Not eligible for live reload.
 - Type: `string`
 - Default: `gzip`
-- Options: `none gzip`
+- Options: `none`, `gzip`
 
 ## Peer Management
 
@@ -571,7 +571,7 @@ Peer management is the mechanism by which Refinery locates its peers.
 - Not eligible for live reload.
 - Type: `string`
 - Default: `file`
-- Options: `redis file`
+- Options: `redis`, `file`
 
 ### `Identifier`
 
@@ -730,7 +730,7 @@ This value will typically be set through an environment variable controlled by t
 If this value is zero or not set, then `MaxMemory` cannot be used to calculate the maximum allocation and `MaxAlloc` will be used instead.
 If set, then this must be a memory size.
 64-bit values are supported.
-Sizes with standard unit suffixes (`MB`, `GiB`, etc) and Kubernetes units (`M`, `Gi`, etc) are also supported.
+Sizes with standard unit suffixes (`MB`, `GiB`, etc.) and Kubernetes units (`M`, `Gi`,  etc.) are also supported.
 
 - Eligible for live reload.
 - Type: `memorysize`

--- a/tools/convert/templates/cfg_docrepo.tmpl
+++ b/tools/convert/templates/cfg_docrepo.tmpl
@@ -73,7 +73,7 @@ The remainder of this document describes the sections within the file and the fi
 {{- println -}}
 {{- end -}}
 {{- if eq $field.ValueType "choice" -}}
-- Options: `{{- printf "%s" (join $field.Choices " ") -}}`
+- Options: `{{- printf "%s" (join $field.Choices "`, `") -}}`
 {{- println -}}
 {{- end -}}
 {{- if $field.Envvar -}}

--- a/tools/convert/templates/cfg_docsite.tmpl
+++ b/tools/convert/templates/cfg_docsite.tmpl
@@ -66,7 +66,7 @@ The remainder of this page describes the sections within the file and the fields
 {{- println -}}
 {{- end -}}
 {{- if eq $field.ValueType "choice" -}}
-- Options: `{{- printf "%s" (join $field.Choices " ") -}}`
+- Options: `{{- printf "%s" (join $field.Choices "`, `") -}}`
 {{- println -}}
 {{- end -}}
 {{- if $field.Envvar -}}


### PR DESCRIPTION
## Which problem is this PR solving?

This PR includes some improvements for generated documentation for Honeycomb docs site to match style guide standards. For example, "etc." is an abbreviation of a Latin expression - and the Honeycomb docs use American English only - but at the very least should have a period included when used.

This PR should also include a comma between generated options, but I will need @kentquirk's help with wrangling that.
For example, the options for https://docs.honeycomb.io/manage-data-volume/refinery/configuration/#type should have commas between them to improve clarity.

![Screenshot 2023-07-11 at 3 31 05 PM](https://github.com/honeycombio/refinery/assets/5807053/afc2dcce-f4cb-4bad-bac4-1b5f881958a3)

## Short description of the changes

- Refer to above

