### PR TITLE
fix: load default config and rules file in service file

### DIFF
--- a/refinery.service
+++ b/refinery.service
@@ -3,7 +3,7 @@ Description=Refinery Honeycomb Trace-Aware Sampling Proxy
 After=network.target
 
 [Service]
-ExecStart=/usr/bin/refinery -c /etc/refinery/refinery.toml -r /etc/refinery/rules.toml
+ExecStart=/usr/bin/refinery
 KillMode=process
 Restart=on-failure
 User=honeycomb


### PR DESCRIPTION
## Which problem is this PR solving?

- #873

## Short description of the changes

This PR removes the old config and rules argument from the service file for systemd. This should make sure that the default config and rules files are correctly loaded

