### PR TITLE
feat: Add darwin-arm64 to the list of binaries.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,6 +100,9 @@ jobs:
       - go-build:
           os: darwin
           arch: amd64
+      - go-build:
+          os: darwin
+          arch: arm64
       - go-build-convert:
           os: linux
           arch: amd64
@@ -109,6 +112,9 @@ jobs:
       - go-build-convert:
           os: darwin
           arch: amd64
+      - go-build-convert:
+          os: darwin
+          arch: arm64
       - run:
           name: apt_get_update
           command: sudo apt-get -qq update


### PR DESCRIPTION

## Which problem is this PR solving?

- Add darwin-arm to the list of built binaries for convert and for refinery. Fixes #824.

## Short description of the changes

- Adjust circle build script

