### PR TITLE
feat: add redis connection pool stats in GetMetrics

### DIFF
--- a/centralstore/centralstore.go
+++ b/centralstore/centralstore.go
@@ -195,9 +195,8 @@ type SmartStorer interface {
 	// set.
 	SetTraceStatuses(ctx context.Context, statuses []*CentralTraceStatus) error
 
-	// GetMetrics returns a map of metrics from the central store, accumulated
-	// since the previous time this method was called.
-	GetMetrics(ctx context.Context) (map[string]interface{}, error)
+	// RecordMetrics Populates metric data from the smart store.
+	RecordMetrics(ctx context.Context) error
 }
 
 // Spec for the central store's internal behavior:
@@ -293,7 +292,6 @@ type BasicStorer interface {
 	// Statuses should include Reason and Rate; do not include State as it will be ignored.
 	KeepTraces(ctx context.Context, statuses []*CentralTraceStatus) error
 
-	// GetMetrics returns a map of metrics from the remote store, accumulated
-	// since the previous time this method was called.
-	GetMetrics(ctx context.Context) (map[string]interface{}, error)
+	// RecordMetrics Populates metric data from the basic store.
+	RecordMetrics(ctx context.Context) error
 }

--- a/centralstore/redis_store.go
+++ b/centralstore/redis_store.go
@@ -12,6 +12,7 @@ import (
 	"github.com/honeycombio/refinery/config"
 	"github.com/honeycombio/refinery/internal/otelutil"
 	"github.com/honeycombio/refinery/internal/redis"
+	"github.com/honeycombio/refinery/metrics"
 	"github.com/jonboulle/clockwork"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -36,6 +37,7 @@ var _ BasicStorer = (*RedisBasicStore)(nil)
 // RedisBasicStore is an implementation of BasicStorer that uses Redis as the backing store.
 type RedisBasicStore struct {
 	Config        config.Config        `inject:""`
+	Metrics       metrics.Metrics      `inject:"genericMetrics"`
 	DecisionCache cache.TraceSentCache `inject:""`
 	RedisClient   redis.Client         `inject:"redis"`
 	Tracer        trace.Tracer         `inject:"tracer"`
@@ -65,6 +67,7 @@ func (r *RedisBasicStore) Start() error {
 	if r.Clock == nil {
 		return errors.New("missing Clock injection in RedisBasicStore")
 	}
+
 	opt := r.Config.GetCentralStoreOptions()
 
 	stateProcessorCfg := traceStateProcessorConfig{
@@ -86,6 +89,23 @@ func (r *RedisBasicStore) Start() error {
 	)
 	r.states = stateProcessor
 
+	// register metrics for each state
+	for _, state := range r.states.states {
+		r.Metrics.Register(metricsPrefixCount+string(state), "gauge")
+	}
+
+	// register metrics for connection pool stats
+	r.Metrics.Register(metricsPrefixConnection+"active", "gauge")
+	r.Metrics.Register(metricsPrefixConnection+"idle", "gauge")
+	r.Metrics.Register(metricsPrefixConnection+"wait", "gauge")
+	r.Metrics.Register(metricsPrefixConnection+"wait_duration", "histogram")
+
+	// register metrics for memory stats
+	r.Metrics.Register(metricsPrefixMemory+"used_total", "gauge")
+	r.Metrics.Register(metricsPrefixMemory+"used_peak", "gauge")
+	r.Metrics.Register(metricsPrefixCount+"keys", "gauge")
+	r.Metrics.Register(metricsPrefixCount+"traces", "gauge")
+
 	return nil
 }
 
@@ -94,21 +114,32 @@ func (r *RedisBasicStore) Stop() error {
 	return nil
 }
 
-func (r *RedisBasicStore) GetMetrics(ctx context.Context) (map[string]interface{}, error) {
+func (r *RedisBasicStore) RecordMetrics(ctx context.Context) error {
 	_, span := r.Tracer.Start(ctx, "GetMetrics")
 	defer span.End()
 
 	m, err := r.DecisionCache.GetMetrics()
 	if err != nil {
-		return nil, err
+		return err
 	}
+
+	for k, v := range m {
+		r.Metrics.Gauge(k, v)
+	}
+
+	// get the connection pool stats from client
+	connStats := r.RedisClient.Stats()
+	r.Metrics.Gauge(metricsPrefixConnection+"active", connStats.ActiveCount)
+	r.Metrics.Gauge(metricsPrefixConnection+"idle", connStats.IdleCount)
+	r.Metrics.Gauge(metricsPrefixConnection+"wait", connStats.WaitCount)
+	r.Metrics.Histogram(metricsPrefixConnection+"wait_duration", connStats.WaitDuration)
 
 	conn := r.RedisClient.Get()
 	defer conn.Close()
 
 	ok, unlock := conn.AcquireLockWithRetries(ctx, metricsKey, 10*time.Second, 3, 1*time.Second)
 	if !ok {
-		return nil, nil
+		return nil
 	}
 
 	defer unlock()
@@ -117,43 +148,31 @@ func (r *RedisBasicStore) GetMetrics(ctx context.Context) (map[string]interface{
 		// get the state counts
 		traceIDs, err := r.states.traceIDsByState(ctx, conn, state, time.Time{}, time.Time{}, -1)
 		if err != nil {
-			return nil, err
+			return err
 		}
-		m[metricsPrefixCount+string(state)] = len(traceIDs)
+		r.Metrics.Gauge(metricsPrefixCount+string(state), len(traceIDs))
 	}
 
 	count, err := r.traces.count(ctx, conn)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	m[metricsPrefixCount+"traces"] = count
-
-	m[metricsPrefixCount+"keys"] = 0
-	m[metricsPrefixMemory+"used_total"] = 0
-	m[metricsPrefixMemory+"used_peak"] = 0
+	r.Metrics.Gauge(metricsPrefixCount+"traces", float64(count))
 
 	// If we can't get memory stats from the redis client, we'll just skip it.
 	memoryStats, _ := conn.MemoryStats()
 	for k, v := range memoryStats {
 		switch k {
 		case "total.allocated":
-			m[metricsPrefixMemory+"used_total"] = v
+			r.Metrics.Gauge(metricsPrefixMemory+"used_total", v)
 		case "peak.allocated":
-			m[metricsPrefixMemory+"used_peak"] = v
+			r.Metrics.Gauge(metricsPrefixMemory+"used_peak", v)
 		case "keys.count":
-			m[metricsPrefixCount+"keys"] = v
+			r.Metrics.Gauge(metricsPrefixCount+"keys", v)
 		}
 	}
 
-	// get the connection pool stats
-	connStats := r.RedisClient.Stats()
-	m[metricsPrefixConnection+"active"] = connStats.ActiveCount
-	m[metricsPrefixConnection+"idle"] = connStats.IdleCount
-	m[metricsPrefixConnection+"wait"] = connStats.WaitCount
-	m[metricsPrefixConnection+"wait_duration"] = connStats.WaitDuration
-
-	return m, nil
-
+	return nil
 }
 
 func (r *RedisBasicStore) WriteSpan(ctx context.Context, span *CentralSpan) error {

--- a/centralstore/redis_store_test.go
+++ b/centralstore/redis_store_test.go
@@ -556,7 +556,6 @@ func NewTestRedisBasicStore(ctx context.Context, t *testing.T) *TestRedisBasicSt
 		{Value: metrics, Name: "genericMetrics"},
 		{Value: redis, Name: "redis"},
 		{Value: store},
-		{Value: &metrics.NullMetrics{}, Name: "genericMetrics"},
 	}
 	g := inject.Graph{Logger: dummyLogger{}}
 	err := g.Provide(objects...)

--- a/centralstore/smartwrapper.go
+++ b/centralstore/smartwrapper.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/honeycombio/refinery/config"
+	"github.com/honeycombio/refinery/metrics"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -15,9 +16,10 @@ type statusMap map[string]*CentralTraceStatus
 
 // This is an implementation of SmartStorer that stores spans in memory locally.
 type SmartWrapper struct {
-	Config         config.Config `inject:""`
-	BasicStore     BasicStorer   `inject:""`
-	Tracer         trace.Tracer  `inject:"tracer"`
+	Config         config.Config   `inject:""`
+	Metrics        metrics.Metrics `inject:"genericMetrics"`
+	BasicStore     BasicStorer     `inject:""`
+	Tracer         trace.Tracer    `inject:"tracer"`
 	keyfields      []string
 	spanChan       chan *CentralSpan
 	stopped        chan struct{}
@@ -262,8 +264,8 @@ func (w *SmartWrapper) SetTraceStatuses(ctx context.Context, statuses []*Central
 	return err
 }
 
-// GetMetrics returns a map of metrics from the central store, accumulated
+// RecordMetrics returns a map of metrics from the central store, accumulated
 // since the previous time this method was called.
-func (w *SmartWrapper) GetMetrics(ctx context.Context) (map[string]any, error) {
-	return w.BasicStore.GetMetrics(ctx)
+func (w *SmartWrapper) RecordMetrics(ctx context.Context) error {
+	return w.BasicStore.RecordMetrics(ctx)
 }

--- a/centralstore/smartwrapper_test.go
+++ b/centralstore/smartwrapper_test.go
@@ -76,7 +76,7 @@ func getAndStartSmartWrapper(storetype string) (*SmartWrapper, func(), error) {
 		{Value: "version", Name: "version"},
 		{Value: &cfg},
 		{Value: &logger.NullLogger{}},
-		{Value: &metrics.NullMetrics{}, Name: "genericMetrics"},
+		{Value: &metrics.MockMetrics{}, Name: "genericMetrics"},
 		{Value: trace.Tracer(noop.Tracer{}), Name: "tracer"},
 		{Value: decisionCache},
 		{Value: redis, Name: "redis"},
@@ -310,9 +310,11 @@ func TestSetTraceStatuses(t *testing.T) {
 	numberOfTraces := 5
 	traceids := make([]string, 0)
 
-	metrics, err := store.GetMetrics(ctx)
+	err = store.RecordMetrics(ctx)
 	require.NoError(t, err)
-	require.EqualValues(t, 0, metrics["redisstore_count_traces"])
+	value, ok := store.Metrics.Get("redisstore_count_traces")
+	require.True(t, ok)
+	require.EqualValues(t, 0, value)
 
 	for t := 0; t < numberOfTraces; t++ {
 		tid := fmt.Sprintf("trace%02d", t)
@@ -366,10 +368,11 @@ func TestSetTraceStatuses(t *testing.T) {
 		for _, state := range statuses {
 			assert.Equal(collect, AwaitingDecision, state.State)
 		}
-
-		metrics, err := store.GetMetrics(ctx)
+		err = store.RecordMetrics(ctx)
 		require.NoError(t, err)
-		assert.Equal(t, numberOfTraces, metrics["redisstore_count_awaiting_decision"])
+		value, ok := store.Metrics.Get("redisstore_count_awaiting_decision")
+		require.True(t, ok)
+		assert.EqualValues(t, numberOfTraces, value)
 	}, 3*time.Second, 100*time.Millisecond)
 
 	for _, status := range statuses {
@@ -398,13 +401,23 @@ func TestSetTraceStatuses(t *testing.T) {
 		}
 	}
 
-	metrics, err = store.GetMetrics(ctx)
+	err = store.RecordMetrics(ctx)
 	require.NoError(t, err)
-	assert.Equal(t, 0, metrics["redisstore_count_awaiting_decision"])
-	assert.EqualValues(t, numberOfTraces, metrics["redisstore_count_traces"])
-	assert.Greater(t, metrics["redisstore_memory_used_total"], int64(0))
-	assert.Greater(t, metrics["redisstore_memory_used_peak"], int64(0))
-	assert.Greater(t, metrics["redisstore_count_keys"], int64(0))
+	count, ok := store.Metrics.Get("redisstore_count_awaiting_decision")
+	require.True(t, ok)
+	assert.Equal(t, float64(0), count)
+	count, ok = store.Metrics.Get("redisstore_count_traces")
+	require.True(t, ok)
+	assert.Equal(t, float64(numberOfTraces), count)
+	count, ok = store.Metrics.Get("redisstore_memory_used_total")
+	require.True(t, ok)
+	assert.Greater(t, count, float64(0))
+	count, ok = store.Metrics.Get("redisstore_memory_used_peak")
+	require.True(t, ok)
+	assert.Greater(t, count, float64(0))
+	count, ok = store.Metrics.Get("redisstore_count_keys")
+	require.True(t, ok)
+	assert.Greater(t, count, float64(0))
 }
 
 func BenchmarkStoreWriteSpan(b *testing.B) {

--- a/centralstore/smartwrapper_test.go
+++ b/centralstore/smartwrapper_test.go
@@ -217,7 +217,6 @@ func TestBasicStoreOperation(t *testing.T) {
 	}
 
 	assert.Equal(t, 10, len(traceids))
-	fmt.Println(traceids)
 	assert.Eventually(t, func() bool {
 		states, err := store.GetStatusForTraces(ctx, traceids)
 		fmt.Println(states, err)

--- a/internal/redis/redis_test.go
+++ b/internal/redis/redis_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gofrs/uuid/v5"
 	"github.com/honeycombio/refinery/config"
 	"github.com/honeycombio/refinery/internal/redis"
+	"github.com/honeycombio/refinery/metrics"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -227,7 +228,7 @@ func (tr *TestRedis) Start(ctx context.Context) {
 		GetRedisTimeoutVal:   5,
 	}
 
-	client := redis.DefaultClient{Config: cfg}
+	client := redis.DefaultClient{Config: cfg, Metrics: &metrics.NullMetrics{}}
 	client.Start()
 
 	tr.Client = &RedisClientStub{

--- a/internal/redis/test_harness.go
+++ b/internal/redis/test_harness.go
@@ -1,8 +1,6 @@
 package redis
 
 import (
-	"fmt"
-
 	"github.com/alicebob/miniredis/v2"
 	"github.com/gomodule/redigo/redis"
 	"github.com/honeycombio/refinery/config"
@@ -19,7 +17,6 @@ type TestService struct {
 }
 
 func (s *TestService) Start() error {
-	fmt.Println("Starting TestService")
 	r, err := miniredis.Run()
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

Providing metrics for measuring contention on redis operations

## Short description of the changes

- Return connection pool stats from redis store
- use prefix for different metrics group

