### PR TITLE
maint: Dont try to publish external PRs to ECR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -244,6 +244,9 @@ workflows:
           requires:
             - build_binaries
             - build_docker
+          filters:
+            branches:
+              ignore: /pull\/.*/
       - publish_github:
           context: Honeycomb Secrets for Public Repos
           requires:


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- external PRs try to publish to ecr but fail because they dont have the secret

## Short description of the changes

- updated ecr publishing to exclude external PRs

