### PR TITLE
feat: add a field with the formula used to decide to activate stress relief

### DIFF
--- a/collect/stressRelief.go
+++ b/collect/stressRelief.go
@@ -279,7 +279,7 @@ func (s *StressRelief) Recalc() {
 			formula = fmt.Sprintf("%s(%v/%v)=%v", c.Algorithm, c.Numerator, c.Denominator, stress)
 		}
 	}
-	s.Logger.Debug().WithField("stress_level", level).WithField("reason", reason).Logf("calculated stress level")
+	s.Logger.Debug().WithField("stress_level", level).WithField("stress_formula", s.formula).WithField("reason", reason).Logf("calculated stress level")
 
 	s.lock.Lock()
 	defer s.lock.Unlock()


### PR DESCRIPTION
## Which problem is this PR solving?

- Currently we don't emit the values we used to determine if stress relief should be activated unless you enable debug logging, but I think the numbers at the time of activation are valuable enough to be present at `WARN`

## Short description of the changes

- adds a `stress_formula` field to the activation message, and adds `formula` to the `StressRelief` struct

