### PR TITLE
feat: run simulator with redis backend

### DIFF
--- a/cmd/test_stores/main.go
+++ b/cmd/test_stores/main.go
@@ -91,9 +91,7 @@ func makeRemoteStore(storeType string) centralstore.BasicStorer {
 	case "local":
 		return centralstore.NewLocalRemoteStore()
 	case "redis":
-		return centralstore.NewRedisBasicStore(&centralstore.RedisBasicStoreOptions{
-			Host: "localhost:6379",
-		})
+		return centralstore.NewRedisBasicStore(&centralstore.RedisBasicStoreOptions{})
 	default:
 		panic("unknown store type " + storeType)
 	}
@@ -111,6 +109,7 @@ type CmdLineOptions struct {
 	NodeIndex          int      `long:"node-number" description:"Index of this node if Total > 1" default:"0"`
 	DecisionReqSize    int      `long:"decision-req-size" description:"Number of traces to request for decision" default:"10"`
 	HnyAPIKey          string   `long:"hny-api-key" description:"API key for traces in Honeycomb" default:"" env:"HONEYCOMB_API_KEY"`
+	HnyEndpoint        string   `long:"hny-endpoint" description:"Endpoint for traces in Honeycomb" default:"https://api.honeycomb.io" env:"HONEYCOMB_ENDPOINT"`
 	HnyDataset         string   `long:"hny-dataset" description:"Dataset/service name for traces in Honeycomb" default:"refinery-store-test" env:"HONEYCOMB_DATASET"`
 }
 

--- a/cmd/test_stores/otel_tracing.go
+++ b/cmd/test_stores/otel_tracing.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/honeycombio/otel-config-go/otelconfig"
@@ -61,10 +62,13 @@ func setupTracing(opts CmdLineOptions) (tracer trace.Tracer, shutdown func()) {
 	if opts.HnyAPIKey != "" {
 		var protocol otelconfig.Protocol = otelconfig.ProtocolHTTPProto
 
+		opts.HnyEndpoint = strings.TrimSuffix(opts.HnyEndpoint, "/")
+		endpoint := fmt.Sprintf("%s:443", opts.HnyEndpoint)
+
 		otelshutdown, err := otelconfig.ConfigureOpenTelemetry(
 			otelconfig.WithExporterProtocol(protocol),
 			otelconfig.WithServiceName(opts.HnyDataset),
-			otelconfig.WithTracesExporterEndpoint("https://api-dogfood.honeycomb.io:443"),
+			otelconfig.WithTracesExporterEndpoint(endpoint),
 			otelconfig.WithMetricsEnabled(false),
 			otelconfig.WithTracesEnabled(true),
 			otelconfig.WithHeaders(map[string]string{


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

This PR enables the simulator to be able to run with a redis backend 

## Short description of the changes

- added opts.HnyEndpoint to enable sending traces to other honeycomb environments
- redis returns the status field as `float64`. Handle that scenario in the decider logic.

