### PR TITLE
fix: add refinery version to refinery metric and log

### DIFF
--- a/logger/honeycomb.go
+++ b/logger/honeycomb.go
@@ -83,6 +83,7 @@ func (h *HoneycombLogger) Start() error {
 	}
 	h.libhClient = libhClient
 
+	h.libhClient.AddField("refinery_version", h.Version)
 	if hostname, err := os.Hostname(); err == nil {
 		h.libhClient.AddField("hostname", hostname)
 	}

--- a/metrics/legacy.go
+++ b/metrics/legacy.go
@@ -118,6 +118,7 @@ func (h *LegacyMetrics) initLibhoney(mc config.LegacyMetricsConfig) error {
 	}
 	h.libhClient = libhClient
 
+	h.libhClient.AddField("refinery_version", h.Version)
 	// add some general go metrics to every report
 	// goroutines
 	if hostname, err := os.Hostname(); err == nil {


### PR DESCRIPTION
## Which problem is this PR solving?

- #847

## Short description of the changes

This PR adds `refinery_version` to both legacy metrics and honeycomb logger.

Example of the newly added field:


![Screenshot 2023-11-13 at 2 15 37 PM](https://github.com/honeycombio/refinery/assets/22300958/13f588e9-f1d2-4dfe-96e4-995cd44447e6)
![Screenshot 2023-11-13 at 2 15 13 PM](https://github.com/honeycombio/refinery/assets/22300958/be67a329-4f9b-467f-876d-ab1b52458869)

