### PR TITLE
feat: use a computed field for current descendant count in rules

### DIFF
--- a/config/sampler_config.go
+++ b/config/sampler_config.go
@@ -30,12 +30,15 @@ const (
 	NotIn          = "not-in"
 )
 
+// ComputedField is a virtual field. It's value is calculated during rule evaluation.
+// We use the `?.` prefix to distinguish computed fields from regular fields.
+type ComputedField string
+
 const (
+	// ComputedFieldPrefix is the prefix for computed fields.
 	ComputedFieldPrefix               = "?."
 	NUM_DESCENDANTS     ComputedField = ComputedFieldPrefix + "NUM_DESCENDANTS"
 )
-
-type ComputedField string
 
 // The json tags in this file are used for conversion from the old format (see tools/convert for details).
 // They are deliberately all lowercase.

--- a/config/sampler_config.go
+++ b/config/sampler_config.go
@@ -30,6 +30,13 @@ const (
 	NotIn          = "not-in"
 )
 
+const (
+	ComputedFieldPrefix               = "?."
+	NUM_DESCENDANTS     ComputedField = ComputedFieldPrefix + "NUM_DESCENDANTS"
+)
+
+type ComputedField string
+
 // The json tags in this file are used for conversion from the old format (see tools/convert for details).
 // They are deliberately all lowercase.
 // The yaml tags are used for the new format and are PascalCase.
@@ -248,6 +255,14 @@ func (r *RulesBasedSamplerCondition) Init() error {
 
 func (r *RulesBasedSamplerCondition) String() string {
 	return fmt.Sprintf("%+v", *r)
+}
+
+func (r *RulesBasedSamplerCondition) GetComputedField() (ComputedField, bool) {
+	if strings.HasPrefix(r.Field, ComputedFieldPrefix) {
+		return ComputedField(r.Field), true
+	}
+	return "", false
+
 }
 
 func (r *RulesBasedSamplerCondition) setMatchesFunction() error {

--- a/sample/rules_test.go
+++ b/sample/rules_test.go
@@ -772,6 +772,126 @@ func TestRules(t *testing.T) {
 			ExpectedName: "no rule matched",
 			ExpectedRate: 1,
 		},
+		{
+			Rules: &config.RulesBasedSamplerConfig{
+				Rules: []*config.RulesBasedSamplerRule{
+					{
+						Name:       "Check that the number of descendants is greater than 3",
+						SampleRate: 1,
+						Conditions: []*config.RulesBasedSamplerCondition{
+							{
+								Field:    string(config.NUM_DESCENDANTS),
+								Operator: config.GT,
+								Value:    int(3),
+								Datatype: "int",
+							},
+						},
+						Drop: true,
+					},
+				},
+			},
+			Spans: []*types.Span{
+				{
+					Event: types.Event{
+						Data: map[string]interface{}{
+							"trace.trace_id":  "12345",
+							"trace.span_id":   "54322",
+							"trace.parent_id": "54321",
+							"meta.span_count": int64(2),
+						},
+					},
+				},
+				{
+					Event: types.Event{
+						Data: map[string]interface{}{
+							"trace.trace_id":  "12345",
+							"trace.span_id":   "654321",
+							"trace.parent_id": "54322",
+						},
+					},
+				},
+				{
+					Event: types.Event{
+						Data: map[string]interface{}{
+							"trace.trace_id":  "12345",
+							"trace.span_id":   "754321",
+							"trace.parent_id": "54322",
+						},
+					},
+				},
+				{
+					Event: types.Event{
+						Data: map[string]interface{}{
+							"trace.trace_id":  "12345",
+							"trace.span_id":   "754321",
+							"trace.parent_id": "54322",
+						},
+					},
+				},
+			},
+			ExpectedName: "Check that the number of descendants is greater than 3",
+			ExpectedKeep: false,
+			ExpectedRate: 1,
+		},
+		{
+			Rules: &config.RulesBasedSamplerConfig{
+				Rules: []*config.RulesBasedSamplerRule{
+					{
+						Name:       "Check that the number of descendants is less than 3",
+						SampleRate: 1,
+						Conditions: []*config.RulesBasedSamplerCondition{
+							{
+								Field:    string(config.NUM_DESCENDANTS),
+								Operator: config.LT,
+								Value:    int(3),
+							},
+						},
+					},
+				},
+			},
+			Spans: []*types.Span{
+				{
+					Event: types.Event{
+						Data: map[string]interface{}{
+							"trace.trace_id":  "12345",
+							"trace.span_id":   "54322",
+							"trace.parent_id": "54321",
+							"meta.span_count": int64(2),
+						},
+					},
+				},
+				{
+					Event: types.Event{
+						Data: map[string]interface{}{
+							"trace.trace_id":  "12345",
+							"trace.span_id":   "654321",
+							"trace.parent_id": "54322",
+						},
+					},
+				},
+				{
+					Event: types.Event{
+						Data: map[string]interface{}{
+							"trace.trace_id":  "12345",
+							"trace.span_id":   "754321",
+							"trace.parent_id": "54322",
+						},
+					},
+				},
+				{
+					Event: types.Event{
+						Data: map[string]interface{}{
+							"trace.trace_id":  "12345",
+							"trace.span_id":   "754321",
+							"trace.parent_id": "54322",
+						},
+					},
+				},
+			},
+			ExpectedName: "no rule matched",
+			ExpectedKeep: true,
+			ExpectedRate: 1,
+		},
 	}
 
 	for _, d := range data {


### PR DESCRIPTION
## Which problem is this PR solving?

Metadata about a trace is added only to root spans. However, it's useful to make sampling decisions before root span arrives. In this PR, I addressed a specific use case described in [this issue](#646 )

## Short description of the changes

This PR adds a new concept called `ComputedField` in rule based sampler. A `ComputedField` is a virtual field that's generated during rule evaluation for a trace. The virtual field isn't actually defined on a span. 

After some discussion with Kent, we decided to use `?.` as the prefix for computed field so that it shouldn't collide with any regular field names.

This PR doesn't include documentation. I will address it in [this PR for all rules related documentation](https://github.com/honeycombio/refinery/pull/951/files).
