### PR TITLE
feat: new metric for drops caused by rules

### DIFF
--- a/sample/rules.go
+++ b/sample/rules.go
@@ -126,16 +126,16 @@ func (s *RulesBasedSampler) GetSampleRate(trace *types.Trace) (rate uint, keep b
 				keep = !rule.Drop && rule.SampleRate > 0 && rand.Intn(rule.SampleRate) == 0
 				reason += rule.Name
 				s.Metrics.Histogram(s.prefix+"sample_rate", float64(rate))
-				if rule.Drop {
-					// If we dropped because of an explicit drop rule, then increment that counter.
-					s.Metrics.Increment(s.prefix + "num_dropped_by_drop_rule")
-				}
 			}
 
 			if keep {
 				s.Metrics.Increment(s.prefix + "num_kept")
 			} else {
 				s.Metrics.Increment(s.prefix + "num_dropped")
+				if rule.Drop {
+					// If we dropped because of an explicit drop rule, then increment that too.
+					s.Metrics.Increment(s.prefix + "num_dropped_by_drop_rule")
+				}
 			}
 			logger.WithFields(map[string]interface{}{
 				"rate":      rate,

--- a/sample/rules.go
+++ b/sample/rules.go
@@ -28,6 +28,7 @@ func (s *RulesBasedSampler) Start() error {
 	s.prefix = "rulesbased_"
 
 	s.Metrics.Register(s.prefix+"num_dropped", "counter")
+	s.Metrics.Register(s.prefix+"num_dropped_by_drop_rule", "counter")
 	s.Metrics.Register(s.prefix+"num_kept", "counter")
 	s.Metrics.Register(s.prefix+"sample_rate", "histogram")
 
@@ -125,6 +126,10 @@ func (s *RulesBasedSampler) GetSampleRate(trace *types.Trace) (rate uint, keep b
 				keep = !rule.Drop && rule.SampleRate > 0 && rand.Intn(rule.SampleRate) == 0
 				reason += rule.Name
 				s.Metrics.Histogram(s.prefix+"sample_rate", float64(rate))
+				if rule.Drop {
+					// If we dropped because of an explicit drop rule, then increment that counter.
+					s.Metrics.Increment(s.prefix + "num_dropped_by_drop_rule")
+				}
 			}
 
 			if keep {


### PR DESCRIPTION
## Which problem is this PR solving?

- When a user puts a Drop rule in a rules file, there's no separate metric that distinguishes that from a drop because of other sampling. See #974 for details.

## Short description of the changes

- Adds a new metric, `num_dropped_by_drop_rule`, which tracks this value.

Fixes #974 
