### PR TITLE
feat: Add Fields option for rules

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -354,7 +354,7 @@ func TestReadRulesConfig(t *testing.T) {
 
 		rule = r.Rules[1]
 		assert.Equal(t, 1, rule.SampleRate)
-		assert.Equal(t, "keep slow 500 errors", rule.Name)
+		assert.Equal(t, "keep slow 500 errors across semantic conventions", rule.Name)
 		assert.Len(t, rule.Conditions, 2)
 
 		rule = r.Rules[3]

--- a/config/metadata/rulesMeta.yaml
+++ b/config/metadata/rulesMeta.yaml
@@ -603,10 +603,32 @@ groups:
       - name: Field
         type: string
         summary: is the field to check.
+        validations:
+          - type: conflictsWith
+            arg: Fields
         description: >
-          The field to check. This can be any field in the trace. If the field
+          The field to check. This can name any field in the trace. If the field
           is not present, then the condition will not match. The comparison is
           case-sensitive.
+      - name: Fields
+        type: stringarray
+        valuetype: stringarray
+        validations:
+          - type: elementType
+            arg: string
+          - type: conflictsWith
+            arg: Field
+        description: >
+          An array of field names to check. These can name any field in the
+          trace. The fields are checked in the order defined here, and the first
+          named field that contains a value will be used for the condition. Only
+          the first populated field will be used, even if the condition fails.
+
+          If none of the fields are present, then the condition will not match.
+          The comparison is case-sensitive.
+
+          All fields are checked as individual fields before any of them are
+          checked as nested fields (see `CheckNestedFields`).
       - name: Operator
         type: string
         valuetype: choice

--- a/config/sampler_config.go
+++ b/config/sampler_config.go
@@ -224,7 +224,8 @@ func (r *RulesBasedSamplerRule) String() string {
 }
 
 type RulesBasedSamplerCondition struct {
-	Field    string                            `json:"field" yaml:"Field" validate:"required"`
+	Field    string                            `json:"field" yaml:"Field"`
+	Fields   []string                          `json:"fields" yaml:"Fields,omitempty"`
 	Operator string                            `json:"operator" yaml:"Operator" validate:"required"`
 	Value    any                               `json:"value" yaml:"Value" `
 	Datatype string                            `json:"datatype" yaml:"Datatype,omitempty"`
@@ -232,6 +233,17 @@ type RulesBasedSamplerCondition struct {
 }
 
 func (r *RulesBasedSamplerCondition) Init() error {
+	// if Field is specified, we move it into Fields so that we don't have to deal with checking both.
+	// we're going to check that both aren't defined -- this should have been caught by validation
+	// but we'll also check here just in case.
+	if r.Field != "" && len(r.Fields) > 0 {
+		return fmt.Errorf("both Field and Fields are defined in a single condition")
+	}
+	// now we know it's safe to move Field into Fields
+	if r.Field != "" {
+		r.Fields = []string{r.Field}
+	}
+
 	return r.setMatchesFunction()
 }
 

--- a/config/sampler_config.go
+++ b/config/sampler_config.go
@@ -234,16 +234,15 @@ type RulesBasedSamplerCondition struct {
 
 func (r *RulesBasedSamplerCondition) Init() error {
 	// if Field is specified, we move it into Fields so that we don't have to deal with checking both.
-	// we're going to check that both aren't defined -- this should have been caught by validation
-	// but we'll also check here just in case.
-	if r.Field != "" && len(r.Fields) > 0 {
-		return fmt.Errorf("both Field and Fields are defined in a single condition")
-	}
-	// now we know it's safe to move Field into Fields
 	if r.Field != "" {
+		// we're going to check that both aren't defined -- this should have been caught by validation
+		// but we'll also check here just in case.
+		if len(r.Fields) > 0 {
+			return fmt.Errorf("both Field and Fields are defined in a single condition")
+		}
+		// now we know it's safe to move Field into Fields
 		r.Fields = []string{r.Field}
 	}
-
 	return r.setMatchesFunction()
 }
 

--- a/config_complete.yaml
+++ b/config_complete.yaml
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created on 2023-12-04 at 18:06:30 UTC from ../../config.yaml using a template generated on 2023-12-04 at 18:06:10 UTC
+# created on 2023-12-13 at 23:01:53 UTC from ../../config.yaml using a template generated on 2023-12-13 at 23:01:51 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of
@@ -206,11 +206,11 @@ RefineryTelemetry:
     ##
     ## If `true`, then Refinery will ignore the `AddSpanCountToRoot` setting
     ## and add the following fields to the root span based on the values at
-    ## the time the sampling decision was made: - `meta.span_count`: the
-    ## number of child spans on the trace - `meta.span_event_count`: the
-    ## number of span events on the trace - `meta.span_link_count`: the
-    ## number of span links on the trace - `meta.event_count`: the number of
-    ## honeycomb events on the trace
+    ## the time the sampling decision was made:
+    ## - `meta.span_count`: the number of child spans on the trace
+    ## - `meta.span_event_count`: the number of span events on the trace
+    ## - `meta.span_link_count`: the number of span links on the trace
+    ## - `meta.event_count`: the number of honeycomb events on the trace
     ##
     ## Eligible for live reload.
     # AddCountsToRoot: false
@@ -457,7 +457,7 @@ StdoutLogger:
     # Structured: false
 
     ## SamplerEnabled controls whether logs are sampled before sending to
-    ## stdout.
+    ## `stdout`.
     ##
     ## The sample rate is controlled by the `SamplerThroughput` setting.
     ##
@@ -469,7 +469,7 @@ StdoutLogger:
     ##
     ## The sampling algorithm attempts to make sure that the average
     ## throughput approximates this value, while also ensuring that all
-    ## unique logs arrive at stdout at least once per sampling period.
+    ## unique logs arrive at `stdout` at least once per sampling period.
     ##
     ## default: 10
     ## Not eligible for live reload.
@@ -822,7 +822,7 @@ Collection:
     ## queue is contingent upon the number of peers within the cluster.
     ## Specifically, with N peers, the queue's span capacity is determined by
     ## (N-1)/N of the total number of spans. Its minimum value should be at
-    ## least three times the CacheCapacity.
+    ## least three times the `CacheCapacity`.
     ##
     ## default: 30000
     ## Not eligible for live reload.
@@ -834,7 +834,7 @@ Collection:
     ## The incoming span queue is used to buffer spans before they are
     ## processed. If this queue fills up, then subsequent spans will be
     ## dropped. Its minimum value should be at least three times the
-    ## CacheCapacity.
+    ## `CacheCapacity`.
     ##
     ## default: 30000
     ## Not eligible for live reload.
@@ -847,10 +847,10 @@ Collection:
     ## controlled by the container or deploy script. If this value is zero or
     ## not set, then `MaxMemoryPercentage` cannot be used to calculate the
     ## maximum allocation and `MaxAlloc` will be used instead. If set, then
-    ## this must be a memory size. Sizes with standard unit suffixes (`MB`,
-    ## `GiB`, etc.) and Kubernetes units (`M`, `Gi`, etc.) are supported.
-    ## Fractional values with a suffix are supported. If `AvailableMemory` is
-    ## set, `Collections.MaxAlloc` must not be defined.
+    ## this must be a memory size. Sizes with standard unit suffixes (such as
+    ## `MB` and `GiB`) and Kubernetes units (such as `M` and `Gi`) are
+    ## supported. Fractional values with a suffix are supported. If
+    ## `AvailableMemory` is set, `Collections.MaxAlloc` must not be defined.
     ##
     ## Eligible for live reload.
     # AvailableMemory: "4.5Gb"
@@ -874,9 +874,9 @@ Collection:
     ## the Collector.
     ##
     ## If set, then this must be a memory size. Sizes with standard unit
-    ## suffixes (`MB`, `GiB`, etc.) and Kubernetes units (`M`, `Gi`, etc.)
-    ## are supported. Fractional values with a suffix are supported. See
-    ## `MaxMemoryPercentage` for more details. If set,
+    ## suffixes (such as `MB` and `GiB`) and Kubernetes units (such as `M`
+    ## and `Gi`) are supported. Fractional values with a suffix are
+    ## supported. See `MaxMemoryPercentage` for more details. If set,
     ## `Collections.AvailableMemory` must not be defined.
     ##
     ## Eligible for live reload.

--- a/rules.md
+++ b/rules.md
@@ -1,7 +1,7 @@
 # Honeycomb Refinery Rules Documentation
 
 This is the documentation for the rules configuration for Honeycomb's Refinery.
-It was automatically generated on 2023-12-04 at 18:06:13 UTC.
+It was automatically generated on 2023-12-13 at 23:01:54 UTC.
 
 ## The Rules file
 
@@ -531,11 +531,23 @@ If there are no conditions, then the rule will always match.
 ### `Field`
 
 The field to check.
-This can be any field in the trace.
+This can name any field in the trace.
 If the field is not present, then the condition will not match.
 The comparison is case-sensitive.
 
 Type: `string`
+
+### `Fields`
+
+An array of field names to check.
+These can name any field in the trace.
+The fields are checked in the order defined here, and the first named field that contains a value will be used for the condition.
+Only the first populated field will be used, even if the condition fails.
+If none of the fields are present, then the condition will not match.
+The comparison is case-sensitive.
+All fields are checked as individual fields before any of them are checked as nested fields (see `CheckNestedFields`).
+
+Type: `stringarray`
 
 ### `Operator`
 
@@ -544,7 +556,7 @@ String comparisons are case-sensitive.
 
 Type: `string`
 
-- Options: `=`, `!=`, `>`, `<`, `>=`, `<=`, `starts-with`, `contains`, `does-not-contain`, `exists`, `not-exists`, `has-root-span`
+- Options: `=`, `!=`, `>`, `<`, `>=`, `<=`, `starts-with`, `contains`, `does-not-contain`, `exists`, `not-exists`, `has-root-span`, `matches`
 
 ### `Value`
 

--- a/rules_complete.yaml
+++ b/rules_complete.yaml
@@ -66,10 +66,12 @@ Samplers:
                     - Field: http.route
                       Operator: =
                       Value: /health-check
-                - Name: keep slow 500 errors
+                - Name: keep slow 500 errors across semantic conventions
                   SampleRate: 1
                   Conditions:
-                    - Field: status_code
+                    - Fields:
+                        - http.status_code
+                        - http.response.status_code
                       Operator: =
                       Value: 500
                       Datatype: int
@@ -77,9 +79,11 @@ Samplers:
                       Operator: '>='
                       Value: 1000
                       Datatype: float
-                - Name: dynamically sample 200 responses
+                - Name: dynamically sample 200 responses across semantic conventions
                   Conditions:
-                    - Field: status_code
+                    - Fields:
+                        - http.status_code
+                        - http.response.status_code
                       Operator: =
                       Value: 200
                       Datatype: int

--- a/sample/rules_test.go
+++ b/sample/rules_test.go
@@ -936,35 +936,74 @@ func TestRulesWithNestedFields(t *testing.T) {
 			ExpectedRate: 1,
 			ExpectedName: "no rule matched",
 		},
+		{
+			Rules: &config.RulesBasedSamplerConfig{
+				Rules: []*config.RulesBasedSamplerRule{
+					{
+						Name:       "nested fields",
+						SampleRate: 10,
+						Conditions: []*config.RulesBasedSamplerCondition{
+							{
+								Fields:   []string{"test.test1", "test.test2"},
+								Operator: config.EQ,
+								Value:    "a",
+							},
+						},
+					},
+				},
+				CheckNestedFields: true,
+			},
+			Spans: []*types.Span{
+				{
+					Event: types.Event{
+						Data: map[string]interface{}{
+							"test": map[string]interface{}{
+								"test2": "a",
+							},
+						},
+					},
+				},
+			},
+			ExpectedKeep: true,
+			ExpectedRate: 10,
+		},
 	}
 
 	for _, d := range data {
-		sampler := &RulesBasedSampler{
-			Config:  d.Rules,
-			Logger:  &logger.NullLogger{},
-			Metrics: &metrics.NullMetrics{},
-		}
+		t.Run(d.Rules.Rules[0].Name, func(t *testing.T) {
+			for _, rule := range d.Rules.Rules {
+				for _, cond := range rule.Conditions {
+					err := cond.Init()
+					assert.NoError(t, err, "error in "+rule.Name)
+				}
+			}
+			sampler := &RulesBasedSampler{
+				Config:  d.Rules,
+				Logger:  &logger.NullLogger{},
+				Metrics: &metrics.NullMetrics{},
+			}
 
-		trace := &types.Trace{}
+			trace := &types.Trace{}
 
-		for _, span := range d.Spans {
-			trace.AddSpan(span)
-		}
+			for _, span := range d.Spans {
+				trace.AddSpan(span)
+			}
 
-		rate, keep, reason, key := sampler.GetSampleRate(trace)
+			rate, keep, reason, key := sampler.GetSampleRate(trace)
 
-		assert.Equal(t, d.ExpectedRate, rate, d.Rules)
-		name := d.ExpectedName
-		if name == "" {
-			name = d.Rules.Rules[0].Name
-		}
-		assert.Contains(t, reason, name)
-		assert.Equal(t, "", key)
+			assert.Equal(t, d.ExpectedRate, rate, d.Rules)
+			name := d.ExpectedName
+			if name == "" {
+				name = d.Rules.Rules[0].Name
+			}
+			assert.Contains(t, reason, name)
+			assert.Equal(t, "", key)
 
-		// we can only test when we don't expect to keep the trace
-		if !d.ExpectedKeep {
-			assert.Equal(t, d.ExpectedKeep, keep, d.Rules)
-		}
+			// we can only test when we don't expect to keep the trace
+			if !d.ExpectedKeep {
+				assert.Equal(t, d.ExpectedKeep, keep, d.Rules)
+			}
+		})
 	}
 }
 
@@ -1015,6 +1054,12 @@ func TestRulesWithDynamicSampler(t *testing.T) {
 	}
 
 	for _, d := range data {
+		for _, rule := range d.Rules.Rules {
+			for _, cond := range rule.Conditions {
+				err := cond.Init()
+				assert.NoError(t, err, "error in "+rule.Name)
+			}
+		}
 		sampler := &RulesBasedSampler{
 			Config:  d.Rules,
 			Logger:  &logger.NullLogger{},
@@ -1095,6 +1140,12 @@ func TestRulesWithEMADynamicSampler(t *testing.T) {
 	}
 
 	for _, d := range data {
+		for _, rule := range d.Rules.Rules {
+			for _, cond := range rule.Conditions {
+				err := cond.Init()
+				assert.NoError(t, err, "error in "+rule.Name)
+			}
+		}
 		sampler := &RulesBasedSampler{
 			Config:  d.Rules,
 			Logger:  &logger.NullLogger{},
@@ -1215,6 +1266,14 @@ func TestRuleMatchesSpanMatchingSpan(t *testing.T) {
 					},
 					Logger:  &logger.NullLogger{},
 					Metrics: &metrics.NullMetrics{},
+				}
+				for _, s := range sampler.samplers {
+					for _, rule := range s.(*RulesBasedSampler).Config.Rules {
+						for _, cond := range rule.Conditions {
+							err := cond.Init()
+							assert.NoError(t, err, "error in "+rule.Name)
+						}
+					}
 				}
 
 				trace := &types.Trace{}
@@ -1935,6 +1994,12 @@ func TestRulesWithDeterministicSampler(t *testing.T) {
 	}
 
 	for _, d := range data {
+		for _, rule := range d.Rules.Rules {
+			for _, cond := range rule.Conditions {
+				err := cond.Init()
+				assert.NoError(t, err, "error in "+rule.Name)
+			}
+		}
 		sampler := &RulesBasedSampler{
 			Config:  d.Rules,
 			Logger:  &logger.NullLogger{},

--- a/tools/convert/Makefile
+++ b/tools/convert/Makefile
@@ -78,6 +78,10 @@ websiterules:
 	go run . website rules --output=../../refinery_rules.md
 
 .PHONY: validate
+#: validate the sample config and rules
+validate: validateSampleConfig validateConfig validateRules
+
+.PHONY: validateSampleConfig
 #: validate the sample config
 validateSampleConfig:
 	@echo
@@ -85,12 +89,14 @@ validateSampleConfig:
 	@echo
 	go run . validate config --input=minimal_config.yaml
 
+.PHONY: validateSampleRules
 validateConfig:
 	@echo
 	@echo "+++ validating sample config"
 	@echo
 	go run . validate config --input=../../config_complete.yaml
 
+.PHONY: validateRules
 validateRules:
 	@echo
 	@echo "+++ validating sample rules"


### PR DESCRIPTION
## Which problem is this PR solving?

This adds a new option for Rules -- instead of specifying `Field` which is a single field name, it's now possible to specify `Fields`, which takes an array of field names. The evaluator iterates over each field in turn and returns the first field that exists in the incoming span. 

This will allow users to write rules that account for field name changes like the upcoming http semantic convention changes.

## Short description of the changes

- Add new Fields element to rules data structure
- Validate that both Field and Fields do not exist, both in the loading code as well as the validator
- Modify Init() so that it copies Field to Fields so that the evaluation code is clean
- Modify evaluation code
- Write some tests
- Fix some old tests that didn't call Init()
- Document this in metadata
- Add examples to rules_complete
- Regenerate docs files

