### PR TITLE
feat: Add `has-root-span` operator to rules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,7 @@ jobs:
           key: v1-dockerize-{{ checksum "Makefile" }}
           paths:
             - dockerize.tar.gz
+      - run: mkdir -p /home/circleci/go/pkg/mod
       - restore_cache:
           keys:
             - v3-go-mod-{{ checksum "go.sum" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,16 +71,15 @@ jobs:
           keys:
             - v1-dockerize-{{ checksum "Makefile" }}
             - v1-dockerize-
-      - run: make verify-licenses
       - run: make dockerize
       - save_cache:
           key: v1-dockerize-{{ checksum "Makefile" }}
           paths:
             - dockerize.tar.gz
-      - run: mkdir -p /home/circleci/go/pkg/mod
       - restore_cache:
           keys:
             - v3-go-mod-{{ checksum "go.sum" }}
+      - run: make verify-licenses
       - run: make test
       - save_cache:
           key: v3-go-mod-{{ checksum "go.sum" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
   test:
     docker:
       - image: cimg/go:1.19
-      - image: redis:6
+      - image: redis:6.2
     steps:
       - checkout
       - restore_cache:

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -338,7 +338,7 @@ func TestReadRulesConfig(t *testing.T) {
 	assert.NoError(t, err)
 	switch r := d.(type) {
 	case *RulesBasedSamplerConfig:
-		assert.Len(t, r.Rules, 5)
+		assert.Len(t, r.Rules, 6)
 
 		var rule *RulesBasedSamplerRule
 
@@ -356,7 +356,7 @@ func TestReadRulesConfig(t *testing.T) {
 		assert.Equal(t, 5, rule.SampleRate)
 		assert.Equal(t, "span", rule.Scope)
 
-		rule = r.Rules[4]
+		rule = r.Rules[5]
 		assert.Equal(t, 10, rule.SampleRate)
 		assert.Equal(t, "", rule.Scope)
 

--- a/config/metadata/rulesMeta.yaml
+++ b/config/metadata/rulesMeta.yaml
@@ -7,7 +7,7 @@ groups:
       `Samplers` maps targets to sampler configurations. Each target is a
       Honeycomb environment (or a dataset for Honeycomb Classic keys).
       The value is the sampler to use for that target. A `__default__`
-      target is required. The target called `__default__` will be used 
+      target is required. The target called `__default__` will be used
       for any target that is not explicitly listed.
 
       The targets are determined by examining the API key used to send the
@@ -33,7 +33,7 @@ groups:
         summary: is the sample rate to use.
         description: >
           The sample rate to use. It indicates a ratio, where one sample trace
-          is kept for every N traces seen. For example, a `SampleRate` of `30` 
+          is kept for every N traces seen. For example, a `SampleRate` of `30`
           will keep 1 out of every 30 traces. The choice on whether to keep any
           specific trace is random, so the rate is approximate.
 
@@ -78,19 +78,19 @@ groups:
           will be handed to the Dynamic Sampler. The combination of values from
           all of these fields should reflect how interesting the trace is
           compared to another.
-          
+
           When choosing field names for `FieldList`, a good field selection
           has consistent values for high-frequency, boring traffic, and
           unique values for outliers and interesting traffic. Including
           an error field, or something like `HTTP status code`, is an
           excellent choice. Using fields with very high cardinality,
           like `k8s.pod.id`, is a bad choice.
-          
+
           If the combination of fields essentially makes each trace unique,
           then the Dynamic Sampler will sample everything. If the combination
           of fields is not unique enough, then you will not be guaranteed
           samples of the most interesting traces.
-          
+
           As an example, consider as a good set of fields: the combination of
           `HTTP endpoint` (high-frequency and boring), `HTTP method`, and
           `status code` (normally boring but can become interesting when
@@ -102,7 +102,7 @@ groups:
           combination of `HTTP endpoint`, `status code`, and `pod id`, since it
           would result in keys that are all unique, and therefore result in
           sampling 100% of traces.
-          
+
           For example, rather than a set of fields, using only the `HTTP
           endpoint` field is a **bad** choice, as it is not unique enough, and
           therefore interesting traces, like traces that experienced a `500`,
@@ -593,6 +593,7 @@ groups:
               - does-not-contain
               - exists
               - not-exists
+              - has-root-span
         summary: is the comparison operator to use.
         description: >
           The comparison operator to use. String comparisons are case-sensitive.

--- a/config/sampler_config.go
+++ b/config/sampler_config.go
@@ -23,6 +23,7 @@ const (
 	StartsWith     = "starts-with"
 	Exists         = "exists"
 	NotExists      = "not-exists"
+	HasRootSpan    = "has-root-span"
 )
 
 // The json tags in this file are used for conversion from the old format (see tools/convert for details).
@@ -249,6 +250,9 @@ func (r *RulesBasedSamplerCondition) setMatchesFunction() error {
 		if err != nil {
 			return err
 		}
+	case HasRootSpan:
+		// this is evaluated at the trace level, so we don't need to do anything here
+		return nil
 	default:
 		return fmt.Errorf("unknown operator '%s'", r.Operator)
 	}
@@ -302,7 +306,7 @@ func tryConvertToString(v any) (string, bool) {
 	return fmt.Sprintf("%v", v), true
 }
 
-func tryConvertToBool(v any) bool {
+func TryConvertToBool(v any) bool {
 	value, ok := tryConvertToString(v)
 	if !ok {
 		return false
@@ -490,12 +494,12 @@ func setCompareOperators(r *RulesBasedSamplerCondition, condition string) error 
 			return nil
 		}
 	case "bool":
-		conditionValue := tryConvertToBool(r.Value)
+		conditionValue := TryConvertToBool(r.Value)
 
 		switch condition {
 		case NEQ:
 			r.Matches = func(spanValue any, exists bool) bool {
-				if n := tryConvertToBool(spanValue); exists {
+				if n := TryConvertToBool(spanValue); exists {
 					return n != conditionValue
 				}
 				return false
@@ -503,7 +507,7 @@ func setCompareOperators(r *RulesBasedSamplerCondition, condition string) error 
 			return nil
 		case EQ:
 			r.Matches = func(spanValue any, exists bool) bool {
-				if n := tryConvertToBool(spanValue); exists {
+				if n := TryConvertToBool(spanValue); exists {
 					return n == conditionValue
 				}
 				return false

--- a/rules_complete.yaml
+++ b/rules_complete.yaml
@@ -66,14 +66,6 @@ Samplers:
                     - Field: http.route
                       Operator: =
                       Value: /health-check
-                - Name: drop incomplete traces from the buggy service
-                  Drop: true
-                  Conditions:
-                    - Operator: has-root-span
-                      Value: false
-                    - Field: service.name
-                      Operator: =
-                      Value: buggy-service
                 - Name: keep slow 500 errors
                   SampleRate: 1
                   Conditions:
@@ -109,6 +101,14 @@ Samplers:
                     - Field: trace.parent_id
                       Operator: =
                       Value: root
+                - Name: drop incomplete traces from the buggy service
+                  Drop: true
+                  Conditions:
+                    - Operator: has-root-span
+                      Value: false
+                    - Field: service.name
+                      Operator: =
+                      Value: buggy-service
                 # This is the default rule (with no conditions) and therefore
                 # sets the sample rate used if no other rule matches.
                 - Name: default rule

--- a/rules_complete.yaml
+++ b/rules_complete.yaml
@@ -66,6 +66,14 @@ Samplers:
                     - Field: http.route
                       Operator: =
                       Value: /health-check
+                - Name: drop incomplete traces from the buggy service
+                  Drop: true
+                  Conditions:
+                    - Operator: has-root-span
+                      Value: false
+                    - Field: service.name
+                      Operator: =
+                      Value: buggy-service
                 - Name: keep slow 500 errors
                   SampleRate: 1
                   Conditions:


### PR DESCRIPTION
Dependent on #813; that should be merged before this one.


## Which problem is this PR solving?

- Fixes #610 

## Short description of the changes

- Adds a new rule operator, `has-root-span`, that evaluates to a boolean based on whether the root span for the trace has arrived when the rules are evaluated. 
- Add tests for it
- Update metadata (but does not regenerate the docs yet; that will come before the release)

