### PR TITLE
fix: Fix OTLP http responses

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -317,7 +317,7 @@ func TestAppIntegrationWithUnauthorizedKey(t *testing.T) {
 
 	resp, err := http.DefaultTransport.RoundTrip(req)
 	assert.NoError(t, err)
-	assert.Equal(t, 400, resp.StatusCode)
+	assert.Equal(t, 401, resp.StatusCode)
 	data, err := io.ReadAll(resp.Body)
 	resp.Body.Close()
 	assert.NoError(t, err)

--- a/route/middleware.go
+++ b/route/middleware.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
-	husky "github.com/honeycombio/husky/otlp"
 	"github.com/honeycombio/refinery/types"
 )
 
@@ -56,26 +55,6 @@ func (r *Router) apiKeyChecker(next http.Handler) http.Handler {
 		}
 		err := fmt.Errorf("api key %s not found in list of authorized keys", apiKey)
 		r.handlerReturnWithError(w, ErrAuthNeeded, err)
-	})
-}
-
-func (r *Router) apiKeyCheckerOTLP(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		apiKey := req.Header.Get(types.APIKeyHeader)
-		if apiKey == "" {
-			apiKey = req.Header.Get(types.APIKeyHeaderShort)
-		}
-		if apiKey == "" {
-			err := errors.New("no " + types.APIKeyHeader + " header found from within authing middleware")
-			r.handleOTLPFailureResponse(w, req, husky.OTLPError{Message: err.Error(), HTTPStatusCode: http.StatusUnauthorized})
-			return
-		}
-		if r.Config.IsAPIKeyValid(apiKey) {
-			next.ServeHTTP(w, req)
-			return
-		}
-		err := fmt.Errorf("api key %s not found in list of authorized keys", apiKey)
-		r.handleOTLPFailureResponse(w, req, husky.OTLPError{Message: err.Error(), HTTPStatusCode: http.StatusUnauthorized})
 	})
 }
 

--- a/route/middleware.go
+++ b/route/middleware.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
+	husky "github.com/honeycombio/husky/otlp"
 	"github.com/honeycombio/refinery/types"
 )
 
@@ -55,6 +56,26 @@ func (r *Router) apiKeyChecker(next http.Handler) http.Handler {
 		}
 		err := fmt.Errorf("api key %s not found in list of authorized keys", apiKey)
 		r.handlerReturnWithError(w, ErrAuthNeeded, err)
+	})
+}
+
+func (r *Router) apiKeyCheckerOTLP(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		apiKey := req.Header.Get(types.APIKeyHeader)
+		if apiKey == "" {
+			apiKey = req.Header.Get(types.APIKeyHeaderShort)
+		}
+		if apiKey == "" {
+			err := errors.New("no " + types.APIKeyHeader + " header found from within authing middleware")
+			r.handleOTLPFailureResponse(w, req, husky.OTLPError{Message: err.Error(), HTTPStatusCode: http.StatusUnauthorized})
+			return
+		}
+		if r.Config.IsAPIKeyValid(apiKey) {
+			next.ServeHTTP(w, req)
+			return
+		}
+		err := fmt.Errorf("api key %s not found in list of authorized keys", apiKey)
+		r.handleOTLPFailureResponse(w, req, husky.OTLPError{Message: err.Error(), HTTPStatusCode: http.StatusUnauthorized})
 	})
 }
 

--- a/route/otlp_trace_test.go
+++ b/route/otlp_trace_test.go
@@ -317,7 +317,7 @@ func TestOTLPHandler(t *testing.T) {
 		w := httptest.NewRecorder()
 		router.postOTLP(w, request)
 		assert.Equal(t, w.Code, http.StatusOK)
-		assert.Equal(t, "", w.Body.String())
+		assert.Equal(t, "{}", w.Body.String())
 
 		assert.Equal(t, 2, len(mockTransmission.Events))
 		mockTransmission.Flush()
@@ -409,7 +409,7 @@ func TestOTLPHandler(t *testing.T) {
 
 		w := httptest.NewRecorder()
 		router.postOTLP(w, request)
-		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
 		assert.Contains(t, w.Body.String(), "not found in list of authorized keys")
 
 		assert.Equal(t, 0, len(mockTransmission.Events))

--- a/route/route.go
+++ b/route/route.go
@@ -904,7 +904,7 @@ func (r *Router) Watch(req *grpc_health_v1.HealthCheckRequest, server grpc_healt
 func (r *Router) AddOTLPMuxxer(muxxer *mux.Router) {
 	// require an auth header for OTLP requests
 	otlpMuxxer := muxxer.PathPrefix("/v1/").Methods("POST").Subrouter()
-	otlpMuxxer.Use(r.apiKeyChecker)
+	otlpMuxxer.Use(r.apiKeyCheckerOTLP)
 
 	// handle OTLP trace requests
 	otlpMuxxer.HandleFunc("/traces", r.postOTLP).Name("otlp")

--- a/route/route.go
+++ b/route/route.go
@@ -904,7 +904,6 @@ func (r *Router) Watch(req *grpc_health_v1.HealthCheckRequest, server grpc_healt
 func (r *Router) AddOTLPMuxxer(muxxer *mux.Router) {
 	// require an auth header for OTLP requests
 	otlpMuxxer := muxxer.PathPrefix("/v1/").Methods("POST").Subrouter()
-	otlpMuxxer.Use(r.apiKeyCheckerOTLP)
 
 	// handle OTLP trace requests
 	otlpMuxxer.HandleFunc("/traces", r.postOTLP).Name("otlp")


### PR DESCRIPTION
## Which problem is this PR solving?

Refinery was not returning the correct OTLP payload and not always using the correct `Content-Type` in the response.

- closes https://github.com/honeycombio/refinery/issues/1008

## Short description of the changes

This PR attempts to fix the OTLP response while leaving other protocols unaffected.

- Creates a new error handler method for the OTLP endpoint
- Ensures a `ExportTraceServiceResponse` object is returned for success and a grpc `Status` object is used for failure.
- Changes the "bad API key" response code from 400 to 401.

