### PR TITLE
feat: properly handle keep state and timestamp for state transition

### DIFF
--- a/centralstore/redis_store.go
+++ b/centralstore/redis_store.go
@@ -40,7 +40,7 @@ var _ BasicStorer = (*RedisBasicStore)(nil)
 
 func NewRedisBasicStore(opt RedisBasicStoreOptions) *RedisBasicStore {
 	host := "localhost:6379"
-	if opt.Host == "" {
+	if opt.Host != "" {
 		host = opt.Host
 	}
 

--- a/centralstore/redis_store.go
+++ b/centralstore/redis_store.go
@@ -819,6 +819,10 @@ const stateChangeScript = `
 	currentState = previousState
   end
 
+  if (currentState ~= previousState) then
+	do return -1 end
+  end
+
   local stateChangeEvent = string.format("%s-%s", currentState, nextState)
   local changeEventIsValid = redis.call('SISMEMBER', possibleStateChangeEvents, stateChangeEvent)
   if (changeEventIsValid == 0) then

--- a/centralstore/redis_store_test.go
+++ b/centralstore/redis_store_test.go
@@ -324,6 +324,7 @@ func TestRedisBasicStore_ConcurrentStateChange(t *testing.T) {
 	status, err := store.GetStatusForTraces([]string{traceID})
 	require.NoError(t, err)
 	require.Len(t, status, 1)
+	require.Equal(t, Collecting, status[0].State)
 	initialTimestamp := status[0].Timestamp
 
 	store.clock.Advance(1 * time.Second)
@@ -340,8 +341,6 @@ func TestRedisBasicStore_ConcurrentStateChange(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		conn := redisClient.Get()
-		defer conn.Close()
 
 		_ = store.ChangeTraceStatus([]string{traceID}, Collecting, DecisionDelay)
 		_ = store.ChangeTraceStatus([]string{traceID}, DecisionDelay, ReadyToDecide)

--- a/centralstore/redis_store_test.go
+++ b/centralstore/redis_store_test.go
@@ -490,7 +490,6 @@ func NewTestRedisBasicStore(t *testing.T, redisClient *TestRedisClient) *TestRed
 			states:        ts.traceStateProcessor,
 			traces:        newTraceStatusStore(clock),
 			decisionCache: decisionCache,
-			errs:          make(chan error, defaultPendingWorkCapacity),
 		},
 		testStateProcessor: ts,
 		clock:              clock,

--- a/centralstore/redis_store_test.go
+++ b/centralstore/redis_store_test.go
@@ -2,6 +2,7 @@ package centralstore
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"sync"
 	"testing"
@@ -17,70 +18,142 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestRedisBasicStore_TraceStateProcessor(t *testing.T) {
+func TestRedisBasicStore_TraceStatus(t *testing.T) {
 	ctx := context.Background()
 	redisClient := NewTestRedis()
 	defer redisClient.Stop(ctx)
 
-	ts := newTestTraceStateProcessor(t, redisClient)
-	conn := redisClient.Get()
-	defer conn.Close()
 	traceID := "traceID0"
-	require.NoError(t, ts.addNewTrace(conn, traceID))
-	require.True(t, ts.exists(conn, Collecting, traceID))
+	store := NewTestRedisBasicStore(t, redisClient)
+	defer store.Stop()
 
-	type stateChange struct {
-		to      CentralTraceState
-		isValid bool
+	testcases := []struct {
+		name               string
+		span               *CentralSpan
+		expectedState      CentralTraceState
+		expectedSpanCount  uint32
+		expectedEventCount uint32
+		expectedLinkCount  uint32
+	}{
+		{
+			name: "first nonroot span",
+			span: &CentralSpan{
+				TraceID:   traceID,
+				SpanID:    "spanID0",
+				ParentID:  traceID,
+				KeyFields: map[string]interface{}{"foo": "bar"},
+				IsRoot:    false,
+			},
+			expectedState:     Collecting,
+			expectedSpanCount: 1,
+		},
+		{
+			name: "event span",
+			span: &CentralSpan{
+				TraceID:   traceID,
+				SpanID:    "spanID1",
+				ParentID:  traceID,
+				Type:      SpanTypeEvent,
+				KeyFields: map[string]interface{}{"event": "bar"},
+				IsRoot:    false,
+			},
+			expectedState:      Collecting,
+			expectedSpanCount:  1,
+			expectedEventCount: 1,
+		},
+		{
+			name: "link span",
+			span: &CentralSpan{
+				TraceID:   traceID,
+				SpanID:    "spanID2",
+				ParentID:  traceID,
+				Type:      SpanTypeLink,
+				KeyFields: map[string]interface{}{"link": "bar"},
+				IsRoot:    false,
+			},
+			expectedState:      Collecting,
+			expectedSpanCount:  1,
+			expectedLinkCount:  1,
+			expectedEventCount: 1,
+		},
+		{
+			name: "root span",
+			span: &CentralSpan{
+				TraceID:   traceID,
+				SpanID:    "spanID3",
+				ParentID:  "",
+				KeyFields: map[string]interface{}{"root": "bar"},
+				IsRoot:    true,
+			},
+			expectedState:      DecisionDelay,
+			expectedSpanCount:  2,
+			expectedLinkCount:  1,
+			expectedEventCount: 1,
+		},
 	}
 
-	for _, tc := range []struct {
-		state   CentralTraceState
-		changes []stateChange
-	}{
-		{Collecting, []stateChange{
-			{Collecting, false},
-			{DecisionDelay, true},
-			{ReadyToDecide, false},
-			{AwaitingDecision, false},
-		}},
-		{DecisionDelay, []stateChange{
-			{Collecting, false},
-			{DecisionDelay, false},
-			{ReadyToDecide, true},
-			{AwaitingDecision, false},
-		}},
-		{ReadyToDecide, []stateChange{
-			{Collecting, false},
-			{DecisionDelay, false},
-			{ReadyToDecide, false},
-			{AwaitingDecision, true},
-		}},
-		{AwaitingDecision, []stateChange{
-			{Collecting, false},
-			{DecisionDelay, false},
-			{ReadyToDecide, true},
-			{AwaitingDecision, false},
-		}},
-	} {
-		t.Run(tc.state.String(), func(t *testing.T) {
-			tc := tc
-			for _, change := range tc.changes {
-				stateChangeEvent := newTraceStateChangeEvent(tc.state, change.to)
-				err := ts.toNextState(conn, stateChangeEvent, traceID)
-				if !ts.isValidStateChange(conn, stateChangeEvent, traceID) {
-					require.Error(t, err)
-					continue
-				}
-
-				require.NoError(t, err)
-
-				require.True(t, ts.exists(conn, change.to, traceID))
-				require.False(t, ts.exists(conn, tc.state, traceID))
-				//TODO: make sure the timestamp is updated
+	var initialTimestamp time.Time
+	for i, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.NoError(t, store.WriteSpan(tc.span))
+			status, err := store.GetStatusForTraces([]string{tc.span.TraceID})
+			require.NoError(t, err)
+			require.Len(t, status, 1)
+			require.NotNil(t, status[0])
+			assert.Equal(t, tc.expectedState, status[0].State)
+			if i == 0 {
+				initialTimestamp = status[0].Timestamp
 			}
+			assert.NotNil(t, status[0].Timestamp)
+			if i > 0 {
+				assert.Equal(t, initialTimestamp, status[0].Timestamp)
+			}
+
+			assert.Equal(t, tc.expectedEventCount, status[0].SpanEventCount())
+			assert.Equal(t, tc.expectedLinkCount, status[0].SpanLinkCount())
+			assert.Equal(t, tc.expectedSpanCount, status[0].SpanCount())
 		})
 	}
+
+}
+
+func TestRedisBasicStore_GetTrace(t *testing.T) {
+	ctx := context.Background()
+	redisClient := NewTestRedis()
+	defer redisClient.Stop(ctx)
+
+	traceID := "traceID0"
+	store := NewTestRedisBasicStore(t, redisClient)
+	defer store.Stop()
+
+	testSpans := []*CentralSpan{
+		{
+			TraceID:   traceID,
+			SpanID:    "spanID0",
+			ParentID:  traceID,
+			KeyFields: map[string]interface{}{"foo": "bar"},
+			IsRoot:    false,
+		},
+		{
+			TraceID:   traceID,
+			SpanID:    "spanID3",
+			ParentID:  "",
+			KeyFields: map[string]interface{}{"root": "bar"},
+			IsRoot:    true,
+		},
+	}
+
+	for _, span := range testSpans {
+		require.NoError(t, store.WriteSpan(span))
+	}
+
+	trace, err := store.GetTrace(traceID)
+	require.NoError(t, err)
+	require.NotNil(t, trace)
+	require.Equal(t, traceID, trace.TraceID)
+	require.Len(t, trace.Spans, 2)
+	assert.EqualValues(t, testSpans, trace.Spans)
+	assert.EqualValues(t, testSpans[1], trace.Root)
 }
 
 func TestRedisBasicStore_ConcurrentStateChange(t *testing.T) {
@@ -105,6 +178,7 @@ func TestRedisBasicStore_ConcurrentStateChange(t *testing.T) {
 	require.Len(t, status, 1)
 	initialTimestamp := status[0].Timestamp
 
+	store.clock.Advance(1 * time.Second)
 	var wg sync.WaitGroup
 	for i := 0; i < 5; i++ {
 		wg.Add(1)
@@ -135,14 +209,12 @@ func TestRedisBasicStore_ConcurrentStateChange(t *testing.T) {
 	require.False(t, store.states.exists(conn, DecisionDelay, traceID))
 	require.False(t, store.states.exists(conn, ReadyToDecide, traceID))
 	require.True(t, store.states.exists(conn, AwaitingDecision, traceID))
-	//TODO: make sure the timestamp is updated
 
 	status, err = store.GetStatusForTraces([]string{traceID})
 	require.NoError(t, err)
 	require.Len(t, status, 1)
 	assert.Equal(t, AwaitingDecision, status[0].State)
 	assert.True(t, status[0].Timestamp.After(initialTimestamp))
-
 }
 
 func TestRedisBasicStore_Cleanup(t *testing.T) {
@@ -176,6 +248,56 @@ func TestRedisBasicStore_Cleanup(t *testing.T) {
 	require.True(t, ts.exists(conn, DecisionDelay, traceIDToKeep))
 }
 
+func TestRedisBasicStore_ValidStateTransition(t *testing.T) {
+	ctx := context.Background()
+	redisClient := NewTestRedis()
+	defer redisClient.Stop(ctx)
+
+	traceID := "traceID0"
+	ts := newTestTraceStateProcessor(t, redisClient)
+	defer ts.Stop()
+
+	type stateChange struct {
+		to      CentralTraceState
+		isValid bool
+	}
+
+	for _, tc := range []struct {
+		state  CentralTraceState
+		change stateChange
+	}{
+		{Collecting, stateChange{Collecting, false}},
+		{Collecting, stateChange{DecisionDelay, true}},
+		{Collecting, stateChange{ReadyToDecide, false}},
+		{Collecting, stateChange{AwaitingDecision, false}},
+		{DecisionDelay, stateChange{Collecting, false}},
+		{DecisionDelay, stateChange{DecisionDelay, false}},
+		{DecisionDelay, stateChange{ReadyToDecide, true}},
+		{DecisionDelay, stateChange{AwaitingDecision, false}},
+		{ReadyToDecide, stateChange{Collecting, false}},
+		{ReadyToDecide, stateChange{DecisionDelay, false}},
+		{ReadyToDecide, stateChange{ReadyToDecide, false}},
+		{ReadyToDecide, stateChange{AwaitingDecision, true}},
+		{AwaitingDecision, stateChange{Collecting, false}},
+		{AwaitingDecision, stateChange{DecisionDelay, false}},
+		{AwaitingDecision, stateChange{ReadyToDecide, true}},
+		{AwaitingDecision, stateChange{AwaitingDecision, false}},
+	} {
+		t.Run(fmt.Sprintf("%s-%s", tc.state.String(), tc.change.to.String()), func(t *testing.T) {
+			tc := tc
+
+			conn := redisClient.Get()
+			defer conn.Close()
+
+			ts.ensureInitialState(t, conn, traceID, tc.state)
+
+			result := ts.isValidStateChangeThroughLua(conn, newTraceStateChangeEvent(tc.state, tc.change.to), traceID)
+			require.Equal(t, tc.change.isValid, result)
+
+		})
+	}
+}
+
 func TestRedisBasicStore_normalizeCentralTraceStatusRedis(t *testing.T) {
 	getFields := func(i interface{}) []string {
 		val := reflect.ValueOf(i).Elem()
@@ -196,46 +318,6 @@ func TestRedisBasicStore_normalizeCentralTraceStatusRedis(t *testing.T) {
 
 	require.EqualValues(t, expected, after)
 
-}
-
-func TestRedisBasicStore_TraceStatus(t *testing.T) {
-	// make sure the trace status is not override by spans arrived after the trace status is set
-	ctx := context.Background()
-	redisClient := NewTestRedis()
-	defer redisClient.Stop(ctx)
-
-	statusStore := newTraceStatusStore(clockwork.NewFakeClock())
-
-	conn := redisClient.Get()
-	defer conn.Close()
-
-	traceID0 := "traceID0"
-	span := &CentralSpan{
-		TraceID:   traceID0,
-		SpanID:    "spanID0",
-		ParentID:  traceID0,
-		KeyFields: map[string]interface{}{"foo": "bar"},
-		IsRoot:    false,
-	}
-	require.NoError(t, statusStore.addStatus(conn, span))
-	status, err := statusStore.getTraceStatuses(conn, []string{traceID0})
-	require.NoError(t, err)
-	require.Len(t, status, 1)
-	require.NotNil(t, status[traceID0])
-	assert.Equal(t, Unknown, status[traceID0].State)
-	span0Timestamp := status[traceID0].Timestamp
-	assert.NotNil(t, span0Timestamp)
-
-	span.SpanID = "spanID1"
-	require.NoError(t, statusStore.addStatus(conn, span))
-	status, err = statusStore.getTraceStatuses(conn, []string{traceID0})
-	require.NoError(t, err)
-	require.Len(t, status, 1)
-	require.NotNil(t, status[traceID0])
-	assert.Equal(t, Unknown, status[traceID0].State)
-	span1Timestamp := status[traceID0].Timestamp
-	assert.NotNil(t, span1Timestamp)
-	assert.Equal(t, span0Timestamp, span1Timestamp)
 }
 
 type TestRedisBasicStore struct {
@@ -307,4 +389,26 @@ func newTestTraceStateProcessor(t *testing.T, redisClient *TestRedisClient) *tes
 	}
 	require.NoError(t, ts.Start(context.TODO(), redisClient))
 	return ts
+}
+
+func (ts *testTraceStateProcessor) ensureInitialState(t *testing.T, conn redis.Conn, traceID string, state CentralTraceState) {
+	for _, state := range ts.states {
+		require.NoError(t, ts.remove(conn, state, traceID))
+	}
+	_, err := conn.Del(ts.traceStatesKey(traceID))
+	require.NoError(t, err)
+
+	require.NoError(t, ts.addNewTrace(conn, traceID))
+	if state == Collecting {
+		return
+	}
+	require.NoError(t, ts.toNextState(conn, newTraceStateChangeEvent(Collecting, DecisionDelay), traceID))
+	if state == DecisionDelay {
+		return
+	}
+	require.NoError(t, ts.toNextState(conn, newTraceStateChangeEvent(Collecting, ReadyToDecide), traceID))
+	if state == ReadyToDecide {
+		return
+	}
+	require.NoError(t, ts.toNextState(conn, newTraceStateChangeEvent(Collecting, AwaitingDecision), traceID))
 }

--- a/centralstore/smartwrapper_test.go
+++ b/centralstore/smartwrapper_test.go
@@ -49,11 +49,7 @@ func makeRemoteStore() BasicStorer {
 	// 	s.SetupDatabase()
 	// 	return s
 	case "redis":
-		return NewRedisBasicStore(RedisBasicStoreOptions{Cache: config.SampleCacheConfig{
-			KeptSize:          100,
-			DroppedSize:       10000,
-			SizeCheckInterval: config.Duration(10 * time.Second),
-		}})
+		return NewRedisBasicStore(&RedisBasicStoreOptions{})
 	case "local":
 		return NewLocalRemoteStore()
 	}

--- a/cmd/test_stores/main.go
+++ b/cmd/test_stores/main.go
@@ -135,6 +135,10 @@ func makeRemoteStore(storeType string) centralstore.BasicStorer {
 	switch storeType {
 	case "local":
 		return centralstore.NewLocalRemoteStore()
+	case "redis":
+		return centralstore.NewRedisBasicStore(centralstore.RedisBasicStoreOptions{
+			Host: "localhost:6379",
+		})
 	default:
 		panic("unknown store type " + storeType)
 	}

--- a/internal/redis/redis.go
+++ b/internal/redis/redis.go
@@ -75,7 +75,7 @@ type Conn interface {
 	LIndexString(string, int) (string, error)
 
 	ZAdd(string, []any) error
-	ZMove(string, string, []int64, []any) error
+	ZMove(string, string, []int64, []string) error
 	ZRange(string, int, int) ([]string, error)
 	ZRangeByScoreString(string, int64) ([]string, error)
 	ZScore(string, string) (int64, error)
@@ -490,7 +490,7 @@ func (c *DefaultConn) ZExist(key string, member string) (bool, error) {
 	return value != 0, nil
 }
 
-func (c *DefaultConn) ZMove(fromKey string, toKey string, scores []int64, members []any) error {
+func (c *DefaultConn) ZMove(fromKey string, toKey string, scores []int64, members []string) error {
 	if err := c.conn.Send("MULTI"); err != nil {
 		return err
 	}
@@ -551,10 +551,6 @@ func (c *DefaultConn) GetStructHash(key string, val interface{}) error {
 	values, err := redis.Values(c.conn.Do("HGETALL", key))
 	if err != nil {
 		return err
-	}
-
-	if len(values) == 0 {
-		return redis.ErrNil
 	}
 
 	return redis.ScanStruct(values, val)

--- a/internal/redis/redis.go
+++ b/internal/redis/redis.go
@@ -155,7 +155,8 @@ func (c *DefaultConn) Close() error {
 }
 
 func (c *DefaultConn) Del(keys ...string) (int64, error) {
-	return redis.Int64(c.conn.Do("DEL", keys))
+	args := redis.Args{}.AddFlat(keys)
+	return redis.Int64(c.conn.Do("DEL", args...))
 }
 
 func (c *DefaultConn) Exists(key string) (bool, error) {
@@ -619,7 +620,7 @@ func (c *DefaultConn) Exec(commands ...Command) error {
 		}
 	}
 
-	_, err = c.conn.Do("EXEC")
+	_, err = redis.Values(c.conn.Do("EXEC"))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
- Keep state
    - this PR makes sure that the keep decision is stored as part of the state transition for a given trace
    - It also adds logic to remove spans information for a given trace when a decision is made
- Timestamp
    - we nee record the current time whenever a state change happens.
    - the precision used before is not sufficient to determine the order of state change events
    - this PR changes the timestamp precision from second to nanosecond

## Short description of the changes

- Modified `KeepTrace`
- return traceIDs that has successfully changed their states from `toNextState` function
- added more tests

