### PR TITLE
fix: change validation type for PeerManagement.Peers to be url

### DIFF
--- a/config.md
+++ b/config.md
@@ -1,7 +1,7 @@
 # Honeycomb Refinery Configuration Documentation
 
 This is the documentation for the configuration file for Honeycomb's Refinery.
-It was automatically generated on 2024-03-08 at 20:13:38 UTC.
+It was automatically generated on 2024-03-11 at 14:44:30 UTC.
 
 ## The Config file
 
@@ -676,7 +676,7 @@ If this value is specified, then Refinery will use the first IPV6 unicast addres
 Peers is the list of peers to use when Type is "file", excluding self.
 
 This list is ignored when Type is "redis".
-The format is a list of strings of the form "schema://host:port".
+The format is a list of strings of the form "scheme://host:port".
 
 - Not eligible for live reload.
 - Type: `stringarray`

--- a/config.md
+++ b/config.md
@@ -676,11 +676,11 @@ If this value is specified, then Refinery will use the first IPV6 unicast addres
 Peers is the list of peers to use when Type is "file", excluding self.
 
 This list is ignored when Type is "redis".
-The format is a list of strings of the form "host:port".
+The format is a list of strings of the form "schema://host:port".
 
 - Not eligible for live reload.
 - Type: `stringarray`
-- Example: `192.168.1.11:8081,192.168.1.12:8081`
+- Example: `http://192.168.1.11:8081,http://192.168.1.12:8081`
 
 ## Redis Peer Management
 

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -824,7 +824,7 @@ groups:
         summary: is the list of peers to use when Type is "file", excluding self.
         description: >
           This list is ignored when Type is "redis". The format is a list of
-          strings of the form "schema://host:port".
+          strings of the form "scheme://host:port".
 
   - name: RedisPeerManagement
     title: "Redis Peer Management"

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -816,15 +816,15 @@ groups:
         v1name: Peers
         type: stringarray
         valuetype: stringarray
-        example: "192.168.1.11:8081,192.168.1.12:8081"
+        example: "http://192.168.1.11:8081,http://192.168.1.12:8081"
         reload: false
         validations:
           - type: elementType
-            arg: hostport
+            arg: url
         summary: is the list of peers to use when Type is "file", excluding self.
         description: >
           This list is ignored when Type is "redis". The format is a list of
-          strings of the form "host:port".
+          strings of the form "schema://host:port".
 
   - name: RedisPeerManagement
     title: "Redis Peer Management"

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -143,6 +143,14 @@ groups:
         validations:
             - type: notempty
 
+  - name: PeerManagement
+    fields:
+      - name: Peers
+        type: stringarray
+        validations:
+          - type: elementType
+            arg: url
+
   - name: RequireTest
     fields:
       - name: FieldA
@@ -305,6 +313,8 @@ func Test_validate(t *testing.T) {
 		{"bad slice elementType", mm("Traces.AStringArray", []any{"0.0.0.0"}), "field Traces.AStringArray[0] (0.0.0.0) must be a hostport: address 0.0.0.0: missing port in address"},
 		{"good map elementType", mm("Traces.AStringMap", map[string]any{"k": "v"}), ""},
 		{"bad map elementType", mm("Traces.AStringMap", map[string]any{"k": 1}), "field Traces.AStringMap[k] must be a string"},
+		{"bad peer url", mm("PeerManagement.Peers", []any{"0.0.0.0:8082", "http://192.168.1.1:8088"}), "must be a valid UR"},
+		{"good peer url", mm("PeerManagement.Peers", []any{"http://0.0.0.0:8082", "http://192.168.1.1:8088"}), ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/config_complete.yaml
+++ b/config_complete.yaml
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created on 2024-02-23 at 22:23:27 UTC from ../../config.yaml using a template generated on 2024-02-23 at 22:23:25 UTC
+# created on 2024-03-08 at 14:51:12 UTC from ../../config.yaml using a template generated on 2024-03-08 at 14:51:10 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of
@@ -695,12 +695,12 @@ PeerManagement:
     ## Peers is the list of peers to use when Type is "file", excluding self.
     ##
     ## This list is ignored when Type is "redis". The format is a list of
-    ## strings of the form "host:port".
+    ## strings of the form "schema://host:port".
     ##
     ## Not eligible for live reload.
     # Peers:
-      # - 192.168.1.11:8081
-      # - 192.168.1.12:8081
+      # - http://192.168.1.11:8081
+      # - http://192.168.1.12:8081
 
 ###########################
 ## Redis Peer Management ##

--- a/config_complete.yaml
+++ b/config_complete.yaml
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created on 2024-03-08 at 14:51:12 UTC from ../../config.yaml using a template generated on 2024-03-08 at 14:51:10 UTC
+# created on 2024-03-11 at 14:44:29 UTC from ../../config.yaml using a template generated on 2024-03-11 at 14:44:15 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of
@@ -695,7 +695,7 @@ PeerManagement:
     ## Peers is the list of peers to use when Type is "file", excluding self.
     ##
     ## This list is ignored when Type is "redis". The format is a list of
-    ## strings of the form "schema://host:port".
+    ## strings of the form "scheme://host:port".
     ##
     ## Not eligible for live reload.
     # Peers:

--- a/refinery_config.md
+++ b/refinery_config.md
@@ -661,11 +661,11 @@ If this value is specified, then Refinery will use the first IPV6 unicast addres
 `Peers` is the list of peers to use when Type is "file", excluding self.
 
 This list is ignored when Type is "redis".
-The format is a list of strings of the form "host:port".
+The format is a list of strings of the form "schema://host:port".
 
 - Not eligible for live reload.
 - Type: `stringarray`
-- Example: `192.168.1.11:8081,192.168.1.12:8081`
+- Example: `http://192.168.1.11:8081,http://192.168.1.12:8081`
 
 ## Redis Peer Management
 

--- a/refinery_config.md
+++ b/refinery_config.md
@@ -661,7 +661,7 @@ If this value is specified, then Refinery will use the first IPV6 unicast addres
 `Peers` is the list of peers to use when Type is "file", excluding self.
 
 This list is ignored when Type is "redis".
-The format is a list of strings of the form "schema://host:port".
+The format is a list of strings of the form "scheme://host:port".
 
 - Not eligible for live reload.
 - Type: `stringarray`

--- a/tools/convert/minimal_config.yaml
+++ b/tools/convert/minimal_config.yaml
@@ -1,5 +1,5 @@
 # sample uncommented config file containing all possible fields
-# automatically generated on 2024-02-23 at 22:23:27 UTC
+# automatically generated on 2024-03-08 at 14:51:11 UTC
 General:
   ConfigurationVersion: 2
   MinRefineryVersion: "v2.0"
@@ -68,8 +68,8 @@ PeerManagement:
   IdentifierInterfaceName: eth0
   UseIPV6Identifier: false
   Peers: 
-    - "192.168.1.11:8081"
-    - "192.168.1.12:8081"
+    - "http://192.168.1.11:8081"
+    - "http://192.168.1.12:8081"
 
 RedisPeerManagement:
   Host: "localhost:6379"

--- a/tools/convert/templates/configV2.tmpl
+++ b/tools/convert/templates/configV2.tmpl
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created {{ now }} from {{ .Input }} using a template generated on 2024-02-23 at 22:23:25 UTC
+# created {{ now }} from {{ .Input }} using a template generated on 2024-03-08 at 14:51:10 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of
@@ -693,10 +693,10 @@ PeerManagement:
     ## Peers is the list of peers to use when Type is "file", excluding self.
     ##
     ## This list is ignored when Type is "redis". The format is a list of
-    ## strings of the form "host:port".
+    ## strings of the form "schema://host:port".
     ##
     ## Not eligible for live reload.
-    {{ renderStringarray .Data "Peers" "PeerManagement.Peers" "192.168.1.11:8081,192.168.1.12:8081" }}
+    {{ renderStringarray .Data "Peers" "PeerManagement.Peers" "http://192.168.1.11:8081,http://192.168.1.12:8081" }}
 
 ###########################
 ## Redis Peer Management ##

--- a/tools/convert/templates/configV2.tmpl
+++ b/tools/convert/templates/configV2.tmpl
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created {{ now }} from {{ .Input }} using a template generated on 2024-03-08 at 14:51:10 UTC
+# created {{ now }} from {{ .Input }} using a template generated on 2024-03-11 at 14:44:15 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of
@@ -693,7 +693,7 @@ PeerManagement:
     ## Peers is the list of peers to use when Type is "file", excluding self.
     ##
     ## This list is ignored when Type is "redis". The format is a list of
-    ## strings of the form "schema://host:port".
+    ## strings of the form "scheme://host:port".
     ##
     ## Not eligible for live reload.
     {{ renderStringarray .Data "Peers" "PeerManagement.Peers" "http://192.168.1.11:8081,http://192.168.1.12:8081" }}


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

we are using `url.Parse` for peer address list.  `host:port` is not a valid url.

## Short description of the changes

- Change validation type for `PeerManagement.Peers` to `url` instead of `hostport`
- After this change, the convert tool will always convert `host:port` to `http://host:port`

fix: #1044 
