### PR TITLE
maint: group minor/patch dep updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,11 @@ updates:
       - "type: dependencies"
     reviewers:
       - "honeycombio/collection-team"
+    groups:
+      minor-patch:
+        update-types:
+        - "minor"
+        - "patch"
     commit-message:
       prefix: "maint"
       include: "scope"


### PR DESCRIPTION
## Which problem is this PR solving?

Reduce the number of dependabot PRs by grouping them.

## Short description of the changes

- groups minor and patch updates into a single PR

