### PR TITLE
feat: add SpanNames config for getting SpanNames

### DIFF
--- a/config.md
+++ b/config.md
@@ -1,7 +1,7 @@
 # Honeycomb Refinery Configuration Documentation
 
 This is the documentation for the configuration file for Honeycomb's Refinery.
-It was automatically generated on 2024-03-22 at 02:37:42 UTC.
+It was automatically generated on 2024-03-27 at 19:47:28 UTC.
 
 ## The Config file
 
@@ -1031,6 +1031,16 @@ A trace without a `parent_id` is assumed to be a root span.
 - Eligible for live reload.
 - Type: `stringarray`
 - Example: `trace.parent_id,parentId`
+
+### `SpanNames`
+
+SpanNames is the list of field names to use for the span ID.
+
+The first field in the list that is present in an event will be used as the span ID.
+
+- Eligible for live reload.
+- Type: `stringarray`
+- Example: `trace.span_id,spanId`
 
 ## gRPC Server Parameters
 

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -1344,6 +1344,19 @@ groups:
           as the parent ID. A trace without a `parent_id` is assumed to be a
           root span.
 
+      - name: SpanNames
+        type: stringarray
+        valuetype: stringarray
+        example: "trace.span_id,spanId"
+        reload: true
+        validations:
+          - type: elementType
+            arg: string
+        summary: is the list of field names to use for the span ID.
+        description: >
+          The first field in the list that is present in an event will be used
+          as the span ID. 
+
   - name: GRPCServerParameters
     title: "gRPC Server Parameters"
     description: >

--- a/config_complete.yaml
+++ b/config_complete.yaml
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created on 2024-03-22 at 02:37:41 UTC from ../../config.yaml using a template generated on 2024-03-22 at 02:37:39 UTC
+# created on 2024-03-27 at 19:47:27 UTC from ../../config.yaml using a template generated on 2024-03-27 at 19:47:25 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of
@@ -1066,6 +1066,16 @@ IDFields:
     # ParentNames:
       # - trace.parent_id
       # - parentId
+
+    ## SpanNames is the list of field names to use for the span ID.
+    ##
+    ## The first field in the list that is present in an event will be used
+    ## as the span ID.
+    ##
+    ## Eligible for live reload.
+    # SpanNames:
+      # - trace.span_id
+      # - spanId
 
 ############################
 ## gRPC Server Parameters ##

--- a/refinery_config.md
+++ b/refinery_config.md
@@ -1017,6 +1017,16 @@ A trace without a `parent_id` is assumed to be a root span.
 - Type: `stringarray`
 - Example: `trace.parent_id,parentId`
 
+### `SpanNames`
+
+`SpanNames` is the list of field names to use for the span ID.
+
+The first field in the list that is present in an event will be used as the span ID.
+
+- Eligible for live reload.
+- Type: `stringarray`
+- Example: `trace.span_id,spanId`
+
 ## gRPC Server Parameters
 
 `GRPCServerParameters` controls the parameters of the gRPC server used to receive OpenTelemetry data in gRPC format.

--- a/tools/convert/configDataNames.txt
+++ b/tools/convert/configDataNames.txt
@@ -1,5 +1,5 @@
 # Names of groups and fields in the new config file format.
-# Automatically generated on 2024-03-22 at 02:37:40 UTC.
+# Automatically generated on 2024-03-27 at 19:47:26 UTC.
 
 General:
   - ConfigurationVersion
@@ -201,6 +201,8 @@ IDFields:
   - TraceNames
 
   - ParentNames
+
+  - SpanNames
 
 
 GRPCServerParameters:

--- a/tools/convert/minimal_config.yaml
+++ b/tools/convert/minimal_config.yaml
@@ -1,5 +1,5 @@
 # sample uncommented config file containing all possible fields
-# automatically generated on 2024-03-22 at 02:37:40 UTC
+# automatically generated on 2024-03-27 at 19:47:26 UTC
 General:
   ConfigurationVersion: 2
   MinRefineryVersion: "v2.0"
@@ -116,6 +116,10 @@ IDFields:
   ParentNames: 
     - "trace.parent_id"
     - parentId
+
+  SpanNames: 
+    - "trace.span_id"
+    - spanId
 
 GRPCServerParameters:
   Enabled: true

--- a/tools/convert/templates/configV2.tmpl
+++ b/tools/convert/templates/configV2.tmpl
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created {{ now }} from {{ .Input }} using a template generated on 2024-03-22 at 02:37:39 UTC
+# created {{ now }} from {{ .Input }} using a template generated on 2024-03-27 at 19:47:25 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of
@@ -1056,6 +1056,14 @@ IDFields:
     ##
     ## Eligible for live reload.
     {{ renderStringarray .Data "ParentNames" "ParentNames" "trace.parent_id,parentId" }}
+
+    ## SpanNames is the list of field names to use for the span ID.
+    ##
+    ## The first field in the list that is present in an event will be used
+    ## as the span ID.
+    ##
+    ## Eligible for live reload.
+    {{ renderStringarray .Data "SpanNames" "SpanNames" "trace.span_id,spanId" }}
 
 ############################
 ## gRPC Server Parameters ##


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

Allow getting span ids from each event sent to refinery

## Short description of the changes

Add a new config option for specifying span ID field name
