### PR TITLE
docs: refinery_rules.md

### DIFF
--- a/config.md
+++ b/config.md
@@ -1,7 +1,7 @@
 # Honeycomb Refinery Configuration Documentation
 
 This is the documentation for the configuration file for Honeycomb's Refinery.
-It was automatically generated on 2023-07-17 at 17:49:09 UTC.
+It was automatically generated on 2023-08-01 at 15:26:34 UTC.
 
 ## The Config file
 
@@ -158,7 +158,6 @@ AcceptOnlyListedKeys is a boolean flag that causes events arriving with API keys
 If `true`, then only traffic using the keys listed in `ReceiveKeys` is accepted.
 Events arriving with API keys not in the `ReceiveKeys` list will be rejected with an HTTP `401` error.
 If `false`, then all traffic is accepted and `ReceiveKeys` is ignored.
-Must be specified if `ReceiveKeys` is specified.
 
 - Eligible for live reload.
 - Type: `bool`
@@ -742,9 +741,11 @@ The number of traces in the cache should be many multiples (100x to 1000x) of th
 AvailableMemory is the amount of system memory available to the Refinery process.
 
 This value will typically be set through an environment variable controlled by the container or deploy script.
-If set, then this must be a memory size and `Collections.maxAlloc` must not be defined to avoid unclear configuration.
+If this value is zero or not set, then `MaxMemory` cannot be used to calculate the maximum allocation and `MaxAlloc` will be used instead.
+If set, then this must be a memory size.
 64-bit values are supported.
 Sizes with standard unit suffixes (`MB`, `GiB`, etc.) and Kubernetes units (`M`, `Gi`, etc.) are also supported.
+If set, `Collections.MaxAlloc` must not be defined.
 
 - Eligible for live reload.
 - Type: `memorysize`
@@ -770,10 +771,11 @@ Useful values for this setting are generally in the range of 70-90.
 
 MaxAlloc is the maximum number of bytes that should be allocated by the Collector.
 
-If set, then this must be a memory size and `Collections.AvailableMemory` must not be defined to avoid unclear configuration.
+If set, then this must be a memory size.
 64-bit values are supported.
 Sizes with standard unit suffixes (`MB`, `GiB`, etc) and Kubernetes units (`M`, `Gi`, etc) are also supported.
 See `MaxMemory` for more details.
+If set, `Collections.AvailableMemory` must not be defined.
 
 - Eligible for live reload.
 - Type: `memorysize`

--- a/config/metadata/rulesMeta.yaml
+++ b/config/metadata/rulesMeta.yaml
@@ -7,7 +7,7 @@ groups:
       `Samplers` maps targets to sampler configurations. Each target is a
       Honeycomb environment (or a dataset for Honeycomb Classic keys).
       The value is the sampler to use for that target. A `__default__`
-      target is required. The target called `__default__` will be used 
+      target is required. The target called `__default__` will be used
       for any target that is not explicitly listed.
 
       The targets are determined by examining the API key used to send the
@@ -33,7 +33,7 @@ groups:
         summary: is the sample rate to use.
         description: >
           The sample rate to use. It indicates a ratio, where one sample trace
-          is kept for every N traces seen. For example, a `SampleRate` of `30` 
+          is kept for every N traces seen. For example, a `SampleRate` of `30`
           will keep 1 out of every 30 traces. The choice on whether to keep any
           specific trace is random, so the rate is approximate.
 
@@ -78,19 +78,19 @@ groups:
           will be handed to the Dynamic Sampler. The combination of values from
           all of these fields should reflect how interesting the trace is
           compared to another.
-          
+
           When choosing field names for `FieldList`, a good field selection
           has consistent values for high-frequency, boring traffic, and
           unique values for outliers and interesting traffic. Including
           an error field, or something like `HTTP status code`, is an
           excellent choice. Using fields with very high cardinality,
           like `k8s.pod.id`, is a bad choice.
-          
+
           If the combination of fields essentially makes each trace unique,
           then the Dynamic Sampler will sample everything. If the combination
           of fields is not unique enough, then you will not be guaranteed
           samples of the most interesting traces.
-          
+
           As an example, consider as a good set of fields: the combination of
           `HTTP endpoint` (high-frequency and boring), `HTTP method`, and
           `status code` (normally boring but can become interesting when
@@ -102,7 +102,7 @@ groups:
           combination of `HTTP endpoint`, `status code`, and `pod id`, since it
           would result in keys that are all unique, and therefore result in
           sampling 100% of traces.
-          
+
           For example, rather than a set of fields, using only the `HTTP
           endpoint` field is a **bad** choice, as it is not unique enough, and
           therefore interesting traces, like traces that experienced a `500`,
@@ -579,6 +579,7 @@ groups:
           case-sensitive.
       - name: Operator
         type: string
+        valuetype: choice
         validations:
           - type: choice
         choices:

--- a/refinery_config.md
+++ b/refinery_config.md
@@ -135,7 +135,6 @@ This list only applies to span traffic - other Honeycomb API actions will be pro
 If `true`, then only traffic using the keys listed in `ReceiveKeys` is accepted.
 Events arriving with API keys not in the `ReceiveKeys` list will be rejected with an HTTP `401` error.
 If `false`, then all traffic is accepted and `ReceiveKeys` is ignored.
-Must be specified if `ReceiveKeys` is specified.
 
 - Eligible for live reload.
 - Type: `bool`
@@ -731,6 +730,7 @@ If this value is zero or not set, then `MaxMemory` cannot be used to calculate t
 If set, then this must be a memory size.
 64-bit values are supported.
 Sizes with standard unit suffixes (`MB`, `GiB`, etc.) and Kubernetes units (`M`, `Gi`, etc.) are also supported.
+If set, `Collections.MaxAlloc` must not be defined.
 
 - Eligible for live reload.
 - Type: `memorysize`
@@ -746,7 +746,6 @@ If nonzero, then it must be an integer value between 1 and 100, representing the
 If set to a non-zero value, then once per tick (see `SendTicker`) the collector will compare total allocated bytes to this calculated value.
 If allocation is too high, then traces will be ejected from the cache early to reduce memory.
 Useful values for this setting are generally in the range of 70-90.
-If this value is `0`, then `MaxAlloc` will be used.
 
 - Eligible for live reload.
 - Type: `percentage`
@@ -761,6 +760,7 @@ If set, then this must be a memory size.
 64-bit values are supported.
 Sizes with standard unit suffixes (`MB`, `GiB`, etc) and Kubernetes units (`M`, `Gi`, etc) are also supported.
 See `MaxMemory` for more details.
+If set, `Collections.AvailableMemory` must not be defined.
 
 - Eligible for live reload.
 - Type: `memorysize`

--- a/refinery_rules.md
+++ b/refinery_rules.md
@@ -49,7 +49,7 @@ It is not influenced by the contents of the trace other than the trace ID.
 
 The sample rate to use.
 It indicates a ratio, where one sample trace is kept for every N traces seen.
-For example, a `SampleRate` of `30`  will keep 1 out of every 30 traces.
+For example, a `SampleRate` of `30` will keep 1 out of every 30 traces.
 The choice on whether to keep any specific trace is random, so the rate is approximate.
 The sample rate is calculated from the trace ID, so all spans with the same trace ID will be sampled or not sampled together.
 
@@ -68,7 +68,7 @@ This sampler uses the `AvgSampleRate` algorithm from that package.
 
 The sample rate to use.
 It indicates a ratio, where one sample trace is kept for every N traces seen.
-For example, a `SampleRate` of `30`  will keep 1 out of every 30 traces.
+For example, a `SampleRate` of `30` will keep 1 out of every 30 traces.
 The choice on whether to keep any specific trace is random, so the rate is approximate.
 The sample rate is calculated from the trace ID, so all spans with the same trace ID will be sampled or not sampled together.
 
@@ -131,7 +131,7 @@ Every key will be represented at least once in any given window and more frequen
 
 The sample rate to use.
 It indicates a ratio, where one sample trace is kept for every N traces seen.
-For example, a `SampleRate` of `30`  will keep 1 out of every 30 traces.
+For example, a `SampleRate` of `30` will keep 1 out of every 30 traces.
 The choice on whether to keep any specific trace is random, so the rate is approximate.
 The sample rate is calculated from the trace ID, so all spans with the same trace ID will be sampled or not sampled together.
 
@@ -488,6 +488,7 @@ The comparison operator to use.
 String comparisons are case-sensitive.
 
 - Type: `string`
+- Options: `=`, `!=`, `>`, `<`, `>=`, `<=`, `starts-with`, `contains`, `does-not-contain`, `exists`, `not-exists`
 
 ### `Value`
 

--- a/refinery_rules.md
+++ b/refinery_rules.md
@@ -504,7 +504,6 @@ Errors in conversion will result in the comparison evaluating to `false`.
 This is especially useful when a field like `http status code` may be rendered as strings by some environments and as numbers or booleans by others.
 
 - Type: `string`
-- Values: one of `bool`, `int`, `float`, or `string`
 
 ## Total Throughput Sampler
 

--- a/refinery_rules.md
+++ b/refinery_rules.md
@@ -4,7 +4,7 @@ The Refinery `rules` file is a YAML file.
 
 ## Example
 
-Here is a simple example of a `rules` file (for a complete example, [visit the refinery GitHub repo](https://github.com/honeycombio/refinery/blob/main/rules_complete.yaml)):
+Here is a simple example of a `rules` file:
 
 ```yaml
 RulesVersion: 2
@@ -60,7 +60,7 @@ The Dynamic Sampler (`DynamicSampler`) is the basic Dynamic Sampler implementati
 Most installations will find the EMA Dynamic Sampler to be a better choice.
 This sampler collects the values of a number of fields from a trace and uses them to form a key.
 This key is handed to the standard dynamic sampler algorithm, which generates a sample rate based on the frequency with which that key has appeared during the previous `ClearFrequency`.
-See https://github.com/honeycombio/dynsampler-go for more detail on the mechanics of the Dynamic Sampler.
+See <https://github.com/honeycombio/dynsampler-go> for more detail on the mechanics of the Dynamic Sampler.
 This sampler uses the `AvgSampleRate` algorithm from that package.
 
 ### `SampleRate`
@@ -321,7 +321,8 @@ Windowed Throughput Sampler (`WindowedThroughputSampler`) is an enhanced version
 Just like the `TotalThroughput` Sampler, `WindowedThroughputSampler` attempts to meet the goal of fixed number of events per second sent to Honeycomb.
 The original throughput sampler updates the sampling rate every "ClearFrequency" seconds.
 While this parameter is configurable, it suffers from the following tradeoff:
-  - Decreasing it is more responsive to load spikes, but with the
+
+- Decreasing it is more responsive to load spikes, but with the
   cost of making the sampling decision on less data.
 - Increasing it is less responsive to load spikes, but sample rates
   will be more stable because they are made with more data.
@@ -512,9 +513,9 @@ This sampler is **deprecated** and present mainly for compatibility.
 Consider using either `EMAThroughputSampler` or `WindowedThroughputSampler` instead.
 If your key space is sharded across different servers, then this is a good method for making sure each server sends roughly the same volume of content to Honeycomb.
 It performs poorly when the active keyspace is very large.
-`GoalThroughputPerSec` * `ClearFrequency` defines the upper limit of the number of keys that can be reported and stay under the goal, but with that many keys, you'll only get one event per key per `ClearFrequencySec`, which is very coarse.
+`GoalThroughputPerSec` *`ClearFrequency` defines the upper limit of the number of keys that can be reported and stay under the goal, but with that many keys, you'll only get one event per key per `ClearFrequencySec`, which is very coarse.
 Aim for at least 1 event per key per sec to 1 event per key per 10sec to get reasonable data.
-In other words, the number of active keys should be less than 10 * `GoalThroughputPerSec`.
+In other words, the number of active keys should be less than 10* `GoalThroughputPerSec`.
 
 ### `GoalThroughputPerSec`
 
@@ -564,4 +565,3 @@ The number of spans is exact, so if there are normally small variations in trace
 If your traces are consistent lengths and changes in trace length is a useful indicator to view in Honeycomb, then set this field to `true`.
 
 - Type: `bool`
-

--- a/refinery_rules.md
+++ b/refinery_rules.md
@@ -4,7 +4,8 @@ The Refinery `rules` file is a YAML file.
 
 ## Example
 
-Here is a simple example of a `rules` file:
+Below is a simple example of a `rules` file.
+For a complete example, [visit the Refinery GitHub repository](https://github.com/honeycombio/refinery/blob/main/rules_complete.yaml).
 
 ```yaml
 RulesVersion: 2
@@ -321,7 +322,7 @@ Windowed Throughput Sampler (`WindowedThroughputSampler`) is an enhanced version
 Just like the `TotalThroughput` Sampler, `WindowedThroughputSampler` attempts to meet the goal of fixed number of events per second sent to Honeycomb.
 The original throughput sampler updates the sampling rate every "ClearFrequency" seconds.
 While this parameter is configurable, it suffers from the following tradeoff:
-- Decreasing it is more responsive to load spikes, but with the
+  - Decreasing it is more responsive to load spikes, but with the
   cost of making the sampling decision on less data.
 - Increasing it is less responsive to load spikes, but sample rates
   will be more stable because they are made with more data.
@@ -563,3 +564,4 @@ The number of spans is exact, so if there are normally small variations in trace
 If your traces are consistent lengths and changes in trace length is a useful indicator to view in Honeycomb, then set this field to `true`.
 
 - Type: `bool`
+

--- a/refinery_rules.md
+++ b/refinery_rules.md
@@ -60,7 +60,7 @@ The Dynamic Sampler (`DynamicSampler`) is the basic Dynamic Sampler implementati
 Most installations will find the EMA Dynamic Sampler to be a better choice.
 This sampler collects the values of a number of fields from a trace and uses them to form a key.
 This key is handed to the standard dynamic sampler algorithm, which generates a sample rate based on the frequency with which that key has appeared during the previous `ClearFrequency`.
-See <https://github.com/honeycombio/dynsampler-go> for more detail on the mechanics of the Dynamic Sampler.
+See https://github.com/honeycombio/dynsampler-go for more detail on the mechanics of the Dynamic Sampler.
 This sampler uses the `AvgSampleRate` algorithm from that package.
 
 ### `SampleRate`
@@ -321,7 +321,6 @@ Windowed Throughput Sampler (`WindowedThroughputSampler`) is an enhanced version
 Just like the `TotalThroughput` Sampler, `WindowedThroughputSampler` attempts to meet the goal of fixed number of events per second sent to Honeycomb.
 The original throughput sampler updates the sampling rate every "ClearFrequency" seconds.
 While this parameter is configurable, it suffers from the following tradeoff:
-
 - Decreasing it is more responsive to load spikes, but with the
   cost of making the sampling decision on less data.
 - Increasing it is less responsive to load spikes, but sample rates
@@ -512,9 +511,9 @@ This sampler is **deprecated** and present mainly for compatibility.
 Consider using either `EMAThroughputSampler` or `WindowedThroughputSampler` instead.
 If your key space is sharded across different servers, then this is a good method for making sure each server sends roughly the same volume of content to Honeycomb.
 It performs poorly when the active keyspace is very large.
-`GoalThroughputPerSec` *`ClearFrequency` defines the upper limit of the number of keys that can be reported and stay under the goal, but with that many keys, you'll only get one event per key per `ClearFrequencySec`, which is very coarse.
+`GoalThroughputPerSec` * `ClearFrequency` defines the upper limit of the number of keys that can be reported and stay under the goal, but with that many keys, you'll only get one event per key per `ClearFrequencySec`, which is very coarse.
 Aim for at least 1 event per key per sec to 1 event per key per 10sec to get reasonable data.
-In other words, the number of active keys should be less than 10* `GoalThroughputPerSec`.
+In other words, the number of active keys should be less than 10 * `GoalThroughputPerSec`.
 
 ### `GoalThroughputPerSec`
 

--- a/refinery_rules.md
+++ b/refinery_rules.md
@@ -4,7 +4,7 @@ The Refinery `rules` file is a YAML file.
 
 ## Example
 
-Here is a simple example of a `rules` file:
+Here is a simple example of a `rules` file (for a complete example, [visit the refinery GitHub repo](https://github.com/honeycombio/refinery/blob/main/rules_complete.yaml)):
 
 ```yaml
 RulesVersion: 2
@@ -503,6 +503,7 @@ Errors in conversion will result in the comparison evaluating to `false`.
 This is especially useful when a field like `http status code` may be rendered as strings by some environments and as numbers or booleans by others.
 
 - Type: `string`
+- Values: one of `bool`, `int`, `float`, or `string`
 
 ## Total Throughput Sampler
 

--- a/rules.md
+++ b/rules.md
@@ -1,7 +1,7 @@
 # Honeycomb Refinery Rules Documentation
 
 This is the documentation for the rules configuration for Honeycomb's Refinery.
-It was automatically generated on 2023-08-01 at 15:01:24 UTC.
+It was automatically generated on 2023-08-01 at 15:26:34 UTC.
 
 ## The Rules file
 
@@ -67,7 +67,7 @@ It is not influenced by the contents of the trace other than the trace ID.
 
 The sample rate to use.
 It indicates a ratio, where one sample trace is kept for every N traces seen.
-For example, a `SampleRate` of `30`  will keep 1 out of every 30 traces.
+For example, a `SampleRate` of `30` will keep 1 out of every 30 traces.
 The choice on whether to keep any specific trace is random, so the rate is approximate.
 The sample rate is calculated from the trace ID, so all spans with the same trace ID will be sampled or not sampled together.
 
@@ -89,7 +89,7 @@ This sampler uses the `AvgSampleRate` algorithm from that package.
 
 The sample rate to use.
 It indicates a ratio, where one sample trace is kept for every N traces seen.
-For example, a `SampleRate` of `30`  will keep 1 out of every 30 traces.
+For example, a `SampleRate` of `30` will keep 1 out of every 30 traces.
 The choice on whether to keep any specific trace is random, so the rate is approximate.
 The sample rate is calculated from the trace ID, so all spans with the same trace ID will be sampled or not sampled together.
 
@@ -155,7 +155,7 @@ Every key will be represented at least once in any given window and more frequen
 
 The sample rate to use.
 It indicates a ratio, where one sample trace is kept for every N traces seen.
-For example, a `SampleRate` of `30`  will keep 1 out of every 30 traces.
+For example, a `SampleRate` of `30` will keep 1 out of every 30 traces.
 The choice on whether to keep any specific trace is random, so the rate is approximate.
 The sample rate is calculated from the trace ID, so all spans with the same trace ID will be sampled or not sampled together.
 
@@ -527,6 +527,8 @@ The comparison operator to use.
 String comparisons are case-sensitive.
 
 Type: `string`
+
+- Options: `=`, `!=`, `>`, `<`, `>=`, `<=`, `starts-with`, `contains`, `does-not-contain`, `exists`, `not-exists`
 
 ### `Value`
 

--- a/rules.md
+++ b/rules.md
@@ -1,12 +1,13 @@
 # Honeycomb Refinery Rules Documentation
 
 This is the documentation for the rules configuration for Honeycomb's Refinery.
-It was automatically generated on 2023-07-11 at 16:32:35 UTC.
+It was automatically generated on 2023-08-01 at 15:01:24 UTC.
 
 ## The Rules file
 
 The rules file is a YAML file.
-Here is a simple example of a rules file:
+Below is a simple example of a `rules` file.
+View a [complete example](https://github.com/honeycombio/refinery/blob/main/rules_complete.yaml).
 
 ```yaml
 RulesVersion: 2

--- a/tools/convert/templates/configV2.tmpl
+++ b/tools/convert/templates/configV2.tmpl
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created {{ now }} from {{ .Input }} using a template generated on 2023-08-01 at 15:01:20 UTC
+# created {{ now }} from {{ .Input }} using a template generated on 2023-08-01 at 15:26:32 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of

--- a/tools/convert/templates/configV2.tmpl
+++ b/tools/convert/templates/configV2.tmpl
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created {{ now }} from {{ .Input }} using a template generated on 2023-07-11 at 17:52:53 UTC
+# created {{ now }} from {{ .Input }} using a template generated on 2023-08-01 at 15:01:20 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of
@@ -138,7 +138,6 @@ AccessKeys:
     ## accepted. Events arriving with API keys not in the `ReceiveKeys` list
     ## will be rejected with an HTTP `401` error.
     ## If `false`, then all traffic is accepted and `ReceiveKeys` is ignored.
-    ## Must be specified if `ReceiveKeys` is specified.
     ##
     ## Eligible for live reload.
     {{ conditional .Data "AcceptOnlyListedKeys" "nostar APIKeys" }}
@@ -751,8 +750,9 @@ Collection:
     ## not set, then `MaxMemory` cannot be used to calculate the maximum
     ## allocation and `MaxAlloc` will be used instead. If set, then this must
     ## be a memory size. 64-bit values are supported. Sizes with standard
-    ## unit suffixes (`MB`, `GiB`, etc) and Kubernetes units (`M`, `Gi`, etc)
-    ## are also supported.
+    ## unit suffixes (`MB`, `GiB`, etc.) and Kubernetes units (`M`, `Gi`,
+    ## etc.) are also supported. If set, `Collections.MaxAlloc` must not be
+    ## defined.
     ##
     ## Eligible for live reload.
     {{ memorysize .Data "AvailableMemory" "AvailableMemory" "4Gb" }}
@@ -766,8 +766,7 @@ Collection:
     ## per tick (see `SendTicker`) the collector will compare total allocated
     ## bytes to this calculated value. If allocation is too high, then traces
     ## will be ejected from the cache early to reduce memory. Useful values
-    ## for this setting are generally in the range of 70-90. If this value is
-    ## `0`, then `MaxAlloc` will be used.
+    ## for this setting are generally in the range of 70-90.
     ##
     ## default: 75
     ## Eligible for live reload.
@@ -779,7 +778,7 @@ Collection:
     ## If set, then this must be a memory size. 64-bit values are supported.
     ## Sizes with standard unit suffixes (`MB`, `GiB`, etc) and Kubernetes
     ## units (`M`, `Gi`, etc) are also supported. See `MaxMemory` for more
-    ## details.
+    ## details. If set, `Collections.AvailableMemory` must not be defined.
     ##
     ## Eligible for live reload.
     {{ memorysize .Data "MaxAlloc" "InMemCollector.MaxAlloc" "" }}

--- a/tools/convert/templates/rules_docrepo.tmpl
+++ b/tools/convert/templates/rules_docrepo.tmpl
@@ -109,7 +109,7 @@ Example: `{{ $field.Example }}`
 
 {{- end }}
 {{ if eq $field.ValueType "choice" -}}
-- {{ printf "Options: %s" (join $field.Choices "`, `") }}
-{{- end }}
+- {{ printf "Options: `%s`" (join $field.Choices "`, `") }}
+{{ end }}
 {{- println -}}
 {{- end -}}

--- a/tools/convert/templates/rules_docrepo.tmpl
+++ b/tools/convert/templates/rules_docrepo.tmpl
@@ -7,7 +7,8 @@ It was automatically generated {{ now }}.
 ## The Rules file
 
 The rules file is a YAML file.
-Here is a simple example of a rules file:
+Below is a simple example of a `rules` file.
+View a [complete example](https://github.com/honeycombio/refinery/blob/main/rules_complete.yaml).
 
 ```yaml
 RulesVersion: 2
@@ -108,8 +109,7 @@ Example: `{{ $field.Example }}`
 
 {{- end }}
 {{ if eq $field.ValueType "choice" -}}
-{{ printf "Options: %s" (join $field.Choices " ") }}
-
+- {{ printf "Options: %s" (join $field.Choices "`, `") }}
 {{- end }}
 {{- println -}}
 {{- end -}}

--- a/tools/convert/templates/rules_docsite.tmpl
+++ b/tools/convert/templates/rules_docsite.tmpl
@@ -81,7 +81,7 @@ The remainder of this page describes the samplers that can be used within the `S
 {{- println -}}
 {{- end -}}
 {{- if eq $field.ValueType "choice" -}}
-- {{ printf "Options: %s" (join $field.Choices "`, `") }}
+- {{ printf "Options: `%s`" (join $field.Choices "`, `") }}
 {{- println -}}
 {{- end }}
 {{- println -}}

--- a/tools/convert/templates/rules_docsite.tmpl
+++ b/tools/convert/templates/rules_docsite.tmpl
@@ -5,7 +5,8 @@ The Refinery `rules` file is a YAML file.
 
 ## Example
 
-Here is a simple example of a `rules` file:
+Below is a simple example of a `rules` file.
+For a complete example, [visit the Refinery GitHub repository](https://github.com/honeycombio/refinery/blob/main/rules_complete.yaml).
 
 ```yaml
 RulesVersion: 2
@@ -80,7 +81,7 @@ The remainder of this page describes the samplers that can be used within the `S
 {{- println -}}
 {{- end -}}
 {{- if eq $field.ValueType "choice" -}}
-- {{ printf "Options: %s" (join $field.Choices " ") }}
+- {{ printf "Options: %s" (join $field.Choices "`, `") }}
 {{- println -}}
 {{- end }}
 {{- println -}}


### PR DESCRIPTION
## Which problem is this PR solving?

- Documentation updates
  - [x] Link to complete refinery rules example
  - [x] generates options/choices for `Datatype`
  - [x] generates options/choices for all valid operators for conditions

## Short description of the changes

- This PR just adds a link to the `rules_complete.yaml` file since that file can be helpful in understanding what a full rules yaml file might look like, and adds the list of valid values for `Datatype`'

Fixes #804

