### PR TITLE
maint: upload test result to circle ci 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,6 +83,8 @@ jobs:
             - v3-go-mod-{{ checksum "go.sum" }}
       - run: make verify-licenses
       - run: make test
+      - store_test_results:
+          path: test_results
       - save_cache:
           key: v3-go-mod-{{ checksum "go.sum" }}
           paths:

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 
 # Test binary, build with `go test -c`
 *.test
+test_results/
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out

--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,10 @@ dockerize.tar.gz:
 	@echo "+++ Retrieving dockerize tool for Redis readiness check."
 	@echo
 # make sure that file is available
+ifeq (, $(shell which file))
 	sudo apt-get update
 	sudo apt-get -y install file
+endif
 	curl --location --silent --show-error \
 		--output dockerize.tar.gz \
 		https://github.com/jwilder/dockerize/releases/download/${DOCKERIZE_VERSION}/${DOCKERIZE_RELEASE_ASSET} \

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ MAKEFLAGS += --warn-undefined-variables
 MAKEFLAGS += --no-builtin-rules
 MAKEFLAGS += --no-builtin-variables
 
-GOTESTCMD = $(if $(shell which gotestsum),gotestsum --junitfile $(1).xml --format testname --,go test)
+GOTESTCMD = $(if $(shell which gotestsum),gotestsum --junitfile ./test_results/$(1).xml --format testname --,go test)
 
 .PHONY: test
 #: run all tests
@@ -10,19 +10,22 @@ test: test_with_race test_all
 
 .PHONY: test_with_race
 #: run only tests tagged with potential race conditions
-test_with_race: wait_for_redis
+test_with_race: test_results wait_for_redis
 	@echo
 	@echo "+++ testing - race conditions?"
 	@echo
-	$(call GOTESTCMD, $@) -tags race --race --timeout 60s -v ./...
+	$(call GOTESTCMD,$@) -tags race --race --timeout 60s -v ./...
 
 .PHONY: test_all
 #: run all tests, but with no race condition detection
-test_all: wait_for_redis
+test_all: test_results wait_for_redis
 	@echo
 	@echo "+++ testing - all the tests"
 	@echo
-	$(call GOTESTCMD, $@) -tags all --timeout 60s -v ./...
+	$(call GOTESTCMD,$@) -tags all --timeout 60s -v ./...
+
+test_results:
+	@mkdir -p test_results
 
 .PHONY: wait_for_redis
 # wait for Redis to become available for test suite
@@ -58,6 +61,7 @@ dockerize.tar.gz:
 clean:
 	rm -f dockerize.tar.gz
 	rm -f dockerize
+	rm -rf test_results
 
 
 .PHONY: install-tools

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ MAKEFLAGS += --warn-undefined-variables
 MAKEFLAGS += --no-builtin-rules
 MAKEFLAGS += --no-builtin-variables
 
+GOTESTCMD = $(if $(shell which gotestsum),gotestsum --junitfile $(1).xml --format testname --,go test)
+
 .PHONY: test
 #: run all tests
 test: test_with_race test_all
@@ -12,7 +14,7 @@ test_with_race: wait_for_redis
 	@echo
 	@echo "+++ testing - race conditions?"
 	@echo
-	go test -tags race --race --timeout 60s -v ./...
+	$(call GOTESTCMD, $@) -tags race --race --timeout 60s -v ./...
 
 .PHONY: test_all
 #: run all tests, but with no race condition detection
@@ -20,7 +22,7 @@ test_all: wait_for_redis
 	@echo
 	@echo "+++ testing - all the tests"
 	@echo
-	go test -tags all --timeout 60s -v ./...
+	$(call GOTESTCMD, $@) -tags all --timeout 60s -v ./...
 
 .PHONY: wait_for_redis
 # wait for Redis to become available for test suite


### PR DESCRIPTION
## Which problem is this PR solving?

Currently, test results in Circle CI is displayed in raw text format like below.
<img width="1182" alt="Screenshot 2023-12-08 at 4 51 05 PM" src="https://github.com/honeycombio/refinery/assets/22300958/b62ed43c-6b9b-4364-bba8-019298020838">
When there're failed tests, it's hard to tell which tests failed without scrolling through the giant test output in circle ci.

## Short description of the changes

This PR utilizes the [`store_test_results`](https://circleci.com/docs/collect-test-data/#introduction ) feature in Circle CI to  have a better UI for finding failed test cases.

Circle CI accepts test results in junit xml file format and has `gotestsum` support builtin in it's image. This PR changes the `Makefile` to run go test using `gotestsum` when `gotestsum` is available.

Here's an example of the new test result output in Circle CI https://app.circleci.com/pipelines/github/honeycombio/refinery/2431/workflows/e8f89378-18f0-454a-bfe5-600d67a85d56/jobs/7065/steps
