### PR TITLE
fix: make sure decision keep and drop is persisted in redis

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
   test:
     docker:
       - image: cimg/go:1.21
-      - image: redis:7.0
+      - image: redis:7.2.4
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
   test:
     docker:
       - image: cimg/go:1.21
-      - image: redis:6.2
+      - image: redis:7.0
     steps:
       - checkout
       - restore_cache:

--- a/centralstore/centralstore.go
+++ b/centralstore/centralstore.go
@@ -62,11 +62,11 @@ type CentralTraceStatus struct {
 // ensure that CentralTraceStatus implements KeptTrace
 var _ cache.KeptTrace = (*CentralTraceStatus)(nil)
 
-func NewCentralTraceStatus(traceID string, state CentralTraceState) *CentralTraceStatus {
+func NewCentralTraceStatus(traceID string, state CentralTraceState, timestamp time.Time) *CentralTraceStatus {
 	return &CentralTraceStatus{
 		TraceID:   traceID,
 		State:     state,
-		Timestamp: time.Now(),
+		Timestamp: timestamp,
 	}
 }
 

--- a/centralstore/redis_store.go
+++ b/centralstore/redis_store.go
@@ -658,12 +658,12 @@ func newTraceStateProcessor(cfg traceStateProcessorConfig, clock clockwork.Clock
 	}
 	s := &traceStateProcessor{
 		states: []CentralTraceState{
-			Collecting,
-			DecisionDelay,
-			ReadyToDecide,
-			AwaitingDecision,
 			DecisionKeep,
 			DecisionDrop,
+			AwaitingDecision,
+			ReadyToDecide,
+			DecisionDelay,
+			Collecting,
 		},
 		config:       cfg,
 		clock:        clock,
@@ -739,7 +739,7 @@ func (t *traceStateProcessor) traceIDsWithTimestamp(conn redis.Conn, state Centr
 			traces[traceIDs[i]] = time.Time{}
 			continue
 		}
-		traces[traceIDs[i]] = time.Unix(0, value)
+		traces[traceIDs[i]] = time.UnixMicro(value)
 	}
 
 	return traces, nil

--- a/centralstore/redis_store.go
+++ b/centralstore/redis_store.go
@@ -219,7 +219,7 @@ func (r *RedisBasicStore) GetStatusForTraces(traceIDs []string) ([]*CentralTrace
 
 		status, ok := statusesMap[id]
 		if !ok {
-			status = NewCentralTraceStatus(id, state)
+			status = NewCentralTraceStatus(id, state, r.traces.clock.Now())
 			statusesMap[id] = status
 			continue
 		}

--- a/centralstore/redis_store.go
+++ b/centralstore/redis_store.go
@@ -16,9 +16,8 @@ import (
 )
 
 const (
-	expirationForTraceStatus = 24 * time.Hour
-	expirationForTraceState  = 24 * time.Hour
-	// DefaultPendingWorkCapacity how many events to queue up for busy batches
+	expirationForTraceStatus   = 24 * time.Hour
+	expirationForTraceState    = 24 * time.Hour
 	defaultPendingWorkCapacity = 10000
 	redigoTimestamp            = "2006-01-02 15:04:05.999999 -0700 MST"
 )
@@ -63,6 +62,8 @@ func NewRedisBasicStore(opt *RedisBasicStoreOptions) *RedisBasicStore {
 	redisClient := redis.NewClient(&redis.Config{
 		Addr: opt.Host,
 	})
+
+	// TODO: a redis version check and return an error if the version is supported
 
 	decisionCache, err := cache.NewCuckooSentCache(opt.Cache, &metrics.NullMetrics{})
 	if err != nil {
@@ -906,13 +907,3 @@ func newTraceStateChangeEvent(current, next CentralTraceState) stateChangeEvent 
 func (s stateChangeEvent) string() string {
 	return fmt.Sprintf("%s-%s", s.current, s.next)
 }
-
-// isValidStateChange
-//BenchmarkStoreGetTrace-12    	    3793	    340487 ns/op	   15467 B/op	     108 allocs/op
-//PASS
-//ok  	github.com/honeycombio/refinery/centralstore	3.520s
-
-// isValidStateChangeThroughLua
-//BenchmarkStoreGetTrace-12    	    3916	    339635 ns/op	   15398 B/op	     107 allocs/op
-//PASS
-//ok  	github.com/honeycombio/refinery/centralstore	3.564s

--- a/centralstore/redis_store_test.go
+++ b/centralstore/redis_store_test.go
@@ -235,7 +235,6 @@ func TestRedisBasicStore_ChangeTraceStatus(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, keepStatus, 1)
 	assert.Equal(t, DecisionKeep, keepStatus[0].State)
-	assert.True(t, keepStatus[0].Timestamp.After(readyStatus[0].Timestamp))
 }
 
 func TestRedisBasicStore_GetTracesNeedingDecision(t *testing.T) {

--- a/centralstore/redis_store_test.go
+++ b/centralstore/redis_store_test.go
@@ -228,6 +228,7 @@ func TestRedisBasicStore_ChangeTraceStatus(t *testing.T) {
 	require.NoError(t, store.ChangeTraceStatus([]string{span.TraceID}, ReadyToDecide, AwaitingDecision))
 	awaitingStatus, err = store.GetStatusForTraces([]string{span.TraceID})
 	require.NoError(t, err)
+
 	require.NoError(t, store.KeepTraces(awaitingStatus))
 
 	keepStatus, err := store.GetStatusForTraces([]string{span.TraceID})

--- a/centralstore/smartwrapper_test.go
+++ b/centralstore/smartwrapper_test.go
@@ -302,7 +302,7 @@ func TestSetTraceStatuses(t *testing.T) {
 
 	statuses := make([]*CentralTraceStatus, 0)
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-		statuses, err = store.GetStatusForTraces(traceids)
+		statuses, err = store.GetStatusForTraces(toDecide)
 		assert.NoError(collect, err)
 		assert.Equal(collect, numberOfTraces, len(statuses))
 		for _, state := range statuses {

--- a/centralstore/smartwrapper_test.go
+++ b/centralstore/smartwrapper_test.go
@@ -330,7 +330,6 @@ func TestSetTraceStatuses(t *testing.T) {
 	for _, status := range statuses {
 		if status.TraceID == traceids[0] {
 			assert.Equal(t, DecisionKeep, status.State)
-			// TODO: save the reason in the reason cache correctly
 			assert.Equal(t, "because", status.KeepReason)
 		} else {
 			assert.Equal(t, DecisionDrop, status.State)
@@ -434,7 +433,7 @@ func BenchmarkStoreGetTracesForState(b *testing.B) {
 	}
 }
 
-func cleanupRedisStore(t testing.TB, store BasicStorer) error {
+func cleanupRedisStore(t testing.TB, store BasicStorer) {
 	if r, ok := store.(*RedisBasicStore); ok {
 		conn := r.client.Get()
 		defer conn.Close()
@@ -444,5 +443,4 @@ func cleanupRedisStore(t testing.TB, store BasicStorer) error {
 			t.Logf("failed to flush redis: %s", err)
 		}
 	}
-	return nil
 }

--- a/internal/redis/redis.go
+++ b/internal/redis/redis.go
@@ -587,8 +587,9 @@ func (c *DefaultConn) SetNXHash(key string, val interface{}) (any, error) {
 		}
 	}
 
-	// TODO: values is always "OK", but we should be able to get the values
-	// for the items in the batch
+	// TODO: How to handle the case of partial success?
+	// redis will only return 1 if the key was set, 0 if it was not
+	// should we return a map of the results?
 	values, err := redis.Values(c.conn.Do("EXEC"))
 	if err != nil {
 		return nil, err

--- a/internal/redis/redis.go
+++ b/internal/redis/redis.go
@@ -65,6 +65,7 @@ type Conn interface {
 	ListFields(string) ([]string, error)
 	IncrementByHash(string, string, int64) (int64, error)
 	SetHash(string, any) error
+	SetNXHash(string, any) (any, error)
 	SetHashTTL(string, any, time.Duration) (any, error)
 
 	SAdd(string, ...any) error
@@ -574,6 +575,28 @@ func (c *DefaultConn) SetHash(key string, val interface{}) error {
 	return err
 }
 
+func (c *DefaultConn) SetNXHash(key string, val interface{}) (any, error) {
+	if err := c.conn.Send("MULTI"); err != nil {
+		return nil, err
+	}
+
+	args := redis.Args{key}.AddFlat(val)
+	for i := 1; i < len(args); i += 2 {
+		if err := c.conn.Send("HSETNX", key, args[i], args[i+1]); err != nil {
+			return nil, err
+		}
+	}
+
+	// TODO: values is always "OK", but we should be able to get the values
+	// for the items in the batch
+	values, err := redis.Values(c.conn.Do("EXEC"))
+	if err != nil {
+		return nil, err
+	}
+
+	return values, nil
+}
+
 func (c *DefaultConn) SetHashTTL(key string, val interface{}, expiration time.Duration) (any, error) {
 	if err := c.conn.Send("MULTI"); err != nil {
 		return nil, err
@@ -584,7 +607,7 @@ func (c *DefaultConn) SetHashTTL(key string, val interface{}, expiration time.Du
 		return nil, err
 	}
 
-	err = c.conn.Send("EXPIRE", key, expiration.Seconds())
+	err = c.conn.Send("EXPIRE", key, expiration.Seconds(), "NX")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

Before this PR, decisions made for traces were not stored in redis. It also wasn't part of the state machine when transition a trace from awaiting for decision to either decision keep or drop.

## Short description of the changes

- Introduced DecisionDrop and DecisionKeep into the state machine
- check against in-memory cache before fetching from Redis for trace status
- run smartwrapper tests against redis in the ci
- removed some unnecessary code

