### PR TITLE
maint: create generic set and use it

### DIFF
--- a/collect/cache/cache.go
+++ b/collect/cache/cache.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"time"
 
+	"github.com/honeycombio/refinery/generics"
 	"github.com/honeycombio/refinery/logger"
 	"github.com/honeycombio/refinery/metrics"
 	"github.com/honeycombio/refinery/types"
@@ -165,13 +166,13 @@ func (d *DefaultInMemCache) TakeExpiredTraces(now time.Time) []*types.Trace {
 
 // RemoveTraces accepts a set of trace IDs and removes any matching ones from
 // the insertion list. This is used in the case of a cache overrun.
-func (d *DefaultInMemCache) RemoveTraces(toDelete map[string]struct{}) {
+func (d *DefaultInMemCache) RemoveTraces(toDelete generics.Set[string]) {
 	d.Metrics.Gauge("collect_cache_capacity", float64(len(d.traceBuffer)))
 	d.Metrics.Histogram("collect_cache_entries", float64(len(d.cache)))
 
 	for i, t := range d.traceBuffer {
 		if t != nil {
-			if _, ok := toDelete[t.TraceID]; ok {
+			if toDelete.Contains(t.TraceID) {
 				d.traceBuffer[i] = nil
 				delete(d.cache, t.TraceID)
 			}

--- a/collect/cache/cache_test.go
+++ b/collect/cache/cache_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/honeycombio/refinery/generics"
 	"github.com/honeycombio/refinery/logger"
 	"github.com/honeycombio/refinery/metrics"
 	"github.com/honeycombio/refinery/types"
@@ -91,13 +92,7 @@ func TestRemoveSentTraces(t *testing.T) {
 		c.Set(t)
 	}
 
-	deletes := map[string]struct{}{
-		"1": {},
-		"3": {},
-		"4": {},
-		"5": {}, // not present
-	}
-
+	deletes := generics.NewSet("1", "2", "4", "5")
 	c.RemoveTraces(deletes)
 
 	all := c.GetAll()

--- a/collect/collect.go
+++ b/collect/collect.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/honeycombio/refinery/collect/cache"
 	"github.com/honeycombio/refinery/config"
+	"github.com/honeycombio/refinery/generics"
 	"github.com/honeycombio/refinery/logger"
 	"github.com/honeycombio/refinery/metrics"
 	"github.com/honeycombio/refinery/sample"
@@ -235,10 +236,10 @@ func (i *InMemCollector) checkAlloc() {
 	i.Metrics.Gauge("collector_cache_size", cap)
 
 	totalDataSizeSent := 0
-	tracesSent := make(map[string]struct{})
+	tracesSent := generics.NewSet[string]()
 	// Send the traces we can't keep.
 	for _, trace := range allTraces {
-		tracesSent[trace.TraceID] = struct{}{}
+		tracesSent.Add(trace.TraceID)
 		totalDataSizeSent += trace.DataSize
 		i.send(trace, TraceSendEjectedMemsize)
 		if totalDataSizeSent > int(totalToRemove) {

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/honeycombio/refinery/generics"
 	"gopkg.in/yaml.v3"
 )
 
@@ -85,7 +86,7 @@ type NetworkConfig struct {
 type AccessKeyConfig struct {
 	ReceiveKeys          []string `yaml:"ReceiveKeys" default:"[]"`
 	AcceptOnlyListedKeys bool     `yaml:"AcceptOnlyListedKeys"`
-	keymap               map[string]struct{}
+	keymap               generics.Set[string]
 }
 
 type RefineryTelemetryConfig struct {
@@ -517,14 +518,10 @@ func (f *fileConfig) IsAPIKeyValid(key string) bool {
 
 	// if we haven't built the keymap yet, do it now
 	if f.mainConfig.AccessKeys.keymap == nil {
-		f.mainConfig.AccessKeys.keymap = make(map[string]struct{})
-		for _, key := range f.mainConfig.AccessKeys.ReceiveKeys {
-			f.mainConfig.AccessKeys.keymap[key] = struct{}{}
-		}
+		f.mainConfig.AccessKeys.keymap = generics.NewSet(f.mainConfig.AccessKeys.ReceiveKeys...)
 	}
 
-	_, ok := f.mainConfig.AccessKeys.keymap[key]
-	return ok
+	return f.mainConfig.AccessKeys.keymap.Contains(key)
 }
 
 func (f *fileConfig) GetPeerManagementType() (string, error) {

--- a/generics/set.go
+++ b/generics/set.go
@@ -1,0 +1,79 @@
+package generics
+
+import "golang.org/x/exp/maps"
+
+// Set is a map[T]struct{}-backed unique set of items.
+type Set[T comparable] map[T]struct{}
+
+// NewSet returns a new Set with elements `es`.
+func NewSet[T comparable](es ...T) Set[T] {
+	s := make(Set[T], len(es))
+	s.Add(es...)
+	return s
+}
+
+func NewSetWithCapacity[T comparable](c int) Set[T] {
+	return make(Set[T], c)
+}
+
+// Add adds elements `es` to the Set.
+func (s Set[T]) Add(es ...T) {
+	for _, e := range es {
+		s[e] = struct{}{}
+	}
+
+}
+func (s Set[T]) Remove(es ...T) {
+	for _, e := range es {
+		delete(s, e)
+	}
+}
+
+// Add adds members of `b` to the Set.
+func (s Set[T]) AddMembers(b Set[T]) {
+	for v := range b {
+		s[v] = struct{}{}
+	}
+}
+
+// Contains returns true if the Set contains `e`.
+func (s Set[T]) Contains(e T) bool {
+	_, ok := s[e]
+	return ok
+}
+
+// Members returns the unique elements of the Set in indeterminate order.
+func (s Set[T]) Members() []T {
+	return maps.Keys(s)
+}
+
+// Intersect returns the common elements of the Set and `b`.
+func (s Set[T]) Intersect(b Set[T]) Set[T] {
+	c := NewSet[T]()
+	for v := range s {
+		if b.Contains(v) {
+			c.Add(v)
+		}
+	}
+	return c
+}
+
+// Difference returns the elements from the Set that do not exist in `b`.
+func (s Set[T]) Difference(b Set[T]) Set[T] {
+	c := NewSet[T]()
+	for v := range s {
+		if !b.Contains(v) {
+			c.Add(v)
+		}
+	}
+	return c
+}
+
+// Union returns the a new Set containing the combination of all unique elements
+// from the Set and `b`.
+func (s Set[T]) Union(b Set[T]) Set[T] {
+	c := make(Set[T], len(s)+len(b))
+	c.AddMembers(s)
+	c.AddMembers(b)
+	return c
+}

--- a/generics/set_test.go
+++ b/generics/set_test.go
@@ -1,0 +1,68 @@
+package generics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSet(t *testing.T) {
+	s := NewSet(1, 2, 2)
+	s.Add(3, 3)
+
+	assert.True(t, s.Contains(1))
+	assert.True(t, s.Contains(2))
+	assert.True(t, s.Contains(3))
+	assert.ElementsMatch(t, []int{1, 2, 3}, s.Members())
+
+	s.AddMembers(NewSet(4))
+	assert.True(t, s.Contains(4))
+	assert.ElementsMatch(t, []int{1, 2, 3, 4}, s.Members())
+
+}
+
+func TestUnion(t *testing.T) {
+	a := NewSet(1, 1, 2, 3, 3, 4)
+	b := NewSet(3, 3, 4, 5, 6, 6)
+	c := a.Union(b)
+	assert.ElementsMatch(t, []int{1, 2, 3, 4, 5, 6}, c.Members())
+
+	d := a.Union(NewSet[int]())
+	assert.ElementsMatch(t, []int{1, 2, 3, 4}, d.Members())
+}
+
+func TestIntersect(t *testing.T) {
+	a := NewSet(1, 1, 2, 3, 3, 4)
+	b := NewSet(3, 3, 4, 5, 6, 6)
+	c := a.Intersect(b)
+	assert.ElementsMatch(t, []int{3, 4}, c.Members())
+
+	assert.Empty(t, a.Intersect(NewSet(9)).Members())
+}
+
+func TestDifference(t *testing.T) {
+	a := NewSet(1, 1, 2, 3, 3, 4)
+	b := NewSet(3, 3, 4, 5, 6, 6)
+	c := a.Difference(b)
+	assert.ElementsMatch(t, []int{1, 2}, c.Members())
+
+	d := b.Difference(a)
+	assert.ElementsMatch(t, []int{5, 6}, d.Members())
+
+}
+
+var res Set[int]
+
+func BenchmarkUnion(b *testing.B) {
+	x := NewSet(0, 1, 2, 3, 4, 5)
+	y := NewSet(1, 3, 5, 7, 9)
+	for i := 0; i < 100; i++ {
+		x.Add(i)
+		y.Add(i)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		res = x.Union(y)
+	}
+}


### PR DESCRIPTION
## Which problem is this PR solving?

- Now that Go supports some forms of generics, we can create and use a generic set rather than monkeying around with `map[T]struct{}`. It's clearer and just as fast.

## Short description of the changes

- This adds a new type in a "generics" package. The code is mostly copied from similar code we have internally in another repository at Honeycomb.
- Same tests as in the original.
- Uses it in all but one of the places it could be used (I didn't touch the last one in `sampler_config.go` because it will affect work going on in a different branch; we can cherry pick this over and then fix it there.)

