### PR TITLE
fix: deal with locking issues at startup

### DIFF
--- a/metrics/legacy.go
+++ b/metrics/legacy.go
@@ -65,6 +65,9 @@ type updown struct {
 }
 
 func (h *LegacyMetrics) Start() error {
+	h.lock.Lock()
+	defer h.lock.Unlock()
+
 	h.Logger.Debug().Logf("Starting LegacyMetrics")
 	defer func() { h.Logger.Debug().Logf("Finished starting LegacyMetrics") }()
 	mc := h.Config.GetLegacyMetricsConfig()

--- a/metrics/multi_metrics.go
+++ b/metrics/multi_metrics.go
@@ -50,8 +50,9 @@ func (m *MultiMetrics) Start() error {
 	return nil
 }
 
-// This is not safe for concurrent use!
 func (m *MultiMetrics) AddChild(met Metrics) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
 	m.children = append(m.children, met)
 }
 

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -30,6 +30,9 @@ func (p *PromMetrics) Start() error {
 	defer func() { p.Logger.Debug().Logf("Finished starting PromMetrics") }()
 	pc := p.Config.GetPrometheusMetricsConfig()
 
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
 	p.metrics = make(map[string]interface{})
 	p.values = make(map[string]float64)
 


### PR DESCRIPTION
## Which problem is this PR solving?

- During startup, refinery sometimes panics. One of them was tracked down to concurrent read/write of a map in otel metrics, but the problem was a bit bigger -- some assumptions about how startup worked that weren't true, and required extra locking.

## Short description of the changes

- Add locks to several metrics-related functions in different types of metrics
- Remove now-unneeded rlock inside one of the new locks.

