### PR TITLE
fix(config/metadata): fix reference in description for MaxMemoryPercentage

### DIFF
--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -1032,7 +1032,7 @@ groups:
         description: >
           This value will typically be set through an environment variable
           controlled by the container or deploy script. If this value is zero or
-          not set, then `MaxMemory` cannot be used to calculate the maximum
+          not set, then `MaxMemoryPercentage` cannot be used to calculate the maximum
           allocation and `MaxAlloc` will be used instead. If set, then this must
           be a memory size. Sizes with standard unit suffixes (`MB`, `GiB`,
           etc.) and Kubernetes units (`M`, `Gi`, etc.) are supported. Fractional
@@ -1075,7 +1075,7 @@ groups:
           If set, then this must be a memory size. Sizes with standard unit
           suffixes (`MB`, `GiB`, etc.) and Kubernetes units (`M`, `Gi`, etc.)
           are supported. Fractional values with a suffix are supported. See
-          `MaxMemory` for more details. If set, `Collections.AvailableMemory`
+          `MaxMemoryPercentage` for more details. If set, `Collections.AvailableMemory`
           must not be defined.
 
   - name: BufferSizes


### PR DESCRIPTION
## Which problem is this PR solving?

- #841 

## Short description of the changes

This PR fixes the description in the config's metadata to correctly reference `MaxMemoryPercentage`.
I didn't run doc-gen since we will run it all at once before a release. This should make the PR review process much easier

