### PR TITLE
docs: Add sampler default intervals to docs

### DIFF
--- a/config/metadata/rulesMeta.yaml
+++ b/config/metadata/rulesMeta.yaml
@@ -67,6 +67,7 @@ groups:
         description: >
           The duration after which the Dynamic Sampler should reset its internal
           counters. It should be specified as a duration string. For example, "30s" or "1m".
+          Defaults to "30s".
       - name: FieldList
         type: stringarray
         validations:
@@ -169,7 +170,7 @@ groups:
         description: >
           The duration after which the EMA Dynamic Sampler should recalculate
           its internal counters. It should be specified as a duration string.
-          For example, "30s" or "1m".
+          For example, "30s" or "1m". Defaults to "15s".
       - name: Weight
         type: float
         validations:
@@ -397,7 +398,7 @@ groups:
         summary: is how often the sampling rate is recomputed.
         description: >
           The duration between sampling rate computations. It should be
-          specified as a duration string. For example, "30s" or "1m".
+          specified as a duration string. For example, "30s" or "1m". Defaults to "1s".
       - name: LookbackFrequency
         type: duration
         summary: how far back in time to look when computing the sampling rate.
@@ -466,7 +467,8 @@ groups:
           throughput will be the value specified in `GoalThroughputPerSec`.
       - name: ClearFrequency
         type: duration
-        summary: is the duration over which the sampler will calculate the throughput.
+        summary: is the duration over which the sampler will calculate the throughput. It should be
+          specified as a duration string. For example, "30s" or "1m". Defaults to "30s".
         description: $DynamicSampler.ClearFrequency
       - name: FieldList
         type: stringarray

--- a/refinery_rules.md
+++ b/refinery_rules.md
@@ -79,6 +79,7 @@ The sample rate is calculated from the trace ID, so all spans with the same trac
 The duration after which the Dynamic Sampler should reset its internal counters.
 It should be specified as a duration string.
 For example, "30s" or "1m".
+Defaults to "30s".
 
 - Type: `duration`
 
@@ -142,6 +143,7 @@ The sample rate is calculated from the trace ID, so all spans with the same trac
 The duration after which the EMA Dynamic Sampler should recalculate its internal counters.
 It should be specified as a duration string.
 For example, "30s" or "1m".
+Defaults to "15s".
 
 - Type: `duration`
 
@@ -253,6 +255,7 @@ This is mainly useful in situations where unsampled throughput is high enough to
 The duration after which the EMA Dynamic Sampler should recalculate its internal counters.
 It should be specified as a duration string.
 For example, "30s" or "1m".
+Defaults to "15s".
 
 - Type: `duration`
 
@@ -364,6 +367,7 @@ If `false`, then the goal throughput will be the value specified in `GoalThrough
 The duration between sampling rate computations.
 It should be specified as a duration string.
 For example, "30s" or "1m".
+Defaults to "1s".
 
 - Type: `duration`
 
@@ -566,6 +570,7 @@ If `false`, then the goal throughput will be the value specified in `GoalThrough
 The duration after which the Dynamic Sampler should reset its internal counters.
 It should be specified as a duration string.
 For example, "30s" or "1m".
+Defaults to "30s".
 
 - Type: `duration`
 

--- a/rules.md
+++ b/rules.md
@@ -100,6 +100,7 @@ Type: `int`
 The duration after which the Dynamic Sampler should reset its internal counters.
 It should be specified as a duration string.
 For example, "30s" or "1m".
+Defaults to "30s".
 
 Type: `duration`
 
@@ -166,6 +167,7 @@ Type: `int`
 The duration after which the EMA Dynamic Sampler should recalculate its internal counters.
 It should be specified as a duration string.
 For example, "30s" or "1m".
+Defaults to "15s".
 
 Type: `duration`
 
@@ -280,6 +282,7 @@ Type: `int`
 The duration after which the EMA Dynamic Sampler should recalculate its internal counters.
 It should be specified as a duration string.
 For example, "30s" or "1m".
+Defaults to "15s".
 
 Type: `duration`
 
@@ -394,6 +397,7 @@ Type: `bool`
 The duration between sampling rate computations.
 It should be specified as a duration string.
 For example, "30s" or "1m".
+Defaults to "1s".
 
 Type: `duration`
 
@@ -609,6 +613,7 @@ Type: `bool`
 The duration after which the Dynamic Sampler should reset its internal counters.
 It should be specified as a duration string.
 For example, "30s" or "1m".
+Defaults to "30s".
 
 Type: `duration`
 


### PR DESCRIPTION
## Which problem is this PR solving?
Updates refinery rules metadata to include the default intervals for each of the sampler types. `rulesmeta.md` was updated manually and the other files were re-generated using the conver tool.

- Closes #992 

## Short description of the changes
- Update each sampler to include the default interval
  - [DynamicSampler](https://github.com/honeycombio/dynsampler-go/blob/main/avgsamplerate.go#L30) & [TotalThroughputSampler](https://github.com/honeycombio/dynsampler-go/blob/main/totalthroughput.go#L31) -> 30s
  - [EMADynamicSampler](https://github.com/honeycombio/dynsampler-go/blob/main/emasamplerate.go#L41) & [EMAThroughputSampler](https://github.com/honeycombio/dynsampler-go/blob/main/emathroughput.go#L38) -> 15s
  - [WindowedThroughputSampler](https://github.com/honeycombio/dynsampler-go/blob/main/windowedthroughput.go#L34) -> 1s

