### PR TITLE
maint: update circleci config to build docker images with go 1.20

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,7 +181,7 @@ jobs:
 
   build_docker:
     docker:
-      - image: cimg/go:1.19
+      - image: cimg/go:1.20
     steps:
       - setup_googleko
       - checkout
@@ -215,7 +215,7 @@ jobs:
 
   publish_docker_to_dockerhub:
     docker:
-      - image: cimg/go:1.19
+      - image: cimg/go:1.20
     steps:
       - setup_googleko
       - checkout


### PR DESCRIPTION
## Which problem is this PR solving?
- We're pulling Refinery images from dockerhub and our Twistlock infrastructure has identified the image as vulnerable since it builds with go 1.19. This updates the build target from go 1.19 to go 1.20, to resolve the positive scans.

## Short description of the changes
- Update `build_docker` and `publish_docker_to_dockerhub` stages to `go:1.20` to match the other build stages.


