### PR TITLE
maint: Move Tracing config to config and do all the things

### DIFF
--- a/cmd/test_stores/main.go
+++ b/cmd/test_stores/main.go
@@ -133,9 +133,9 @@ type CmdLineOptions struct {
 	NodeIndex          int      `long:"node-number" description:"Index of this node if Total > 1" default:"0"`
 	DecisionReqSize    int      `long:"decision-req-size" description:"Number of traces to request for decision" default:"10"`
 	ParallelDecider    bool     `long:"parallel-decider" description:"Run the decider in parallel with the sender"`
-	HnyAPIKey          string   `long:"hny-api-key" description:"API key for traces in Honeycomb" default:"" env:"HONEYCOMB_API_KEY"`
-	HnyEndpoint        string   `long:"hny-endpoint" description:"Endpoint for traces in Honeycomb" default:"https://api.honeycomb.io" env:"HONEYCOMB_ENDPOINT"`
-	HnyDataset         string   `long:"hny-dataset" description:"Dataset/service name for traces in Honeycomb" default:"refinery-store-test" env:"HONEYCOMB_DATASET"`
+	APIKey             string   `long:"apikey" description:"API key for traces in Honeycomb" default:"" env:"HONEYCOMB_API_KEY"`
+	APIHost            string   `long:"apihost" description:"Endpoint for traces in Honeycomb" default:"https://api.honeycomb.io" env:"HONEYCOMB_ENDPOINT"`
+	Dataset            string   `long:"dataset" description:"Dataset/service name for traces in Honeycomb" default:"refinery-store-test" env:"HONEYCOMB_DATASET"`
 }
 
 func parseCmdLineOptions() CmdLineOptions {
@@ -182,10 +182,10 @@ func main() {
 	}()
 
 	// let's set up some OTel tracing
-	tracer, shutdown := otelutil.SetupTracing(otelutil.TracingConfig{
-		HnyAPIKey:   opts.HnyAPIKey,
-		HnyDataset:  opts.HnyDataset,
-		HnyEndpoint: opts.HnyEndpoint,
+	tracer, shutdown := otelutil.SetupTracing(config.OTelTracingConfig{
+		APIHost: opts.APIHost,
+		APIKey:  opts.APIKey,
+		Dataset: opts.Dataset,
 	}, ResourceLibrary, ResourceVersion)
 	defer shutdown()
 

--- a/config.md
+++ b/config.md
@@ -1,7 +1,7 @@
 # Honeycomb Refinery Configuration Documentation
 
 This is the documentation for the configuration file for Honeycomb's Refinery.
-It was automatically generated on 2024-03-22 at 01:48:13 UTC.
+It was automatically generated on 2024-03-22 at 02:37:42 UTC.
 
 ## The Config file
 
@@ -37,7 +37,7 @@ The remainder of this document describes the sections within the file and the fi
 - [Prometheus Metrics](#prometheus-metrics)
 - [Legacy Metrics](#legacy-metrics)
 - [OpenTelemetry Metrics](#opentelemetry-metrics)
-- [Refinery Tracing](#refinery-tracing)
+- [OpenTelemetry Tracing](#opentelemetry-tracing)
 - [Peer Management](#peer-management)
 - [Redis Peer Management](#redis-peer-management)
 - [Collection Settings](#collection-settings)
@@ -623,9 +623,9 @@ In rare circumstances, compression costs may outweigh the benefits, in which cas
 - Default: `gzip`
 - Options: `none`, `gzip`
 
-## Refinery Tracing
+## OpenTelemetry Tracing
 
-`Tracing` contains configuration for tracing.
+`OTelTracing` contains configuration for Refinery's own tracing.
 ### `Type`
 
 Type is the type of tracing to use for Refinery's own traces.

--- a/config.md
+++ b/config.md
@@ -1,7 +1,7 @@
 # Honeycomb Refinery Configuration Documentation
 
 This is the documentation for the configuration file for Honeycomb's Refinery.
-It was automatically generated on 2024-03-20 at 20:36:41 UTC.
+It was automatically generated on 2024-03-22 at 01:48:13 UTC.
 
 ## The Config file
 
@@ -37,6 +37,7 @@ The remainder of this document describes the sections within the file and the fi
 - [Prometheus Metrics](#prometheus-metrics)
 - [Legacy Metrics](#legacy-metrics)
 - [OpenTelemetry Metrics](#opentelemetry-metrics)
+- [Refinery Tracing](#refinery-tracing)
 - [Peer Management](#peer-management)
 - [Redis Peer Management](#redis-peer-management)
 - [Collection Settings](#collection-settings)
@@ -396,7 +397,7 @@ Refinery's internal logs will be sent to this host using the standard Honeycomb 
 
 APIKey is the API key used to send Refinery's logs to Honeycomb.
 
-It is recommended that you create a separate team and key for Refinery logs.
+It is recommended that you create a separate team and key for Refinery telemetry.
 
 - Not eligible for live reload.
 - Type: `string`
@@ -525,7 +526,7 @@ Refinery's internal metrics will be sent to this host using the standard Honeyco
 
 APIKey is the API key used by Refinery to send its metrics to Honeycomb.
 
-It is recommended that you create a separate team and key for Refinery metrics.
+It is recommended that you create a separate team and key for Refinery telemetry.
 
 - Not eligible for live reload.
 - Type: `string`
@@ -582,7 +583,7 @@ Refinery's internal metrics will be sent to the `/v1/metrics` endpoint on this h
 
 APIKey is the API key used to send Honeycomb metrics via OpenTelemetry.
 
-It is recommended that you create a separate team and key for Refinery metrics.
+It is recommended that you create a separate team and key for Refinery telemetry.
 If this is blank, then Refinery will not set the Honeycomb-specific headers for OpenTelemetry, and your `APIHost` must be set to a valid OpenTelemetry endpoint.
 
 - Not eligible for live reload.
@@ -592,7 +593,7 @@ If this is blank, then Refinery will not set the Honeycomb-specific headers for 
 
 ### `Dataset`
 
-Dataset is the Honeycomb dataset that Refinery sends its OpenTelemetry metrics.
+Dataset is the Honeycomb dataset to which Refinery sends its OpenTelemetry metrics.
 
 Only used if `APIKey` is specified.
 
@@ -621,6 +622,54 @@ In rare circumstances, compression costs may outweigh the benefits, in which cas
 - Type: `string`
 - Default: `gzip`
 - Options: `none`, `gzip`
+
+## Refinery Tracing
+
+`Tracing` contains configuration for tracing.
+### `Type`
+
+Type is the type of tracing to use for Refinery's own traces.
+
+The setting specifies how (and if) Refinery sends traces.
+`none` means that traces are discarded.
+`otel` means that OpenTelemetry traces will be generated according to the settings in this section.
+
+- Not eligible for live reload.
+- Type: `string`
+- Default: `none`
+- Options: `otel`, `none`
+
+### `APIHost`
+
+APIHost is the URL of the OpenTelemetry API to which traces will be sent.
+
+Refinery's internal traces will be sent to the `/v1/traces` endpoint on this host.
+
+- Not eligible for live reload.
+- Type: `url`
+- Default: `https://api.honeycomb.io`
+
+### `APIKey`
+
+APIKey is the API key used to send Refinery's traces to Honeycomb.
+
+It is recommended that you create a separate team and key for Refinery telemetry.
+If this is blank, then Refinery will not set the Honeycomb-specific headers for OpenTelemetry, and your `APIHost` must be set to a valid OpenTelemetry endpoint.
+
+- Not eligible for live reload.
+- Type: `string`
+- Example: `SetThisToAHoneycombKey`
+- Environment variable: `REFINERY_HONEYCOMB_TRACES_API_KEY, REFINERY_HONEYCOMB_API_KEY`
+
+### `Dataset`
+
+Dataset is the Honeycomb dataset to which Refinery sends its OpenTelemetry metrics.
+
+Only used if `APIKey` is specified.
+
+- Not eligible for live reload.
+- Type: `string`
+- Default: `Refinery Traces`
 
 ## Peer Management
 

--- a/config/cmdenv.go
+++ b/config/cmdenv.go
@@ -40,6 +40,7 @@ type CmdEnv struct {
 	HoneycombLoggerAPIKey string     `long:"logger-api-key" env:"REFINERY_HONEYCOMB_LOGGER_API_KEY" description:"Honeycomb logger API key"`
 	LegacyMetricsAPIKey   string     `long:"legacy-metrics-api-key" env:"REFINERY_HONEYCOMB_METRICS_API_KEY" description:"API key for legacy Honeycomb metrics"`
 	OTelMetricsAPIKey     string     `long:"otel-metrics-api-key" env:"REFINERY_OTEL_METRICS_API_KEY" description:"API key for OTel metrics if being sent to Honeycomb"`
+	OTelTracesAPIKey      string     `long:"otel-traces-api-key" env:"REFINERY_OTEL_TRACES_API_KEY" description:"API key for OTel metrics if being sent to Honeycomb"`
 	QueryAuthToken        string     `long:"query-auth-token" env:"REFINERY_QUERY_AUTH_TOKEN" description:"Token for debug/management queries"`
 	AvailableMemory       MemorySize `long:"available-memory" env:"REFINERY_AVAILABLE_MEMORY" description:"The maximum memory available for Refinery to use (ex: 4GiB)."`
 	Debug                 bool       `short:"d" long:"debug" description:"Runs debug service (on the first open port between localhost:6060 and :6069 by default)"`

--- a/config/config.go
+++ b/config/config.go
@@ -141,6 +141,9 @@ type Config interface {
 	// GetOTelMetricsConfig returns the config specific to OTelMetrics
 	GetOTelMetricsConfig() OTelMetricsConfig
 
+	// GetOTelTracingConfig returns the config specific to OTelTracing
+	GetOTelTracingConfig() OTelTracingConfig
+
 	// GetUpstreamBufferSize returns the size of the libhoney buffer to use for the upstream
 	// libhoney client
 	GetUpstreamBufferSize() int

--- a/config/configLoadHelpers.go
+++ b/config/configLoadHelpers.go
@@ -165,6 +165,9 @@ func validateConfig(opts *CmdEnv) ([]string, error) {
 	if config.OTelMetrics.APIKey == "" {
 		config.OTelMetrics.APIKey = "InvalidHoneycombAPIKey"
 	}
+	if config.OTelTracing.APIKey == "" {
+		config.OTelTracing.APIKey = "InvalidHoneycombAPIKey"
+	}
 
 	// write it out to a YAML buffer
 	buf := new(bytes.Buffer)

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -59,6 +59,7 @@ type configContents struct {
 	PrometheusMetrics    PrometheusMetricsConfig   `yaml:"PrometheusMetrics"`
 	LegacyMetrics        LegacyMetricsConfig       `yaml:"LegacyMetrics"`
 	OTelMetrics          OTelMetricsConfig         `yaml:"OTelMetrics"`
+	OTelTracing          OTelTracingConfig         `yaml:"OTelTracing"`
 	PeerManagement       PeerManagementConfig      `yaml:"PeerManagement"`
 	RedisPeerManagement  RedisPeerManagementConfig `yaml:"RedisPeerManagement"`
 	Collection           CollectionConfig          `yaml:"Collection"`
@@ -182,6 +183,13 @@ type OTelMetricsConfig struct {
 	Dataset           string   `yaml:"Dataset" default:"Refinery Metrics"`
 	Compression       string   `yaml:"Compression" default:"gzip"`
 	ReportingInterval Duration `yaml:"ReportingInterval" default:"30s"`
+}
+
+type OTelTracingConfig struct {
+	Type    string `yaml:"Type" default:"none"`
+	APIHost string `yaml:"APIHost" default:"https://api.honeycomb.io"`
+	APIKey  string `yaml:"APIKey" cmdenv:"OTelTracesAPIKey,HoneycombAPIKey"`
+	Dataset string `yaml:"Dataset" default:"Refinery Traces"`
 }
 
 type PeerManagementConfig struct {
@@ -771,6 +779,13 @@ func (f *fileConfig) GetOTelMetricsConfig() OTelMetricsConfig {
 	defer f.mux.RUnlock()
 
 	return f.mainConfig.OTelMetrics
+}
+
+func (f *fileConfig) GetOTelTracingConfig() OTelTracingConfig {
+	f.mux.RLock()
+	defer f.mux.RUnlock()
+
+	return f.mainConfig.OTelTracing
 }
 
 func (f *fileConfig) GetSendDelay() (time.Duration, error) {

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -472,7 +472,7 @@ groups:
         summary: is the API key used to send Refinery's logs to Honeycomb.
         description: >
           It is recommended that you create a separate team and key for
-          Refinery logs.
+          Refinery telemetry.
 
       - name: Dataset
         v1group: HoneycombLogger
@@ -628,7 +628,7 @@ groups:
         summary: is the API key used by Refinery to send its metrics to Honeycomb.
         description: >
           It is recommended that you create a separate team and key for
-          Refinery metrics.
+          Refinery telemetry.
 
       - name: Dataset
         v1group: HoneycombMetrics
@@ -699,7 +699,7 @@ groups:
         summary: is the API key used to send Honeycomb metrics via OpenTelemetry.
         description: >
           It is recommended that you create a separate team and key for
-          Refinery metrics.
+          Refinery telemetry.
 
           If this is blank, then Refinery will not set the Honeycomb-specific
           headers for OpenTelemetry, and your `APIHost` must be set to a
@@ -713,7 +713,7 @@ groups:
         validations:
           - type: notempty
         firstversion: v2.0
-        summary: is the Honeycomb dataset that Refinery sends its OpenTelemetry metrics.
+        summary: is the Honeycomb dataset to which Refinery sends its OpenTelemetry metrics.
         description: >
           Only used if `APIKey` is specified.
 
@@ -739,6 +739,72 @@ groups:
           `gzip` is the default and recommended value. In rare circumstances,
           compression costs may outweigh the benefits, in which case `none`
           may be used.
+
+  - name: Tracing
+    title: "Refinery Tracing"
+    description: contains configuration for tracing.
+    fields:
+      - name: Type
+        type: string
+        valuetype: choice
+        choices: ["otel", "none"]
+        default: "none"
+        reload: false
+        validations:
+          - type: choice
+        summary: is the type of tracing to use for Refinery's own traces.
+        description: >
+          The setting specifies how (and if) Refinery sends traces.
+
+          `none` means that traces are discarded.
+
+          `otel` means that OpenTelemetry traces will be generated according
+          to the settings in this section.
+
+      - name: APIHost
+        type: url
+        valuetype: nondefault
+        default: "https://api.honeycomb.io"
+        reload: false
+        firstversion: v2.6
+        summary: is the URL of the OpenTelemetry API to which traces will be sent.
+        description: >
+          Refinery's internal traces will be sent to the `/v1/traces`
+          endpoint on this host.
+
+      - name: APIKey
+        type: string
+        pattern: apikey
+        valuetype: nonemptystring
+        default: ""
+        example: "SetThisToAHoneycombKey"
+        reload: false
+        firstversion: v2.6
+        envvar: REFINERY_HONEYCOMB_TRACES_API_KEY, REFINERY_HONEYCOMB_API_KEY
+        commandline: traces-api-key
+        validations:
+          - type: format
+            arg: apikey
+        summary: is the API key used to send Refinery's traces to Honeycomb.
+        description: >
+          It is recommended that you create a separate team and key for
+          Refinery telemetry.
+
+          If this is blank, then Refinery will not set the Honeycomb-specific
+          headers for OpenTelemetry, and your `APIHost` must be set to a
+          valid OpenTelemetry endpoint.
+
+      - name: Dataset
+        type: string
+        valuetype: nondefault
+        default: "Refinery Traces"
+        reload: false
+        validations:
+          - type: notempty
+        firstversion: v2.0
+        summary: is the Honeycomb dataset to which Refinery sends its OpenTelemetry metrics.
+        description: >
+          Only used if `APIKey` is specified.
 
   - name: PeerManagement
     title: "Peer Management"

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -740,9 +740,9 @@ groups:
           compression costs may outweigh the benefits, in which case `none`
           may be used.
 
-  - name: Tracing
-    title: "Refinery Tracing"
-    description: contains configuration for tracing.
+  - name: OTelTracing
+    title: "OpenTelemetry Tracing"
+    description: contains configuration for Refinery's own tracing.
     fields:
       - name: Type
         type: string
@@ -775,13 +775,13 @@ groups:
       - name: APIKey
         type: string
         pattern: apikey
-        valuetype: nonemptystring
+        valuetype: nondefault
         default: ""
         example: "SetThisToAHoneycombKey"
         reload: false
         firstversion: v2.6
         envvar: REFINERY_HONEYCOMB_TRACES_API_KEY, REFINERY_HONEYCOMB_API_KEY
-        commandline: traces-api-key
+        commandline: otel-traces-api-key
         validations:
           - type: format
             arg: apikey

--- a/config/mock.go
+++ b/config/mock.go
@@ -61,6 +61,7 @@ type MockConfig struct {
 	GetLegacyMetricsConfigVal        LegacyMetricsConfig
 	GetPrometheusMetricsConfigVal    PrometheusMetricsConfig
 	GetOTelMetricsConfigVal          OTelMetricsConfig
+	GetOTelTracingConfigVal          OTelTracingConfig
 	GetSendDelayErr                  error
 	GetSendDelayVal                  time.Duration
 	GetBatchTimeoutVal               time.Duration
@@ -318,6 +319,13 @@ func (m *MockConfig) GetOTelMetricsConfig() OTelMetricsConfig {
 	defer m.Mux.RUnlock()
 
 	return m.GetOTelMetricsConfigVal
+}
+
+func (m *MockConfig) GetOTelTracingConfig() OTelTracingConfig {
+	m.Mux.RLock()
+	defer m.Mux.RUnlock()
+
+	return m.GetOTelTracingConfigVal
 }
 
 func (m *MockConfig) GetSendDelay() (time.Duration, error) {

--- a/config_complete.yaml
+++ b/config_complete.yaml
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created on 2024-03-20 at 20:36:41 UTC from ../../config.yaml using a template generated on 2024-03-20 at 20:36:38 UTC
+# created on 2024-03-22 at 01:48:12 UTC from ../../config.yaml using a template generated on 2024-03-22 at 01:48:10 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of
@@ -410,7 +410,7 @@ HoneycombLogger:
     ## APIKey is the API key used to send Refinery's logs to Honeycomb.
     ##
     ## It is recommended that you create a separate team and key for Refinery
-    ## logs.
+    ## telemetry.
     ##
     ## Not eligible for live reload.
     # APIKey: SetThisToAHoneycombKey
@@ -541,7 +541,7 @@ LegacyMetrics:
     ## Honeycomb.
     ##
     ## It is recommended that you create a separate team and key for Refinery
-    ## metrics.
+    ## telemetry.
     ##
     ## Not eligible for live reload.
     # APIKey: ""
@@ -595,7 +595,7 @@ OTelMetrics:
     ## OpenTelemetry.
     ##
     ## It is recommended that you create a separate team and key for Refinery
-    ## metrics.
+    ## telemetry.
     ## If this is blank, then Refinery will not set the Honeycomb-specific
     ## headers for OpenTelemetry, and your `APIHost` must be set to a valid
     ## OpenTelemetry endpoint.
@@ -603,8 +603,8 @@ OTelMetrics:
     ## Not eligible for live reload.
     # APIKey: ""
 
-    ## Dataset is the Honeycomb dataset that Refinery sends its OpenTelemetry
-    ## metrics.
+    ## Dataset is the Honeycomb dataset to which Refinery sends its
+    ## OpenTelemetry metrics.
     ##
     ## Only used if `APIKey` is specified.
     ##
@@ -633,6 +633,54 @@ OTelMetrics:
     ## Not eligible for live reload.
     ## Options: none gzip
     # Compression: gzip
+
+######################
+## Refinery Tracing ##
+######################
+Tracing:
+  ## Tracing contains configuration for tracing.
+  ####
+    ## Type is the type of tracing to use for Refinery's own traces.
+    ##
+    ## The setting specifies how (and if) Refinery sends traces.
+    ## `none` means that traces are discarded.
+    ## `otel` means that OpenTelemetry traces will be generated according to
+    ## the settings in this section.
+    ##
+    ## default: none
+    ## Not eligible for live reload.
+    ## Options: otel none
+    # Type: none
+
+    ## APIHost is the URL of the OpenTelemetry API to which traces will be
+    ## sent.
+    ##
+    ## Refinery's internal traces will be sent to the `/v1/traces` endpoint
+    ## on this host.
+    ##
+    ## default: https://api.honeycomb.io
+    ## Not eligible for live reload.
+    # APIHost: "https://api.honeycomb.io"
+
+    ## APIKey is the API key used to send Refinery's traces to Honeycomb.
+    ##
+    ## It is recommended that you create a separate team and key for Refinery
+    ## telemetry.
+    ## If this is blank, then Refinery will not set the Honeycomb-specific
+    ## headers for OpenTelemetry, and your `APIHost` must be set to a valid
+    ## OpenTelemetry endpoint.
+    ##
+    ## Not eligible for live reload.
+    # APIKey: SetThisToAHoneycombKey
+
+    ## Dataset is the Honeycomb dataset to which Refinery sends its
+    ## OpenTelemetry metrics.
+    ##
+    ## Only used if `APIKey` is specified.
+    ##
+    ## default: Refinery Traces
+    ## Not eligible for live reload.
+    # Dataset: "Refinery Traces"
 
 #####################
 ## Peer Management ##

--- a/config_complete.yaml
+++ b/config_complete.yaml
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created on 2024-03-22 at 01:48:12 UTC from ../../config.yaml using a template generated on 2024-03-22 at 01:48:10 UTC
+# created on 2024-03-22 at 02:37:41 UTC from ../../config.yaml using a template generated on 2024-03-22 at 02:37:39 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of
@@ -634,11 +634,11 @@ OTelMetrics:
     ## Options: none gzip
     # Compression: gzip
 
-######################
-## Refinery Tracing ##
-######################
-Tracing:
-  ## Tracing contains configuration for tracing.
+###########################
+## OpenTelemetry Tracing ##
+###########################
+OTelTracing:
+  ## OTelTracing contains configuration for Refinery's own tracing.
   ####
     ## Type is the type of tracing to use for Refinery's own traces.
     ##
@@ -671,7 +671,7 @@ Tracing:
     ## OpenTelemetry endpoint.
     ##
     ## Not eligible for live reload.
-    # APIKey: SetThisToAHoneycombKey
+    # APIKey: ""
 
     ## Dataset is the Honeycomb dataset to which Refinery sends its
     ## OpenTelemetry metrics.

--- a/internal/otelutil/otel_tracing.go
+++ b/internal/otelutil/otel_tracing.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/honeycombio/otel-config-go/otelconfig"
+	"github.com/honeycombio/refinery/config"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -52,30 +53,21 @@ func AddSpanFields(span trace.Span, fields map[string]interface{}) {
 	}
 }
 
-type TracingConfig struct {
-	// Honeycomb API key
-	HnyAPIKey string
-	// Honeycomb dataset
-	HnyDataset string
-	// Honeycomb endpoint
-	HnyEndpoint string
-}
-
-func SetupTracing(cfg TracingConfig, resourceLibrary string, resourceVersion string) (tracer trace.Tracer, shutdown func()) {
-	if cfg.HnyAPIKey != "" {
+func SetupTracing(cfg config.OTelTracingConfig, resourceLibrary string, resourceVersion string) (tracer trace.Tracer, shutdown func()) {
+	if cfg.APIKey != "" {
 		var protocol otelconfig.Protocol = otelconfig.ProtocolHTTPProto
 
-		cfg.HnyEndpoint = strings.TrimSuffix(cfg.HnyEndpoint, "/")
-		endpoint := fmt.Sprintf("%s:443", cfg.HnyEndpoint)
+		cfg.APIHost = strings.TrimSuffix(cfg.APIHost, "/")
+		apihost := fmt.Sprintf("%s:443", cfg.APIHost)
 
 		otelshutdown, err := otelconfig.ConfigureOpenTelemetry(
 			otelconfig.WithExporterProtocol(protocol),
-			otelconfig.WithServiceName(cfg.HnyDataset),
-			otelconfig.WithTracesExporterEndpoint(endpoint),
+			otelconfig.WithServiceName(cfg.Dataset),
+			otelconfig.WithTracesExporterEndpoint(apihost),
 			otelconfig.WithMetricsEnabled(false),
 			otelconfig.WithTracesEnabled(true),
 			otelconfig.WithHeaders(map[string]string{
-				"x-honeycomb-team": cfg.HnyAPIKey,
+				"x-honeycomb-team": cfg.APIKey,
 			}),
 		)
 		if err != nil {

--- a/refinery_config.md
+++ b/refinery_config.md
@@ -377,7 +377,7 @@ Refinery's internal logs will be sent to this host using the standard Honeycomb 
 
 `APIKey` is the API key used to send Refinery's logs to Honeycomb.
 
-It is recommended that you create a separate team and key for Refinery logs.
+It is recommended that you create a separate team and key for Refinery telemetry.
 
 - Not eligible for live reload.
 - Type: `string`
@@ -508,7 +508,7 @@ Refinery's internal metrics will be sent to this host using the standard Honeyco
 
 `APIKey` is the API key used by Refinery to send its metrics to Honeycomb.
 
-It is recommended that you create a separate team and key for Refinery metrics.
+It is recommended that you create a separate team and key for Refinery telemetry.
 
 - Not eligible for live reload.
 - Type: `string`
@@ -565,7 +565,7 @@ Refinery's internal metrics will be sent to the `/v1/metrics` endpoint on this h
 
 `APIKey` is the API key used to send Honeycomb metrics via OpenTelemetry.
 
-It is recommended that you create a separate team and key for Refinery metrics.
+It is recommended that you create a separate team and key for Refinery telemetry.
 If this is blank, then Refinery will not set the Honeycomb-specific headers for OpenTelemetry, and your `APIHost` must be set to a valid OpenTelemetry endpoint.
 
 - Not eligible for live reload.
@@ -575,7 +575,7 @@ If this is blank, then Refinery will not set the Honeycomb-specific headers for 
 
 ### `Dataset`
 
-`Dataset` is the Honeycomb dataset that Refinery sends its OpenTelemetry metrics.
+`Dataset` is the Honeycomb dataset to which Refinery sends its OpenTelemetry metrics.
 
 Only used if `APIKey` is specified.
 
@@ -604,6 +604,55 @@ In rare circumstances, compression costs may outweigh the benefits, in which cas
 - Type: `string`
 - Default: `gzip`
 - Options: `none`, `gzip`
+
+## Refinery Tracing
+
+`Tracing` contains configuration for tracing.
+
+### `Type`
+
+`Type` is the type of tracing to use for Refinery's own traces.
+
+The setting specifies how (and if) Refinery sends traces.
+`none` means that traces are discarded.
+`otel` means that OpenTelemetry traces will be generated according to the settings in this section.
+
+- Not eligible for live reload.
+- Type: `string`
+- Default: `none`
+- Options: `otel`, `none`
+
+### `APIHost`
+
+`APIHost` is the URL of the OpenTelemetry API to which traces will be sent.
+
+Refinery's internal traces will be sent to the `/v1/traces` endpoint on this host.
+
+- Not eligible for live reload.
+- Type: `url`
+- Default: `https://api.honeycomb.io`
+
+### `APIKey`
+
+`APIKey` is the API key used to send Refinery's traces to Honeycomb.
+
+It is recommended that you create a separate team and key for Refinery telemetry.
+If this is blank, then Refinery will not set the Honeycomb-specific headers for OpenTelemetry, and your `APIHost` must be set to a valid OpenTelemetry endpoint.
+
+- Not eligible for live reload.
+- Type: `string`
+- Example: `SetThisToAHoneycombKey`
+- Environment variable: `REFINERY_HONEYCOMB_TRACES_API_KEY, REFINERY_HONEYCOMB_API_KEY`
+
+### `Dataset`
+
+`Dataset` is the Honeycomb dataset to which Refinery sends its OpenTelemetry metrics.
+
+Only used if `APIKey` is specified.
+
+- Not eligible for live reload.
+- Type: `string`
+- Default: `Refinery Traces`
 
 ## Peer Management
 

--- a/refinery_config.md
+++ b/refinery_config.md
@@ -605,9 +605,9 @@ In rare circumstances, compression costs may outweigh the benefits, in which cas
 - Default: `gzip`
 - Options: `none`, `gzip`
 
-## Refinery Tracing
+## OpenTelemetry Tracing
 
-`Tracing` contains configuration for tracing.
+`OTelTracing` contains configuration for Refinery's own tracing.
 
 ### `Type`
 

--- a/rules.md
+++ b/rules.md
@@ -1,7 +1,7 @@
 # Honeycomb Refinery Rules Documentation
 
 This is the documentation for the rules configuration for Honeycomb's Refinery.
-It was automatically generated on 2024-03-20 at 20:36:42 UTC.
+It was automatically generated on 2024-03-22 at 01:48:13 UTC.
 
 ## The Rules file
 

--- a/tools/convert/configDataNames.txt
+++ b/tools/convert/configDataNames.txt
@@ -1,5 +1,5 @@
 # Names of groups and fields in the new config file format.
-# Automatically generated on 2024-03-20 at 20:36:39 UTC.
+# Automatically generated on 2024-03-22 at 01:48:11 UTC.
 
 General:
   - ConfigurationVersion
@@ -115,6 +115,16 @@ OTelMetrics:
   - ReportingInterval
 
   - Compression
+
+
+Tracing:
+  - Type
+
+  - APIHost
+
+  - APIKey
+
+  - Dataset
 
 
 PeerManagement:

--- a/tools/convert/configDataNames.txt
+++ b/tools/convert/configDataNames.txt
@@ -1,5 +1,5 @@
 # Names of groups and fields in the new config file format.
-# Automatically generated on 2024-03-22 at 01:48:11 UTC.
+# Automatically generated on 2024-03-22 at 02:37:40 UTC.
 
 General:
   - ConfigurationVersion
@@ -117,7 +117,7 @@ OTelMetrics:
   - Compression
 
 
-Tracing:
+OTelTracing:
   - Type
 
   - APIHost

--- a/tools/convert/minimal_config.yaml
+++ b/tools/convert/minimal_config.yaml
@@ -1,5 +1,5 @@
 # sample uncommented config file containing all possible fields
-# automatically generated on 2024-03-22 at 01:48:12 UTC
+# automatically generated on 2024-03-22 at 02:37:40 UTC
 General:
   ConfigurationVersion: 2
   MinRefineryVersion: "v2.0"
@@ -62,7 +62,7 @@ OTelMetrics:
   Dataset: "Refinery Metrics"
   ReportingInterval: 30s
   Compression: gzip
-Tracing:
+OTelTracing:
   Type: none
   APIHost: "https://api.honeycomb.io"
   APIKey: SetThisToAHoneycombKey

--- a/tools/convert/minimal_config.yaml
+++ b/tools/convert/minimal_config.yaml
@@ -1,5 +1,5 @@
 # sample uncommented config file containing all possible fields
-# automatically generated on 2024-03-20 at 20:36:40 UTC
+# automatically generated on 2024-03-22 at 01:48:12 UTC
 General:
   ConfigurationVersion: 2
   MinRefineryVersion: "v2.0"
@@ -62,6 +62,11 @@ OTelMetrics:
   Dataset: "Refinery Metrics"
   ReportingInterval: 30s
   Compression: gzip
+Tracing:
+  Type: none
+  APIHost: "https://api.honeycomb.io"
+  APIKey: SetThisToAHoneycombKey
+  Dataset: "Refinery Traces"
 PeerManagement:
   Type: file
   Identifier: "192.168.1.1"

--- a/tools/convert/templates/configV2.tmpl
+++ b/tools/convert/templates/configV2.tmpl
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created {{ now }} from {{ .Input }} using a template generated on 2024-03-22 at 01:48:10 UTC
+# created {{ now }} from {{ .Input }} using a template generated on 2024-03-22 at 02:37:39 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of
@@ -632,11 +632,11 @@ OTelMetrics:
     ## Options: none gzip
     {{ choice .Data "Compression" "Compression" (makeSlice "none" "gzip") "gzip" }}
 
-######################
-## Refinery Tracing ##
-######################
-Tracing:
-  ## Tracing contains configuration for tracing.
+###########################
+## OpenTelemetry Tracing ##
+###########################
+OTelTracing:
+  ## OTelTracing contains configuration for Refinery's own tracing.
   ####
     ## Type is the type of tracing to use for Refinery's own traces.
     ##
@@ -669,7 +669,7 @@ Tracing:
     ## OpenTelemetry endpoint.
     ##
     ## Not eligible for live reload.
-    {{ nonEmptyString .Data "APIKey" "APIKey" "SetThisToAHoneycombKey" }}
+    {{ nonDefaultOnly .Data "APIKey" "APIKey" "" }}
 
     ## Dataset is the Honeycomb dataset to which Refinery sends its
     ## OpenTelemetry metrics.

--- a/tools/convert/templates/configV2.tmpl
+++ b/tools/convert/templates/configV2.tmpl
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created {{ now }} from {{ .Input }} using a template generated on 2024-03-20 at 20:36:38 UTC
+# created {{ now }} from {{ .Input }} using a template generated on 2024-03-22 at 01:48:10 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of
@@ -408,7 +408,7 @@ HoneycombLogger:
     ## APIKey is the API key used to send Refinery's logs to Honeycomb.
     ##
     ## It is recommended that you create a separate team and key for Refinery
-    ## logs.
+    ## telemetry.
     ##
     ## Not eligible for live reload.
     {{ nonEmptyString .Data "APIKey" "HoneycombLogger.LoggerAPIKey" "SetThisToAHoneycombKey" }}
@@ -539,7 +539,7 @@ LegacyMetrics:
     ## Honeycomb.
     ##
     ## It is recommended that you create a separate team and key for Refinery
-    ## metrics.
+    ## telemetry.
     ##
     ## Not eligible for live reload.
     {{ nonDefaultOnly .Data "APIKey" "HoneycombMetrics.MetricsAPIKey" "" }}
@@ -593,7 +593,7 @@ OTelMetrics:
     ## OpenTelemetry.
     ##
     ## It is recommended that you create a separate team and key for Refinery
-    ## metrics.
+    ## telemetry.
     ## If this is blank, then Refinery will not set the Honeycomb-specific
     ## headers for OpenTelemetry, and your `APIHost` must be set to a valid
     ## OpenTelemetry endpoint.
@@ -601,8 +601,8 @@ OTelMetrics:
     ## Not eligible for live reload.
     {{ nonDefaultOnly .Data "APIKey" "APIKey" "" }}
 
-    ## Dataset is the Honeycomb dataset that Refinery sends its OpenTelemetry
-    ## metrics.
+    ## Dataset is the Honeycomb dataset to which Refinery sends its
+    ## OpenTelemetry metrics.
     ##
     ## Only used if `APIKey` is specified.
     ##
@@ -631,6 +631,54 @@ OTelMetrics:
     ## Not eligible for live reload.
     ## Options: none gzip
     {{ choice .Data "Compression" "Compression" (makeSlice "none" "gzip") "gzip" }}
+
+######################
+## Refinery Tracing ##
+######################
+Tracing:
+  ## Tracing contains configuration for tracing.
+  ####
+    ## Type is the type of tracing to use for Refinery's own traces.
+    ##
+    ## The setting specifies how (and if) Refinery sends traces.
+    ## `none` means that traces are discarded.
+    ## `otel` means that OpenTelemetry traces will be generated according to
+    ## the settings in this section.
+    ##
+    ## default: none
+    ## Not eligible for live reload.
+    ## Options: otel none
+    {{ choice .Data "Type" "Type" (makeSlice "otel" "none") "none" }}
+
+    ## APIHost is the URL of the OpenTelemetry API to which traces will be
+    ## sent.
+    ##
+    ## Refinery's internal traces will be sent to the `/v1/traces` endpoint
+    ## on this host.
+    ##
+    ## default: https://api.honeycomb.io
+    ## Not eligible for live reload.
+    {{ nonDefaultOnly .Data "APIHost" "APIHost" "https://api.honeycomb.io" }}
+
+    ## APIKey is the API key used to send Refinery's traces to Honeycomb.
+    ##
+    ## It is recommended that you create a separate team and key for Refinery
+    ## telemetry.
+    ## If this is blank, then Refinery will not set the Honeycomb-specific
+    ## headers for OpenTelemetry, and your `APIHost` must be set to a valid
+    ## OpenTelemetry endpoint.
+    ##
+    ## Not eligible for live reload.
+    {{ nonEmptyString .Data "APIKey" "APIKey" "SetThisToAHoneycombKey" }}
+
+    ## Dataset is the Honeycomb dataset to which Refinery sends its
+    ## OpenTelemetry metrics.
+    ##
+    ## Only used if `APIKey` is specified.
+    ##
+    ## default: Refinery Traces
+    ## Not eligible for live reload.
+    {{ nonDefaultOnly .Data "Dataset" "Dataset" "Refinery Traces" }}
 
 #####################
 ## Peer Management ##


### PR DESCRIPTION
To properly inject tracing, we needed the config, so this moves the tracing config to the config area, sets up the metadata for it, generates all the docs, and uses it. It also sets up injection of the centralStore and the basicStore, making it possible to use them in Refinery.
