### PR TITLE
fix: [build] disable cgo for binary-only deploys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,7 @@ commands:
       - run: |
           GOOS=<< parameters.os >> \
           GOARCH=<< parameters.arch >> \
+          CGO_ENABLED=0 \
           go build -ldflags "-X main.BuildID=${CIRCLE_TAG:-${CIRCLE_SHA1:0:7}}" \
           -o $GOPATH/bin/refinery-<< parameters.os >>-<< parameters.arch >> \
           ./cmd/refinery
@@ -42,6 +43,7 @@ commands:
       - run: |
           GOOS=<< parameters.os >> \
           GOARCH=<< parameters.arch >> \
+          CGO_ENABLED=0 \
           go build -ldflags "-X main.BuildID=${CIRCLE_TAG:-${CIRCLE_SHA1:0:7}}" \
           -o $GOPATH/bin/convert-<< parameters.os >>-<< parameters.arch >> \
           ./tools/convert


### PR DESCRIPTION
## Which problem is this PR solving?

- While the Dockerfile builds with CGO_ENABLED=0, the .circleci/config.yml file left it unspecified, causing builds made for the same GOOS & GOARCH as the builder (linux/amd64 by default) to use CGO by accident since [a matching C toolchain is present](https://pkg.go.dev/cmd/cgo#:~:text=any%20other%20version.-,The%20cgo%20tool%20is,0%20to%20disable%20it.,-The%20go%20tool) in the cimg/go convenience image.

```
root@182da09223e8:/# file /r2/refinery-linux-amd64
/r2/refinery-linux-amd64: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, Go BuildID=Hw78705HCrBK7Q8pUdVk/sdhqsE46-B48P0Cvx0qG/X_WRhP-ApFipSmIba6pM/l4KJK8EedZWWVdz6GgZq, with debug_info, not stripped
root@182da09223e8:/# file /r2/refinery-linux-arm64
/r2/refinery-linux-arm64: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=6i4lQA7a7nhfoijLp2bK/6a_KXrmer50H0_jir0AP/OH9eHnFudWb2KB0T2KP0/3GuMnP0C6IjvA_6jUOS9, with debug_info, not stripped
```

- This results in clients using minimal/alpine or other base images with different GLIBC versions to fail to invoke only the linux/amd64 version if they copy the built binary into their environment.

```
/usr/local/bin/otelsamplingproxy: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /usr/local/bin/otelsamplingproxy)
/usr/local/bin/otelsamplingproxy: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /usr/local/bin/otelsamplingproxy)
```

## Short description of the changes

- Sets CGO_ENABLED=0 for go_build step on Circle.

