### PR TITLE
chore: fix license tracking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ clean:
 
 .PHONY: install-tools
 install-tools:
-	go install github.com/google/go-licenses@latest
+	go install github.com/google/go-licenses@v1.0.0
 
 .PHONY: update-licenses
 update-licenses: install-tools


### PR DESCRIPTION


<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

[go-licenses v1.1.0 dropped support for packages that aren't Go modules](https://github.com/google/go-licenses/releases/tag/v1.1.0). That or any later version run against our current repo state will result in many dozens of this error:

> Package •thingie• does not have module info. Non go modules projects are no longer supported. For feedback, refer to https://github.com/google/go-licenses/issues/128.



## Short description of the changes

Pinning our install to v1.0.0 seems to produce the LICENSES output consistent with what the project has been tracking so far.

