### PR TITLE
rel: prepare v2.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Refinery Changelog
 
+## 2.4.1 2024-02-26
+
+This is a bug fix release for matching fields in the root span context.
+
+### Fixes
+
+The implementation in v2.4.0 can crash if the trace's root span is not present at the time a sampling decision is being made.
+Root spans are often not present when the root span is taking longer to complete than the time configured for Refinery to wait for a trace's spans to arrive (`TraceTimeout`).
+This release contains a fix for this crash and is a recommended upgrade for anyone using this new feature.
+
+- fix: handle root prefix when no root span on trace (#1006) | [fchikwekwe](https://github.com/fchikwekwe)
+
+### Maintenance
+
+- refactor: add default true type (#998) | [fchikwekwe](https://github.com/fchikwekwe)
+
 ## 2.4.0 2024-2-20
 
 ## Features
@@ -7,7 +23,7 @@
 - Update refinery_rules.md | [fchikwekwe](https://github.com/fchikwekwe)
 - feat: allow user to sample on root span context (#981) | [fchikwekwe](https://github.com/fchikwekwe)
 
-## Fixes 
+## Fixes
 
 - fix: flaky TestOriginalSampleRateIsNotedInMetaField (#991) | [Robb Kidd](https://github.com/robbkidd)
 - chore: consolidate routine dependency updates (#994) | [Robb Kidd](https://github.com/robbkidd)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,17 +2,25 @@
 
 While [CHANGELOG.md](./CHANGELOG.md) contains detailed documentation and links to all the source code changes in a given release, this document is intended to be aimed at a more comprehensible version of the contents of the release from the point of view of users of Refinery.
 
+## Version 2.4.1
+
+This is a bug fix release for matching fields in the root span context.
+
+The implementation in v2.4.0 can crash if the trace's root span is not present at the time a sampling decision is being made.
+Root spans are often not present when the root span is taking longer to complete than the time configured for Refinery to wait for a trace's spans to arrive (`TraceTimeout`).
+This release contains a fix for this crash and is a recommended upgrade for anyone using this new feature.
+
 ## Version 2.4.0
 
-This release includes an update to allow users to specify root span context in their rules. It also includes some bug 
+This release includes an update to allow users to specify root span context in their rules. It also includes some bug
 fixes, improvements, and dependency updates.
 
 ### Root Span Context
 
-Users can now specify rules that match only the root span of a trace (i.e. `root.http.status`). 
+Users can now specify rules that match only the root span of a trace (i.e. `root.http.status`).
 
-### Notable Fixes 
-* Previously, rules with a default of boolean `true` that we set to `false` by configuration would be overridden back to `true` when defaults were applied to the config. We have fixed this by using the `*bool` type for these values as well as adding helper functions to avoid strange behavior related to how booleans work in Go. 
+### Notable Fixes
+* Previously, rules with a default of boolean `true` that we set to `false` by configuration would be overridden back to `true` when defaults were applied to the config. We have fixed this by using the `*bool` type for these values as well as adding helper functions to avoid strange behavior related to how booleans work in Go.
 
 ## Version 2.3.0
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -16,13 +16,13 @@ been changes to `rules.md`, you may need to manually modify the `rules_complete.
     (the `git log` command can't do this automatically)
     - organize each commit based on their prefix into below three categories:
     ```
-        ## Features
+        ### Features
          - <a-commit-with-feat-prefix>
 
-        ## Fixes
+        ### Fixes
          - <a-commit-with-fix-prefix>
 
-        ## Maintenance
+        ### Maintenance
          - <a-commit-with-maintenance-prefix>
     ```
 5. Add a summary of release changes to [release notes](./RELEASE_NOTES.md)

--- a/config.md
+++ b/config.md
@@ -1,7 +1,7 @@
 # Honeycomb Refinery Configuration Documentation
 
 This is the documentation for the configuration file for Honeycomb's Refinery.
-It was automatically generated on 2024-02-23 at 17:42:44 UTC.
+It was automatically generated on 2024-02-23 at 22:23:28 UTC.
 
 ## The Config file
 

--- a/config/metadata/rulesMeta.yaml
+++ b/config/metadata/rulesMeta.yaml
@@ -611,19 +611,19 @@ groups:
         description: >
           The field to check. This can name any field in the trace. If the field
           is not present, then the condition will not match. The comparison is
-          case-sensitive. 
-          
+          case-sensitive.
+
           The field can also include a prefix that changes the span used for evaluation of the field.
           The only prefix currently supported is `root`, as in `root.http.status`. Specifying `root.`
           causes the condition to be evaluated against the root span.
-          
+
           For example, if the `Field` is `root.url`, then the condition will be processed using the url
           field from the root span.
-          
+
           The setting `Scope: span` for a rule does not change the meaning of this prefix --
-          the condition is still evaluated on the root span and is treated as if it were part of the 
+          the condition is still evaluated on the root span and is treated as if it were part of the
           span being processed.
-          
+
           When using the `root.` prefix on a field with a `not-exists` operator, include the `has-root-span: true` condition in the rule.
           The `not-exists` condition on a `root.`-prefixed field will evaluate to false if the existence of the root span is not checked and the root span does not exist.
           The primary reason a root span is not present on a trace when a sampling decision is being made is when the root span takes longer to complete than the configured TraceTimeout.
@@ -641,7 +641,7 @@ groups:
           trace. The fields are checked in the order defined here, and the first
           named field that contains a value will be used for the condition. Only
           the first populated field will be used, even if the condition fails.
-          
+
           If a `root.` prefix is present on a field, but the root span is not on
           the trace, that field will be skipped.
 

--- a/config_complete.yaml
+++ b/config_complete.yaml
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created on 2024-02-23 at 17:42:43 UTC from ../../config.yaml using a template generated on 2024-02-23 at 17:42:41 UTC
+# created on 2024-02-23 at 22:23:27 UTC from ../../config.yaml using a template generated on 2024-02-23 at 22:23:25 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of

--- a/refinery_rules.md
+++ b/refinery_rules.md
@@ -503,7 +503,7 @@ The field can also include a prefix that changes the span used for evaluation of
 The only prefix currently supported is `root`, as in `root.http.status`.
 Specifying `root.` causes the condition to be evaluated against the root span.
 For example, if the `Field` is `root.url`, then the condition will be processed using the url field from the root span.
-The setting `Scope: span` for a rule does not change the meaning of this prefix -- the condition is still evaluated on the root span and is treated as if it were part of the  span being processed.
+The setting `Scope: span` for a rule does not change the meaning of this prefix -- the condition is still evaluated on the root span and is treated as if it were part of the span being processed.
 When using the `root.` prefix on a field with a `not-exists` operator, include the `has-root-span: true` condition in the rule.
 The `not-exists` condition on a `root.`-prefixed field will evaluate to false if the existence of the root span is not checked and the root span does not exist.
 The primary reason a root span is not present on a trace when a sampling decision is being made is when the root span takes longer to complete than the configured TraceTimeout.

--- a/rules.md
+++ b/rules.md
@@ -1,7 +1,7 @@
 # Honeycomb Refinery Rules Documentation
 
 This is the documentation for the rules configuration for Honeycomb's Refinery.
-It was automatically generated on 2024-02-23 at 17:42:45 UTC.
+It was automatically generated on 2024-02-23 at 22:23:29 UTC.
 
 ## The Rules file
 

--- a/tools/convert/configDataNames.txt
+++ b/tools/convert/configDataNames.txt
@@ -1,5 +1,5 @@
 # Names of groups and fields in the new config file format.
-# Automatically generated on 2024-02-23 at 17:42:42 UTC.
+# Automatically generated on 2024-02-23 at 22:23:26 UTC.
 
 General:
   - ConfigurationVersion

--- a/tools/convert/minimal_config.yaml
+++ b/tools/convert/minimal_config.yaml
@@ -1,5 +1,5 @@
 # sample uncommented config file containing all possible fields
-# automatically generated on 2024-02-23 at 17:42:42 UTC
+# automatically generated on 2024-02-23 at 22:23:27 UTC
 General:
   ConfigurationVersion: 2
   MinRefineryVersion: "v2.0"

--- a/tools/convert/templates/configV2.tmpl
+++ b/tools/convert/templates/configV2.tmpl
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created {{ now }} from {{ .Input }} using a template generated on 2024-02-23 at 17:42:41 UTC
+# created {{ now }} from {{ .Input }} using a template generated on 2024-02-23 at 22:23:25 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of


### PR DESCRIPTION
## Which problem is this PR solving?

- Releasing 2.4.1 into the wild!

## Short description of the changes

- generate doc updates
- update changelog and release notes
- update RELEASING: add release sub-categories (Features, Fixes, etc) at H3 because release version section header is at H2
