### PR TITLE
feat: Validate Collection memory config through adding `conflictsWith` validation

### DIFF
--- a/config.md
+++ b/config.md
@@ -742,8 +742,7 @@ The number of traces in the cache should be many multiples (100x to 1000x) of th
 AvailableMemory is the amount of system memory available to the Refinery process.
 
 This value will typically be set through an environment variable controlled by the container or deploy script.
-If this value is zero or not set, then `MaxMemory` cannot be used to calculate the maximum allocation and `MaxAlloc` will be used instead.
-If set, then this must be a memory size.
+If set, then this must be a memory size and `Collections.maxAlloc` must not be defined to avoid unclear configuration.
 64-bit values are supported.
 Sizes with standard unit suffixes (`MB`, `GiB`, etc) and Kubernetes units (`M`, `Gi`, etc) are also supported.
 
@@ -761,7 +760,6 @@ If nonzero, then it must be an integer value between 1 and 100, representing the
 If set to a non-zero value, then once per tick (see `SendTicker`) the collector will compare total allocated bytes to this calculated value.
 If allocation is too high, then traces will be ejected from the cache early to reduce memory.
 Useful values for this setting are generally in the range of 70-90.
-If this value is `0`, then `MaxAlloc` will be used.
 
 - Eligible for live reload.
 - Type: `percentage`
@@ -772,7 +770,7 @@ If this value is `0`, then `MaxAlloc` will be used.
 
 MaxAlloc is the maximum number of bytes that should be allocated by the Collector.
 
-If set, then this must be a memory size.
+If set, then this must be a memory size and `Collections.AvailableMemory` must not be defined to avoid unclear configuration.
 64-bit values are supported.
 Sizes with standard unit suffixes (`MB`, `GiB`, etc) and Kubernetes units (`M`, `Gi`, etc) are also supported.
 See `MaxMemory` for more details.

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -160,8 +160,7 @@ groups:
           accepted. Events arriving with API keys not in the `ReceiveKeys` list
           will be rejected with an HTTP `401` error.
 
-          If `false`, then all traffic is accepted and `ReceiveKeys` is
-          ignored. Must be specified if `ReceiveKeys` is specified.
+          If `false`, then all traffic is accepted and `ReceiveKeys` is ignored.
 
   - name: RefineryTelemetry
     title: "Refinery Telemetry"
@@ -935,7 +934,7 @@ groups:
           allocation and `MaxAlloc` will be used instead. If set, then this must
           be a memory size. 64-bit values are supported. Sizes with standard
           unit suffixes (`MB`, `GiB`, etc.) and Kubernetes units (`M`, `Gi`, 
-          etc.) are also supported. If set, `Collections.maxAlloc` must not be
+          etc.) are also supported. If set, `Collections.MaxAlloc` must not be
           defined.
 
       - name: MaxMemoryPercentage

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -935,7 +935,8 @@ groups:
           allocation and `MaxAlloc` will be used instead. If set, then this must
           be a memory size. 64-bit values are supported. Sizes with standard
           unit suffixes (`MB`, `GiB`, etc.) and Kubernetes units (`M`, `Gi`, 
-          etc.) are also supported.
+          etc.) are also supported. If set, `Collections.maxAlloc` must not be
+          defined.
 
       - name: MaxMemoryPercentage
         type: percentage
@@ -957,7 +958,6 @@ groups:
           allocated bytes to this calculated value. If allocation is too high,
           then traces will be ejected from the cache early to reduce memory.
           Useful values for this setting are generally in the range of 70-90.
-          If this value is `0`, then `MaxAlloc` will be used.
 
       - name: MaxAlloc
         v1group: InMemCollector
@@ -966,11 +966,15 @@ groups:
         valuetype: memorysize
         default: 0
         reload: true
+        validatons:
+          - type: conflictsWith
+            arg: AvailableMemory
         summary: is the maximum number of bytes that should be allocated by the Collector.
         description: >
           If set, then this must be a memory size. 64-bit values are supported.
           Sizes with standard unit suffixes (`MB`, `GiB`, etc) and Kubernetes units
           (`M`, `Gi`, etc) are also supported. See `MaxMemory` for more details.
+          If set, `Collections.AvailableMemory` must not be defined.
 
   - name: BufferSizes
     title: "Buffer Sizes"

--- a/config/validate.go
+++ b/config/validate.go
@@ -376,7 +376,7 @@ func (m *Metadata) Validate(data map[string]any) []string {
 					otherName := validation.Arg.(string)
 					if _, ok := flatdata[group.Name+"."+otherName]; ok {
 						if _, ok := flatdata[group.Name+"."+field.Name]; ok {
-                            errors = append(errors, fmt.Sprintf("the group %s includes %s, which conflicts with %s", group.Name, otherName, field.Name))
+							errors = append(errors, fmt.Sprintf("the group %s includes %s, which conflicts with %s", group.Name, otherName, field.Name))
 						}
 					}
 				}

--- a/config/validate.go
+++ b/config/validate.go
@@ -373,6 +373,8 @@ func (m *Metadata) Validate(data map[string]any) []string {
 						}
 					}
 				case "conflictsWith":
+					// if both values are defined then report an error. Default values can also lead to conflicts and should not be
+					// used with this validation.
 					otherName := validation.Arg.(string)
 					if _, ok := flatdata[group.Name+"."+otherName]; ok {
 						if _, ok := flatdata[group.Name+"."+field.Name]; ok {

--- a/config/validate.go
+++ b/config/validate.go
@@ -340,7 +340,7 @@ func (m *Metadata) Validate(data map[string]any) []string {
 						}
 					}
 				}
-			case "required", "requiredInGroup", "requiredWith":
+			case "required", "requiredInGroup", "requiredWith", "conflictsWith":
 				// these are handled below
 			default:
 				panic("unknown validation type: " + validation.Type)
@@ -368,8 +368,15 @@ func (m *Metadata) Validate(data map[string]any) []string {
 					// if the named key is specified then this one must be also
 					otherName := validation.Arg.(string)
 					if _, ok := flatdata[group.Name+"."+otherName]; ok {
-						if _, ok := flatdata[group.Name+"."+field.Name]; !ok {
+						if _, ok := flatdata[group.Name+"."+field.Name]; !ok && m.GetField(group.Name+"."+field.Name).Default == nil {
 							errors = append(errors, fmt.Sprintf("the group %s includes %s, which also requires %s", group.Name, otherName, field.Name))
+						}
+					}
+				case "conflictsWith":
+					otherName := validation.Arg.(string)
+					if _, ok := flatdata[group.Name+"."+otherName]; ok {
+						if _, ok := flatdata[group.Name+"."+field.Name]; ok {
+                            errors = append(errors, fmt.Sprintf("the group %s includes %s, which conflicts with %s", group.Name, otherName, field.Name))
 						}
 					}
 				}

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -152,7 +152,22 @@ groups:
         validations:
           - type: requiredWith
             arg: FieldB
+      - name: FieldE
+        type: int
+        validations:
+          - type: requiredWith
+            arg: FieldA
+        default: 100
 
+  - name: ConflictTest
+    fields:
+      - name: FieldA
+        type: int
+      - name: FieldB
+        type: int
+        validations:
+          - type: conflictsWith
+            arg: FieldA
 
   - name: Traces
     fields:
@@ -276,8 +291,10 @@ func Test_validate(t *testing.T) {
 		{"good require A", mm("RequireTest.FieldA", 1, "RequireTest.FieldC", 3), ""},
 		{"good require B", mm("RequireTest.FieldB", 2, "RequireTest.FieldC", 3, "RequireTest.FieldD", 4), ""},
 		{"good require C", mm("RequireTest.FieldC", 3), ""},
+        {"good require E with default", mm("RequireTest.FieldA", 2, "RequireTest.FieldC", 3), ""},
 		{"bad require", mm("RequireTest.FieldA", 1), "the group RequireTest is missing its required field FieldC"},
-		{"bad require", mm("RequireTest.FieldA", 1, "RequireTest.FieldB", 2), "the group RequireTest includes FieldB, which also requires FieldD"},
+        {"bad conflicts with A", mm("ConflictTest.FieldA", 2, "ConflictTest.FieldB", 3), "the group ConflictTest includes FieldA, which conflicts with FieldB"},
+        {"good conflicts with A", mm("ConflictTest.FieldA", 2), ""},
 		{"good slice elementType", mm("Traces.AStringArray", []any{"0.0.0.0:8080", "192.168.1.1:8080"}), ""},
 		{"bad slice elementType", mm("Traces.AStringArray", []any{"0.0.0.0"}), "field Traces.AStringArray[0] (0.0.0.0) must be a hostport: address 0.0.0.0: missing port in address"},
 		{"good map elementType", mm("Traces.AStringMap", map[string]any{"k": "v"}), ""},


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

Fixes https://github.com/honeycombio/refinery/issues/803 by ensuring that only both `AvailableMemory` and `MaxAlloc` cannot be set at the same. `MaxMemoryPercentage` may still be set regardless as it has a default value defined. 

While making this changes I noticed that when only `AvailableMemory` was defined I ran into a validation `requireWith` error. The validation only fails on the first pass before defaults are loaded in from the config struct. If the failure is intentional then we probably should remove the default -- only breaking change I could see is if someone was running with validations turned off explicitly. 

```bash
 $ docker-compose up
[+] Running 1/0
 ✔ Container refinery-refinery-1  Recreated                                                                   0.0s
Attaching to refinery-refinery-1
refinery-refinery-1  | 2023/07/24 07:57:40 maxprocs: Leaving GOMAXPROCS=6: CPU quota undefined
refinery-refinery-1  | Validation failed for config file /etc/refinery/config.yaml:
refinery-refinery-1  |   the group Collection includes AvailableMemory, which also requires MaxMemoryPercentage
refinery-refinery-1  |
refinery-refinery-1  |
refinery-refinery-1 exited with code 1
$ cat config.yaml 
General:
  ConfigurationVersion: 2
  MinRefineryVersion: v2.0


Collection:
  AvailableMemory: 2Gb

```



## Short description of the changes

- Adds `conflictsWith` validation type acting in an opposite way to `requireWith` 
- Modified `requireWith` to check whether or not the required field has a default value

Fixes #803.