### PR TITLE
fix: Integration tests fail in parallel

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -223,8 +223,6 @@ func post(t testing.TB, req *http.Request) {
 }
 
 func TestAppIntegration(t *testing.T) {
-	t.Parallel()
-
 	var out bytes.Buffer
 	_, graph := newStartedApp(t, &transmission.WriterSender{W: &out}, 10000, nil, false)
 
@@ -252,8 +250,6 @@ func TestAppIntegration(t *testing.T) {
 }
 
 func TestAppIntegrationWithNonLegacyKey(t *testing.T) {
-	t.Parallel()
-
 	var out bytes.Buffer
 	a, graph := newStartedApp(t, &transmission.WriterSender{W: &out}, 10500, nil, false)
 	a.IncomingRouter.SetEnvironmentCache(time.Second, func(s string) (string, error) { return "test", nil })
@@ -284,8 +280,6 @@ func TestAppIntegrationWithNonLegacyKey(t *testing.T) {
 }
 
 func TestAppIntegrationWithUnauthorizedKey(t *testing.T) {
-	t.Parallel()
-
 	var out bytes.Buffer
 	a, graph := newStartedApp(t, &transmission.WriterSender{W: &out}, 10500, nil, false)
 	a.IncomingRouter.SetEnvironmentCache(time.Second, func(s string) (string, error) { return "test", nil })


### PR DESCRIPTION
## Which problem is this PR solving?

- After merging #934, integration tests started failing because they can't safely run in parallel. 

## Short description of the changes

- Remove the parallelization markers.

