### PR TITLE
feat: Record why a trace was sent

### DIFF
--- a/collect/collect.go
+++ b/collect/collect.go
@@ -552,7 +552,7 @@ func (i *InMemCollector) isRootSpan(sp *types.Span) bool {
 	return true
 }
 
-func (i *InMemCollector) send(trace *types.Trace, reason string) {
+func (i *InMemCollector) send(trace *types.Trace, sendReason string) {
 	if trace.Sent {
 		// someone else already sent this so we shouldn't also send it.
 		i.Logger.Debug().
@@ -572,7 +572,7 @@ func (i *InMemCollector) send(trace *types.Trace, reason string) {
 		i.Metrics.Increment("trace_send_no_root")
 	}
 
-	i.Metrics.Increment(reason)
+	i.Metrics.Increment(sendReason)
 
 	var sampler sample.Sampler
 	var found bool
@@ -630,6 +630,7 @@ func (i *InMemCollector) send(trace *types.Trace, reason string) {
 	for _, sp := range trace.GetSpans() {
 		if i.Config.GetAddRuleReasonToTrace() {
 			sp.Data["meta.refinery.reason"] = reason
+			sp.Data["meta.refinery.send_reason"] = sendReason
 			if key != "" {
 				sp.Data["meta.refinery.sample_key"] = key
 			}

--- a/config.md
+++ b/config.md
@@ -1,7 +1,7 @@
 # Honeycomb Refinery Configuration Documentation
 
 This is the documentation for the configuration file for Honeycomb's Refinery.
-It was automatically generated on 2023-08-02 at 02:45:17 UTC.
+It was automatically generated on 2023-08-02 at 23:32:04 UTC.
 
 ## The Config file
 
@@ -171,6 +171,9 @@ AddRuleReasonToTrace controls whether to decorate traces with Refinery rule eval
 
 When enabled, this setting causes traces that are sent to Honeycomb to include the field `meta.refinery.reason`.
 This field contains text indicating which rule was evaluated that caused the trace to be included.
+This setting also includes the field `meta.refinery.send_reason`, which contains the reason that the trace was sent.
+Possible values of this field are `trace_send_got_root`, which means that the root span arrived; `trace_send_expired`, which means that TraceTimeout was reached; `trace_send_ejected_full`, which means that the trace cache was full; and `trace_send_ejected_memsize`, which means that refinery was out of memory.
+These names are also the names of metrics that refinery tracks.
 We recommend enabling this setting whenever a rules-based sampler is in use, as it is useful for debugging and understanding the behavior of your Refinery installation.
 
 - Eligible for live reload.

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -178,7 +178,18 @@ groups:
           When enabled, this setting causes traces that are sent to Honeycomb
           to include the field `meta.refinery.reason`. This field contains text
           indicating which rule was evaluated that caused the trace to be
-          included. We recommend enabling this setting whenever a rules-based
+          included.
+
+          This setting also includes the field `meta.refinery.send_reason`,
+          which contains the reason that the trace was sent. Possible values of
+          this field are `trace_send_got_root`, which means that the root span
+          arrived; `trace_send_expired`, which means that TraceTimeout was reached;
+          `trace_send_ejected_full`, which means that the trace cache was full; and
+          `trace_send_ejected_memsize`, which means that refinery was out of memory.
+
+          These names are also the names of metrics that refinery tracks.
+
+          We recommend enabling this setting whenever a rules-based
           sampler is in use, as it is useful for debugging and understanding
           the behavior of your Refinery installation.
 

--- a/refinery_config.md
+++ b/refinery_config.md
@@ -149,6 +149,9 @@ If `false`, then all traffic is accepted and `ReceiveKeys` is ignored.
 
 When enabled, this setting causes traces that are sent to Honeycomb to include the field `meta.refinery.reason`.
 This field contains text indicating which rule was evaluated that caused the trace to be included.
+This setting also includes the field `meta.refinery.send_reason`, which contains the reason that the trace was sent.
+Possible values of this field are `trace_send_got_root`, which means that the root span arrived; `trace_send_expired`, which means that TraceTimeout was reached; `trace_send_ejected_full`, which means that the trace cache was full; and `trace_send_ejected_memsize`, which means that refinery was out of memory.
+These names are also the names of metrics that refinery tracks.
 We recommend enabling this setting whenever a rules-based sampler is in use, as it is useful for debugging and understanding the behavior of your Refinery installation.
 
 - Eligible for live reload.

--- a/tools/convert/templates/configV2.tmpl
+++ b/tools/convert/templates/configV2.tmpl
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created {{ now }} from {{ .Input }} using a template generated on 2023-08-02 at 02:45:16 UTC
+# created {{ now }} from {{ .Input }} using a template generated on 2023-08-02 at 23:32:03 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of
@@ -156,9 +156,18 @@ RefineryTelemetry:
     ## When enabled, this setting causes traces that are sent to Honeycomb to
     ## include the field `meta.refinery.reason`. This field contains text
     ## indicating which rule was evaluated that caused the trace to be
-    ## included. We recommend enabling this setting whenever a rules-based
-    ## sampler is in use, as it is useful for debugging and understanding the
-    ## behavior of your Refinery installation.
+    ## included.
+    ## This setting also includes the field `meta.refinery.send_reason`,
+    ## which contains the reason that the trace was sent. Possible values of
+    ## this field are `trace_send_got_root`, which means that the root span
+    ## arrived; `trace_send_expired`, which means that TraceTimeout was
+    ## reached; `trace_send_ejected_full`, which means that the trace cache
+    ## was full; and `trace_send_ejected_memsize`, which means that refinery
+    ## was out of memory.
+    ## These names are also the names of metrics that refinery tracks.
+    ## We recommend enabling this setting whenever a rules-based sampler is
+    ## in use, as it is useful for debugging and understanding the behavior
+    ## of your Refinery installation.
     ##
     ## Eligible for live reload.
     {{ nonDefaultOnly .Data "AddRuleReasonToTrace" "AddRuleReasonToTrace" false }}


### PR DESCRIPTION
## Which problem is this PR solving?

- #281 is a longstanding issue; this fixes it.

## Short description of the changes

- Record the name of the metric we increment on trace decisions in a meta field, only when `AddRuleReasonToTrace` is specified.
- Update docs
- Regen docs

