### PR TITLE
maint: update doc for release process and config/rules doc generation process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,9 +22,9 @@ With the new configuration format redesign in v2.0.0, the workflow for making a 
 
 - Make changes to the YAML tags for a configuration struct.
 - Update `config/metadata/configMeta.yaml` or `config/metadata/rulesMeta.yaml` to reflect such change.
-- Run the command below from inside the `./refinery/tools/` directory to generate the updated `config_complete.yaml` and `rules_complete.yaml`. These two files are used to generate the official Refinery configuration documentation.
-
+- Run the command below from inside the `./refinery/tools/convert/` directory to generate the updated `config.md`, `config_complete.md`, and `rules.md`. These two files are used to generate the official Refinery configuration documentation.
 `make all`
+- If there're changes to rules, you should manually update `rules_complete.yaml`.
 
 # References
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ With the new configuration format redesign in v2.0.0, the workflow for making a 
 - Update `config/metadata/configMeta.yaml` or `config/metadata/rulesMeta.yaml` to reflect such change.
 - Run the command below from inside the `./refinery/tools/convert/` directory to generate the updated `config.md`, `config_complete.md`, and `rules.md`. These two files are used to generate the official Refinery configuration documentation.
 `make all`
-- If there're changes to rules, you should manually update `rules_complete.yaml`.
+- The `rules_complete.yaml` file is an example file constructed manually. If there are substantive changes to rules, you should manually update `rules_complete.yaml`.
 
 # References
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,12 +1,29 @@
 # Release Process
 
 1. Check that licenses are current with `make verify-licenses`
-2. Regenerate documentation with `make all` from within the `tools/convert` folder
-3. Add release entry to [changelog](./CHANGELOG.md)
-4. Add a summary of release changes to [release notes](./RELEASE_NOTES.md)
-5. Open a PR with the above, and merge that into main
-6. Create new tag on merged commit with the new version (e.g. `v1.4.1`)
-7. Push the tag upstream (this will kick off the release pipeline in CI)
-8. Copy change log entry for newest version into draft GitHub release created as part of CI publish steps
-9. Update the `appVersion` and any relevant chart changes in [helm-charts](https://github.com/honeycombio/helm-charts/tree/main/charts/refinery)
-10. If either `refinery_config.md` or `refinery_rules.md` were modified in this release, you must also copy these files to docs and do a docs PR.
+2. Regenerate documentation with `make all` from within the `tools/convert` folder. If there's changes to `rules.md`, you must manually modify the `rules_complete.yaml` to reflect the same change.
+3. If either `refinery_config.md` or `refinery_rules.md` were modified in this release, you must also copy these files to [docs](https://github.com/honeycombio/docs) and do a docs PR. Address any feedback from the the docs team and apply those feedback back into this repo.
+4. After addressing any docs change, add release entry to [changelog](./CHANGELOG.md)
+    - Use below command to get a list of all commits since last release
+    ```
+        git log <last-release-tag>..HEAD --pretty='%Creset- %s | [%an](https://github.com/%an)'
+    ```
+    - Copy the output from the command above into the top of [changelog](./CHANGELOG.md)
+    - fix each `https://github.com/<author-name>` to point to the correct github username
+    - organize each commit based on their prefix into below three categories:
+    ```
+        ## Features
+         - <a-commit-with-feat-prefix>
+
+        ## Fixes
+         - <a-commit-with-fix-prefix>
+
+        ## Maintenance
+         - <a-commit-with-maintenance-prefix>
+    ```
+5. Add a summary of release changes to [release notes](./RELEASE_NOTES.md)
+6. Open a PR with the above, and merge that into main
+7. Create new tag on merged commit with the new version (e.g. `v1.4.1`)
+8. Push the tag upstream (this will kick off the release pipeline in CI)
+9. Once the build for the new tag is finished, copy change log entry for newest version into draft GitHub release created as part of CI publish steps
+10. Update the `appVersion` and any relevant chart changes in [helm-charts](https://github.com/honeycombio/helm-charts/tree/main/charts/refinery)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,8 +1,9 @@
 # Release Process
 
 1. Check that licenses are current with `make verify-licenses`
-2. Regenerate documentation with `make all` from within the `tools/convert` folder. If there's changes to `rules.md`, you must manually modify the `rules_complete.yaml` to reflect the same change.
-3. If either `refinery_config.md` or `refinery_rules.md` were modified in this release, you must also copy these files to [docs](https://github.com/honeycombio/docs) and do a docs PR. Address any feedback from the the docs team and apply those feedback back into this repo.
+2. Regenerate documentation with `make all` from within the `tools/convert` folder. If there have
+been changes to `rules.md`, you may need to manually modify the `rules_complete.yaml` to reflect the same change.
+3. If either `refinery_config.md` or `refinery_rules.md` were modified in this release, you must also copy these files to [docs](https://github.com/honeycombio/docs) and do a docs PR. Address any feedback from the the docs team and apply that feedback back into this repo.
 4. After addressing any docs change, add release entry to [changelog](./CHANGELOG.md)
     - Use below command to get a list of all commits since last release
     ```
@@ -10,6 +11,7 @@
     ```
     - Copy the output from the command above into the top of [changelog](./CHANGELOG.md)
     - fix each `https://github.com/<author-name>` to point to the correct github username
+    (the `git log` command can't do this automatically)
     - organize each commit based on their prefix into below three categories:
     ```
         ## Features

--- a/tools/convert/Makefile
+++ b/tools/convert/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all
 #: build all the things
-all: template names sample docs validateConfig validateRules build
+all: template names sample complete docs validate build
 
 .PHONY: build
 #: build the binary
@@ -33,6 +33,14 @@ sample:
 	@echo "+++ generating sample config"
 	@echo
 	go run . sample --output=minimal_config.yaml
+
+.PHONY: complete
+#: generate the complete config
+complete:
+	@echo
+	@echo "+++ generating complete config"
+	@echo
+	go run . config --input=../../config.yaml --output=../../config_complete.yaml
 
 .PHONY: docs
 docs: docconfig docrules websiteconfig websiterules
@@ -71,11 +79,17 @@ websiterules:
 
 .PHONY: validate
 #: validate the sample config
-validateConfig:
+validateSampleConfig:
 	@echo
 	@echo "+++ validating sample config"
 	@echo
 	go run . validate config --input=minimal_config.yaml
+
+validateConfig:
+	@echo
+	@echo "+++ validating sample config"
+	@echo
+	go run . validate config --input=../../config_complete.yaml
 
 validateRules:
 	@echo

--- a/tools/convert/README.md
+++ b/tools/convert/README.md
@@ -22,9 +22,9 @@ Usage:
 	For config files, the new v2 config file is commented in detail to help explain what each
 	value does in the new configuration.
 
-	For example, if the v1 file specifield has the same value as the default value, it will be commented out in the output file. Only non-default
-	value is not commented out.d "MetricsAPIKey" in the "HoneycombMetrics" section, the v2
-	file will list that key under the "LegacyMetrics" section under the "APIKey" name.
+	Values that are the same as default values are commented out in the generated output file
+	(since the default values are correct). Only values that do not match the default are
+	enabled in the output file.
 
 	The tool can also convert rules files to the new rules file format.
 

--- a/tools/convert/README.md
+++ b/tools/convert/README.md
@@ -22,7 +22,8 @@ Usage:
 	For config files, the new v2 config file is commented in detail to help explain what each
 	value does in the new configuration.
 
-	For example, if the v1 file specified "MetricsAPIKey" in the "HoneycombMetrics" section, the v2
+	For example, if the v1 file specifield has the same value as the default value, it will be commented out in the output file. Only non-default
+	value is not commented out.d "MetricsAPIKey" in the "HoneycombMetrics" section, the v2
 	file will list that key under the "LegacyMetrics" section under the "APIKey" name.
 
 	The tool can also convert rules files to the new rules file format.
@@ -60,3 +61,15 @@ Help Options:
   -h, --help         Show this help message
 
 ```
+
+## Workflow
+
+The convert tool employs Go templates to dynamically generate output based on metadata definitions located in the `config/metadata/` directory.
+This process involves comparing an input file with the template to produce an updated configuration or rules file.
+
+The metadata in the `config/metadata/` directory serves as a reference for default values and documentation and outlines the structure of the output files.
+
+During the comparison process, if a field in the input file holds the same value as its corresponding default value specified in the metadata, the convert tool
+intelligently comments out that particular field in the output file. Consequently, only fields with non-default values are retained in the uncommented sections of the output file.
+
+For instance, when provided with a minimal config.yaml file containing only necessary values for a barebone setup, the convert tool generates a comprehensive configuration file with all default values. 


### PR DESCRIPTION
## Which problem is this PR solving?

- #883 

## Short description of the changes

This PR adds more details on the release process and config/rules convert tool workflow.
It also fixes a mistake in the `CONTRIBUTING.md` doc regarding the config/rules doc update process
