### PR TITLE
fix: handle root prefix when no root span on trace

### DIFF
--- a/config.md
+++ b/config.md
@@ -1,7 +1,7 @@
 # Honeycomb Refinery Configuration Documentation
 
 This is the documentation for the configuration file for Honeycomb's Refinery.
-It was automatically generated on 2024-02-20 at 18:13:44 UTC.
+It was automatically generated on 2024-02-22 at 18:03:10 UTC.
 
 ## The Config file
 
@@ -200,7 +200,7 @@ This value is available to the rules-based sampler, making it possible to write 
 If `true` and `AddCountsToRoot` is set to false, then Refinery will add `meta.span_count` to the root span.
 
 - Eligible for live reload.
-- Type: `bool`
+- Type: `defaulttrue`
 - Default: `true`
 
 ### `AddCountsToRoot`
@@ -223,7 +223,7 @@ AddHostMetadataToTrace specifies whether to add host metadata to traces.
 If `true`, then Refinery will add the following tag to all traces: - `meta.refinery.local_hostname`: the hostname of the Refinery node
 
 - Eligible for live reload.
-- Type: `bool`
+- Type: `defaulttrue`
 - Default: `true`
 
 ## Traces
@@ -420,7 +420,7 @@ The sample rate is controlled by the `SamplerThroughput` setting.
 The sampler used throttles the rate of logs sent to Honeycomb from any given source within Refinery -- it should effectively limit the rate of redundant messages.
 
 - Not eligible for live reload.
-- Type: `bool`
+- Type: `defaulttrue`
 - Default: `true`
 
 ### `SamplerThroughput`
@@ -917,7 +917,7 @@ If it costs money to transmit data between Refinery instances (for example, when
 The option to disable it is provided as an escape hatch for deployments that value lower CPU utilization over data transfer costs.
 
 - Not eligible for live reload.
-- Type: `bool`
+- Type: `defaulttrue`
 - Default: `true`
 
 ### `AdditionalAttributes`
@@ -969,7 +969,8 @@ Enabled specifies whether the gRPC server is enabled.
 If `false`, then the gRPC server is not started and no gRPC traffic is accepted.
 
 - Not eligible for live reload.
-- Type: `bool`
+- Type: `defaulttrue`
+- Default: `true`
 
 ### `ListenAddr`
 

--- a/config.md
+++ b/config.md
@@ -1,7 +1,7 @@
 # Honeycomb Refinery Configuration Documentation
 
 This is the documentation for the configuration file for Honeycomb's Refinery.
-It was automatically generated on 2024-02-22 at 18:03:10 UTC.
+It was automatically generated on 2024-02-23 at 17:42:44 UTC.
 
 ## The Config file
 

--- a/config/metadata/rulesMeta.yaml
+++ b/config/metadata/rulesMeta.yaml
@@ -641,7 +641,7 @@ groups:
           named field that contains a value will be used for the condition. Only
           the first populated field will be used, even if the condition fails.
           
-          If a `root.` prefix is present on a field but the root span is not on
+          If a `root.` prefix is present on a field, but the root span is not on
           the trace, that field will be skipped.
 
           If none of the fields are present, then the condition will not match.

--- a/config/metadata/rulesMeta.yaml
+++ b/config/metadata/rulesMeta.yaml
@@ -625,7 +625,7 @@ groups:
           span being processed.
           
           When using the `not-exists` operator to check a condition with a `root.` prefix, if the root
-          span does not exist on the trace, then the condition will evaluate to false.
+          span does not exist on the trace, as in the case when a root span is taking a long time to complete and does not arrive before a sampling decision is being made, then the condition will evaluate to false.
 
       - name: Fields
         type: stringarray

--- a/config/metadata/rulesMeta.yaml
+++ b/config/metadata/rulesMeta.yaml
@@ -625,7 +625,7 @@ groups:
           span being processed.
           
           When using the `not-exists` operator to check a condition with a `root.` prefix, if the root
-          span does not exist on the trace then the condition will evaluate to false.
+          span does not exist on the trace, then the condition will evaluate to false.
 
       - name: Fields
         type: stringarray

--- a/config/metadata/rulesMeta.yaml
+++ b/config/metadata/rulesMeta.yaml
@@ -624,8 +624,9 @@ groups:
           the condition is still evaluated on the root span and is treated as if it were part of the 
           span being processed.
           
-          When using the `not-exists` operator to check a condition with a `root.` prefix, if the root
-          span does not exist on the trace, as in the case when a root span is taking a long time to complete and does not arrive before a sampling decision is being made, then the condition will evaluate to false.
+          When using the `root.` prefix on a field with a `not-exists` operator, include the `has-root-span: true` condition in the rule.
+          The `not-exists` condition on a `root.`-prefixed field will evaluate to false if the existence of the root span is not checked and the root span does not exist.
+          The primary reason a root span is not present on a trace when a sampling decision is being made is when the root span takes longer to complete than the configured TraceTimeout.
 
       - name: Fields
         type: stringarray

--- a/config/metadata/rulesMeta.yaml
+++ b/config/metadata/rulesMeta.yaml
@@ -615,14 +615,18 @@ groups:
           
           The field can also include a prefix that changes the span used for evaluation of the field.
           The only prefix currently supported is `root`, as in `root.http.status`. Specifying `root.`
-          causes the condition to be evaluated against the root span. 
+          causes the condition to be evaluated against the root span.
           
           For example, if the `Field` is `root.url`, then the condition will be processed using the url
-          field from the root span. 
+          field from the root span.
           
           The setting `Scope: span` for a rule does not change the meaning of this prefix --
           the condition is still evaluated on the root span and is treated as if it were part of the 
-          span being processed. 
+          span being processed.
+          
+          When using the `not-exists` operator to check a condition with a `root.` prefix, if the root
+          span does not exist on the trace then the condition will evaluate to false.
+
       - name: Fields
         type: stringarray
         valuetype: stringarray
@@ -636,6 +640,9 @@ groups:
           trace. The fields are checked in the order defined here, and the first
           named field that contains a value will be used for the condition. Only
           the first populated field will be used, even if the condition fails.
+          
+          If a `root.` prefix is present on a field but the root span is not on
+          the trace, that field will be skipped.
 
           If none of the fields are present, then the condition will not match.
           The comparison is case-sensitive.

--- a/config_complete.yaml
+++ b/config_complete.yaml
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created on 2024-02-20 at 18:13:43 UTC from ../../config.yaml using a template generated on 2024-02-20 at 18:13:41 UTC
+# created on 2024-02-22 at 18:03:09 UTC from ../../config.yaml using a template generated on 2024-02-22 at 18:03:07 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of
@@ -1009,6 +1009,7 @@ GRPCServerParameters:
     ## If `false`, then the gRPC server is not started and no gRPC traffic is
     ## accepted.
     ##
+    ## default: true
     ## Not eligible for live reload.
     # Enabled: false
 

--- a/config_complete.yaml
+++ b/config_complete.yaml
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created on 2024-02-22 at 18:03:09 UTC from ../../config.yaml using a template generated on 2024-02-22 at 18:03:07 UTC
+# created on 2024-02-23 at 17:42:43 UTC from ../../config.yaml using a template generated on 2024-02-23 at 17:42:41 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of

--- a/refinery_config.md
+++ b/refinery_config.md
@@ -178,7 +178,7 @@ This value is available to the rules-based sampler, making it possible to write 
 If `true` and `AddCountsToRoot` is set to false, then Refinery will add `meta.span_count` to the root span.
 
 - Eligible for live reload.
-- Type: `bool`
+- Type: `defaulttrue`
 - Default: `true`
 
 ### `AddCountsToRoot`
@@ -201,7 +201,7 @@ If `true`, then Refinery will ignore the `AddSpanCountToRoot` setting and add th
 If `true`, then Refinery will add the following tag to all traces: - `meta.refinery.local_hostname`: the hostname of the Refinery node
 
 - Eligible for live reload.
-- Type: `bool`
+- Type: `defaulttrue`
 - Default: `true`
 
 ## Traces
@@ -402,7 +402,7 @@ The sample rate is controlled by the `SamplerThroughput` setting.
 The sampler used throttles the rate of logs sent to Honeycomb from any given source within Refinery -- it should effectively limit the rate of redundant messages.
 
 - Not eligible for live reload.
-- Type: `bool`
+- Type: `defaulttrue`
 - Default: `true`
 
 ### `SamplerThroughput`
@@ -903,7 +903,7 @@ If it costs money to transmit data between Refinery instances (for example, when
 The option to disable it is provided as an escape hatch for deployments that value lower CPU utilization over data transfer costs.
 
 - Not eligible for live reload.
-- Type: `bool`
+- Type: `defaulttrue`
 - Default: `true`
 
 ### `AdditionalAttributes`
@@ -955,7 +955,8 @@ A trace without a `parent_id` is assumed to be a root span.
 If `false`, then the gRPC server is not started and no gRPC traffic is accepted.
 
 - Not eligible for live reload.
-- Type: `bool`
+- Type: `defaulttrue`
+- Default: `true`
 
 ### `ListenAddr`
 

--- a/refinery_rules.md
+++ b/refinery_rules.md
@@ -504,6 +504,7 @@ The only prefix currently supported is `root`, as in `root.http.status`.
 Specifying `root.` causes the condition to be evaluated against the root span.
 For example, if the `Field` is `root.url`, then the condition will be processed using the url field from the root span.
 The setting `Scope: span` for a rule does not change the meaning of this prefix -- the condition is still evaluated on the root span and is treated as if it were part of the  span being processed.
+When using the `not-exists` operator to check a condition with a `root.` prefix, if the root span does not exist on the trace then the condition will evaluate to false.
 
 - Type: `string`
 
@@ -513,6 +514,7 @@ An array of field names to check.
 These can name any field in the trace.
 The fields are checked in the order defined here, and the first named field that contains a value will be used for the condition.
 Only the first populated field will be used, even if the condition fails.
+If a `root.` prefix is present on a field but the root span is not on the trace, that field will be skipped.
 If none of the fields are present, then the condition will not match.
 The comparison is case-sensitive.
 All fields are checked as individual fields before any of them are checked as nested fields (see `CheckNestedFields`).

--- a/refinery_rules.md
+++ b/refinery_rules.md
@@ -504,7 +504,9 @@ The only prefix currently supported is `root`, as in `root.http.status`.
 Specifying `root.` causes the condition to be evaluated against the root span.
 For example, if the `Field` is `root.url`, then the condition will be processed using the url field from the root span.
 The setting `Scope: span` for a rule does not change the meaning of this prefix -- the condition is still evaluated on the root span and is treated as if it were part of the  span being processed.
-When using the `not-exists` operator to check a condition with a `root.` prefix, if the root span does not exist on the trace then the condition will evaluate to false.
+When using the `root.` prefix on a field with a `not-exists` operator, include the `has-root-span: true` condition in the rule.
+The `not-exists` condition on a `root.`-prefixed field will evaluate to false if the existence of the root span is not checked and the root span does not exist.
+The primary reason a root span is not present on a trace when a sampling decision is being made is when the root span takes longer to complete than the configured TraceTimeout.
 
 - Type: `string`
 
@@ -514,7 +516,7 @@ An array of field names to check.
 These can name any field in the trace.
 The fields are checked in the order defined here, and the first named field that contains a value will be used for the condition.
 Only the first populated field will be used, even if the condition fails.
-If a `root.` prefix is present on a field but the root span is not on the trace, that field will be skipped.
+If a `root.` prefix is present on a field, but the root span is not on the trace, that field will be skipped.
 If none of the fields are present, then the condition will not match.
 The comparison is case-sensitive.
 All fields are checked as individual fields before any of them are checked as nested fields (see `CheckNestedFields`).

--- a/rules.md
+++ b/rules.md
@@ -1,7 +1,7 @@
 # Honeycomb Refinery Rules Documentation
 
 This is the documentation for the rules configuration for Honeycomb's Refinery.
-It was automatically generated on 2024-02-20 at 18:13:45 UTC.
+It was automatically generated on 2024-02-22 at 18:03:11 UTC.
 
 ## The Rules file
 
@@ -540,9 +540,10 @@ If the field is not present, then the condition will not match.
 The comparison is case-sensitive.
 The field can also include a prefix that changes the span used for evaluation of the field.
 The only prefix currently supported is `root`, as in `root.http.status`.
-Specifying `root.`  causes the condition to be evaluated against the root span.
-For example, if the `Field` is `root.url`, then the condition will be processed using the url  field from the root span.
-The setting `Scope: span` for a rule does not change the meaning of this prefix -- the condition is still evaluated on the root span and is treated as if it were part of the   span being processed.
+Specifying `root.` causes the condition to be evaluated against the root span.
+For example, if the `Field` is `root.url`, then the condition will be processed using the url field from the root span.
+The setting `Scope: span` for a rule does not change the meaning of this prefix -- the condition is still evaluated on the root span and is treated as if it were part of the  span being processed.
+When using the `not-exists` operator to check a condition with a `root.` prefix, if the root span does not exist on the trace then the condition will evaluate to false.
 
 Type: `string`
 
@@ -552,6 +553,7 @@ An array of field names to check.
 These can name any field in the trace.
 The fields are checked in the order defined here, and the first named field that contains a value will be used for the condition.
 Only the first populated field will be used, even if the condition fails.
+If a `root.` prefix is present on a field but the root span is not on the trace, that field will be skipped.
 If none of the fields are present, then the condition will not match.
 The comparison is case-sensitive.
 All fields are checked as individual fields before any of them are checked as nested fields (see `CheckNestedFields`).

--- a/rules.md
+++ b/rules.md
@@ -542,7 +542,7 @@ The field can also include a prefix that changes the span used for evaluation of
 The only prefix currently supported is `root`, as in `root.http.status`.
 Specifying `root.` causes the condition to be evaluated against the root span.
 For example, if the `Field` is `root.url`, then the condition will be processed using the url field from the root span.
-The setting `Scope: span` for a rule does not change the meaning of this prefix -- the condition is still evaluated on the root span and is treated as if it were part of the  span being processed.
+The setting `Scope: span` for a rule does not change the meaning of this prefix -- the condition is still evaluated on the root span and is treated as if it were part of the span being processed.
 When using the `root.` prefix on a field with a `not-exists` operator, include the `has-root-span: true` condition in the rule.
 The `not-exists` condition on a `root.`-prefixed field will evaluate to false if the existence of the root span is not checked and the root span does not exist.
 The primary reason a root span is not present on a trace when a sampling decision is being made is when the root span takes longer to complete than the configured TraceTimeout.

--- a/rules.md
+++ b/rules.md
@@ -543,7 +543,7 @@ The only prefix currently supported is `root`, as in `root.http.status`.
 Specifying `root.` causes the condition to be evaluated against the root span.
 For example, if the `Field` is `root.url`, then the condition will be processed using the url field from the root span.
 The setting `Scope: span` for a rule does not change the meaning of this prefix -- the condition is still evaluated on the root span and is treated as if it were part of the  span being processed.
-When using the `not-exists` operator to check a condition with a `root.` prefix, if the root span does not exist on the trace then the condition will evaluate to false.
+When using the `exists` or `not-exists` operators to check a field containing a `root.` prefix, if the trace has no root span, it will be treated as if the field did not exist.
 
 Type: `string`
 

--- a/rules.md
+++ b/rules.md
@@ -1,7 +1,7 @@
 # Honeycomb Refinery Rules Documentation
 
 This is the documentation for the rules configuration for Honeycomb's Refinery.
-It was automatically generated on 2024-02-22 at 18:03:11 UTC.
+It was automatically generated on 2024-02-23 at 17:42:45 UTC.
 
 ## The Rules file
 
@@ -543,7 +543,9 @@ The only prefix currently supported is `root`, as in `root.http.status`.
 Specifying `root.` causes the condition to be evaluated against the root span.
 For example, if the `Field` is `root.url`, then the condition will be processed using the url field from the root span.
 The setting `Scope: span` for a rule does not change the meaning of this prefix -- the condition is still evaluated on the root span and is treated as if it were part of the  span being processed.
-When using the `exists` or `not-exists` operators to check a field containing a `root.` prefix, if the trace has no root span, it will be treated as if the field did not exist.
+When using the `root.` prefix on a field with a `not-exists` operator, include the `has-root-span: true` condition in the rule.
+The `not-exists` condition on a `root.`-prefixed field will evaluate to false if the existence of the root span is not checked and the root span does not exist.
+The primary reason a root span is not present on a trace when a sampling decision is being made is when the root span takes longer to complete than the configured TraceTimeout.
 
 Type: `string`
 
@@ -553,7 +555,7 @@ An array of field names to check.
 These can name any field in the trace.
 The fields are checked in the order defined here, and the first named field that contains a value will be used for the condition.
 Only the first populated field will be used, even if the condition fails.
-If a `root.` prefix is present on a field but the trace does not contain a root span, that field will be skipped.
+If a `root.` prefix is present on a field, but the root span is not on the trace, that field will be skipped.
 If none of the fields are present, then the condition will not match.
 The comparison is case-sensitive.
 All fields are checked as individual fields before any of them are checked as nested fields (see `CheckNestedFields`).

--- a/rules.md
+++ b/rules.md
@@ -553,7 +553,7 @@ An array of field names to check.
 These can name any field in the trace.
 The fields are checked in the order defined here, and the first named field that contains a value will be used for the condition.
 Only the first populated field will be used, even if the condition fails.
-If a `root.` prefix is present on a field but the root span is not on the trace, that field will be skipped.
+If a `root.` prefix is present on a field but the trace does not contain a root span, that field will be skipped.
 If none of the fields are present, then the condition will not match.
 The comparison is case-sensitive.
 All fields are checked as individual fields before any of them are checked as nested fields (see `CheckNestedFields`).

--- a/sample/rules.go
+++ b/sample/rules.go
@@ -223,8 +223,9 @@ func ruleMatchesSpanInTrace(trace *types.Trace, rule *config.RulesBasedSamplerRu
 	return false
 }
 
-// extractValueFromSpan extracts from a span the value found at the first of the given condition's fields found on a span.
-// It returns the extracted value and an exists boolean indicating whether any of the condition's fields are present on the span.
+// extractValueFromSpan extracts the `value` found at the first of the given condition's fields found on the input `span`.
+// It returns the extracted `value` and an `exists` boolean indicating whether any of the condition's fields are present
+// on input the span.
 func extractValueFromSpan(trace *types.Trace, span *types.Span, condition *config.RulesBasedSamplerCondition, checkNestedFields bool) (value interface{}, exists bool) {
 	// If the condition is a descendant count, we extract the count from trace and return it.
 	if f, ok := condition.GetComputedField(); ok {

--- a/sample/rules.go
+++ b/sample/rules.go
@@ -243,6 +243,7 @@ func extractValueFromSpan(trace *types.Trace, span *types.Span, condition *confi
 				field = field[len(RootPrefix):]
 				span = trace.RootSpan
 			} else {
+				// we wanted root span but this trace doesn't have one, so just skip it
 				continue
 			}
 		}

--- a/sample/rules.go
+++ b/sample/rules.go
@@ -223,7 +223,8 @@ func ruleMatchesSpanInTrace(trace *types.Trace, rule *config.RulesBasedSamplerRu
 	return false
 }
 
-// exists does it refer to valid cond field present
+// extractValueFromSpan extracts from a span the value found at the first of the given condition's fields found on a span.
+// It returns the extracted value and an exists boolean indicating whether any of the condition's fields are present on the span.
 func extractValueFromSpan(trace *types.Trace, span *types.Span, condition *config.RulesBasedSamplerCondition, checkNestedFields bool) (value interface{}, exists bool) {
 	// If the condition is a descendant count, we extract the count from trace and return it.
 	if f, ok := condition.GetComputedField(); ok {

--- a/tools/convert/configDataNames.txt
+++ b/tools/convert/configDataNames.txt
@@ -1,5 +1,5 @@
 # Names of groups and fields in the new config file format.
-# Automatically generated on 2024-02-22 at 18:03:08 UTC.
+# Automatically generated on 2024-02-23 at 17:42:42 UTC.
 
 General:
   - ConfigurationVersion

--- a/tools/convert/configDataNames.txt
+++ b/tools/convert/configDataNames.txt
@@ -1,5 +1,5 @@
 # Names of groups and fields in the new config file format.
-# Automatically generated on 2024-02-20 at 20:25:19 UTC.
+# Automatically generated on 2024-02-22 at 18:03:08 UTC.
 
 General:
   - ConfigurationVersion

--- a/tools/convert/minimal_config.yaml
+++ b/tools/convert/minimal_config.yaml
@@ -1,5 +1,5 @@
 # sample uncommented config file containing all possible fields
-# automatically generated on 2024-02-22 at 18:03:08 UTC
+# automatically generated on 2024-02-23 at 17:42:42 UTC
 General:
   ConfigurationVersion: 2
   MinRefineryVersion: "v2.0"

--- a/tools/convert/minimal_config.yaml
+++ b/tools/convert/minimal_config.yaml
@@ -1,5 +1,5 @@
 # sample uncommented config file containing all possible fields
-# automatically generated on 2024-02-20 at 20:25:19 UTC
+# automatically generated on 2024-02-22 at 18:03:08 UTC
 General:
   ConfigurationVersion: 2
   MinRefineryVersion: "v2.0"
@@ -111,7 +111,7 @@ IDFields:
     - parentId
 
 GRPCServerParameters:
-  Enabled: false
+  Enabled: true
   ListenAddr: ""
   MaxConnectionIdle: 1m
   MaxConnectionAge: 3m

--- a/tools/convert/templates/configV2.tmpl
+++ b/tools/convert/templates/configV2.tmpl
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created {{ now }} from {{ .Input }} using a template generated on 2024-02-20 at 18:13:41 UTC
+# created {{ now }} from {{ .Input }} using a template generated on 2024-02-22 at 18:03:07 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of
@@ -999,6 +999,7 @@ GRPCServerParameters:
     ## If `false`, then the gRPC server is not started and no gRPC traffic is
     ## accepted.
     ##
+    ## default: true
     ## Not eligible for live reload.
     {{ conditional .Data "Enabled" "nonempty GRPCListenAddr" }}
 

--- a/tools/convert/templates/configV2.tmpl
+++ b/tools/convert/templates/configV2.tmpl
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created {{ now }} from {{ .Input }} using a template generated on 2024-02-22 at 18:03:07 UTC
+# created {{ now }} from {{ .Input }} using a template generated on 2024-02-23 at 17:42:41 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of


### PR DESCRIPTION
## Which problem is this PR solving?

- Handle case where `root.` prefix is used but a root span is not present for the trace at the time a sampling decision is being made, for example: a late-arriving root span.

## Short description of the changes

- Check for root span when trying to use `root.` prefix; document current behavior when root span is not present on trace

