### PR TITLE
maint: Docker tagging updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,7 +198,6 @@ jobs:
           command: |
             set -x
 
-            export TAG="$(test "${CIRCLE_BRANCH}" == "main" && echo "" || echo "branch-")${BUILD_ID}"
             export ECR_HOST=702835727665.dkr.ecr.us-east-1.amazonaws.com
             export KO_DOCKER_REPO=${ECR_HOST}
 
@@ -245,9 +244,6 @@ workflows:
           requires:
             - build_binaries
             - build_docker
-          filters:
-            branches:
-              only: main
       - publish_github:
           context: Honeycomb Secrets for Public Repos
           requires:

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -1,14 +1,42 @@
+#!/usr/bin/env bash
 set -o nounset
 set -o pipefail
 set -o xtrace
 
-TAGS="latest"
+TAGS=""
+# Check if CIRCLE_BRANCH is set and not empty
+if [[ -n "${CIRCLE_BRANCH}" ]]; then
+    export TAGS="${CIRCLE_BUILD_NUM},branch-${CIRCLE_BRANCH}"
+fi
+
+# We only want to tag main with latest on ECR
+if [[ "${CIRCLE_BRANCH}" == "main" ]]; then
+    TAGS+=",latest"
+fi
+
+# Local builds just get "dev" for version
 VERSION="dev"
+
+# If we are doing a dev build on circle, we will version it as the circleci buildnumber
+if [[ -n "${CIRCLE_BUILD_NUM}" ]]; then
+    VERSION="${CIRCLE_BUILD_NUM}"
+fi
+
+# if we're running off a git tag, it is a release which we tag with the versions as well as latest
+# caution: this means if we ever release an update to a previous version, it will be marked latest
+# it is probably best if people just use the major or minor version tags
+
 if [[ -n ${CIRCLE_TAG:-} ]]; then
     # trim 'v' prefix if present
     VERSION=${CIRCLE_TAG#"v"}
-    # append version to image tags
-    TAGS+=",$VERSION"
+
+    # Extract major, major.minor, and major.minor.patch versions
+    MAJOR_VERSION=${VERSION%%.*}
+    MINOR_VERSION=${VERSION%.*}
+
+    # Append versions to image tags
+    # So 2.1.1 would be tagged with "2","2.1","2.1.1"
+    TAGS="$MAJOR_VERSION,$MINOR_VERSION,$VERSION,latest"
 fi
 
 unset GOOS


### PR DESCRIPTION
## Which problem is this PR solving?
#790 
-

## Short description of the changes
- For internal dev builds, the version will be the build # from circle. They will also be tagged with this build number
- The tags for dev builds will include `branch-branchname` such as `branch-terra.myawesomebranch`
- For internal dev builds for `main` will be tagged with latest
- For releases, we will tag with `major`, `major.minor`, and `semver` in addition to `latest` (for compatibility) such as `2`, `2.1`, and `2.1.5`
- All dev builds will now be available in our ECR repo, I will separately add a lifecycle policy to it so it only keeps so many days of non-release builds (90 maybe?)

