### PR TITLE
fix: change sample key to not include args in honeycomb logger

### DIFF
--- a/logger/honeycomb.go
+++ b/logger/honeycomb.go
@@ -237,7 +237,9 @@ func (h *HoneycombEntry) Logf(f string, args ...interface{}) {
 		level = "unknown"
 	}
 	if h.sampler != nil {
-		rate := h.sampler.GetSampleRate(fmt.Sprintf(`%s:%s`, level, msg))
+		// use the level and the format string as the key for the sampler
+		// this allows us to avoid sampling on high-cardinality fields in the message
+		rate := h.sampler.GetSampleRate(fmt.Sprintf(`%s:%s`, level, f))
 		ev.SampleRate = uint(rate)
 	}
 	ev.Send()


### PR DESCRIPTION
## Which problem is this PR solving?

Previously, Honeycomb logger uses the entire log message as the sampling key. If a log message contains high-cardinality fields, the throttle mechanism will no longer work.

## Short description of the changes

This PR changes the key used for sampling from the entire log message to only use the format string

