### PR TITLE
fix: Update metadata for bad envvar and regenerate

### DIFF
--- a/config.md
+++ b/config.md
@@ -1,7 +1,7 @@
 # Honeycomb Refinery Configuration Documentation
 
 This is the documentation for the configuration file for Honeycomb's Refinery.
-It was automatically generated on 2023-07-11 at 21:19:53 UTC.
+It was automatically generated on 2023-07-17 at 17:49:09 UTC.
 
 ## The Config file
 
@@ -538,7 +538,7 @@ If this is blank, then Refinery will not set the Honeycomb-specific headers for 
 - Not eligible for live reload.
 - Type: `string`
 - Example: `SetThisToAHoneycombKey`
-- Environment variable: `REFINERY_METRICS_OTEL_API_KEY, HONEYCOMB_API_KEY`
+- Environment variable: `REFINERY_OTEL_METRICS_API_KEY, HONEYCOMB_API_KEY`
 
 ### `Dataset`
 
@@ -744,7 +744,7 @@ AvailableMemory is the amount of system memory available to the Refinery process
 This value will typically be set through an environment variable controlled by the container or deploy script.
 If set, then this must be a memory size and `Collections.maxAlloc` must not be defined to avoid unclear configuration.
 64-bit values are supported.
-Sizes with standard unit suffixes (`MB`, `GiB`, etc) and Kubernetes units (`M`, `Gi`, etc) are also supported.
+Sizes with standard unit suffixes (`MB`, `GiB`, etc.) and Kubernetes units (`M`, `Gi`, etc.) are also supported.
 
 - Eligible for live reload.
 - Type: `memorysize`

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -614,7 +614,7 @@ groups:
         validations:
           - type: format
             arg: apikey
-        envvar: REFINERY_METRICS_OTEL_API_KEY, HONEYCOMB_API_KEY
+        envvar: REFINERY_OTEL_METRICS_API_KEY, HONEYCOMB_API_KEY
         commandline: otel-metrics-api-key
         firstversion: v2.0
         summary: is the API key used to send Honeycomb metrics via OpenTelemetry.
@@ -933,7 +933,7 @@ groups:
           not set, then `MaxMemory` cannot be used to calculate the maximum
           allocation and `MaxAlloc` will be used instead. If set, then this must
           be a memory size. 64-bit values are supported. Sizes with standard
-          unit suffixes (`MB`, `GiB`, etc.) and Kubernetes units (`M`, `Gi`, 
+          unit suffixes (`MB`, `GiB`, etc.) and Kubernetes units (`M`, `Gi`,
           etc.) are also supported. If set, `Collections.MaxAlloc` must not be
           defined.
 

--- a/refinery_config.md
+++ b/refinery_config.md
@@ -522,7 +522,7 @@ If this is blank, then Refinery will not set the Honeycomb-specific headers for 
 - Not eligible for live reload.
 - Type: `string`
 - Example: `SetThisToAHoneycombKey`
-- Environment variable: `REFINERY_METRICS_OTEL_API_KEY, HONEYCOMB_API_KEY`
+- Environment variable: `REFINERY_OTEL_METRICS_API_KEY, HONEYCOMB_API_KEY`
 
 ### `Dataset`
 
@@ -730,7 +730,7 @@ This value will typically be set through an environment variable controlled by t
 If this value is zero or not set, then `MaxMemory` cannot be used to calculate the maximum allocation and `MaxAlloc` will be used instead.
 If set, then this must be a memory size.
 64-bit values are supported.
-Sizes with standard unit suffixes (`MB`, `GiB`, etc.) and Kubernetes units (`M`, `Gi`,  etc.) are also supported.
+Sizes with standard unit suffixes (`MB`, `GiB`, etc.) and Kubernetes units (`M`, `Gi`, etc.) are also supported.
 
 - Eligible for live reload.
 - Type: `memorysize`


### PR DESCRIPTION
## Which problem is this PR solving?

- This is fixing the source for the [Docs PR here](https://github.com/honeycombio/docs/pull/1852) which correctly documents the proper value for the environment variable. 

## Short description of the changes

- Change the source
- Regenerate docs

This does NOT require updating the docs site -- the site already has these changes.

