### PR TITLE
maint: finish conversion to generics.Set

### DIFF
--- a/config/file_config.go
+++ b/config/file_config.go
@@ -341,7 +341,7 @@ func newFileConfig(opts *CmdEnv) (*fileConfig, error) {
 		return nil, err
 	}
 
-	rulesconf.SetUniqueSamplingFields()
+	rulesconf.ExtractUniqueSamplingFields()
 
 	cfg := &fileConfig{
 		mainConfig:  mainconf,


### PR DESCRIPTION
NOTE -- this is against the `feat_dynamic_scaling` branch.

## Which problem is this PR solving?

- Finishes using `generic.Set` everywhere we can

## Short description of the changes

- Convert to Set in sampler_config.go
- Rename SetUniqueSamplingFields to ExtractUniqueSamplingFields because Set implies that it takes a parameter.

