### PR TITLE
fix: [config]: fix structured logging

### DIFF
--- a/config.md
+++ b/config.md
@@ -1,7 +1,7 @@
 # Honeycomb Refinery Configuration Documentation
 
 This is the documentation for the configuration file for Honeycomb's Refinery.
-It was automatically generated on 2023-08-02 at 23:32:04 UTC.
+It was automatically generated on 2023-10-31 at 20:19:42 UTC.
 
 ## The Config file
 
@@ -419,7 +419,6 @@ Structured controls whether to use structured logging.
 
 - Not eligible for live reload.
 - Type: `bool`
-- Default: `true`
 
 ## Prometheus Metrics
 
@@ -670,6 +669,16 @@ Many Redis installations do not use this field.
 - Not eligible for live reload.
 - Type: `string`
 - Environment variable: `REFINERY_REDIS_PASSWORD`
+
+### `AuthCode`
+
+AuthCode is the string used to connect to Redis for peer cluster membership management using an explicit AUTH command.
+
+Many Redis installations do not use this field.
+
+- Not eligible for live reload.
+- Type: `string`
+- Environment variable: `REFINERY_REDIS_AUTH_CODE`
 
 ### `Prefix`
 

--- a/config/config.go
+++ b/config/config.go
@@ -109,6 +109,9 @@ type Config interface {
 	// GetHoneycombLoggerConfig returns the config specific to the HoneycombLogger
 	GetHoneycombLoggerConfig() (HoneycombLoggerConfig, error)
 
+	// GetStdoutLoggerConfig returns the config specific to the StdoutLogger
+	GetStdoutLoggerConfig() (StdoutLoggerConfig, error)
+
 	// GetCollectionConfig returns the config specific to the InMemCollector
 	GetCollectionConfig() (CollectionConfig, error)
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -590,6 +590,44 @@ func TestHoneycombLoggerConfigDefaults(t *testing.T) {
 	assert.Equal(t, 5, loggerConfig.SamplerThroughput)
 }
 
+func TestStdoutLoggerConfig(t *testing.T) {
+	cm := makeYAML(
+		"General.ConfigurationVersion", 2,
+		"Logger.Type", "stdout",
+		"StdoutLogger.Structured", true,
+	)
+	rm := makeYAML("ConfigVersion", 2)
+	config, rules := createTempConfigs(t, cm, rm)
+	fmt.Println(config)
+	defer os.Remove(rules)
+	defer os.Remove(config)
+	c, err := getConfig([]string{"--no-validate", "--config", config, "--rules_config", rules})
+	assert.NoError(t, err)
+
+	loggerConfig, err := c.GetStdoutLoggerConfig()
+
+	assert.NoError(t, err)
+
+	assert.True(t, loggerConfig.Structured)
+}
+
+func TestStdoutLoggerConfigDefaults(t *testing.T) {
+	cm := makeYAML(
+		"General.ConfigurationVersion", 2,
+	)
+	rm := makeYAML("ConfigVersion", 2)
+	config, rules := createTempConfigs(t, cm, rm)
+	defer os.Remove(rules)
+	defer os.Remove(config)
+	c, err := getConfig([]string{"--no-validate", "--config", config, "--rules_config", rules})
+	assert.NoError(t, err)
+
+	loggerConfig, err := c.GetStdoutLoggerConfig()
+
+	assert.NoError(t, err)
+
+	assert.False(t, loggerConfig.Structured)
+}
 func TestDatasetPrefix(t *testing.T) {
 	cm := makeYAML(
 		"General.ConfigurationVersion", 2,

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -275,7 +275,7 @@ type HoneycombLoggerConfig struct {
 }
 
 type StdoutLoggerConfig struct {
-	Structured bool `yaml:"Structured" default:"true"`
+	Structured bool `yaml:"Structured" default:"false"`
 }
 
 type PrometheusMetricsConfig struct {
@@ -753,6 +753,13 @@ func (f *fileConfig) GetHoneycombLoggerConfig() (HoneycombLoggerConfig, error) {
 	defer f.mux.RUnlock()
 
 	return f.mainConfig.HoneycombLogger, nil
+}
+
+func (f *fileConfig) GetStdoutLoggerConfig() (StdoutLoggerConfig, error) {
+	f.mux.RLock()
+	defer f.mux.RUnlock()
+
+	return f.mainConfig.StdoutLogger, nil
 }
 
 func (f *fileConfig) GetAllSamplerRules() (*V2SamplerConfig, error) {

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -477,7 +477,7 @@ groups:
       - name: Structured
         type: bool
         valuetype: nondefault
-        default: true
+        default: false
         reload: false
         summary: controls whether to use structured logging.
         description: >

--- a/config/mock.go
+++ b/config/mock.go
@@ -29,6 +29,8 @@ type MockConfig struct {
 	GetLoggerTypeVal                 string
 	GetHoneycombLoggerConfigErr      error
 	GetHoneycombLoggerConfigVal      HoneycombLoggerConfig
+	GetStdoutLoggerConfigErr         error
+	GetStdoutLoggerConfigVal         StdoutLoggerConfig
 	GetLoggerLevelVal                Level
 	GetPeersErr                      error
 	GetPeersVal                      []string
@@ -188,6 +190,13 @@ func (m *MockConfig) GetHoneycombLoggerConfig() (HoneycombLoggerConfig, error) {
 	defer m.Mux.RUnlock()
 
 	return m.GetHoneycombLoggerConfigVal, m.GetHoneycombLoggerConfigErr
+}
+
+func (m *MockConfig) GetStdoutLoggerConfig() (StdoutLoggerConfig, error) {
+	m.Mux.RLock()
+	defer m.Mux.RUnlock()
+
+	return m.GetStdoutLoggerConfigVal, m.GetStdoutLoggerConfigErr
 }
 
 func (m *MockConfig) GetLoggerLevel() Level {

--- a/config_complete.yaml
+++ b/config_complete.yaml
@@ -413,9 +413,9 @@ StdoutLogger:
     ## `true` generates structured logs (JSON). `false` generates plain text
     ## logs.
     ##
-    ## default: true
+    ## default: false
     ## Not eligible for live reload.
-    # Structured: true
+    # Structured: false
 
 ########################
 ## Prometheus Metrics ##

--- a/logger/logrus.go
+++ b/logger/logrus.go
@@ -25,6 +25,15 @@ type LogrusEntry struct {
 func (l *StdoutLogger) Start() error {
 	l.logger = logrus.New()
 	l.logger.SetLevel(l.level)
+	cfg, err := l.Config.GetStdoutLoggerConfig()
+	if err != nil {
+		return err
+	}
+
+	if cfg.Structured {
+		l.logger.SetFormatter(&logrus.JSONFormatter{})
+	}
+
 	return nil
 }
 

--- a/refinery_config.md
+++ b/refinery_config.md
@@ -402,7 +402,6 @@ Only used if `Logger.Type` is "stdout".
 
 - Not eligible for live reload.
 - Type: `bool`
-- Default: `true`
 
 ## Prometheus Metrics
 
@@ -655,6 +654,16 @@ Many Redis installations do not use this field.
 - Not eligible for live reload.
 - Type: `string`
 - Environment variable: `REFINERY_REDIS_PASSWORD`
+
+### `AuthCode`
+
+`AuthCode` is the string used to connect to Redis for peer cluster membership management using an explicit AUTH command.
+
+Many Redis installations do not use this field.
+
+- Not eligible for live reload.
+- Type: `string`
+- Environment variable: `REFINERY_REDIS_AUTH_CODE`
 
 ### `Prefix`
 

--- a/rules.md
+++ b/rules.md
@@ -1,7 +1,7 @@
 # Honeycomb Refinery Rules Documentation
 
 This is the documentation for the rules configuration for Honeycomb's Refinery.
-It was automatically generated on 2023-08-02 at 02:45:17 UTC.
+It was automatically generated on 2023-10-31 at 20:19:43 UTC.
 
 ## The Rules file
 

--- a/tools/convert/templates/configV2.tmpl
+++ b/tools/convert/templates/configV2.tmpl
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created {{ now }} from {{ .Input }} using a template generated on 2023-08-02 at 23:32:03 UTC
+# created {{ now }} from {{ .Input }} using a template generated on 2023-10-31 at 20:19:40 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of
@@ -420,9 +420,8 @@ StdoutLogger:
     ## `true` generates structured logs (JSON). `false` generates plain text
     ## logs.
     ##
-    ## default: true
     ## Not eligible for live reload.
-    {{ nonDefaultOnly .Data "Structured" "Structured" true }}
+    {{ nonDefaultOnly .Data "Structured" "Structured" false }}
 
 ########################
 ## Prometheus Metrics ##
@@ -677,6 +676,14 @@ RedisPeerManagement:
     ##
     ## Not eligible for live reload.
     {{ nonEmptyString .Data "Password" "PeerManagement.Password" "" }}
+
+    ## AuthCode is the string used to connect to Redis for peer cluster
+    ## membership management using an explicit AUTH command.
+    ##
+    ## Many Redis installations do not use this field.
+    ##
+    ## Not eligible for live reload.
+    {{ nonEmptyString .Data "AuthCode" "PeerManagement.AuthCode" "" }}
 
     ## Prefix is a string used as a prefix for the keys in Redis while
     ## storing the peer membership.


### PR DESCRIPTION
## Which problem is this PR solving?
#842
Currently, the structured logging is not working as expected when using stdout logger. 

## Short description of the changes

This PR makes sure the `StdoutLogger.Structured` is applied to the logger implementation. If it's set to true, the logger will use JSON formatter. Otherwise, it's default to using plain text.

