### PR TITLE
maint: use Go v1.20

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ commands:
 jobs:
   test:
     docker:
-      - image: cimg/go:1.19
+      - image: cimg/go:1.20
       - image: redis:6.2
     steps:
       - checkout
@@ -88,7 +88,7 @@ jobs:
 
   build_binaries:
     docker:
-      - image: cimg/go:1.19
+      - image: cimg/go:1.20
     steps:
       - checkout
       - go-build:
@@ -190,7 +190,7 @@ jobs:
 
   publish_docker_to_ecr:
     docker:
-      - image: cimg/go:1.19
+      - image: cimg/go:1.20
     steps:
       - setup_googleko
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,6 +100,9 @@ jobs:
       - go-build:
           os: darwin
           arch: amd64
+      - go-build:
+          os: darwin
+          arch: arm64
       - go-build-convert:
           os: linux
           arch: amd64
@@ -109,6 +112,9 @@ jobs:
       - go-build-convert:
           os: darwin
           arch: amd64
+      - go-build-convert:
+          os: darwin
+          arch: arm64
       - run:
           name: apt_get_update
           command: sudo apt-get -qq update

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/honeycombio/refinery
 
-go 1.19
+go 1.20
 
 require (
 	github.com/agnivade/levenshtein v1.1.1


### PR DESCRIPTION
## Which problem is this PR solving?

- Go 1.20 was released in February; we've been using it for development with no problems. There's no reason not to upgrade.

## Short description of the changes

- Bump builds and go.mod to 1.20.

