### PR TITLE
maint: replace slash with dash in branch name

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -6,7 +6,8 @@ set -o xtrace
 TAGS=""
 # Check if CIRCLE_BRANCH is set and not empty
 if [[ -n "${CIRCLE_BRANCH}" ]]; then
-    export TAGS="${CIRCLE_BUILD_NUM},branch-${CIRCLE_BRANCH}"
+    BRANCH_TAG=${CIRCLE_BRANCH//\//-}
+    TAGS="${CIRCLE_BUILD_NUM},branch-${BRANCH_TAG}"
 fi
 
 # We only want to tag main with latest on ECR


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- the build-docker.sh script has started including the branch name as a tag, but that breaks CI if the branch name includes a slash (`/`), which are not allowed in tags
- Unable to run CI against external PRs

## Short description of the changes

- Updated the script to replace `/` with `-` in branch names.

