### PR TITLE
feat: Extract unique field names from sampler configs

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -331,7 +331,7 @@ func TestReadRulesConfig(t *testing.T) {
 
 	rules, err := c.GetAllSamplerRules()
 	assert.NoError(t, err)
-	assert.Len(t, rules.UniqueFields(), 10)
+	assert.Len(t, rules.UniqueSamplingFields(), 10)
 
 	d, name, err := c.GetSamplerConfigForDestName("doesnt-exist")
 	assert.NoError(t, err)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -329,6 +329,10 @@ func TestReadRulesConfig(t *testing.T) {
 	c, err := getConfig([]string{"--no-validate", "--config", "../config.yaml", "--rules_config", "../rules_complete.yaml"})
 	assert.NoError(t, err)
 
+	rules, err := c.GetAllSamplerRules()
+	assert.NoError(t, err)
+	assert.Len(t, rules.UniqueFields(), 10)
+
 	d, name, err := c.GetSamplerConfigForDestName("doesnt-exist")
 	assert.NoError(t, err)
 	assert.IsType(t, &DeterministicSamplerConfig{}, d)

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -329,7 +329,7 @@ func newFileConfig(opts *CmdEnv) (*fileConfig, error) {
 		return nil, err
 	}
 
-	rulesconf.SetUniqueFields()
+	rulesconf.SetUniqueSamplingFields()
 
 	cfg := &fileConfig{
 		mainConfig:  mainconf,

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -329,6 +329,8 @@ func newFileConfig(opts *CmdEnv) (*fileConfig, error) {
 		return nil, err
 	}
 
+	rulesconf.SetUniqueFields()
+
 	cfg := &fileConfig{
 		mainConfig:  mainconf,
 		mainHash:    mainhash,

--- a/config/sampler_config.go
+++ b/config/sampler_config.go
@@ -166,7 +166,7 @@ func (v *V2SamplerConfig) SetUniqueSamplingFields() {
 		}
 
 		if c, ok := s.(GetSamplingFielder); ok {
-			for _, field := range c.GeFields() {
+			for _, field := range c.GetSamplingFields() {
 				v.uniqueSamplingFields[field] = struct{}{}
 			}
 		}
@@ -174,7 +174,7 @@ func (v *V2SamplerConfig) SetUniqueSamplingFields() {
 }
 
 type GetSamplingFielder interface {
-	GeFields() []string
+	GetSamplingFields() []string
 }
 
 var _ GetSamplingFielder = (*DeterministicSamplerConfig)(nil)
@@ -183,7 +183,7 @@ type DeterministicSamplerConfig struct {
 	SampleRate int `json:"samplerate" yaml:"SampleRate,omitempty" default:"1" validate:"required,gte=1"`
 }
 
-func (d *DeterministicSamplerConfig) GeFields() []string {
+func (d *DeterministicSamplerConfig) GetSamplingFields() []string {
 	return nil
 }
 
@@ -197,7 +197,7 @@ type DynamicSamplerConfig struct {
 	UseTraceLength bool     `json:"usetracelength" yaml:"UseTraceLength,omitempty"`
 }
 
-func (d *DynamicSamplerConfig) GeFields() []string {
+func (d *DynamicSamplerConfig) GetSamplingFields() []string {
 	return d.FieldList
 }
 
@@ -215,7 +215,7 @@ type EMADynamicSamplerConfig struct {
 	UseTraceLength      bool     `json:"usetracelength" yaml:"UseTraceLength,omitempty"`
 }
 
-func (d *EMADynamicSamplerConfig) GeFields() []string {
+func (d *EMADynamicSamplerConfig) GetSamplingFields() []string {
 	return d.FieldList
 }
 
@@ -235,7 +235,7 @@ type EMAThroughputSamplerConfig struct {
 	UseTraceLength       bool     `json:"usetracelength" yaml:"UseTraceLength,omitempty"`
 }
 
-func (d *EMAThroughputSamplerConfig) GeFields() []string {
+func (d *EMAThroughputSamplerConfig) GetSamplingFields() []string {
 	return d.FieldList
 }
 
@@ -251,7 +251,7 @@ type WindowedThroughputSamplerConfig struct {
 	UseTraceLength       bool     `json:"usetracelength" yaml:"UseTraceLength,omitempty"`
 }
 
-func (d *WindowedThroughputSamplerConfig) GeFields() []string {
+func (d *WindowedThroughputSamplerConfig) GetSamplingFields() []string {
 	return d.FieldList
 }
 
@@ -266,7 +266,7 @@ type TotalThroughputSamplerConfig struct {
 	UseTraceLength       bool     `json:"usetracelength" yaml:"UseTraceLength,omitempty"`
 }
 
-func (d *TotalThroughputSamplerConfig) GeFields() []string {
+func (d *TotalThroughputSamplerConfig) GetSamplingFields() []string {
 	return d.FieldList
 }
 
@@ -278,7 +278,7 @@ type RulesBasedSamplerConfig struct {
 	CheckNestedFields bool                     `json:"checknestedfields" yaml:"CheckNestedFields,omitempty"`
 }
 
-func (r *RulesBasedSamplerConfig) GeFields() []string {
+func (r *RulesBasedSamplerConfig) GetSamplingFields() []string {
 	fields := make([]string, 0)
 
 	for _, rule := range r.Rules {
@@ -295,7 +295,7 @@ func (r *RulesBasedSamplerConfig) GeFields() []string {
 		}
 
 		if rule.Sampler != nil {
-			fields = append(fields, rule.Sampler.GeFields()...)
+			fields = append(fields, rule.Sampler.GetSamplingFields()...)
 		}
 	}
 
@@ -313,31 +313,31 @@ type RulesBasedDownstreamSampler struct {
 	DeterministicSampler      *DeterministicSamplerConfig      `json:"deterministicsampler" yaml:"DeterministicSampler,omitempty"`
 }
 
-func (r *RulesBasedDownstreamSampler) GeFields() []string {
+func (r *RulesBasedDownstreamSampler) GetSamplingFields() []string {
 	fields := make([]string, 0)
 
 	if r.DeterministicSampler != nil {
-		fields = append(fields, r.DeterministicSampler.GeFields()...)
+		fields = append(fields, r.DeterministicSampler.GetSamplingFields()...)
 	}
 
 	if r.DynamicSampler != nil {
-		fields = append(fields, r.DynamicSampler.GeFields()...)
+		fields = append(fields, r.DynamicSampler.GetSamplingFields()...)
 	}
 
 	if r.EMADynamicSampler != nil {
-		fields = append(fields, r.EMADynamicSampler.GeFields()...)
+		fields = append(fields, r.EMADynamicSampler.GetSamplingFields()...)
 	}
 
 	if r.EMAThroughputSampler != nil {
-		fields = append(fields, r.EMAThroughputSampler.GeFields()...)
+		fields = append(fields, r.EMAThroughputSampler.GetSamplingFields()...)
 	}
 
 	if r.WindowedThroughputSampler != nil {
-		fields = append(fields, r.WindowedThroughputSampler.GeFields()...)
+		fields = append(fields, r.WindowedThroughputSampler.GetSamplingFields()...)
 	}
 
 	if r.TotalThroughputSampler != nil {
-		fields = append(fields, r.TotalThroughputSampler.GeFields()...)
+		fields = append(fields, r.TotalThroughputSampler.GetSamplingFields()...)
 	}
 
 	return fields

--- a/config/sampler_config.go
+++ b/config/sampler_config.go
@@ -165,29 +165,29 @@ func (v *V2SamplerConfig) SetUniqueSamplingFields() {
 			continue
 		}
 
-		if c, ok := s.(SamplerConfigger); ok {
-			for _, field := range c.GetSamplingFields() {
+		if c, ok := s.(GetSamplingFielder); ok {
+			for _, field := range c.GeFields() {
 				v.uniqueSamplingFields[field] = struct{}{}
 			}
 		}
 	}
 }
 
-type SamplerConfigger interface {
-	GetSamplingFields() []string
+type GetSamplingFielder interface {
+	GeFields() []string
 }
 
-var _ SamplerConfigger = (*DeterministicSamplerConfig)(nil)
+var _ GetSamplingFielder = (*DeterministicSamplerConfig)(nil)
 
 type DeterministicSamplerConfig struct {
 	SampleRate int `json:"samplerate" yaml:"SampleRate,omitempty" default:"1" validate:"required,gte=1"`
 }
 
-func (d *DeterministicSamplerConfig) GetSamplingFields() []string {
+func (d *DeterministicSamplerConfig) GeFields() []string {
 	return nil
 }
 
-var _ SamplerConfigger = (*DynamicSamplerConfig)(nil)
+var _ GetSamplingFielder = (*DynamicSamplerConfig)(nil)
 
 type DynamicSamplerConfig struct {
 	SampleRate     int64    `json:"samplerate" yaml:"SampleRate,omitempty" validate:"required,gte=1"`
@@ -197,11 +197,11 @@ type DynamicSamplerConfig struct {
 	UseTraceLength bool     `json:"usetracelength" yaml:"UseTraceLength,omitempty"`
 }
 
-func (d *DynamicSamplerConfig) GetSamplingFields() []string {
+func (d *DynamicSamplerConfig) GeFields() []string {
 	return d.FieldList
 }
 
-var _ SamplerConfigger = (*EMADynamicSamplerConfig)(nil)
+var _ GetSamplingFielder = (*EMADynamicSamplerConfig)(nil)
 
 type EMADynamicSamplerConfig struct {
 	GoalSampleRate      int      `json:"goalsamplerate" yaml:"GoalSampleRate,omitempty" validate:"gte=1"`
@@ -215,11 +215,11 @@ type EMADynamicSamplerConfig struct {
 	UseTraceLength      bool     `json:"usetracelength" yaml:"UseTraceLength,omitempty"`
 }
 
-func (d *EMADynamicSamplerConfig) GetSamplingFields() []string {
+func (d *EMADynamicSamplerConfig) GeFields() []string {
 	return d.FieldList
 }
 
-var _ SamplerConfigger = (*EMAThroughputSamplerConfig)(nil)
+var _ GetSamplingFielder = (*EMAThroughputSamplerConfig)(nil)
 
 type EMAThroughputSamplerConfig struct {
 	GoalThroughputPerSec int      `json:"goalthroughputpersec" yaml:"GoalThroughputPerSec,omitempty"`
@@ -235,11 +235,11 @@ type EMAThroughputSamplerConfig struct {
 	UseTraceLength       bool     `json:"usetracelength" yaml:"UseTraceLength,omitempty"`
 }
 
-func (d *EMAThroughputSamplerConfig) GetSamplingFields() []string {
+func (d *EMAThroughputSamplerConfig) GeFields() []string {
 	return d.FieldList
 }
 
-var _ SamplerConfigger = (*WindowedThroughputSamplerConfig)(nil)
+var _ GetSamplingFielder = (*WindowedThroughputSamplerConfig)(nil)
 
 type WindowedThroughputSamplerConfig struct {
 	UpdateFrequency      Duration `json:"updatefrequency" yaml:"UpdateFrequency,omitempty"`
@@ -251,11 +251,11 @@ type WindowedThroughputSamplerConfig struct {
 	UseTraceLength       bool     `json:"usetracelength" yaml:"UseTraceLength,omitempty"`
 }
 
-func (d *WindowedThroughputSamplerConfig) GetSamplingFields() []string {
+func (d *WindowedThroughputSamplerConfig) GeFields() []string {
 	return d.FieldList
 }
 
-var _ SamplerConfigger = (*TotalThroughputSamplerConfig)(nil)
+var _ GetSamplingFielder = (*TotalThroughputSamplerConfig)(nil)
 
 type TotalThroughputSamplerConfig struct {
 	GoalThroughputPerSec int      `json:"goalthroughputpersec" yaml:"GoalThroughputPerSec,omitempty" validate:"gte=1"`
@@ -266,11 +266,11 @@ type TotalThroughputSamplerConfig struct {
 	UseTraceLength       bool     `json:"usetracelength" yaml:"UseTraceLength,omitempty"`
 }
 
-func (d *TotalThroughputSamplerConfig) GetSamplingFields() []string {
+func (d *TotalThroughputSamplerConfig) GeFields() []string {
 	return d.FieldList
 }
 
-var _ SamplerConfigger = (*RulesBasedSamplerConfig)(nil)
+var _ GetSamplingFielder = (*RulesBasedSamplerConfig)(nil)
 
 type RulesBasedSamplerConfig struct {
 	// Rules has deliberately different names for json and yaml for conversion from old to new format
@@ -278,7 +278,7 @@ type RulesBasedSamplerConfig struct {
 	CheckNestedFields bool                     `json:"checknestedfields" yaml:"CheckNestedFields,omitempty"`
 }
 
-func (r *RulesBasedSamplerConfig) GetSamplingFields() []string {
+func (r *RulesBasedSamplerConfig) GeFields() []string {
 	fields := make([]string, 0)
 
 	for _, rule := range r.Rules {
@@ -295,14 +295,14 @@ func (r *RulesBasedSamplerConfig) GetSamplingFields() []string {
 		}
 
 		if rule.Sampler != nil {
-			fields = append(fields, rule.Sampler.GetSamplingFields()...)
+			fields = append(fields, rule.Sampler.GeFields()...)
 		}
 	}
 
 	return fields
 }
 
-var _ SamplerConfigger = (*RulesBasedDownstreamSampler)(nil)
+var _ GetSamplingFielder = (*RulesBasedDownstreamSampler)(nil)
 
 type RulesBasedDownstreamSampler struct {
 	DynamicSampler            *DynamicSamplerConfig            `json:"dynamicsampler" yaml:"DynamicSampler,omitempty"`
@@ -313,31 +313,31 @@ type RulesBasedDownstreamSampler struct {
 	DeterministicSampler      *DeterministicSamplerConfig      `json:"deterministicsampler" yaml:"DeterministicSampler,omitempty"`
 }
 
-func (r *RulesBasedDownstreamSampler) GetSamplingFields() []string {
+func (r *RulesBasedDownstreamSampler) GeFields() []string {
 	fields := make([]string, 0)
 
 	if r.DeterministicSampler != nil {
-		fields = append(fields, r.DeterministicSampler.GetSamplingFields()...)
+		fields = append(fields, r.DeterministicSampler.GeFields()...)
 	}
 
 	if r.DynamicSampler != nil {
-		fields = append(fields, r.DynamicSampler.GetSamplingFields()...)
+		fields = append(fields, r.DynamicSampler.GeFields()...)
 	}
 
 	if r.EMADynamicSampler != nil {
-		fields = append(fields, r.EMADynamicSampler.GetSamplingFields()...)
+		fields = append(fields, r.EMADynamicSampler.GeFields()...)
 	}
 
 	if r.EMAThroughputSampler != nil {
-		fields = append(fields, r.EMAThroughputSampler.GetSamplingFields()...)
+		fields = append(fields, r.EMAThroughputSampler.GeFields()...)
 	}
 
 	if r.WindowedThroughputSampler != nil {
-		fields = append(fields, r.WindowedThroughputSampler.GetSamplingFields()...)
+		fields = append(fields, r.WindowedThroughputSampler.GeFields()...)
 	}
 
 	if r.TotalThroughputSampler != nil {
-		fields = append(fields, r.TotalThroughputSampler.GetSamplingFields()...)
+		fields = append(fields, r.TotalThroughputSampler.GeFields()...)
 	}
 
 	return fields

--- a/config/sampler_config.go
+++ b/config/sampler_config.go
@@ -177,6 +177,8 @@ type SamplerConfigger interface {
 	GetSamplingFields() []string
 }
 
+var _ SamplerConfigger = (*DeterministicSamplerConfig)(nil)
+
 type DeterministicSamplerConfig struct {
 	SampleRate int `json:"samplerate" yaml:"SampleRate,omitempty" default:"1" validate:"required,gte=1"`
 }
@@ -184,6 +186,8 @@ type DeterministicSamplerConfig struct {
 func (d *DeterministicSamplerConfig) GetSamplingFields() []string {
 	return nil
 }
+
+var _ SamplerConfigger = (*DynamicSamplerConfig)(nil)
 
 type DynamicSamplerConfig struct {
 	SampleRate     int64    `json:"samplerate" yaml:"SampleRate,omitempty" validate:"required,gte=1"`
@@ -196,6 +200,8 @@ type DynamicSamplerConfig struct {
 func (d *DynamicSamplerConfig) GetSamplingFields() []string {
 	return d.FieldList
 }
+
+var _ SamplerConfigger = (*EMADynamicSamplerConfig)(nil)
 
 type EMADynamicSamplerConfig struct {
 	GoalSampleRate      int      `json:"goalsamplerate" yaml:"GoalSampleRate,omitempty" validate:"gte=1"`
@@ -212,6 +218,8 @@ type EMADynamicSamplerConfig struct {
 func (d *EMADynamicSamplerConfig) GetSamplingFields() []string {
 	return d.FieldList
 }
+
+var _ SamplerConfigger = (*EMAThroughputSamplerConfig)(nil)
 
 type EMAThroughputSamplerConfig struct {
 	GoalThroughputPerSec int      `json:"goalthroughputpersec" yaml:"GoalThroughputPerSec,omitempty"`
@@ -231,6 +239,8 @@ func (d *EMAThroughputSamplerConfig) GetSamplingFields() []string {
 	return d.FieldList
 }
 
+var _ SamplerConfigger = (*WindowedThroughputSamplerConfig)(nil)
+
 type WindowedThroughputSamplerConfig struct {
 	UpdateFrequency      Duration `json:"updatefrequency" yaml:"UpdateFrequency,omitempty"`
 	LookbackFrequency    Duration `json:"lookbackfrequency" yaml:"LookbackFrequency,omitempty"`
@@ -245,6 +255,8 @@ func (d *WindowedThroughputSamplerConfig) GetSamplingFields() []string {
 	return d.FieldList
 }
 
+var _ SamplerConfigger = (*TotalThroughputSamplerConfig)(nil)
+
 type TotalThroughputSamplerConfig struct {
 	GoalThroughputPerSec int      `json:"goalthroughputpersec" yaml:"GoalThroughputPerSec,omitempty" validate:"gte=1"`
 	UseClusterSize       bool     `json:"useclustersize" yaml:"UseClusterSize,omitempty"`
@@ -257,6 +269,8 @@ type TotalThroughputSamplerConfig struct {
 func (d *TotalThroughputSamplerConfig) GetSamplingFields() []string {
 	return d.FieldList
 }
+
+var _ SamplerConfigger = (*RulesBasedSamplerConfig)(nil)
 
 type RulesBasedSamplerConfig struct {
 	// Rules has deliberately different names for json and yaml for conversion from old to new format
@@ -287,6 +301,8 @@ func (r *RulesBasedSamplerConfig) GetSamplingFields() []string {
 
 	return fields
 }
+
+var _ SamplerConfigger = (*RulesBasedDownstreamSampler)(nil)
 
 type RulesBasedDownstreamSampler struct {
 	DynamicSampler            *DynamicSamplerConfig            `json:"dynamicsampler" yaml:"DynamicSampler,omitempty"`

--- a/config/sampler_config.go
+++ b/config/sampler_config.go
@@ -143,17 +143,17 @@ func (v *RulesBasedDownstreamSampler) NameMeaningfulRate() string {
 }
 
 type V2SamplerConfig struct {
-	RulesVersion int                         `json:"rulesversion" yaml:"RulesVersion" validate:"required,ge=2"`
-	Samplers     map[string]*V2SamplerChoice `json:"samplers" yaml:"Samplers,omitempty" validate:"required"`
-	uniqueFields map[string]struct{}
+	RulesVersion         int                         `json:"rulesversion" yaml:"RulesVersion" validate:"required,ge=2"`
+	Samplers             map[string]*V2SamplerChoice `json:"samplers" yaml:"Samplers,omitempty" validate:"required"`
+	uniqueSamplingFields map[string]struct{}
 }
 
-func (v *V2SamplerConfig) UniqueFields() map[string]struct{} {
-	return v.uniqueFields
+func (v *V2SamplerConfig) UniqueSamplingFields() map[string]struct{} {
+	return v.uniqueSamplingFields
 }
 
-func (v *V2SamplerConfig) SetUniqueFields() {
-	v.uniqueFields = make(map[string]struct{})
+func (v *V2SamplerConfig) SetUniqueSamplingFields() {
+	v.uniqueSamplingFields = make(map[string]struct{})
 
 	for _, sampler := range v.Samplers {
 		if sampler == nil {
@@ -166,22 +166,22 @@ func (v *V2SamplerConfig) SetUniqueFields() {
 		}
 
 		if c, ok := s.(SamplerConfigger); ok {
-			for _, field := range c.GetFields() {
-				v.uniqueFields[field] = struct{}{}
+			for _, field := range c.GetSamplingFields() {
+				v.uniqueSamplingFields[field] = struct{}{}
 			}
 		}
 	}
 }
 
 type SamplerConfigger interface {
-	GetFields() []string
+	GetSamplingFields() []string
 }
 
 type DeterministicSamplerConfig struct {
 	SampleRate int `json:"samplerate" yaml:"SampleRate,omitempty" default:"1" validate:"required,gte=1"`
 }
 
-func (d *DeterministicSamplerConfig) GetFields() []string {
+func (d *DeterministicSamplerConfig) GetSamplingFields() []string {
 	return nil
 }
 
@@ -193,7 +193,7 @@ type DynamicSamplerConfig struct {
 	UseTraceLength bool     `json:"usetracelength" yaml:"UseTraceLength,omitempty"`
 }
 
-func (d *DynamicSamplerConfig) GetFields() []string {
+func (d *DynamicSamplerConfig) GetSamplingFields() []string {
 	return d.FieldList
 }
 
@@ -209,7 +209,7 @@ type EMADynamicSamplerConfig struct {
 	UseTraceLength      bool     `json:"usetracelength" yaml:"UseTraceLength,omitempty"`
 }
 
-func (d *EMADynamicSamplerConfig) GetFields() []string {
+func (d *EMADynamicSamplerConfig) GetSamplingFields() []string {
 	return d.FieldList
 }
 
@@ -227,7 +227,7 @@ type EMAThroughputSamplerConfig struct {
 	UseTraceLength       bool     `json:"usetracelength" yaml:"UseTraceLength,omitempty"`
 }
 
-func (d *EMAThroughputSamplerConfig) GetFields() []string {
+func (d *EMAThroughputSamplerConfig) GetSamplingFields() []string {
 	return d.FieldList
 }
 
@@ -241,7 +241,7 @@ type WindowedThroughputSamplerConfig struct {
 	UseTraceLength       bool     `json:"usetracelength" yaml:"UseTraceLength,omitempty"`
 }
 
-func (d *WindowedThroughputSamplerConfig) GetFields() []string {
+func (d *WindowedThroughputSamplerConfig) GetSamplingFields() []string {
 	return d.FieldList
 }
 
@@ -254,7 +254,7 @@ type TotalThroughputSamplerConfig struct {
 	UseTraceLength       bool     `json:"usetracelength" yaml:"UseTraceLength,omitempty"`
 }
 
-func (d *TotalThroughputSamplerConfig) GetFields() []string {
+func (d *TotalThroughputSamplerConfig) GetSamplingFields() []string {
 	return d.FieldList
 }
 
@@ -264,7 +264,7 @@ type RulesBasedSamplerConfig struct {
 	CheckNestedFields bool                     `json:"checknestedfields" yaml:"CheckNestedFields,omitempty"`
 }
 
-func (r *RulesBasedSamplerConfig) GetFields() []string {
+func (r *RulesBasedSamplerConfig) GetSamplingFields() []string {
 	fields := make([]string, 0)
 
 	for _, rule := range r.Rules {
@@ -281,7 +281,7 @@ func (r *RulesBasedSamplerConfig) GetFields() []string {
 		}
 
 		if rule.Sampler != nil {
-			fields = append(fields, rule.Sampler.GetFields()...)
+			fields = append(fields, rule.Sampler.GetSamplingFields()...)
 		}
 	}
 
@@ -297,31 +297,31 @@ type RulesBasedDownstreamSampler struct {
 	DeterministicSampler      *DeterministicSamplerConfig      `json:"deterministicsampler" yaml:"DeterministicSampler,omitempty"`
 }
 
-func (r *RulesBasedDownstreamSampler) GetFields() []string {
+func (r *RulesBasedDownstreamSampler) GetSamplingFields() []string {
 	fields := make([]string, 0)
 
 	if r.DeterministicSampler != nil {
-		fields = append(fields, r.DeterministicSampler.GetFields()...)
+		fields = append(fields, r.DeterministicSampler.GetSamplingFields()...)
 	}
 
 	if r.DynamicSampler != nil {
-		fields = append(fields, r.DynamicSampler.GetFields()...)
+		fields = append(fields, r.DynamicSampler.GetSamplingFields()...)
 	}
 
 	if r.EMADynamicSampler != nil {
-		fields = append(fields, r.EMADynamicSampler.GetFields()...)
+		fields = append(fields, r.EMADynamicSampler.GetSamplingFields()...)
 	}
 
 	if r.EMAThroughputSampler != nil {
-		fields = append(fields, r.EMAThroughputSampler.GetFields()...)
+		fields = append(fields, r.EMAThroughputSampler.GetSamplingFields()...)
 	}
 
 	if r.WindowedThroughputSampler != nil {
-		fields = append(fields, r.WindowedThroughputSampler.GetFields()...)
+		fields = append(fields, r.WindowedThroughputSampler.GetSamplingFields()...)
 	}
 
 	if r.TotalThroughputSampler != nil {
-		fields = append(fields, r.TotalThroughputSampler.GetFields()...)
+		fields = append(fields, r.TotalThroughputSampler.GetSamplingFields()...)
 	}
 
 	return fields


### PR DESCRIPTION
To reduce the amount of across AZ zone data within a Refinery cluster, we came up with an idea to only store information needed for making a sampling decision in a central store. In order to extract those information from a span, we need to have a list of fields used in sampler configs.

This PR adds the code to generate the list mentioned above both during Refinery startup and config reload by adding the generating code in the `newFileConfig` function.

***Attention***
This PR is not merging into the current `main` branch. We are using a feature branch for the dynamic scaling work