### PR TITLE
fix: flaky TestOriginalSampleRateIsNotedInMetaField

### DIFF
--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -196,7 +196,7 @@ func TestOriginalSampleRateIsNotedInMetaField(t *testing.T) {
 	// Find the Refinery-sampled-and-sent event that had no upstream sampling which
 	// should be the last event on the transmission queue.
 	var noUpstreamSampleRateEvent *types.Event
-	assert.Eventually(t, func() bool {
+	require.Eventually(t, func() bool {
 		transmission.Mux.RLock()
 		defer transmission.Mux.RUnlock()
 		noUpstreamSampleRateEvent = transmission.Events[len(transmission.Events)-1]

--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -166,13 +166,14 @@ func TestOriginalSampleRateIsNotedInMetaField(t *testing.T) {
 				Data:       make(map[string]interface{}),
 			},
 		}
-		coll.AddSpan(span)
+		err := coll.AddSpan(span)
+		require.NoError(t, err, "must be able to add the span")
 		time.Sleep(conf.SendTickerVal * 5)
 	}
 
-	// At least one event should have been transmitted by now with an original sample rate from upstream sampling.
 	transmission.Mux.RLock()
-	assert.Greater(t, len(transmission.Events), 0, "should be at least one event transmitted")
+	require.Greater(t, len(transmission.Events), 0,
+		"At least one event should have been sampled and transmitted by now for us to make assertions upon.")
 	upstreamSampledEvent := transmission.Events[0]
 	transmission.Mux.RUnlock()
 
@@ -191,7 +192,7 @@ func TestOriginalSampleRateIsNotedInMetaField(t *testing.T) {
 			Data:       make(map[string]interface{}),
 		},
 	})
-	require.NoError(t, err, "should be able to add the span")
+	require.NoError(t, err, "must be able to add the span")
 
 	// Find the Refinery-sampled-and-sent event that had no upstream sampling which
 	// should be the last event on the transmission queue.


### PR DESCRIPTION
## Which problem is this PR solving?

- [a flaky test](https://app.circleci.com/pipelines/github/honeycombio/refinery/2623/workflows/95075937-b4b3-472e-8d34-a9e2a7e9ba31/jobs/7681/tests#failed-test-0)

## Short description of the changes

- drop the assumption that only 2 spans are sent to transmission: don't inspect the second event on the transmission queue, inspect the last event
