### PR TITLE
feat: Add `matches` operator to rules

### DIFF
--- a/config/metadata/rulesMeta.yaml
+++ b/config/metadata/rulesMeta.yaml
@@ -625,6 +625,7 @@ groups:
               - exists
               - not-exists
               - has-root-span
+              - matches
         summary: is the comparison operator to use.
         description: >
           The comparison operator to use. String comparisons are case-sensitive.

--- a/sample/rules.go
+++ b/sample/rules.go
@@ -235,6 +235,10 @@ func extractValueFromSpan(span *types.Span, condition *config.RulesBasedSamplerC
 	return value, exists
 }
 
+// This only gets called when we're using one of the basic operators, and
+// there is no datatype specified (meaning that the Matches function has not
+// been set). In this case, we need to do some type conversion and comparison
+// to determine whether the condition matches the value.
 func conditionMatchesValue(condition *config.RulesBasedSamplerCondition, value interface{}, exists bool) bool {
 	var match bool
 	switch exists {
@@ -265,30 +269,6 @@ func conditionMatchesValue(condition *config.RulesBasedSamplerCondition, value i
 		case config.LTE:
 			if comparison, ok := compare(value, condition.Value); ok {
 				match = comparison == less || comparison == equal
-			}
-		case config.StartsWith:
-			switch a := value.(type) {
-			case string:
-				switch b := condition.Value.(type) {
-				case string:
-					match = strings.HasPrefix(a, b)
-				}
-			}
-		case config.Contains:
-			switch a := value.(type) {
-			case string:
-				switch b := condition.Value.(type) {
-				case string:
-					match = strings.Contains(a, b)
-				}
-			}
-		case config.DoesNotContain:
-			switch a := value.(type) {
-			case string:
-				switch b := condition.Value.(type) {
-				case string:
-					match = !strings.Contains(a, b)
-				}
 			}
 		}
 	case false:

--- a/sample/rules_test.go
+++ b/sample/rules_test.go
@@ -1,6 +1,7 @@
 package sample
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/honeycombio/refinery/config"
@@ -687,6 +688,12 @@ func TestRules(t *testing.T) {
 	}
 
 	for _, d := range data {
+		for _, rule := range d.Rules.Rules {
+			for _, cond := range rule.Conditions {
+				err := cond.Init()
+				assert.NoError(t, err)
+			}
+		}
 		sampler := &RulesBasedSampler{
 			Config:  d.Rules,
 			Logger:  &logger.NullLogger{},
@@ -1638,6 +1645,62 @@ func TestRulesDatatypes(t *testing.T) {
 			ExpectedKeep: true,
 			ExpectedRate: 10,
 		},
+		{
+			Rules: &config.RulesBasedSamplerConfig{
+				Rules: []*config.RulesBasedSamplerRule{
+					{
+						Name:       "regexp1",
+						SampleRate: 10,
+						Conditions: []*config.RulesBasedSamplerCondition{
+							{
+								Field:    "test",
+								Operator: config.MatchesRegexp,
+								Value:    "^[0-9]+$",
+							},
+						},
+					},
+				},
+			},
+			Spans: []*types.Span{
+				{
+					Event: types.Event{
+						Data: map[string]interface{}{
+							"test": int64(123),
+						},
+					},
+				},
+			},
+			ExpectedKeep: true,
+			ExpectedRate: 10,
+		},
+		{
+			Rules: &config.RulesBasedSamplerConfig{
+				Rules: []*config.RulesBasedSamplerRule{
+					{
+						Name:       "regexpWholeStringFail",
+						SampleRate: 10,
+						Conditions: []*config.RulesBasedSamplerCondition{
+							{
+								Field:    "test",
+								Operator: config.MatchesRegexp,
+								Value:    "^[0-9]+$",
+							},
+						},
+					},
+				},
+			},
+			Spans: []*types.Span{
+				{
+					Event: types.Event{
+						Data: map[string]interface{}{
+							"test": "abc",
+						},
+					},
+				},
+			},
+			ExpectedKeep: false,
+			ExpectedRate: 99,
+		},
 	}
 
 	for _, d := range data {
@@ -1662,6 +1725,79 @@ func TestRulesDatatypes(t *testing.T) {
 			if !d.ExpectedKeep {
 				assert.Equal(t, d.ExpectedKeep, keep, d.Rules)
 			}
+		})
+	}
+}
+
+func TestRegexpRules(t *testing.T) {
+	testdata := []struct {
+		re      string
+		value   any
+		rate    uint
+		wantErr bool
+	}{
+		{`\d+`, "abc", 1, false},
+		{`\d+`, "123", 10, false},
+		{`^\d+$`, "123abc", 1, false},
+		{`^\d+`, "123abc", 10, false},
+		{`\d+$`, "123abc", 1, false},
+		{`\d+`, 123, 10, false},
+		{`/foo/bar/[a-z]+`, "/foo/bar/abc", 10, false},
+		{`/foo/bar/[a-z]+`, "/foo/bar/123", 1, false},
+		{`[a-z+`, "/foo/bar/123", 1, true},
+	}
+
+	for i, d := range testdata {
+		name := fmt.Sprintf("regexp-%d", i)
+		t.Run(name, func(t *testing.T) {
+			rules := &config.RulesBasedSamplerConfig{
+				Rules: []*config.RulesBasedSamplerRule{
+					{
+						Name:       name,
+						SampleRate: 10,
+						Conditions: []*config.RulesBasedSamplerCondition{
+							{
+								Field:    "test",
+								Operator: config.MatchesRegexp,
+								Value:    d.re,
+							},
+						},
+					},
+				},
+			}
+			for _, rule := range rules.Rules {
+				err := rule.Conditions[0].Init()
+				if d.wantErr != (err != nil) {
+					t.Errorf("parse error = %v, wantErr %v", err, d.wantErr)
+				}
+			}
+
+			sampler := &RulesBasedSampler{
+				Config:  rules,
+				Logger:  &logger.NullLogger{},
+				Metrics: &metrics.NullMetrics{},
+			}
+
+			sampler.Start()
+
+			trace := &types.Trace{}
+
+			spans := []*types.Span{
+				{
+					Event: types.Event{
+						Data: map[string]interface{}{
+							"test": d.value,
+						},
+					},
+				},
+			}
+
+			for _, span := range spans {
+				trace.AddSpan(span)
+			}
+
+			rate, _, _, _ := sampler.GetSampleRate(trace)
+			assert.Equal(t, d.rate, rate, d)
 		})
 	}
 }

--- a/sample/rules_test.go
+++ b/sample/rules_test.go
@@ -1698,8 +1698,8 @@ func TestRulesDatatypes(t *testing.T) {
 					},
 				},
 			},
-			ExpectedKeep: false,
-			ExpectedRate: 99,
+			ExpectedKeep: true,
+			ExpectedRate: 1,
 		},
 	}
 


### PR DESCRIPTION
## Which problem is this PR solving?

- Adds a regular expression `matches` operator to rules which should make some rules easier to write, especially when dealing with URLs or complex string fields.

## Short description of the changes

- Add `matches` operator
- Remove some unused switch cases from `conditionMatchesOperator` (to avoid implementing another one)
- Add tests for it

This is part of #822.

This one will need further documentation, but that will be addressed in a separate PR.

