### PR TITLE
feat: process state transitions in batches

### DIFF
--- a/centralstore/redis_store.go
+++ b/centralstore/redis_store.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"time"
 
+	redigo "github.com/gomodule/redigo/redis"
 	"github.com/honeycombio/refinery/collect/cache"
 	"github.com/honeycombio/refinery/config"
 	"github.com/honeycombio/refinery/internal/otelutil"
@@ -125,7 +126,8 @@ func (r *RedisBasicStore) GetMetrics(ctx context.Context) (map[string]interface{
 }
 
 func (r *RedisBasicStore) WriteSpan(ctx context.Context, span *CentralSpan) error {
-	writeSpan := trace.SpanFromContext(ctx)
+	_, writeSpan := r.tracer.Start(ctx, "WriteSpan")
+	defer writeSpan.End()
 
 	conn := r.client.Get()
 	defer conn.Close()
@@ -773,7 +775,11 @@ func (t *traceStateProcessor) Stop() {
 func (t *traceStateProcessor) addNewTrace(ctx context.Context, conn redis.Conn, traceID string) error {
 	ctx, span := t.tracer.Start(ctx, "addNewTrace", trace.WithAttributes(attribute.KeyValue{Key: "trace_id", Value: attribute.StringValue(traceID)}))
 	defer span.End()
-	return t.applyStateChange(ctx, conn, newTraceStateChangeEvent(Unknown, Collecting), traceID)
+	_, err := t.applyStateChange(ctx, conn, newTraceStateChangeEvent(Unknown, Collecting), []string{traceID})
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func (t *traceStateProcessor) stateByTraceIDsKey(state CentralTraceState) string {
@@ -843,24 +849,12 @@ func (t *traceStateProcessor) toNextState(ctx context.Context, conn redis.Conn, 
 		"to_state":      changeEvent.next,
 	})
 
-	succeed := make([]string, 0, len(traceIDs))
-	for _, traceID := range traceIDs {
-		err := t.applyStateChange(ctx, conn, changeEvent, traceID)
-		if err != nil {
-			fmt.Println("apply_state_change_error", err)
-			continue
-		}
-		succeed = append(succeed, traceID)
-	}
-	otelutil.AddSpanField(span, "num_of_succeed", len(succeed))
-
-	if len(succeed) == 0 {
-		err := errors.New("failed to apply state change")
-		otelutil.AddSpanField(span, "error", err)
+	result, err := t.applyStateChange(ctx, conn, changeEvent, traceIDs)
+	if err != nil {
 		return nil, err
 	}
 
-	return succeed, nil
+	return result, err
 }
 
 // cleanupExpiredTraces removes traces from the state map if they have been in the state for longer than
@@ -900,77 +894,108 @@ func (t *traceStateProcessor) removeExpiredTraces(client redis.Client) {
 
 }
 
-// get the latest state from the state list
-// check if the current state change event is valid
-// if it is, then add the state to state list
-// and add the trace to the state set
-// if it's not, then don't add the state to the state list	and abort
-func (t *traceStateProcessor) applyStateChange(ctx context.Context, conn redis.Conn, stateChange stateChangeEvent, traceID string) error {
+// applyStateChange runs a lua script that atomically moves traces between states and returns the trace IDs that has completed a state change.
+func (t *traceStateProcessor) applyStateChange(ctx context.Context, conn redis.Conn, stateChange stateChangeEvent, traceIDs []string) ([]string, error) {
 	ctx, span := t.tracer.Start(ctx, "applyStateChange")
 	defer span.End()
 
-	otelutil.AddSpanField(span, "trace_id", traceID)
+	otelutil.AddSpanField(span, "num_traces", len(traceIDs))
+
+	args := redigo.Args{validStateChangeEventsKey, stateChange.current.String(), stateChange.next.String(),
+		expirationForTraceState.Seconds(), t.clock.Now().UnixMicro()}.AddFlat(traceIDs)
+
 	result, err := t.config.changeState.Do(ctx,
-		conn, t.traceStatesKey(traceID), validStateChangeEventsKey,
-		stateChange.current.String(), stateChange.next.String(),
-		expirationForTraceState.Seconds(), traceID, t.clock.Now().UnixMicro())
+		conn, args...)
+
 	if err != nil {
 		otelutil.AddSpanField(span, "error", err.Error())
-		return err
+		return nil, err
 	}
-	val, ok := result.(int64)
-	if !ok {
-		return fmt.Errorf("unexpected return value from state change script: %v", result)
+	val, err := redigo.Strings(result, err)
+	if err != nil {
+		return nil, err
 	}
-	if val != 1 {
-		otelutil.AddSpanFields(span, map[string]interface{}{
-			"result":   val,
-			"is_valid": ok,
-		})
-		return errors.New("failed to apply state change")
+	if len(val) == 0 {
+		return nil, errors.New("failed to apply state changes")
 	}
 	otelutil.AddSpanFields(span, map[string]interface{}{
 		"result": val,
 	})
 
-	return nil
+	return val, nil
 }
 
-const stateChangeKey = 2
+// stateChangeScript is a lua script that atomically moves traces between states and returns
+// the trace IDs that has completed a state change.
+// It takes the following arguments:
+// KEYS[1] - the set of valid state change events
+// ARGV[1] - the previous state. This is the current state submmited by the client
+// ARGV[2] - the next state
+// ARGV[3] - the expiration time for the state
+// ARGV[4] - the current time
+// The rest of the arguments are the traceIDs to move between states.
+
+// The script works as follows:
+// 1. For each traceID, get the current state from its trace state list. If it doesn't exist yet, use the previous state
+// 2. If the current state doesn't match with the previous state, that means the state for the trace has changed
+// the current state is no longer valid, so we should abort
+// 3. If the current state matches with the state submitted by the client, check if the state change event is valid
+// 4. If the state change event is valid, add the trace to the next state sorted set and remove it from the current state sorted set
+const stateChangeKey = 1
 const stateChangeScript = `
-  local traceStateKey = KEYS[1]
-  local possibleStateChangeEvents = KEYS[2]
+  local possibleStateChangeEvents = KEYS[1]
   local previousState = ARGV[1]
   local nextState = ARGV[2]
   local ttl = ARGV[3]
-  local traceID = ARGV[4]
-  local timestamp = ARGV[5]
+  local timestamp = ARGV[4]
+  local result = {}
 
-  local currentState = redis.call('LINDEX', traceStateKey, -1)
-  if (currentState == nil or currentState == false) then
-	currentState = previousState
+  -- iterate through the traceIDs and move them to the next state
+  for i, traceID in ipairs(ARGV) do
+    -- unfortunately, Lua doesn't support "continue" statement in for loops.
+	-- even though, Lua 5.2+ supports "goto" statement, we can't use it here because
+	-- Redis only supports Lua 5.1. 
+	-- using "repeat" and "do break end" is a common pattern to simulate "continue" in Lua
+  	repeat
+		-- the first 4 arguments are not traceIDs, so skip them
+	    if i < 5 then
+		  do break end
+		end
+
+		--  get current state for the trace. If it doesn't exist yet, use the previous state
+		local traceStateKey = string.format("%s:states", traceID)
+	    local currentState = redis.call('LINDEX', traceStateKey, -1)
+	    if (currentState == nil or currentState == false) then
+	 	  currentState = previousState
+	    end
+	
+	   -- if the current state doesn't match with the previous state, that means the state change is
+	   --  no longer valid, so we should abort
+	   if (currentState ~= previousState) then
+	 	  do break end
+	   end
+	
+	   -- check if the state change event is valid 
+	   local stateChangeEvent = string.format("%s-%s", currentState, nextState)
+	   local changeEventIsValid = redis.call('SISMEMBER', possibleStateChangeEvents, stateChangeEvent)
+	   if (changeEventIsValid == 0) then
+	     do break end
+	   end
+	
+	   redis.call('RPUSH', traceStateKey, nextState)
+	   redis.call('EXPIRE', traceStateKey, ttl)
+	
+	   local added = redis.call('ZADD', string.format("%s:traces", nextState), "NX", timestamp, traceID)
+	
+	   local removed = redis.call('ZREM', string.format("%s:traces", currentState), traceID)
+
+	   -- add it to the result list 
+	   table.insert(result, traceID)
+	until true
   end
 
-  if (currentState ~= previousState) then
-	do return -1 end
-  end
 
-  local stateChangeEvent = string.format("%s-%s", currentState, nextState)
-  local changeEventIsValid = redis.call('SISMEMBER', possibleStateChangeEvents, stateChangeEvent)
-  if (changeEventIsValid == 0) then
-    do return -2 end
-  end
-
-  redis.call('RPUSH', traceStateKey, nextState)
-  redis.call('EXPIRE', traceStateKey, ttl)
-
-  local added = redis.call('ZADD', string.format("%s:traces", nextState), "NX", timestamp, traceID)
-  if (added == 0) then
-	do return -3 end
-  end
-
-  local removed = redis.call('ZREM', string.format("%s:traces", currentState), traceID)
-  return 1
+ return result
 `
 
 const validStateChangeEventsKey = "valid-state-change-events"
@@ -1002,6 +1027,8 @@ func newTraceStateChangeEvent(current, next CentralTraceState) stateChangeEvent 
 	}
 }
 
+// string returns a string representation of the state change event
+// this formatting logic should match the one in the stateChange lua script
 func (s stateChangeEvent) string() string {
 	return fmt.Sprintf("%s-%s", s.current, s.next)
 }

--- a/centralstore/redis_store.go
+++ b/centralstore/redis_store.go
@@ -631,7 +631,7 @@ func (t *tracesStore) getTraceStatuses(ctx context.Context, conn redis.Conn, tra
 }
 
 func (t *tracesStore) traceStatusKey(traceID string) string {
-	return fmt.Sprintf("%s:status", traceID)
+	return traceID + ":status"
 }
 
 // storeSpan stores the span in the spans hash and increments the span count for the trace.
@@ -683,7 +683,7 @@ func (t *tracesStore) incrementSpanCountsCMD(traceID string, spanType SpanType) 
 }
 
 func spansHashByTraceIDKey(traceID string) string {
-	return fmt.Sprintf("%s:spans", traceID)
+	return traceID + ":spans"
 }
 
 // central span -> blobs
@@ -919,7 +919,6 @@ func (t *traceStateProcessor) applyStateChange(ctx context.Context, conn redis.C
 
 	args := redis.Args(validStateChangeEventsKey, stateChange.current.String(), stateChange.next.String(),
 		expirationForTraceState.Seconds(), t.clock.Now().UnixMicro()).AddFlat(traceIDs)
-	fmt.Println(args...)
 
 	result, err := t.config.changeState.DoStrings(ctx,
 		conn, args...)

--- a/centralstore/redis_store_test.go
+++ b/centralstore/redis_store_test.go
@@ -376,6 +376,8 @@ func TestRedisBasicStore_Cleanup(t *testing.T) {
 
 	ts := newTestTraceStateProcessor(t, redisClient, nil, noopTracer())
 	ts.config.maxTraceRetention = 1 * time.Minute
+	ts.config.reaperRunInterval = 500 * time.Millisecond
+	require.NoError(t, ts.Start(ctx, redisClient))
 
 	conn := redisClient.Get()
 	defer conn.Close()
@@ -395,9 +397,10 @@ func TestRedisBasicStore_Cleanup(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, ts.exists(ctx, conn, DecisionDelay, traceIDToKeep))
 
-	ts.removeExpiredTraces(redisClient.Client)
-	require.False(t, ts.exists(ctx, conn, DecisionDelay, traceIDToBeRemoved))
-	require.True(t, ts.exists(ctx, conn, DecisionDelay, traceIDToKeep))
+	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+		require.False(collect, ts.exists(ctx, conn, DecisionDelay, traceIDToBeRemoved))
+		require.True(collect, ts.exists(ctx, conn, DecisionDelay, traceIDToKeep))
+	}, 1*time.Second, 200*time.Millisecond)
 }
 
 func TestRedisBasicStore_ValidStateTransition(t *testing.T) {
@@ -407,6 +410,7 @@ func TestRedisBasicStore_ValidStateTransition(t *testing.T) {
 
 	traceID := "traceID0"
 	ts := newTestTraceStateProcessor(t, redisClient, nil, noopTracer())
+	require.NoError(t, ts.Start(ctx, redisClient))
 	defer ts.Stop()
 
 	type stateChange struct {
@@ -495,6 +499,7 @@ func NewTestRedisBasicStore(t *testing.T, redisClient *TestRedisClient) *TestRed
 	require.NoError(t, err)
 	tracer := noopTracer()
 	ts := newTestTraceStateProcessor(t, redisClient, clock, tracer)
+	require.NoError(t, ts.Start(context.TODO(), redisClient))
 	return &TestRedisBasicStore{
 		RedisBasicStore: &RedisBasicStore{
 			client:        redisClient,
@@ -562,13 +567,12 @@ func newTestTraceStateProcessor(t *testing.T, redisClient *TestRedisClient, cloc
 		}, clock, tracer),
 		clock: clock,
 	}
-	require.NoError(t, ts.Start(context.TODO(), redisClient))
 	return ts
 }
 
 func (ts *testTraceStateProcessor) ensureInitialState(t *testing.T, ctx context.Context, conn redis.Conn, traceID string, state CentralTraceState) {
 	for _, state := range ts.states {
-		require.NoError(t, ts.remove(conn, state, traceID))
+		require.NoError(t, ts.remove(ctx, conn, state, traceID))
 	}
 	_, err := conn.Del(ts.traceStatesKey(traceID))
 	require.NoError(t, err)

--- a/centralstore/redis_store_test.go
+++ b/centralstore/redis_store_test.go
@@ -443,8 +443,10 @@ func TestRedisBasicStore_ValidStateTransition(t *testing.T) {
 
 			ts.ensureInitialState(t, ctx, conn, traceID, tc.state)
 
-			err := ts.applyStateChange(ctx, conn, newTraceStateChangeEvent(tc.state, tc.change.to), traceID)
+			result, err := ts.applyStateChange(ctx, conn, newTraceStateChangeEvent(tc.state, tc.change.to), []string{traceID})
 			if tc.change.isValid {
+				require.Len(t, result, 1)
+				require.Equal(t, traceID, result[0])
 				require.NoError(t, err)
 			} else {
 				require.Error(t, err)


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

Perviously, each trace state change needs to make a redis call. When client can't take advantage of parallelism since each call is serialized in redis store anyway. This PR makes it possible to process multiple traces in one redis call for state change.


**Before**
<img width="1339" alt="Screenshot 2024-03-04 at 6 47 53 PM" src="https://github.com/honeycombio/refinery/assets/22300958/752c84f6-51f0-4935-8b83-517761fe0c27">


**After**
<img width="1339" alt="Screenshot 2024-03-04 at 6 48 22 PM" src="https://github.com/honeycombio/refinery/assets/22300958/9279e6eb-7f7e-4859-918c-0d322af42eb0">


## Short description of the changes

- Processing state transitions in a batch instead of one trace per redis call


