### PR TITLE
fix: add missing metrics fields

### DIFF
--- a/collect/collect.go
+++ b/collect/collect.go
@@ -607,6 +607,8 @@ func (i *InMemCollector) send(trace *types.Trace, reason string) {
 	if key != "" {
 		logFields["sample_key"] = key
 	}
+	// This will observe sample rate attempts even if the trace is dropped
+	i.Metrics.Histogram("trace_aggregate_sample_rate", float64(rate))
 
 	i.sampleTraceCache.Record(trace, shouldSend)
 
@@ -617,6 +619,8 @@ func (i *InMemCollector) send(trace *types.Trace, reason string) {
 		return
 	}
 	i.Metrics.Increment("trace_send_kept")
+	// This will observe sample rate decisions only if the trace is kept
+	i.Metrics.Histogram("trace_kept_sample_rate", float64(rate))
 
 	// ok, we're not dropping this trace; send all the spans
 	if i.Config.GetIsDryRun() && !shouldSend {

--- a/metrics/otel_metrics.go
+++ b/metrics/otel_metrics.go
@@ -119,6 +119,7 @@ func (o *OTelMetrics) Start() error {
 		resource.WithAttributes(resource.Default().Attributes()...),
 		resource.WithAttributes(attribute.KeyValue{Key: "service.name", Value: attribute.StringValue("refinery")}),
 		resource.WithAttributes(attribute.KeyValue{Key: "service.version", Value: attribute.StringValue(o.Version)}),
+		resource.WithAttributes(attribute.KeyValue{Key: "host.name", Value: attribute.StringValue(hostname)}),
 		resource.WithAttributes(attribute.KeyValue{Key: "hostname", Value: attribute.StringValue(hostname)}),
 	)
 
@@ -151,10 +152,9 @@ func (o *OTelMetrics) Start() error {
 	name = "memory_inuse"
 	// This is just reporting the gauge we already track under a different name.
 	var fmem metric.Float64Callback = func(_ context.Context, result metric.Float64Observer) error {
-		o.lock.RLock()
+		// this is an 'ok' value, not an error, so it's safe to ignore it.
 		v, _ := o.Get("memory_heap_allocation")
 		result.Observe(v)
-		o.lock.RUnlock()
 		return nil
 	}
 	g, err = o.meter.Float64ObservableGauge(name, metric.WithFloat64Callback(fmem))

--- a/metrics/otel_metrics.go
+++ b/metrics/otel_metrics.go
@@ -3,6 +3,8 @@ package metrics
 import (
 	"context"
 	"net/url"
+	"os"
+	"runtime"
 	"sync"
 	"time"
 
@@ -105,10 +107,19 @@ func (o *OTelMetrics) Start() error {
 		return err
 	}
 
+	// Fetch the hostname once and add it as an attribute to all metrics
+	var hostname string
+	if hn, err := os.Hostname(); err != nil {
+		hostname = "unknown: " + err.Error()
+	} else {
+		hostname = hn
+	}
+
 	res, err := resource.New(ctx,
 		resource.WithAttributes(resource.Default().Attributes()...),
 		resource.WithAttributes(attribute.KeyValue{Key: "service.name", Value: attribute.StringValue("refinery")}),
 		resource.WithAttributes(attribute.KeyValue{Key: "service.version", Value: attribute.StringValue(o.Version)}),
+		resource.WithAttributes(attribute.KeyValue{Key: "hostname", Value: attribute.StringValue(hostname)}),
 	)
 
 	if err != nil {
@@ -124,6 +135,46 @@ func (o *OTelMetrics) Start() error {
 		sdkmetric.WithResource(res),
 	)
 	o.meter = provider.Meter("otelmetrics")
+
+	// These metrics are dynamic fields that should always be collected
+	name := "num_goroutines"
+	var fgo metric.Float64Callback = func(_ context.Context, result metric.Float64Observer) error {
+		result.Observe(float64(runtime.NumGoroutine()))
+		return nil
+	}
+	g, err := o.meter.Float64ObservableGauge(name, metric.WithFloat64Callback(fgo))
+	if err != nil {
+		return err
+	}
+	o.gauges[name] = g
+
+	name = "memory_inuse"
+	// This is just reporting the gauge we already track under a different name.
+	var fmem metric.Float64Callback = func(_ context.Context, result metric.Float64Observer) error {
+		o.lock.RLock()
+		v, _ := o.Get("memory_heap_allocation")
+		result.Observe(v)
+		o.lock.RUnlock()
+		return nil
+	}
+	g, err = o.meter.Float64ObservableGauge(name, metric.WithFloat64Callback(fmem))
+	if err != nil {
+		return err
+	}
+	o.gauges[name] = g
+
+	startTime := time.Now()
+	name = "process_uptime_seconds"
+	var fup metric.Float64Callback = func(_ context.Context, result metric.Float64Observer) error {
+		result.Observe(float64(time.Since(startTime) / time.Second))
+		return nil
+	}
+	g, err = o.meter.Float64ObservableGauge(name, metric.WithFloat64Callback(fup))
+	if err != nil {
+		return err
+	}
+	o.gauges[name] = g
+
 	return nil
 }
 


### PR DESCRIPTION

## Which problem is this PR solving?

- Fixes #801. OTelMetrics was missing some fields that were present in LegacyMetrics. This adds them.
- Adds new sample rate metrics

## Short description of the changes

- Add mechanism that adds the dynamic fields to otel.
- Add some histograms for aggregate sample rate and kept sample rate.

