### PR TITLE
fix: Support 'none' as a logger type

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -39,6 +39,8 @@ func GetLoggerImplementation(c config.Config) Logger {
 		logger = &HoneycombLogger{}
 	case "stdout":
 		logger = &StdoutLogger{}
+	case "none":
+		logger = &NullLogger{}
 	default:
 		fmt.Printf("unknown logger type %s. Exiting.\n", loggerType)
 		os.Exit(1)


### PR DESCRIPTION
## Which problem is this PR solving?

- Documentation says you can set Logger.Type to 'none', but that doesn't work

## Short description of the changes

- Allow logger type to be 'none' and create a NullLogger when it is

