### PR TITLE
Explain how ReceiveKeys are "special"

### DIFF
--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -140,11 +140,13 @@ groups:
         validations:
           - type: elementType
             arg: string
-        summary: is a set of Honeycomb API keys that the proxy will treat specially.
+        summary: is a set of Honeycomb API keys that the proxy will pass along to Honeycomb.
         description: >
-          This list only applies to span traffic - other Honeycomb API actions
-          will be proxied through to the upstream API directly without modifying
-          keys.
+          This list of Honeycomb API keys will be verified against incoming span
+          traffic. Depending on `AcceptOnlyListedKeys`, spans with API Keys not
+          matching this list could be rejected. This list only applies to span
+          traffic - other Honeycomb API actions will be proxied through to the
+          upstream API directly without modifying keys.
 
       - name: AcceptOnlyListedKeys
         type: bool


### PR DESCRIPTION
We were having a little trouble understanding exactly what `AccessKeys.ReceiveKeys` are meant to be. From talking with Honeycomb folks in sour Slack, it sounds like they are a list of the Honeycomb API keys that OTel clients have/send along with Spans. Then Refinery uses those to forward sampled Spans on to Honeycomb itself.

This change attempts to update the docs to reflect that more clearly.
