### PR TITLE
chore: Revert "chore: fix license tracking (#989)"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ clean:
 
 .PHONY: install-tools
 install-tools:
-	go install github.com/google/go-licenses@v1.0.0
+	go install github.com/google/go-licenses@latest
 
 .PHONY: update-licenses
 update-licenses: install-tools


### PR DESCRIPTION
This reverts commit 52c5f084bb7e961de431c410ae2a1686ea023a79.

The go-licenses@v1.0.0 pin breaks when run in CI. Needs further investigation.