### PR TITLE
feat: implement span cache

### DIFF
--- a/collect/cache/cuckoo_test.go
+++ b/collect/cache/cuckoo_test.go
@@ -5,20 +5,17 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgryski/go-wyhash"
 	"github.com/honeycombio/refinery/metrics"
 	"github.com/sourcegraph/conc/pool"
 )
 
 // genID returns a random hex string of length numChars
 func genID(numChars int) string {
-	seed := 3565269841805
-
 	const charset = "abcdef0123456789"
 
 	id := make([]byte, numChars)
 	for i := 0; i < numChars; i++ {
-		id[i] = charset[int(wyhash.Rng(seed))%len(charset)]
+		id[i] = charset[rand.Intn(len(charset))]
 	}
 	return string(id)
 }

--- a/collect/cache/span_cache.go
+++ b/collect/cache/span_cache.go
@@ -1,0 +1,91 @@
+package cache
+
+import (
+	"github.com/facebookgo/startstop"
+	"github.com/honeycombio/refinery/types"
+	"github.com/jonboulle/clockwork"
+)
+
+type SpanCache interface {
+	Set(span *types.Span) error
+	Get(traceID string) (*types.Trace, error)
+	GetOldest(n int) []*types.Trace
+	Remove(traceID string) error
+	Len() int
+}
+
+// we're going to start with a naive implementation that uses a map
+// and doesn't try to be clever about memory usage or allocations
+type spanCache struct {
+	Clock clockwork.Clock `inject:""`
+	cache map[string]*types.Trace
+}
+
+// ensure that spanCache implements SpanCache
+var _ SpanCache = &spanCache{}
+
+// ensure that spanCache implements startstop.Starter
+var _ startstop.Starter = &spanCache{}
+
+// ensure that spanCache implements startstop.Stopper
+var _ startstop.Stopper = &spanCache{}
+
+func (sc *spanCache) Start() error {
+	sc.cache = make(map[string]*types.Trace)
+	return nil
+}
+
+func (sc *spanCache) Stop() error {
+	sc.cache = nil
+	return nil
+}
+
+func (sc *spanCache) Set(sp *types.Span) error {
+	traceID := sp.TraceID
+	trace, ok := sc.cache[traceID]
+	if !ok {
+		trace = &types.Trace{
+			APIHost:     sp.APIHost,
+			APIKey:      sp.APIKey,
+			Dataset:     sp.Dataset,
+			TraceID:     traceID,
+			ArrivalTime: sc.Clock.Now(),
+		}
+		sc.cache[traceID] = trace
+	}
+	trace.AddSpan(sp)
+	return nil
+}
+
+func (sc *spanCache) Get(traceID string) (*types.Trace, error) {
+	trace, ok := sc.cache[traceID]
+	if !ok {
+		return nil, nil
+	}
+	return trace, nil
+}
+
+func (sc *spanCache) GetOldest(n int) []*types.Trace {
+	// this is a naive implementation that just returns the first n traces
+	// in the cache. in a real implementation, we would want to sort the
+	// traces by arrival time and return the oldest n.
+	// It's useful for benchmarks because it's probably the fastest way to
+	// get n traces.
+	traces := make([]*types.Trace, 0, n)
+	for _, trace := range sc.cache {
+		traces = append(traces, trace)
+		if len(traces) == n {
+			break
+		}
+	}
+	return traces
+}
+
+func (sc *spanCache) Remove(traceID string) error {
+	delete(sc.cache, traceID)
+	return nil
+}
+
+func (sc *spanCache) Len() int {
+	return len(sc.cache)
+}

--- a/collect/cache/span_cache.go
+++ b/collect/cache/span_cache.go
@@ -1,91 +1,30 @@
 package cache
 
 import (
-	"github.com/facebookgo/startstop"
 	"github.com/honeycombio/refinery/types"
 	"github.com/jonboulle/clockwork"
 )
 
 type SpanCache interface {
+	// Adds a span to the cache. If a trace with the same traceID already exists,
+	// the span will be added to that trace. If no trace with the traceID exists,
+	// a new trace will be created. Only returns an error if there is a problem
+	// adding the span to the cache.
 	Set(span *types.Span) error
-	Get(traceID string) (*types.Trace, error)
-	GetOldest(n int) []*types.Trace
-	Remove(traceID string) error
+	// Retrieves a trace from the cache by traceID. If no trace with the traceID
+	// exists, returns nil.
+	Get(traceID string) *types.Trace
+	// Returns the desired fraction of oldest trace IDs in the cache.
+	// (e.g. if fract is 0.1, returns the oldest 10% of trace IDs)
+	GetOldest(fract float64) []string
+	// Returns up to n trace IDs from the cache; successive calls will return
+	// different trace IDs until all have been returned, then it will start over.
+	GetTraceIDs(n int) []string
+	// Removes a trace from the cache by traceID. If no trace with the traceID exists,
+	// does nothing.
+	Remove(traceID string)
+	// Returns the number of traces in the cache.
 	Len() int
-}
-
-// we're going to start with a naive implementation that uses a map
-// and doesn't try to be clever about memory usage or allocations
-type spanCache struct {
-	Clock clockwork.Clock `inject:""`
-	cache map[string]*types.Trace
-}
-
-// ensure that spanCache implements SpanCache
-var _ SpanCache = &spanCache{}
-
-// ensure that spanCache implements startstop.Starter
-var _ startstop.Starter = &spanCache{}
-
-// ensure that spanCache implements startstop.Stopper
-var _ startstop.Stopper = &spanCache{}
-
-func (sc *spanCache) Start() error {
-	sc.cache = make(map[string]*types.Trace)
-	return nil
-}
-
-func (sc *spanCache) Stop() error {
-	sc.cache = nil
-	return nil
-}
-
-func (sc *spanCache) Set(sp *types.Span) error {
-	traceID := sp.TraceID
-	trace, ok := sc.cache[traceID]
-	if !ok {
-		trace = &types.Trace{
-			APIHost:     sp.APIHost,
-			APIKey:      sp.APIKey,
-			Dataset:     sp.Dataset,
-			TraceID:     traceID,
-			ArrivalTime: sc.Clock.Now(),
-		}
-		sc.cache[traceID] = trace
-	}
-	trace.AddSpan(sp)
-	return nil
-}
-
-func (sc *spanCache) Get(traceID string) (*types.Trace, error) {
-	trace, ok := sc.cache[traceID]
-	if !ok {
-		return nil, nil
-	}
-	return trace, nil
-}
-
-func (sc *spanCache) GetOldest(n int) []*types.Trace {
-	// this is a naive implementation that just returns the first n traces
-	// in the cache. in a real implementation, we would want to sort the
-	// traces by arrival time and return the oldest n.
-	// It's useful for benchmarks because it's probably the fastest way to
-	// get n traces.
-	traces := make([]*types.Trace, 0, n)
-	for _, trace := range sc.cache {
-		traces = append(traces, trace)
-		if len(traces) == n {
-			break
-		}
-	}
-	return traces
-}
-
-func (sc *spanCache) Remove(traceID string) error {
-	delete(sc.cache, traceID)
-	return nil
-}
-
-func (sc *spanCache) Len() int {
-	return len(sc.cache)
+	// Clock returns the clock used by the cache.
+	GetClock() clockwork.Clock
 }

--- a/collect/cache/span_cache_basic.go
+++ b/collect/cache/span_cache_basic.go
@@ -1,0 +1,122 @@
+package cache
+
+import (
+	"sync"
+
+	"github.com/facebookgo/startstop"
+	"github.com/honeycombio/refinery/types"
+	"github.com/jonboulle/clockwork"
+)
+
+// this is a naive implementation that uses a map
+// and doesn't try to be clever about memory usage or allocations
+type spanCache_basic struct {
+	Clock   clockwork.Clock `inject:""`
+	cache   map[string]*types.Trace
+	current []string
+	nextix  int
+	mut     sync.RWMutex
+}
+
+// ensure that spanCache implements SpanCache
+var _ SpanCache = &spanCache_basic{}
+
+// ensure that spanCache implements startstop.Starter
+var _ startstop.Starter = &spanCache_basic{}
+
+// ensure that spanCache implements startstop.Stopper
+var _ startstop.Stopper = &spanCache_basic{}
+
+func (sc *spanCache_basic) Start() error {
+	sc.cache = make(map[string]*types.Trace)
+	return nil
+}
+
+func (sc *spanCache_basic) Stop() error {
+	sc.cache = nil
+	return nil
+}
+
+func (sc *spanCache_basic) GetClock() clockwork.Clock {
+	return sc.Clock
+}
+
+func (sc *spanCache_basic) Set(sp *types.Span) error {
+	sc.mut.Lock()
+	defer sc.mut.Unlock()
+	traceID := sp.TraceID
+	trace, ok := sc.cache[traceID]
+	if !ok {
+		trace = &types.Trace{
+			APIHost:     sp.APIHost,
+			APIKey:      sp.APIKey,
+			Dataset:     sp.Dataset,
+			TraceID:     traceID,
+			ArrivalTime: sc.Clock.Now(),
+		}
+		sc.cache[traceID] = trace
+	}
+	trace.AddSpan(sp)
+	return nil
+}
+
+func (sc *spanCache_basic) Get(traceID string) *types.Trace {
+	sc.mut.RLock()
+	defer sc.mut.RUnlock()
+	trace, ok := sc.cache[traceID]
+	if !ok {
+		return nil
+	}
+	return trace
+}
+
+// doesn't bother to sort the spans by arrival time, just returns the
+// appropriate fraction of traces
+func (sc *spanCache_basic) GetOldest(fract float64) []string {
+	n := int(float64(len(sc.cache)) * fract)
+	ret := make([]string, 0, n)
+	sc.mut.RLock()
+	i := 0
+	for traceID := range sc.cache {
+		ret = append(ret, traceID)
+		i++
+		if i >= n {
+			break
+		}
+	}
+	sc.mut.RUnlock()
+	return ret
+}
+
+// This gets a batch of up to n traceIDs from the cache; it's used to get a
+// batch of traceIDs to process in parallel. It snapshots the active map and
+// returns a slice of traceIDs that were current at the time of the call. It
+// will return successive slices of traceIDs until it has returned all of them,
+// then it will start over from a fresh snapshot.
+func (sc *spanCache_basic) GetTraceIDs(n int) []string {
+	// this is the only function that looks at current or nextix so it
+	// doesn't need to lock those fields
+	if sc.current == nil || sc.nextix >= len(sc.current) {
+		sc.mut.RLock()
+		sc.current = make([]string, 0, len(sc.cache))
+		for traceID := range sc.cache {
+			sc.current = append(sc.current, traceID)
+		}
+		sc.mut.RUnlock()
+		sc.nextix = 0
+	}
+	if sc.nextix+n > len(sc.current) {
+		n = len(sc.current) - sc.nextix
+	}
+	return sc.current[sc.nextix : sc.nextix+n]
+}
+
+func (sc *spanCache_basic) Remove(traceID string) {
+	sc.mut.Lock()
+	defer sc.mut.Unlock()
+	delete(sc.cache, traceID)
+}
+
+func (sc *spanCache_basic) Len() int {
+	return len(sc.cache)
+}

--- a/collect/cache/span_cache_basic.go
+++ b/collect/cache/span_cache_basic.go
@@ -13,7 +13,7 @@ import (
 
 // this is a naive implementation that uses a map
 // and doesn't try to be clever about memory usage or allocations
-type spanCache_basic struct {
+type SpanCache_basic struct {
 	Cfg   config.Config   `inject:""`
 	Clock clockwork.Clock `inject:""`
 	cache map[string]*types.Trace
@@ -26,21 +26,21 @@ type spanCache_basic struct {
 }
 
 // ensure that spanCache implements SpanCache
-var _ SpanCache = &spanCache_basic{}
+var _ SpanCache = &SpanCache_basic{}
 
 // ensure that spanCache implements startstop.Starter
-var _ startstop.Starter = &spanCache_basic{}
+var _ startstop.Starter = &SpanCache_basic{}
 
-func (sc *spanCache_basic) Start() error {
+func (sc *SpanCache_basic) Start() error {
 	sc.cache = make(map[string]*types.Trace)
 	return nil
 }
 
-func (sc *spanCache_basic) GetClock() clockwork.Clock {
+func (sc *SpanCache_basic) GetClock() clockwork.Clock {
 	return sc.Clock
 }
 
-func (sc *spanCache_basic) Set(sp *types.Span) error {
+func (sc *SpanCache_basic) Set(sp *types.Span) error {
 	sc.mut.Lock()
 	defer sc.mut.Unlock()
 	traceID := sp.TraceID
@@ -59,7 +59,7 @@ func (sc *spanCache_basic) Set(sp *types.Span) error {
 	return nil
 }
 
-func (sc *spanCache_basic) Get(traceID string) *types.Trace {
+func (sc *SpanCache_basic) Get(traceID string) *types.Trace {
 	sc.mut.RLock()
 	defer sc.mut.RUnlock()
 	trace, ok := sc.cache[traceID]
@@ -69,7 +69,7 @@ func (sc *spanCache_basic) Get(traceID string) *types.Trace {
 	return trace
 }
 
-func (sc *spanCache_basic) GetOldest(fract float64) []string {
+func (sc *SpanCache_basic) GetOldest(fract float64) []string {
 	type tidWithImpact struct {
 		id     string
 		impact int
@@ -112,7 +112,7 @@ func (sc *spanCache_basic) GetOldest(fract float64) []string {
 // then it will start over from a fresh snapshot.
 // GetTraceIDs is not concurrency-safe; it is intended to be called from a
 // single goroutine.
-func (sc *spanCache_basic) GetTraceIDs(n int) []string {
+func (sc *SpanCache_basic) GetTraceIDs(n int) []string {
 	// this is the only function that looks at current or nextix so it
 	// doesn't need to lock those fields
 	if sc.current == nil || sc.nextix >= len(sc.current) {
@@ -130,13 +130,13 @@ func (sc *spanCache_basic) GetTraceIDs(n int) []string {
 	return sc.current[sc.nextix : sc.nextix+n]
 }
 
-func (sc *spanCache_basic) Remove(traceID string) {
+func (sc *SpanCache_basic) Remove(traceID string) {
 	sc.mut.Lock()
 	defer sc.mut.Unlock()
 	delete(sc.cache, traceID)
 }
 
-func (sc *spanCache_basic) Len() int {
+func (sc *SpanCache_basic) Len() int {
 	sc.mut.RLock()
 	defer sc.mut.RUnlock()
 	return len(sc.cache)

--- a/collect/cache/span_cache_basic.go
+++ b/collect/cache/span_cache_basic.go
@@ -71,8 +71,6 @@ func (sc *spanCache_basic) Get(traceID string) *types.Trace {
 	return trace
 }
 
-// doesn't bother to sort the spans by arrival time, just returns the
-// appropriate fraction of traces
 func (sc *spanCache_basic) GetOldest(fract float64) []string {
 	n := int(float64(len(sc.cache)) * fract)
 	ids := make([]string, 0, len(sc.cache))

--- a/collect/cache/span_cache_complex.go
+++ b/collect/cache/span_cache_complex.go
@@ -1,0 +1,161 @@
+package cache
+
+import (
+	"sort"
+	"sync"
+
+	"github.com/facebookgo/startstop"
+	"github.com/honeycombio/refinery/config"
+	"github.com/honeycombio/refinery/types"
+	"github.com/jonboulle/clockwork"
+)
+
+// this cache is designed to be performant by pooling the allocated objects and
+// reusing them.
+// List of spans have capacity
+type spanCache_complex struct {
+	Cfg       config.Config   `inject:""`
+	Clock     clockwork.Clock `inject:""`
+	active    map[string]int
+	freeSlots []int
+	cache     []*types.Trace
+	current   []string
+	nextix    int
+	mut       sync.RWMutex
+}
+
+// ensure that spanCache implements SpanCache
+var _ SpanCache = &spanCache_complex{}
+
+// ensure that spanCache implements startstop.Starter
+var _ startstop.Starter = &spanCache_complex{}
+
+// ensure that spanCache implements startstop.Stopper
+var _ startstop.Stopper = &spanCache_complex{}
+
+func (sc *spanCache_complex) Start() error {
+	cfg, err := sc.Cfg.GetCollectionConfig()
+	if err != nil {
+		return err
+	}
+	sc.active = make(map[string]int, cfg.CacheCapacity)
+	sc.freeSlots = make([]int, 0, cfg.CacheCapacity)
+	sc.cache = make([]*types.Trace, 0, cfg.CacheCapacity)
+	return nil
+}
+
+func (sc *spanCache_complex) Stop() error {
+	sc.cache = nil
+	return nil
+}
+
+func (sc *spanCache_complex) GetClock() clockwork.Clock {
+	return sc.Clock
+}
+
+func (sc *spanCache_complex) Set(sp *types.Span) error {
+	var trace *types.Trace
+	traceID := sp.TraceID
+	sc.mut.Lock()
+	defer sc.mut.Unlock()
+	index, ok := sc.active[traceID]
+	if ok {
+		trace = sc.cache[index]
+	} else {
+		// we don't have a trace for this span yet so we need to set one up
+		// see if we have any free slots
+		if len(sc.freeSlots) > 0 {
+			// we have a free slot, so we can reuse it
+			// pop the last element off the freeSlots slice
+			index = sc.freeSlots[len(sc.freeSlots)-1]
+			sc.freeSlots = sc.freeSlots[:len(sc.freeSlots)-1]
+			trace = sc.cache[index]
+		} else {
+			// we don't have any free slots, so we need to allocate a new slot
+			// on the end of the cache
+			index = len(sc.cache)
+			trace = &types.Trace{}
+			sc.cache = append(sc.cache, trace)
+		}
+		sc.active[traceID] = index
+	}
+	trace.APIHost = sp.APIHost
+	trace.APIKey = sp.APIKey
+	trace.Dataset = sp.Dataset
+	trace.TraceID = traceID
+	trace.ArrivalTime = sc.Clock.Now()
+	trace.AddSpan(sp)
+	return nil
+}
+
+func (sc *spanCache_complex) Get(traceID string) *types.Trace {
+	sc.mut.RLock()
+	defer sc.mut.RUnlock()
+	index, ok := sc.active[traceID]
+	if !ok {
+		return nil
+	}
+	return sc.cache[index]
+}
+
+// Returns the oldest fraction of traces in the cache. This is used to decide
+// which traces to drop when the cache is full. It's moderately expensive
+// because it has to sort the traces by arrival time, but I couldn't find a
+// faster way to do it.
+func (sc *spanCache_complex) GetOldest(fract float64) []string {
+	n := int(float64(len(sc.active)) * fract)
+	ret := make([]string, 0, n)
+	sc.mut.RLock()
+	for traceID := range sc.active {
+		ret = append(ret, traceID)
+	}
+	sc.mut.RUnlock()
+	sort.Slice(ret, func(i, j int) bool {
+		t1 := sc.cache[sc.active[ret[i]]]
+		t2 := sc.cache[sc.active[ret[j]]]
+		return t1.ArrivalTime.Before(t2.ArrivalTime)
+	})
+	if len(ret) < n {
+		n = len(ret)
+	}
+	return ret[:n]
+}
+
+// This gets a batch of up to n traceIDs from the cache; it's used to get a
+// batch of traceIDs to process in parallel. It snapshots the active map and
+// returns a slice of traceIDs that were current at the time of the call. It
+// will return successive slices of traceIDs until it has returned all of them,
+// then it will start over from a fresh snapshot.
+func (sc *spanCache_complex) GetTraceIDs(n int) []string {
+	// this is the only function that looks at current or nextix so it
+	// doesn't need to lock those fields
+	if sc.current == nil || sc.nextix >= len(sc.current) {
+		sc.mut.RLock()
+		sc.current = make([]string, 0, len(sc.active))
+		for traceID := range sc.active {
+			sc.current = append(sc.current, traceID)
+		}
+		sc.mut.RUnlock()
+		sc.nextix = 0
+	}
+	if sc.nextix+n > len(sc.current) {
+		n = len(sc.current) - sc.nextix
+	}
+	return sc.current[sc.nextix : sc.nextix+n]
+}
+
+func (sc *spanCache_complex) Remove(traceID string) {
+	sc.mut.Lock()
+	defer sc.mut.Unlock()
+	index, ok := sc.active[traceID]
+	if !ok {
+		return
+	}
+	// we don't have to touch the cache itself, just the active map and the freeSlots
+	delete(sc.active, traceID)
+	sc.freeSlots = append(sc.freeSlots, index)
+}
+
+func (sc *spanCache_complex) Len() int {
+	return len(sc.active)
+}

--- a/collect/cache/span_cache_complex.go
+++ b/collect/cache/span_cache_complex.go
@@ -125,8 +125,6 @@ func (sc *spanCache_complex) GetOldest(fract float64) []string {
 	for i := 0; i < n; i++ {
 		ret[i] = sc.cache[ids[i]].TraceID
 	}
-
-	// truncate the slice to the desired length AND capacity without reallocating
 	return ret
 }
 

--- a/collect/cache/span_cache_complex.go
+++ b/collect/cache/span_cache_complex.go
@@ -14,7 +14,7 @@ import (
 // this cache is designed to be performant by pooling the allocated objects and
 // reusing them.
 // List of spans have capacity
-type spanCache_complex struct {
+type SpanCache_complex struct {
 	Cfg       config.Config   `inject:""`
 	Clock     clockwork.Clock `inject:""`
 	active    map[string]int
@@ -29,12 +29,12 @@ type spanCache_complex struct {
 }
 
 // ensure that spanCache implements SpanCache
-var _ SpanCache = &spanCache_complex{}
+var _ SpanCache = &SpanCache_complex{}
 
 // ensure that spanCache implements startstop.Starter
-var _ startstop.Starter = &spanCache_complex{}
+var _ startstop.Starter = &SpanCache_complex{}
 
-func (sc *spanCache_complex) Start() error {
+func (sc *SpanCache_complex) Start() error {
 	cfg, err := sc.Cfg.GetCollectionConfig()
 	if err != nil {
 		return err
@@ -45,11 +45,11 @@ func (sc *spanCache_complex) Start() error {
 	return nil
 }
 
-func (sc *spanCache_complex) GetClock() clockwork.Clock {
+func (sc *SpanCache_complex) GetClock() clockwork.Clock {
 	return sc.Clock
 }
 
-func (sc *spanCache_complex) Set(sp *types.Span) error {
+func (sc *SpanCache_complex) Set(sp *types.Span) error {
 	var trace *types.Trace
 	traceID := sp.TraceID
 	sc.mut.Lock()
@@ -84,7 +84,7 @@ func (sc *spanCache_complex) Set(sp *types.Span) error {
 	return nil
 }
 
-func (sc *spanCache_complex) Get(traceID string) *types.Trace {
+func (sc *SpanCache_complex) Get(traceID string) *types.Trace {
 	sc.mut.RLock()
 	defer sc.mut.RUnlock()
 	index, ok := sc.active[traceID]
@@ -98,7 +98,7 @@ func (sc *spanCache_complex) Get(traceID string) *types.Trace {
 // which traces to drop when the cache is full. It's moderately expensive
 // because it has to sort the traces by arrival time, but I couldn't find a
 // faster way to do it.
-func (sc *spanCache_complex) GetOldest(fract float64) []string {
+func (sc *SpanCache_complex) GetOldest(fract float64) []string {
 	type tidWithImpact struct {
 		id     string
 		impact int
@@ -142,7 +142,7 @@ func (sc *spanCache_complex) GetOldest(fract float64) []string {
 // then it will start over from a fresh snapshot.
 // GetTraceIDs is not concurrency-safe; it is intended to be called from a
 // single goroutine.
-func (sc *spanCache_complex) GetTraceIDs(n int) []string {
+func (sc *SpanCache_complex) GetTraceIDs(n int) []string {
 	// this is the only function that looks at current or nextix so it
 	// doesn't need to lock those fields
 	if sc.current == nil || sc.nextix >= len(sc.current) {
@@ -160,7 +160,7 @@ func (sc *spanCache_complex) GetTraceIDs(n int) []string {
 	return sc.current[sc.nextix : sc.nextix+n]
 }
 
-func (sc *spanCache_complex) Remove(traceID string) {
+func (sc *SpanCache_complex) Remove(traceID string) {
 	sc.mut.Lock()
 	defer sc.mut.Unlock()
 	index, ok := sc.active[traceID]
@@ -172,7 +172,7 @@ func (sc *spanCache_complex) Remove(traceID string) {
 	sc.freeSlots = append(sc.freeSlots, index)
 }
 
-func (sc *spanCache_complex) Len() int {
+func (sc *SpanCache_complex) Len() int {
 	sc.mut.RLock()
 	defer sc.mut.RUnlock()
 	return len(sc.active)

--- a/collect/cache/span_cache_test.go
+++ b/collect/cache/span_cache_test.go
@@ -1,106 +1,247 @@
 package cache
 
 import (
+	"math/rand"
 	"testing"
 
+	"github.com/facebookgo/startstop"
+	"github.com/honeycombio/refinery/config"
 	"github.com/honeycombio/refinery/types"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestXxx(t *testing.T) {
-	c := spanCache{
-		Clock: clockwork.NewFakeClock(),
-	}
-	err := c.Start()
-	require.NoError(t, err)
-	defer c.Stop()
-
-	// test that we can add a span
-	span := &types.Span{
-		TraceID: "trace1",
-		Event: types.Event{
-			APIHost: "apihost",
-			APIKey:  "apikey",
-			Dataset: "dataset",
+func getCache(typ string, clock clockwork.Clock) SpanCache {
+	cfg := &config.MockConfig{
+		GetCollectionConfigVal: config.CollectionConfig{
+			CacheCapacity: 10000,
 		},
 	}
-	err = c.Set(span)
-	require.NoError(t, err)
+	switch typ {
+	case "basic":
+		return &spanCache_basic{
+			Clock: clock,
+		}
+	case "complex":
+		return &spanCache_complex{
+			Cfg:   cfg,
+			Clock: clock,
+		}
+	default:
+		panic("unknown cache type")
+	}
+}
 
-	// test that we can retrieve the span
-	trace, err := c.Get("trace1")
-	require.NoError(t, err)
-	assert.Equal(t, "trace1", trace.TraceID)
-	assert.Equal(t, "apihost", trace.APIHost)
-	assert.Equal(t, "apikey", trace.APIKey)
-	assert.Equal(t, "dataset", trace.Dataset)
-	assert.Equal(t, c.Clock.Now(), trace.ArrivalTime)
-	assert.Equal(t, 1, c.Len())
+func TestSpanCache(t *testing.T) {
+	for _, typ := range []string{"basic", "complex"} {
+		c := getCache(typ, clockwork.NewFakeClock())
+		t.Run(typ, func(t *testing.T) {
 
-	// test that we can remove the span
-	err = c.Remove("trace1")
-	require.NoError(t, err)
-	_, err = c.Get("trace1")
-	require.NoError(t, err) // should not return an error
-	require.Equal(t, 0, c.Len())
+			err := c.(startstop.Starter).Start()
+			require.NoError(t, err)
+			defer c.(startstop.Stopper).Stop()
+
+			// test that we can add a span
+			span := &types.Span{
+				TraceID: "trace1",
+				Event: types.Event{
+					APIHost: "apihost",
+					APIKey:  "apikey",
+					Dataset: "dataset",
+				},
+			}
+			err = c.Set(span)
+			require.NoError(t, err)
+
+			// test that we can retrieve the span
+			trace := c.Get("trace1")
+			assert.Equal(t, "trace1", trace.TraceID)
+			assert.Equal(t, "apihost", trace.APIHost)
+			assert.Equal(t, "apikey", trace.APIKey)
+			assert.Equal(t, "dataset", trace.Dataset)
+			// assert.Equal(t, c.Clock.Now(), trace.ArrivalTime)
+			assert.Equal(t, 1, c.Len())
+
+			// test that we can remove the span
+			c.Remove("trace1")
+			c.Get("trace1")
+			require.Equal(t, 0, c.Len())
+		})
+	}
 }
 
 func BenchmarkSpanCacheAdd(b *testing.B) {
-	c := spanCache{
-		Clock: clockwork.NewFakeClock(),
-	}
-	c.Start()
-	defer c.Stop()
+	for _, typ := range []string{"basic", "complex"} {
+		c := getCache(typ, clockwork.NewFakeClock())
+		b.Run(typ, func(b *testing.B) {
 
-	ids := make([]string, b.N)
-	for i := 0; i < b.N; i++ {
-		ids[i] = genID(32)
-	}
-	evt := types.Event{
-		APIHost: "apihost",
-		APIKey:  "apikey",
-		Dataset: "dataset",
-	}
-	b.ResetTimer()
+			c.(startstop.Starter).Start()
+			defer c.(startstop.Stopper).Stop()
 
-	for i := 0; i < b.N; i++ {
-		span := &types.Span{
-			TraceID: "",
-			Event:   evt,
-		}
-		c.Set(span)
+			ids := make([]string, b.N)
+			for i := 0; i < b.N; i++ {
+				ids[i] = genID(32)
+			}
+			evt := types.Event{
+				APIHost: "apihost",
+				APIKey:  "apikey",
+				Dataset: "dataset",
+			}
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				span := &types.Span{
+					TraceID: ids[i],
+					Event:   evt,
+				}
+				c.Set(span)
+			}
+		})
 	}
 }
 
 func BenchmarkSpanCacheGet(b *testing.B) {
-	c := spanCache{
-		Clock: clockwork.NewFakeClock(),
-	}
-	c.Start()
-	defer c.Stop()
+	for _, typ := range []string{"basic", "complex"} {
+		c := getCache(typ, clockwork.NewFakeClock())
+		b.Run(typ, func(b *testing.B) {
 
-	ids := make([]string, b.N)
-	for i := 0; i < b.N; i++ {
-		ids[i] = genID(32)
-	}
-	evt := types.Event{
-		APIHost: "apihost",
-		APIKey:  "apikey",
-		Dataset: "dataset",
-	}
+			c.(startstop.Starter).Start()
+			defer c.(startstop.Stopper).Stop()
 
-	for i := 0; i < b.N; i++ {
-		span := &types.Span{
-			TraceID: "",
-			Event:   evt,
-		}
-		c.Set(span)
-	}
-	b.ResetTimer()
+			ids := make([]string, b.N)
+			for i := 0; i < b.N; i++ {
+				ids[i] = genID(32)
+			}
+			evt := types.Event{
+				APIHost: "apihost",
+				APIKey:  "apikey",
+				Dataset: "dataset",
+			}
 
-	for i := 0; i < b.N; i++ {
-		c.Get(ids[i])
+			for i := 0; i < b.N; i++ {
+				span := &types.Span{
+					TraceID: ids[i],
+					Event:   evt,
+				}
+				c.Set(span)
+			}
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				c.Get(ids[i])
+			}
+		})
+	}
+}
+
+func BenchmarkSpanCacheGetTraceIDs(b *testing.B) {
+	for _, typ := range []string{"basic", "complex"} {
+		c := getCache(typ, clockwork.NewFakeClock())
+		b.Run(typ, func(b *testing.B) {
+
+			c.(startstop.Starter).Start()
+			defer c.(startstop.Stopper).Stop()
+
+			ids := make([]string, b.N)
+			for i := 0; i < b.N; i++ {
+				ids[i] = genID(32)
+			}
+			evt := types.Event{
+				APIHost: "apihost",
+				APIKey:  "apikey",
+				Dataset: "dataset",
+			}
+
+			for i := 0; i < b.N; i++ {
+				span := &types.Span{
+					TraceID: ids[i],
+					Event:   evt,
+				}
+				c.Set(span)
+			}
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				c.GetTraceIDs(50)
+			}
+		})
+	}
+}
+func BenchmarkSpanCacheGetOldest(b *testing.B) {
+	for _, typ := range []string{"basic", "complex"} {
+		c := getCache(typ, clockwork.NewRealClock())
+		b.Run(typ, func(b *testing.B) {
+
+			c.(startstop.Starter).Start()
+			defer c.(startstop.Stopper).Stop()
+
+			ids := make([]string, b.N)
+			for i := 0; i < b.N; i++ {
+				ids[i] = genID(32)
+			}
+			evt := types.Event{
+				APIHost: "apihost",
+				APIKey:  "apikey",
+				Dataset: "dataset",
+			}
+
+			for i := 0; i < b.N; i++ {
+				span := &types.Span{
+					TraceID:     ids[i],
+					Event:       evt,
+					ArrivalTime: c.GetClock().Now(),
+				}
+				c.Set(span)
+			}
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				c.GetOldest(.10)
+			}
+		})
+	}
+}
+
+func BenchmarkSpanCacheMixed(b *testing.B) {
+	const numIDs = 10000
+	for _, typ := range []string{"basic", "complex"} {
+		c := getCache(typ, clockwork.NewFakeClock())
+		b.Run(typ, func(b *testing.B) {
+
+			c.(startstop.Starter).Start()
+			defer c.(startstop.Stopper).Stop()
+
+			ids := make([]string, numIDs)
+			for i := 0; i < numIDs; i++ {
+				ids[i] = genID(32)
+			}
+			evt := types.Event{
+				APIHost: "apihost",
+				APIKey:  "apikey",
+				Dataset: "dataset",
+			}
+
+			b.ResetTimer()
+			// we have numIDs IDs, and we'll iterate and for each
+			// ID we'll either:
+			// - add a span (80% of the time)
+			// - get a trace (10% of the time)
+			// - delete a trace (10% of the time)
+			for i := 0; i < b.N; i++ {
+				switch rand.Intn(10) {
+				case 0:
+					c.Remove(ids[i%numIDs])
+				case 1:
+					c.Get(ids[i%numIDs])
+				default:
+					span := &types.Span{
+						TraceID: ids[i%numIDs],
+						Event:   evt,
+					}
+					c.Set(span)
+				}
+			}
+		})
 	}
 }

--- a/collect/cache/span_cache_test.go
+++ b/collect/cache/span_cache_test.go
@@ -22,12 +22,12 @@ func getCache(typ string, clock clockwork.Clock) SpanCache {
 	}
 	switch typ {
 	case "basic":
-		return &spanCache_basic{
+		return &SpanCache_basic{
 			Cfg:   cfg,
 			Clock: clock,
 		}
 	case "complex":
-		return &spanCache_complex{
+		return &SpanCache_complex{
 			Cfg:   cfg,
 			Clock: clock,
 		}

--- a/collect/cache/span_cache_test.go
+++ b/collect/cache/span_cache_test.go
@@ -40,7 +40,6 @@ func TestSpanCache(t *testing.T) {
 
 			err := c.(startstop.Starter).Start()
 			require.NoError(t, err)
-			defer c.(startstop.Stopper).Stop()
 
 			// test that we can add a span
 			span := &types.Span{
@@ -65,8 +64,9 @@ func TestSpanCache(t *testing.T) {
 
 			// test that we can remove the span
 			c.Remove("trace1")
-			c.Get("trace1")
-			require.Equal(t, 0, c.Len())
+			trace = c.Get("trace1")
+			assert.Nil(t, trace)
+			assert.Equal(t, 0, c.Len())
 		})
 	}
 }
@@ -78,7 +78,6 @@ func TestGetOldest(t *testing.T) {
 
 			err := c.(startstop.Starter).Start()
 			require.NoError(t, err)
-			defer c.(startstop.Stopper).Stop()
 
 			const numIDs = 20
 			ids := make([]string, numIDs)
@@ -114,7 +113,6 @@ func BenchmarkSpanCacheAdd(b *testing.B) {
 		b.Run(typ, func(b *testing.B) {
 
 			c.(startstop.Starter).Start()
-			defer c.(startstop.Stopper).Stop()
 
 			ids := make([]string, b.N)
 			for i := 0; i < b.N; i++ {
@@ -144,7 +142,6 @@ func BenchmarkSpanCacheGet(b *testing.B) {
 		b.Run(typ, func(b *testing.B) {
 
 			c.(startstop.Starter).Start()
-			defer c.(startstop.Stopper).Stop()
 
 			ids := make([]string, b.N)
 			for i := 0; i < b.N; i++ {
@@ -178,7 +175,6 @@ func BenchmarkSpanCacheGetTraceIDs(b *testing.B) {
 		b.Run(typ, func(b *testing.B) {
 
 			c.(startstop.Starter).Start()
-			defer c.(startstop.Stopper).Stop()
 
 			ids := make([]string, b.N)
 			for i := 0; i < b.N; i++ {
@@ -212,7 +208,6 @@ func BenchmarkSpanCacheGetOldest(b *testing.B) {
 		b.Run(typ, func(b *testing.B) {
 
 			c.(startstop.Starter).Start()
-			defer c.(startstop.Stopper).Stop()
 
 			ids := make([]string, b.N)
 			for i := 0; i < b.N; i++ {
@@ -248,7 +243,6 @@ func BenchmarkSpanCacheMixed(b *testing.B) {
 		b.Run(typ, func(b *testing.B) {
 
 			c.(startstop.Starter).Start()
-			defer c.(startstop.Stopper).Stop()
 
 			ids := make([]string, numIDs)
 			for i := 0; i < numIDs; i++ {

--- a/collect/cache/span_cache_test.go
+++ b/collect/cache/span_cache_test.go
@@ -1,0 +1,106 @@
+package cache
+
+import (
+	"testing"
+
+	"github.com/honeycombio/refinery/types"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestXxx(t *testing.T) {
+	c := spanCache{
+		Clock: clockwork.NewFakeClock(),
+	}
+	err := c.Start()
+	require.NoError(t, err)
+	defer c.Stop()
+
+	// test that we can add a span
+	span := &types.Span{
+		TraceID: "trace1",
+		Event: types.Event{
+			APIHost: "apihost",
+			APIKey:  "apikey",
+			Dataset: "dataset",
+		},
+	}
+	err = c.Set(span)
+	require.NoError(t, err)
+
+	// test that we can retrieve the span
+	trace, err := c.Get("trace1")
+	require.NoError(t, err)
+	assert.Equal(t, "trace1", trace.TraceID)
+	assert.Equal(t, "apihost", trace.APIHost)
+	assert.Equal(t, "apikey", trace.APIKey)
+	assert.Equal(t, "dataset", trace.Dataset)
+	assert.Equal(t, c.Clock.Now(), trace.ArrivalTime)
+	assert.Equal(t, 1, c.Len())
+
+	// test that we can remove the span
+	err = c.Remove("trace1")
+	require.NoError(t, err)
+	_, err = c.Get("trace1")
+	require.NoError(t, err) // should not return an error
+	require.Equal(t, 0, c.Len())
+}
+
+func BenchmarkSpanCacheAdd(b *testing.B) {
+	c := spanCache{
+		Clock: clockwork.NewFakeClock(),
+	}
+	c.Start()
+	defer c.Stop()
+
+	ids := make([]string, b.N)
+	for i := 0; i < b.N; i++ {
+		ids[i] = genID(32)
+	}
+	evt := types.Event{
+		APIHost: "apihost",
+		APIKey:  "apikey",
+		Dataset: "dataset",
+	}
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		span := &types.Span{
+			TraceID: "",
+			Event:   evt,
+		}
+		c.Set(span)
+	}
+}
+
+func BenchmarkSpanCacheGet(b *testing.B) {
+	c := spanCache{
+		Clock: clockwork.NewFakeClock(),
+	}
+	c.Start()
+	defer c.Stop()
+
+	ids := make([]string, b.N)
+	for i := 0; i < b.N; i++ {
+		ids[i] = genID(32)
+	}
+	evt := types.Event{
+		APIHost: "apihost",
+		APIKey:  "apikey",
+		Dataset: "dataset",
+	}
+
+	for i := 0; i < b.N; i++ {
+		span := &types.Span{
+			TraceID: "",
+			Event:   evt,
+		}
+		c.Set(span)
+	}
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		c.Get(ids[i])
+	}
+}


### PR DESCRIPTION
This contains two implementations of a span cache; `basic` is basically just a map of traceID to trace. The second, `complex`, trades off complexity and slightly slower performance for an implementation that tries to avoid allocating memory most of the time. This may prove valuable in a very high-throughput environment, but today I can't prove it -- in all the benchmarks I've written, the *only* advantage is low-allocation. So we have both implementations and we can play with them in a working refinery.

One thing that I tried was to avoid the big sort in GetOldest; I implemented an attempt to use a tdigest to find the threshold so that I could avoid the sort, but the tdigest was more expensive than sorting, even with 1 million items in the list, so I've abandoned that approach. Sorting a slice of ints is really fast even for big lists.

I'm now using the same cache impact calculation as was already in use for the previous span cache. 

## Which problem is this PR solving?

The dynscaling system needs a new kind of cache for traces. This defines the interface and also has two implementations to choose from.

## Short description of the changes

- Define an interface
- Basic implementation of span cache
- Complex implementation that avoids some memory allocations
- Tests and benchmarks


