### PR TITLE
feat(config): expose IdleTimeout for http.Server

### DIFF
--- a/config.md
+++ b/config.md
@@ -1,7 +1,7 @@
 # Honeycomb Refinery Configuration Documentation
 
 This is the documentation for the configuration file for Honeycomb's Refinery.
-It was automatically generated on 2023-11-30 at 19:50:23 UTC.
+It was automatically generated on 2023-11-30 at 22:36:51 UTC.
 
 ## The Config file
 
@@ -130,6 +130,17 @@ Incoming traffic is expected to be HTTP, so if using SSL use something like ngin
 - Default: `0.0.0.0:8081`
 - Environment variable: `REFINERY_PEER_LISTEN_ADDRESS`
 - Command line switch: `--peer-listen-address`
+
+### `HTTPIdleTimeout`
+
+HTTPIdleTimeout is the duration the http server waits for activity on the connection.
+
+This is the amount of time after which if the http server does not see any activity, then it pings the client to see if the transport is still alive.
+"0s" means no timeout.
+
+- Not eligible for live reload.
+- Type: `duration`
+- Default: `0s`
 
 ### `HoneycombAPI`
 
@@ -1035,6 +1046,28 @@ This is the amount of time after which if the server does not see any activity, 
 - Not eligible for live reload.
 - Type: `duration`
 - Default: `20s`
+
+### `MaxSendMsgSize`
+
+MaxSendMsgSize is the maximum message size the server can send.
+
+The server enforces a maximum message size to avoid exhausting the memory available to the process by a single request.
+The size is expressed in bytes.
+
+- Not eligible for live reload.
+- Type: `memorysize`
+- Default: `6MiB`
+
+### `MaxRecvMsgSize`
+
+MaxRecvMsgSize is the maximum message size the server can receive.
+
+The server enforces a maximum message size to avoid exhausting the memory available to the process by a single request.
+The size is expressed in bytes.
+
+- Not eligible for live reload.
+- Type: `memorysize`
+- Default: `7MiB`
 
 ## Sample Cache
 

--- a/config/config.go
+++ b/config/config.go
@@ -31,6 +31,9 @@ type Config interface {
 	// peer traffic
 	GetPeerListenAddr() (string, error)
 
+	// GetHTTPIdleTimeout returns the idle timeout for refinery's HTTP server
+	GetHTTPIdleTimeout() time.Duration
+
 	// GetCompressPeerCommunication will be true if refinery should compress
 	// data before forwarding it to a peer.
 	GetCompressPeerCommunication() bool

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -423,6 +423,20 @@ func TestDebugServiceAddr(t *testing.T) {
 	}
 }
 
+func TestHTTPIdleTimeout(t *testing.T) {
+	cm := makeYAML("General.ConfigurationVersion", 2, "Network.HTTPIdleTimeout", "60s")
+	rm := makeYAML("ConfigVersion", 2)
+	config, rules := createTempConfigs(t, cm, rm)
+	defer os.Remove(rules)
+	defer os.Remove(config)
+	c, err := getConfig([]string{"--no-validate", "--config", config, "--rules_config", rules})
+	assert.NoError(t, err)
+
+	if d := c.GetHTTPIdleTimeout(); d != time.Minute {
+		t.Error("received", d, "expected", time.Minute)
+	}
+}
+
 func TestDryRun(t *testing.T) {
 	cm := makeYAML("General.ConfigurationVersion", 2, "Debugging.DryRun", true)
 	rm := makeYAML("ConfigVersion", 2)

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -76,9 +76,10 @@ type GeneralConfig struct {
 }
 
 type NetworkConfig struct {
-	ListenAddr     string `yaml:"ListenAddr" default:"0.0.0.0:8080" cmdenv:"HTTPListenAddr"`
-	PeerListenAddr string `yaml:"PeerListenAddr" default:"0.0.0.0:8081" cmdenv:"PeerListenAddr"`
-	HoneycombAPI   string `yaml:"HoneycombAPI" default:"https://api.honeycomb.io" cmdenv:"HoneycombAPI"`
+	ListenAddr      string   `yaml:"ListenAddr" default:"0.0.0.0:8080" cmdenv:"HTTPListenAddr"`
+	PeerListenAddr  string   `yaml:"PeerListenAddr" default:"0.0.0.0:8081" cmdenv:"PeerListenAddr"`
+	HoneycombAPI    string   `yaml:"HoneycombAPI" default:"https://api.honeycomb.io" cmdenv:"HoneycombAPI"`
+	HTTPIdleTimeout Duration `yaml:"HTTPIdleTimeout"`
 }
 
 type AccessKeyConfig struct {
@@ -463,6 +464,13 @@ func (f *fileConfig) GetPeerListenAddr() (string, error) {
 		return "", err
 	}
 	return f.mainConfig.Network.PeerListenAddr, nil
+}
+
+func (f *fileConfig) GetHTTPIdleTimeout() time.Duration {
+	f.mux.RLock()
+	defer f.mux.RUnlock()
+
+	return time.Duration(f.mainConfig.Network.HTTPIdleTimeout)
 }
 
 func (f *fileConfig) GetCompressPeerCommunication() bool {

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -111,6 +111,21 @@ groups:
           Incoming traffic is expected to be HTTP, so if using SSL
           use something like nginx or a load balancer to do the decryption.
 
+      - name: HTTPIdleTimeout
+        type: duration
+        valuetype: nondefault
+        firstversion: v2.2
+        reload: false
+        default: 0s
+        validations:
+          - type: minOrZero
+            arg: 1s
+        summary: is the duration the http server waits for activity on the connection.
+        description: >
+          This is the amount of time after which if the http server does not see any
+          activity, then it pings the client to see if the transport is still
+          alive. "0s" means no timeout.
+
       - name: HoneycombAPI
         type: url
         valuetype: nondefault

--- a/config/mock.go
+++ b/config/mock.go
@@ -21,6 +21,7 @@ type MockConfig struct {
 	GetListenAddrVal                 string
 	GetPeerListenAddrErr             error
 	GetPeerListenAddrVal             string
+	GetHTTPIdleTimeoutVal            time.Duration
 	GetCompressPeerCommunicationsVal bool
 	GetGRPCEnabledVal                bool
 	GetGRPCListenAddrErr             error
@@ -153,6 +154,13 @@ func (m *MockConfig) GetPeerListenAddr() (string, error) {
 	defer m.Mux.RUnlock()
 
 	return m.GetPeerListenAddrVal, m.GetPeerListenAddrErr
+}
+
+func (m *MockConfig) GetHTTPIdleTimeout() time.Duration {
+	m.Mux.RLock()
+	defer m.Mux.RUnlock()
+
+	return m.GetHTTPIdleTimeoutVal
 }
 
 func (m *MockConfig) GetCompressPeerCommunication() bool {

--- a/config/validate.go
+++ b/config/validate.go
@@ -301,7 +301,7 @@ func (m *Metadata) Validate(data map[string]any) []string {
 					errors = append(errors, msg)
 				} else {
 					fm := mustFloat(validation.Arg)
-					if fv == 0 || fv < fm {
+					if fv != 0 && fv < fm {
 						errors = append(errors, fmt.Sprintf("field %s must be at least %v, or zero", k, validation.Arg))
 					}
 				}

--- a/refinery_config.md
+++ b/refinery_config.md
@@ -102,6 +102,17 @@ Incoming traffic is expected to be HTTP, so if using SSL use something like ngin
 - Environment variable: `REFINERY_PEER_LISTEN_ADDRESS`
 - Command line switch: `--peer-listen-address`
 
+### `HTTPIdleTimeout`
+
+`HTTPIdleTimeout` is the duration the http server waits for activity on the connection.
+
+This is the amount of time after which if the http server does not see any activity, then it pings the client to see if the transport is still alive.
+"0s" means no timeout.
+
+- Not eligible for live reload.
+- Type: `duration`
+- Default: `0s`
+
 ### `HoneycombAPI`
 
 `HoneycombAPI` is the URL of the upstream Honeycomb API where the data will be sent.
@@ -1006,6 +1017,28 @@ This is the amount of time after which if the server does not see any activity, 
 - Not eligible for live reload.
 - Type: `duration`
 - Default: `20s`
+
+### `MaxSendMsgSize`
+
+`MaxSendMsgSize` is the maximum message size the server can send.
+
+The server enforces a maximum message size to avoid exhausting the memory available to the process by a single request.
+The size is expressed in bytes.
+
+- Not eligible for live reload.
+- Type: `memorysize`
+- Default: `6MiB`
+
+### `MaxRecvMsgSize`
+
+`MaxRecvMsgSize` is the maximum message size the server can receive.
+
+The server enforces a maximum message size to avoid exhausting the memory available to the process by a single request.
+The size is expressed in bytes.
+
+- Not eligible for live reload.
+- Type: `memorysize`
+- Default: `7MiB`
 
 ## Sample Cache
 

--- a/route/route.go
+++ b/route/route.go
@@ -204,8 +204,9 @@ func (r *Router) LnS(incomingOrPeer string) {
 
 	r.iopLogger.Info().Logf("Listening on %s", listenAddr)
 	r.server = &http.Server{
-		Addr:    listenAddr,
-		Handler: muxxer,
+		Addr:        listenAddr,
+		Handler:     muxxer,
+		IdleTimeout: r.Config.GetHTTPIdleTimeout(),
 	}
 
 	if r.Config.GetGRPCEnabled() && len(grpcAddr) > 0 {

--- a/tools/convert/templates/configV2.tmpl
+++ b/tools/convert/templates/configV2.tmpl
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created {{ now }} from {{ .Input }} using a template generated on 2023-11-30 at 19:50:21 UTC
+# created {{ now }} from {{ .Input }} using a template generated on 2023-11-30 at 22:36:48 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of
@@ -102,6 +102,18 @@ Network:
     ## default: 0.0.0.0:8081
     ## Not eligible for live reload.
     {{ nonDefaultOnly .Data "PeerListenAddr" "PeerListenAddr" "0.0.0.0:8081" }}
+
+    ## HTTPIdleTimeout is the duration the http server waits for activity on
+    ## the connection.
+    ##
+    ## This is the amount of time after which if the http server does not see
+    ## any activity, then it pings the client to see if the transport is
+    ## still alive. "0s" means no timeout.
+    ##
+    ## Accepts a duration string with units, like "0s".
+    ## default: 0s
+    ## Not eligible for live reload.
+    {{ nonDefaultOnly .Data "HTTPIdleTimeout" "HTTPIdleTimeout" "0s" }}
 
     ## HoneycombAPI is the URL of the upstream Honeycomb API where the data
     ## will be sent.
@@ -1055,6 +1067,26 @@ GRPCServerParameters:
     ## default: 20s
     ## Not eligible for live reload.
     {{ nonDefaultOnly .Data "KeepAliveTimeout" "GRPCServerParameters.Timeout" "20s" }}
+
+    ## MaxSendMsgSize is the maximum message size the server can send.
+    ##
+    ## The server enforces a maximum message size to avoid exhausting the
+    ## memory available to the process by a single request. The size is
+    ## expressed in bytes.
+    ##
+    ## default: 6MiB
+    ## Not eligible for live reload.
+    {{ memorysize .Data "MaxSendMsgSize" "MaxSendMsgSize" "" }}
+
+    ## MaxRecvMsgSize is the maximum message size the server can receive.
+    ##
+    ## The server enforces a maximum message size to avoid exhausting the
+    ## memory available to the process by a single request. The size is
+    ## expressed in bytes.
+    ##
+    ## default: 7MiB
+    ## Not eligible for live reload.
+    {{ memorysize .Data "MaxRecvMsgSize" "MaxRecvMsgSize" "" }}
 
 ##################
 ## Sample Cache ##


### PR DESCRIPTION
## Which problem is this PR solving?

- #825 

## Short description of the changes

This PR adds a new config option `HTTPIdleTimeout` for users to control refinery's http server's idle timeout setting.

I also found and fixed an issue in the `minOrZero` validation logic that prevents users to actually set a field as 0

fix #825 