### PR TITLE
maint: Update Husky to handle invalid content type errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/grafana/pyroscope-go/godeltaprof v0.1.7
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/honeycombio/dynsampler-go v0.6.0
-	github.com/honeycombio/husky v0.24.0
+	github.com/honeycombio/husky v0.25.1-0.20240229103413-71c269e7a175
 	github.com/honeycombio/libhoney-go v1.20.0
 	github.com/jessevdk/go-flags v1.5.0
 	github.com/json-iterator/go v1.1.12

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/grafana/pyroscope-go/godeltaprof v0.1.7
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/honeycombio/dynsampler-go v0.6.0
-	github.com/honeycombio/husky v0.25.1-0.20240229103413-71c269e7a175
+	github.com/honeycombio/husky v0.25.1
 	github.com/honeycombio/libhoney-go v1.20.0
 	github.com/jessevdk/go-flags v1.5.0
 	github.com/json-iterator/go v1.1.12

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/honeycombio/cuckoofilter v0.0.0-20230630225016-cf48793fb7c1 h1:MXRxSU
 github.com/honeycombio/cuckoofilter v0.0.0-20230630225016-cf48793fb7c1/go.mod h1:VvArVnXCHeB+tpxMOLWvaoItNHWYEgOx8Lgs1JoS+cI=
 github.com/honeycombio/dynsampler-go v0.6.0 h1:fs4mrfeFGU5V+ClwpblFzbWqn4Apb+lKlE7Ja5zL22I=
 github.com/honeycombio/dynsampler-go v0.6.0/go.mod h1:pJqWFeoMN3syX74PEvlusieyGBbtIBjmTVjLc3thmK4=
-github.com/honeycombio/husky v0.24.0 h1:/kaua19ixUFVBLirnHMvffDdK0QSEy1pkG1ZTOWm/nk=
-github.com/honeycombio/husky v0.24.0/go.mod h1:7qtQ3fCfYpfhN57rE+yS1St1QpnWKUTGLtpQVuWa9bQ=
+github.com/honeycombio/husky v0.25.1-0.20240229103413-71c269e7a175 h1:1hb9heSgrYO12CWk9wqeElrjIA/g0htREB8k2OUBYEs=
+github.com/honeycombio/husky v0.25.1-0.20240229103413-71c269e7a175/go.mod h1:t0eBcATeP38Acksmr0Ayh2gaNUS4FKPOVuhoYNKY9ps=
 github.com/honeycombio/libhoney-go v1.20.0 h1:PL54R0P9vxIyb28H3twbLb+DCqQlJdMQM55VZg1abKA=
 github.com/honeycombio/libhoney-go v1.20.0/go.mod h1:RIaurCpfg5NDWSEV8t3QLcda9dUAiVNyWeHRAaSpN90=
 github.com/honeycombio/opentelemetry-proto-go/otlp v0.19.0-compat h1:fMpIzVAl5C260HisnRWV//vfckZIC4qvn656M3VLLOY=

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/honeycombio/cuckoofilter v0.0.0-20230630225016-cf48793fb7c1 h1:MXRxSU
 github.com/honeycombio/cuckoofilter v0.0.0-20230630225016-cf48793fb7c1/go.mod h1:VvArVnXCHeB+tpxMOLWvaoItNHWYEgOx8Lgs1JoS+cI=
 github.com/honeycombio/dynsampler-go v0.6.0 h1:fs4mrfeFGU5V+ClwpblFzbWqn4Apb+lKlE7Ja5zL22I=
 github.com/honeycombio/dynsampler-go v0.6.0/go.mod h1:pJqWFeoMN3syX74PEvlusieyGBbtIBjmTVjLc3thmK4=
-github.com/honeycombio/husky v0.25.1-0.20240229103413-71c269e7a175 h1:1hb9heSgrYO12CWk9wqeElrjIA/g0htREB8k2OUBYEs=
-github.com/honeycombio/husky v0.25.1-0.20240229103413-71c269e7a175/go.mod h1:t0eBcATeP38Acksmr0Ayh2gaNUS4FKPOVuhoYNKY9ps=
+github.com/honeycombio/husky v0.25.1 h1:5fjysSfjcXXYtBpsgIjkLd4oSf+xyvabgrvfOhoef6k=
+github.com/honeycombio/husky v0.25.1/go.mod h1:t0eBcATeP38Acksmr0Ayh2gaNUS4FKPOVuhoYNKY9ps=
 github.com/honeycombio/libhoney-go v1.20.0 h1:PL54R0P9vxIyb28H3twbLb+DCqQlJdMQM55VZg1abKA=
 github.com/honeycombio/libhoney-go v1.20.0/go.mod h1:RIaurCpfg5NDWSEV8t3QLcda9dUAiVNyWeHRAaSpN90=
 github.com/honeycombio/opentelemetry-proto-go/otlp v0.19.0-compat h1:fMpIzVAl5C260HisnRWV//vfckZIC4qvn656M3VLLOY=

--- a/route/errors.go
+++ b/route/errors.go
@@ -77,22 +77,12 @@ func (r *Router) handlerReturnWithError(w http.ResponseWriter, he handlerError, 
 
 func (r *Router) handleOTLPFailureResponse(w http.ResponseWriter, req *http.Request, otlpErr husky.OTLPError) {
 	r.Logger.Error().Logf(otlpErr.Error())
-
-	if otlpErr != husky.ErrInvalidContentType {
-		err := husky.WriteOtlpHttpFailureResponse(w, req, otlpErr)
-		if err != nil {
-			// If we made it here we had a problem writing an OTLP HTTP response
-			resp := fmt.Sprintf("failed to write otlp http response, %v", err.Error())
-			r.Logger.Error().Logf(resp)
-			w.Header().Set("Content-Type", "text/plain")
-			w.WriteHeader(http.StatusInternalServerError)
-			_, _ = io.WriteString(w, resp)
-		}
-	} else {
-		// Since we have an invalid content type for an OTLP HTTP response we choose to use to text/plain
+	if err := husky.WriteOtlpHttpFailureResponse(w, req, otlpErr); err != nil {
+		// If we made it here we had a problem writing an OTLP HTTP response
+		resp := fmt.Sprintf("failed to write otlp http response, %v", err.Error())
+		r.Logger.Error().Logf(resp)
 		w.Header().Set("Content-Type", "text/plain")
-		w.WriteHeader(otlpErr.HTTPStatusCode)
-		_, _ = io.WriteString(w, otlpErr.Message)
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = io.WriteString(w, resp)
 	}
-
 }

--- a/route/otlp_trace.go
+++ b/route/otlp_trace.go
@@ -15,17 +15,17 @@ import (
 func (r *Router) postOTLP(w http.ResponseWriter, req *http.Request) {
 	ri := huskyotlp.GetRequestInfoFromHttpHeaders(req.Header)
 
-	if !r.Config.IsAPIKeyValid(ri.ApiKey) {
-		r.handleOTLPFailureResponse(w, req, huskyotlp.OTLPError{Message: fmt.Sprintf("api key %s not found in list of authorized keys", ri.ApiKey), HTTPStatusCode: http.StatusUnauthorized})
-		return
-	}
-
 	if err := ri.ValidateTracesHeaders(); err != nil {
 		if errors.Is(err, huskyotlp.ErrInvalidContentType) {
 			r.handleOTLPFailureResponse(w, req, huskyotlp.ErrInvalidContentType)
 		} else {
 			r.handleOTLPFailureResponse(w, req, huskyotlp.OTLPError{Message: err.Error(), HTTPStatusCode: http.StatusUnauthorized})
 		}
+		return
+	}
+
+	if !r.Config.IsAPIKeyValid(ri.ApiKey) {
+		r.handleOTLPFailureResponse(w, req, huskyotlp.OTLPError{Message: fmt.Sprintf("api key %s not found in list of authorized keys", ri.ApiKey), HTTPStatusCode: http.StatusUnauthorized})
 		return
 	}
 


### PR DESCRIPTION
## Which problem is this PR solving?
Updates Husky to v0.25.1 which includes fixes handling invalid content types for OTLP requests.

See the following PR for changes:
- https://github.com/honeycombio/husky/pull/243

**NOTE**: This PR is based on an unreleased version of husky. We'll wait for husky to be released before merging this fix.

## Short description of the changes
- Updating Husky to 0.25.1
- Updating the error handler to use husky to write a text/plain response for invalid content type errors
- Move validation of API keys from config after request headers check
