### PR TITLE
rel: prep v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Refinery Changelog
 
+## 2.1.0 2023-08-04
+
+This is a minor release with several new features and bug fixes, and is recommended for all Refinery users. See [Release Notes](./RELEASE_NOTES.md) for a summary of changes.
+
+## Features
+- feat: Add darwin-arm64 to the list of binaries. (#829) | [Kent Quirk](https://github.com/kentquirk)
+- feat: Allow setting throughput for the cluster. (#827) | [Kent Quirk](https://github.com/kentquirk)
+- feat: Record the event that caused trace evaluation. (#828) | [Kent Quirk](https://github.com/kentquirk)
+- feat: Add `has-root-span` operator to rules. (#814) | [Kent Quirk](https://github.com/kentquirk)
+- feat: Validate Collection memory config through adding `conflictsWith` validation.(#806) | [Mason Legere](https://github.com/MasonLegere)
+- feat: add a field with the formula used to decide to activate stress relief (#805) | [Terra Field](https://github.com/RainOfTerra)
+
+## Fixes
+- fix: Change default ConfigReloadInterval, add jitter, fix docs (#823) | [Kent Quirk](https://github.com/kentquirk)
+- fix: add missing metrics fields (#811) | [Kent Quirk](https://github.com/kentquirk)
+- fix: live reload deadlock (#810) | [Kent Quirk](https://github.com/kentquirk)
+- fix: location and content of sample_rate metric (#809) | [Kent Quirk](https://github.com/kentquirk)
+- fix: Update metadata for bad envvar and regenerate (#800) | [Kent Quirk](https://github.com/kentquirk)
+
+## Maintenance
+- docs: Touch up readme (#832) | [Kent Quirk](https://github.com/kentquirk)
+- maint: use Go v1.20 (#831) | [Kent Quirk](https://github.com/kentquirk)
+- maint: convert hardcoded operators to constants (#813) | [Kent Quirk](https://github.com/kentquirk)
+- maint: Bump dependencies (#821) | [Kent Quirk](https://github.com/kentquirk)
+- docs: refinery_rules.md (#802) | [Terra Field](https://github.com/RainOfTerra)
 
 ## 2.0.2 2023-07-14
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ helm install refinery honeycomb/refinery --values /path/to/refinery-values.yaml
 
 When operating in a cluster, Refinery expects to gather all of the spans in a trace onto a single instance so that it can make a trace decision. Since each span arrives independently, each Refinery instance needs to be able to communicate with all of its peers in order to distribute traces to the correct instance.
 
-This communication can be managed in two ways: via an explicit list of peers the configuration file, or by using self-registration via a shared Redis cache. Installations should generally prefer to use Redis. Even in large installations, the load on the Redis server is quite light, with each instance only making a few requests per minute. A single Redis instance with fractional CPU is usually sufficient.
+This communication can be managed in two ways: via an explicit list of peers in the configuration file, or by using self-registration via a shared Redis cache. Installations should generally prefer to use Redis. Even in large installations, the load on the Redis server is quite light, with each instance only making a few requests per minute. A single Redis instance with fractional CPU is usually sufficient.
 
 
 ## Configuration

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,12 +2,30 @@
 
 While [CHANGELOG.md](./CHANGELOG.md) contains detailed documentation and links to all of the source code changes in a given release, this document is intended to be aimed at a more comprehensible version of the contents of the release from the point of view of users of Refinery.
 
+## Version 2.1.0
+
+This is a minor release with several new features and bug fixes, and is recommended for all Refinery users.
+
+### Notable features
+- The Throughput samplers now include an [optional configuration parameter](./refinery_rules.md#useclustersize-2) called `UseClusterSize` -- when set to `true`, this causes the sampler to treat `GoalThroughputPerSec` as a target for the cluster as a whole, meaning that if the number of instances changes, the configuration doesn't have to change.
+- When using `AddRuleReasonToTrace`, Refinery now also [records an additional](./refinery_config.md#addrulereasontotrace) field, `meta.refinery.send_reason`, that indicates the event which caused refinery to evaluate the trace.
+- There is a new rules operator, `has-root-span`, which returns a boolean value indicating if the trace being evaluated has a root span. The most likely use case is for dropping potentially large long-lived traces.
+- Refinery builds now include binaries for OS/X using arm64 (Apple's M series CPUs)
+
+### Notable fixes
+- The default value for `ConfigReloadInterval` has been lowered to 15s and [its documentation](./refinery_config.md#configreloadinterval) was fixed; it had been incorrectly documented with a feature that was not implemented.
+- OtelMetrics now includes some metrics that were inadvertently omitted from previous releases, like `num_goroutines` and `host.name`.
+- LiveReload now works without deadlocking Refinery.
+- Documentation was improved.
+
+See [the Changelog](./CHANGELOG.md) for the full list of changes.
+
 ## Version 2.0.2
 
 This is a patch release to address additional issues with Refinery 2.0:
 
-* Fixes a performance issue where cluster membership was being queried from Redis with an unreasonably small limit, requiring many round trips and causing occasional timeouts in very large clusters.
-* Fixes a situation where OTel metrics was inappropriately initialized when not configured, causing many errors to be logged as it tried to communicate with Honeycomb.
+- Fixes a performance issue where cluster membership was being queried from Redis with an unreasonably small limit, requiring many round trips and causing occasional timeouts in very large clusters.
+- Fixes a situation where OTel metrics was inappropriately initialized when not configured, causing many errors to be logged as it tried to communicate with Honeycomb.
 
 ## Version 2.0.1
 


### PR DESCRIPTION
This is the prep for the v2.1.0 release.

It includes a 1-word typo fix in the README. Breaking the rules slightly, but VERY slightly.