### PR TITLE
maint: Remove error return from (almost) all the get functions in config

### DIFF
--- a/collect/cache/span_cache_basic.go
+++ b/collect/cache/span_cache_basic.go
@@ -3,7 +3,6 @@ package cache
 import (
 	"sort"
 	"sync"
-	"time"
 
 	"github.com/facebookgo/startstop"
 	"github.com/honeycombio/refinery/config"
@@ -76,11 +75,7 @@ func (sc *SpanCache_basic) GetOldest(fract float64) []string {
 	}
 	n := int(float64(len(sc.cache)) * fract)
 	ids := make([]tidWithImpact, 0, len(sc.cache))
-
-	timeout, err := sc.Cfg.GetTraceTimeout()
-	if err != nil {
-		timeout = 60 * time.Second
-	}
+	timeout := sc.Cfg.GetTraceTimeout()
 
 	sc.mut.RLock()
 	for traceID := range sc.cache {

--- a/collect/cache/span_cache_complex.go
+++ b/collect/cache/span_cache_complex.go
@@ -3,7 +3,6 @@ package cache
 import (
 	"sort"
 	"sync"
-	"time"
 
 	"github.com/facebookgo/startstop"
 	"github.com/honeycombio/refinery/config"
@@ -35,10 +34,7 @@ var _ SpanCache = &SpanCache_complex{}
 var _ startstop.Starter = &SpanCache_complex{}
 
 func (sc *SpanCache_complex) Start() error {
-	cfg, err := sc.Cfg.GetCollectionConfig()
-	if err != nil {
-		return err
-	}
+	cfg := sc.Cfg.GetCollectionConfig()
 	sc.active = make(map[string]int, cfg.CacheCapacity)
 	sc.freeSlots = make([]int, 0, cfg.CacheCapacity)
 	sc.cache = make([]*types.Trace, 0, cfg.CacheCapacity)
@@ -105,11 +101,7 @@ func (sc *SpanCache_complex) GetOldest(fract float64) []string {
 	}
 	n := int(float64(len(sc.active)) * fract)
 	ids := make([]tidWithImpact, 0, len(sc.active))
-
-	timeout, err := sc.Cfg.GetTraceTimeout()
-	if err != nil {
-		timeout = 60 * time.Second
-	}
+	timeout := sc.Cfg.GetTraceTimeout()
 
 	sc.mut.RLock()
 	for _, ix := range sc.active {

--- a/collect/central_collector.go
+++ b/collect/central_collector.go
@@ -46,10 +46,7 @@ type CentralCollector struct {
 
 func (c *CentralCollector) Start() error {
 	// call reload config and then get the updated unique fields
-	collectorCfg, err := c.Config.GetCollectionConfig()
-	if err != nil {
-		return err
-	}
+	collectorCfg := c.Config.GetCollectionConfig()
 
 	// listen for config reloads
 	c.Config.RegisterReloadCallback(c.sendReloadSignal)
@@ -194,12 +191,12 @@ func (c *CentralCollector) sendTracesForDecision() {
 }
 
 func (c *CentralCollector) checkAlloc() {
-	inMemConfig, err := c.Config.GetCollectionConfig()
+	inMemConfig := c.Config.GetCollectionConfig()
 	maxAlloc := inMemConfig.GetMaxAlloc()
 
 	var mem runtime.MemStats
 	runtime.ReadMemStats(&mem)
-	if err != nil || maxAlloc == 0 || mem.Alloc < uint64(maxAlloc) {
+	if maxAlloc == 0 || mem.Alloc < uint64(maxAlloc) {
 		return
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -25,11 +25,11 @@ type Config interface {
 
 	// GetListenAddr returns the address and port on which to listen for
 	// incoming events
-	GetListenAddr() (string, error)
+	GetListenAddr() string
 
 	// GetPeerListenAddr returns the address and port on which to listen for
 	// peer traffic
-	GetPeerListenAddr() (string, error)
+	GetPeerListenAddr() string
 
 	// GetHTTPIdleTimeout returns the idle timeout for refinery's HTTP server
 	GetHTTPIdleTimeout() time.Duration
@@ -43,7 +43,7 @@ type Config interface {
 
 	// GetGRPCListenAddr returns the address and port on which to listen for
 	// incoming events over gRPC
-	GetGRPCListenAddr() (string, error)
+	GetGRPCListenAddr() string
 
 	// Returns the entire GRPC config block
 	GetGRPCConfig() GRPCServerParameters
@@ -52,25 +52,25 @@ type Config interface {
 	IsAPIKeyValid(key string) bool
 
 	// GetPeers returns a list of other servers participating in this proxy cluster
-	GetPeers() ([]string, error)
+	GetPeers() []string
 
-	GetPeerManagementType() (string, error)
+	GetPeerManagementType() string
 
 	// GetRedisHost returns the address of a Redis instance to use for peer
 	// management.
-	GetRedisHost() (string, error)
+	GetRedisHost() string
 
 	// GetRedisUsername returns the username of a Redis instance to use for peer
 	// management.
-	GetRedisUsername() (string, error)
+	GetRedisUsername() string
 
 	// GetRedisPassword returns the password of a Redis instance to use for peer
 	// management.
-	GetRedisPassword() (string, error)
+	GetRedisPassword() string
 
 	// GetRedisAuthCode returns the AUTH string to use for connecting to a Redis
 	// instance to use for peer management
-	GetRedisAuthCode() (string, error)
+	GetRedisAuthCode() string
 
 	// GetRedisPrefix returns the prefix string used in the keys for peer
 	// management.
@@ -81,10 +81,10 @@ type Config interface {
 
 	// GetUseTLS returns true when TLS must be enabled to dial the Redis instance to
 	// use for peer management.
-	GetUseTLS() (bool, error)
+	GetUseTLS() bool
 
 	// UseTLSInsecure returns true when certificate checks are disabled
-	GetUseTLSInsecure() (bool, error)
+	GetUseTLSInsecure() bool
 
 	GetRedisMaxIdle() int
 
@@ -92,11 +92,11 @@ type Config interface {
 
 	// GetHoneycombAPI returns the base URL (protocol, hostname, and port) of
 	// the upstream Honeycomb API server
-	GetHoneycombAPI() (string, error)
+	GetHoneycombAPI() string
 
 	// GetSendDelay returns the number of seconds to pause after a trace is
 	// complete before sending it, to allow stragglers to arrive
-	GetSendDelay() (time.Duration, error)
+	GetSendDelay() time.Duration
 
 	// GetBatchTimeout returns how often to send off batches in seconds
 	GetBatchTimeout() time.Duration
@@ -104,33 +104,33 @@ type Config interface {
 	// GetTraceTimeout is how long to wait before sending a trace even if it's
 	// not complete. This should be longer than the longest expected trace
 	// duration.
-	GetTraceTimeout() (time.Duration, error)
+	GetTraceTimeout() time.Duration
 
 	// GetMaxBatchSize is the number of events to be included in the batch for sending
 	GetMaxBatchSize() uint
 
 	// GetLoggerType returns the type of the logger to use. Valid types are in
 	// the logger package
-	GetLoggerType() (string, error)
+	GetLoggerType() string
 
 	// GetLoggerLevel returns the level of the logger to use.
 	GetLoggerLevel() Level
 
 	// GetHoneycombLoggerConfig returns the config specific to the HoneycombLogger
-	GetHoneycombLoggerConfig() (HoneycombLoggerConfig, error)
+	GetHoneycombLoggerConfig() HoneycombLoggerConfig
 
 	// GetStdoutLoggerConfig returns the config specific to the StdoutLogger
-	GetStdoutLoggerConfig() (StdoutLoggerConfig, error)
+	GetStdoutLoggerConfig() StdoutLoggerConfig
 
 	// GetCollectionConfig returns the config specific to the InMemCollector
-	GetCollectionConfig() (CollectionConfig, error)
+	GetCollectionConfig() CollectionConfig
 
 	// GetSamplerConfigForDestName returns the sampler type and name to use for
 	// the given destination (environment, or dataset in classic)
 	GetSamplerConfigForDestName(string) (interface{}, string, error)
 
 	// GetAllSamplerRules returns all rules in a single map, including the default rules
-	GetAllSamplerRules() (*V2SamplerConfig, error)
+	GetAllSamplerRules() *V2SamplerConfig
 
 	// GetLegacyMetricsConfig returns the config specific to LegacyMetrics
 	GetLegacyMetricsConfig() LegacyMetricsConfig
@@ -151,18 +151,18 @@ type Config interface {
 	// libhoney client
 	GetPeerBufferSize() int
 
-	GetIdentifierInterfaceName() (string, error)
+	GetIdentifierInterfaceName() string
 
-	GetUseIPV6Identifier() (bool, error)
+	GetUseIPV6Identifier() bool
 
-	GetRedisIdentifier() (string, error)
+	GetRedisIdentifier() string
 
 	// GetSendTickerValue returns the duration to use to check for traces to send
 	GetSendTickerValue() time.Duration
 
 	// GetDebugServiceAddr sets the IP and port the debug service will run on (you must provide the
 	// command line flag -d to start the debug service)
-	GetDebugServiceAddr() (string, error)
+	GetDebugServiceAddr() string
 
 	GetIsDryRun() bool
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -74,7 +74,7 @@ func TestGRPCListenAddrEnvVar(t *testing.T) {
 	c, err := getConfig([]string{"--no-validate", "--config", "../config.yaml", "--rules_config", "../rules.yaml"})
 	assert.NoError(t, err)
 
-	if a, _ := c.GetGRPCListenAddr(); a != address {
+	if a := c.GetGRPCListenAddr(); a != address {
 		t.Error("received", a, "expected", address)
 	}
 }
@@ -87,7 +87,7 @@ func TestRedisHostEnvVar(t *testing.T) {
 	c, err := getConfig([]string{"--no-validate", "--config", "../config.yaml", "--rules_config", "../rules.yaml"})
 	assert.NoError(t, err)
 
-	if d, _ := c.GetRedisHost(); d != host {
+	if d := c.GetRedisHost(); d != host {
 		t.Error("received", d, "expected", host)
 	}
 }
@@ -100,7 +100,7 @@ func TestRedisUsernameEnvVar(t *testing.T) {
 	c, err := getConfig([]string{"--no-validate", "--config", "../config.yaml", "--rules_config", "../rules.yaml"})
 	assert.NoError(t, err)
 
-	if d, _ := c.GetRedisUsername(); d != username {
+	if d := c.GetRedisUsername(); d != username {
 		t.Error("received", d, "expected", username)
 	}
 }
@@ -113,7 +113,7 @@ func TestRedisPasswordEnvVar(t *testing.T) {
 	c, err := getConfig([]string{"--no-validate", "--config", "../config.yaml", "--rules_config", "../rules.yaml"})
 	assert.NoError(t, err)
 
-	if d, _ := c.GetRedisPassword(); d != password {
+	if d := c.GetRedisPassword(); d != password {
 		t.Error("received", d, "expected", password)
 	}
 }
@@ -126,7 +126,7 @@ func TestRedisAuthCodeEnvVar(t *testing.T) {
 	c, err := getConfig([]string{"--no-validate", "--config", "../config.yaml", "--rules_config", "../rules.yaml"})
 	assert.NoError(t, err)
 
-	if d, _ := c.GetRedisAuthCode(); d != authCode {
+	if d := c.GetRedisAuthCode(); d != authCode {
 		t.Error("received", d, "expected", authCode)
 	}
 }
@@ -204,7 +204,7 @@ func TestReload(t *testing.T) {
 	c, err := getConfig([]string{"--no-validate", "--config", config, "--rules_config", rules})
 	assert.NoError(t, err)
 
-	if d, _ := c.GetListenAddr(); d != "0.0.0.0:8080" {
+	if d := c.GetListenAddr(); d != "0.0.0.0:8080" {
 		t.Error("received", d, "expected", "0.0.0.0:8080")
 	}
 
@@ -250,7 +250,7 @@ func TestReload(t *testing.T) {
 
 	wg.Wait()
 
-	if d, _ := c.GetListenAddr(); d != "0.0.0.0:9000" {
+	if d := c.GetListenAddr(); d != "0.0.0.0:9000" {
 		t.Error("received", d, "expected", "0.0.0.0:9000")
 	}
 
@@ -265,7 +265,7 @@ func TestReloadDisabled(t *testing.T) {
 	c, err := getConfig([]string{"--no-validate", "--config", config, "--rules_config", rules})
 	assert.NoError(t, err)
 
-	if d, _ := c.GetListenAddr(); d != "0.0.0.0:8080" {
+	if d := c.GetListenAddr(); d != "0.0.0.0:8080" {
 		t.Error("received", d, "expected", "0.0.0.0:8080")
 	}
 
@@ -278,7 +278,7 @@ func TestReloadDisabled(t *testing.T) {
 
 	time.Sleep(5 * time.Second)
 
-	if d, _ := c.GetListenAddr(); d != "0.0.0.0:8080" {
+	if d := c.GetListenAddr(); d != "0.0.0.0:8080" {
 		t.Error("received", d, "expected", "0.0.0.0:8080")
 	}
 }
@@ -287,11 +287,11 @@ func TestReadDefaults(t *testing.T) {
 	c, err := getConfig([]string{"--no-validate", "--config", "../config.yaml", "--rules_config", "../rules.yaml"})
 	assert.NoError(t, err)
 
-	if d, _ := c.GetSendDelay(); d != 2*time.Second {
+	if d := c.GetSendDelay(); d != 2*time.Second {
 		t.Error("received", d, "expected", 2*time.Second)
 	}
 
-	if d, _ := c.GetTraceTimeout(); d != 60*time.Second {
+	if d := c.GetTraceTimeout(); d != 60*time.Second {
 		t.Error("received", d, "expected", 60*time.Second)
 	}
 
@@ -299,11 +299,11 @@ func TestReadDefaults(t *testing.T) {
 		t.Error("received", d, "expected", 100*time.Millisecond)
 	}
 
-	if d, _ := c.GetPeerManagementType(); d != "file" {
+	if d := c.GetPeerManagementType(); d != "file" {
 		t.Error("received", d, "expected", "file")
 	}
 
-	if d, _ := c.GetUseIPV6Identifier(); d != false {
+	if d := c.GetUseIPV6Identifier(); d != false {
 		t.Error("received", d, "expected", false)
 	}
 
@@ -387,7 +387,7 @@ func TestPeerManagementType(t *testing.T) {
 	c, err := getConfig([]string{"--no-validate", "--config", config, "--rules_config", rules})
 	assert.NoError(t, err)
 
-	if d, _ := c.GetPeerManagementType(); d != "redis" {
+	if d := c.GetPeerManagementType(); d != "redis" {
 		t.Error("received", d, "expected", "redis")
 	}
 
@@ -409,7 +409,7 @@ func TestDebugServiceAddr(t *testing.T) {
 	c, err := getConfig([]string{"--no-validate", "--config", config, "--rules_config", rules})
 	assert.NoError(t, err)
 
-	if d, _ := c.GetDebugServiceAddr(); d != "localhost:8085" {
+	if d := c.GetDebugServiceAddr(); d != "localhost:8085" {
 		t.Error("received", d, "expected", "localhost:8085")
 	}
 }
@@ -452,7 +452,7 @@ func TestMaxAlloc(t *testing.T) {
 	assert.NoError(t, err)
 
 	expected := MemorySize(16 * 1024 * 1024 * 1024)
-	inMemConfig, err := c.GetCollectionConfig()
+	inMemConfig := c.GetCollectionConfig()
 	assert.NoError(t, err)
 	assert.Equal(t, expected, inMemConfig.MaxAlloc)
 }
@@ -498,8 +498,7 @@ func TestPeerAndIncomingQueueSize(t *testing.T) {
 		c, err := getConfig([]string{"--no-validate", "--config", config, "--rules_config", rules})
 		assert.NoError(t, err)
 
-		inMemConfig, err := c.GetCollectionConfig()
-		assert.NoError(t, err)
+		inMemConfig := c.GetCollectionConfig()
 		assert.Equal(t, tc.expectedForPeer, inMemConfig.GetPeerQueueSize())
 		assert.Equal(t, tc.expectedForIncoming, inMemConfig.GetIncomingQueueSize())
 	}
@@ -515,8 +514,7 @@ func TestAvailableMemoryCmdLine(t *testing.T) {
 	assert.NoError(t, err)
 
 	expected := MemorySize(2*1024*1024*1024 + 512*1024*1024)
-	inMemConfig, err := c.GetCollectionConfig()
-	assert.NoError(t, err)
+	inMemConfig := c.GetCollectionConfig()
 	assert.Equal(t, expected, inMemConfig.AvailableMemory)
 }
 
@@ -609,9 +607,7 @@ func TestHoneycombLoggerConfig(t *testing.T) {
 	c, err := getConfig([]string{"--no-validate", "--config", config, "--rules_config", rules})
 	assert.NoError(t, err)
 
-	loggerConfig, err := c.GetHoneycombLoggerConfig()
-
-	assert.NoError(t, err)
+	loggerConfig := c.GetHoneycombLoggerConfig()
 
 	assert.Equal(t, "http://honeycomb.io", loggerConfig.APIHost)
 	assert.Equal(t, "1234", loggerConfig.APIKey)
@@ -635,9 +631,7 @@ func TestHoneycombLoggerConfigDefaults(t *testing.T) {
 	c, err := getConfig([]string{"--no-validate", "--config", config, "--rules_config", rules})
 	assert.NoError(t, err)
 
-	loggerConfig, err := c.GetHoneycombLoggerConfig()
-
-	assert.NoError(t, err)
+	loggerConfig := c.GetHoneycombLoggerConfig()
 
 	assert.Equal(t, true, loggerConfig.GetSamplerEnabled())
 	assert.Equal(t, 10, loggerConfig.SamplerThroughput)
@@ -658,8 +652,7 @@ func TestHoneycombGRPCConfigDefaults(t *testing.T) {
 
 	assert.Equal(t, true, c.GetGRPCEnabled())
 
-	a, err := c.GetGRPCListenAddr()
-	assert.NoError(t, err)
+	a := c.GetGRPCListenAddr()
 	assert.Equal(t, "localhost:4343", a)
 
 	grpcConfig := c.GetGRPCConfig()
@@ -690,9 +683,7 @@ func TestStdoutLoggerConfig(t *testing.T) {
 	c, err := getConfig([]string{"--no-validate", "--config", config, "--rules_config", rules})
 	assert.NoError(t, err)
 
-	loggerConfig, err := c.GetStdoutLoggerConfig()
-
-	assert.NoError(t, err)
+	loggerConfig := c.GetStdoutLoggerConfig()
 
 	assert.True(t, loggerConfig.Structured)
 	assert.True(t, loggerConfig.SamplerEnabled)
@@ -710,9 +701,7 @@ func TestStdoutLoggerConfigDefaults(t *testing.T) {
 	c, err := getConfig([]string{"--no-validate", "--config", config, "--rules_config", rules})
 	assert.NoError(t, err)
 
-	loggerConfig, err := c.GetStdoutLoggerConfig()
-
-	assert.NoError(t, err)
+	loggerConfig := c.GetStdoutLoggerConfig()
 
 	assert.False(t, loggerConfig.Structured)
 	assert.False(t, loggerConfig.SamplerEnabled)
@@ -774,8 +763,7 @@ func TestGRPCServerParameters(t *testing.T) {
 	assert.Equal(t, 4*time.Minute, time.Duration(gc.KeepAlive))
 	assert.Equal(t, 5*time.Minute, time.Duration(gc.KeepAliveTimeout))
 	assert.Equal(t, true, c.GetGRPCEnabled())
-	addr, err := c.GetGRPCListenAddr()
-	assert.NoError(t, err)
+	addr := c.GetGRPCListenAddr()
 	assert.Equal(t, "localhost:4317", addr)
 }
 
@@ -909,8 +897,7 @@ func TestOverrideConfigDefaults(t *testing.T) {
 
 	assert.Equal(t, false, c.GetAddSpanCountToRoot())
 	assert.Equal(t, false, c.GetAddHostMetadataToTrace())
-	loggerConfig, err := c.GetHoneycombLoggerConfig()
-	assert.NoError(t, err)
+	loggerConfig := c.GetHoneycombLoggerConfig()
 	assert.Equal(t, false, loggerConfig.GetSamplerEnabled())
 	assert.Equal(t, false, c.GetCompressPeerCommunication())
 	assert.Equal(t, false, c.GetGRPCEnabled())

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -499,26 +499,22 @@ func (f *fileConfig) RegisterReloadCallback(cb func()) {
 	f.callbacks = append(f.callbacks, cb)
 }
 
-func (f *fileConfig) GetListenAddr() (string, error) {
+func (f *fileConfig) GetListenAddr() string {
 	f.mux.RLock()
 	defer f.mux.RUnlock()
 
 	_, _, err := net.SplitHostPort(f.mainConfig.Network.ListenAddr)
 	if err != nil {
-		return "", err
+		return ""
 	}
-	return f.mainConfig.Network.ListenAddr, nil
+	return f.mainConfig.Network.ListenAddr
 }
 
-func (f *fileConfig) GetPeerListenAddr() (string, error) {
+func (f *fileConfig) GetPeerListenAddr() string {
 	f.mux.RLock()
 	defer f.mux.RUnlock()
 
-	_, _, err := net.SplitHostPort(f.mainConfig.Network.PeerListenAddr)
-	if err != nil {
-		return "", err
-	}
-	return f.mainConfig.Network.PeerListenAddr, nil
+	return f.mainConfig.Network.PeerListenAddr
 }
 
 func (f *fileConfig) GetHTTPIdleTimeout() time.Duration {
@@ -542,18 +538,11 @@ func (f *fileConfig) GetGRPCEnabled() bool {
 	return f.mainConfig.GRPCServerParameters.Enabled.Get()
 }
 
-func (f *fileConfig) GetGRPCListenAddr() (string, error) {
+func (f *fileConfig) GetGRPCListenAddr() string {
 	f.mux.RLock()
 	defer f.mux.RUnlock()
 
-	// GRPC listen addr is optional, only check value is valid if not empty
-	if f.mainConfig.GRPCServerParameters.ListenAddr != "" {
-		_, _, err := net.SplitHostPort(f.mainConfig.GRPCServerParameters.ListenAddr)
-		if err != nil {
-			return "", err
-		}
-	}
-	return f.mainConfig.GRPCServerParameters.ListenAddr, nil
+	return f.mainConfig.GRPCServerParameters.ListenAddr
 }
 
 func (f *fileConfig) GetGRPCConfig() GRPCServerParameters {
@@ -579,32 +568,32 @@ func (f *fileConfig) IsAPIKeyValid(key string) bool {
 	return f.mainConfig.AccessKeys.keymap.Contains(key)
 }
 
-func (f *fileConfig) GetPeerManagementType() (string, error) {
+func (f *fileConfig) GetPeerManagementType() string {
 	f.mux.RLock()
 	defer f.mux.RUnlock()
 
-	return f.mainConfig.PeerManagement.Type, nil
+	return f.mainConfig.PeerManagement.Type
 }
 
-func (f *fileConfig) GetPeers() ([]string, error) {
+func (f *fileConfig) GetPeers() []string {
 	f.mux.RLock()
 	defer f.mux.RUnlock()
 
-	return f.mainConfig.PeerManagement.Peers, nil
+	return f.mainConfig.PeerManagement.Peers
 }
 
-func (f *fileConfig) GetRedisHost() (string, error) {
+func (f *fileConfig) GetRedisHost() string {
 	f.mux.RLock()
 	defer f.mux.RUnlock()
 
-	return f.mainConfig.RedisPeerManagement.Host, nil
+	return f.mainConfig.RedisPeerManagement.Host
 }
 
-func (f *fileConfig) GetRedisUsername() (string, error) {
+func (f *fileConfig) GetRedisUsername() string {
 	f.mux.RLock()
 	defer f.mux.RUnlock()
 
-	return f.mainConfig.RedisPeerManagement.Username, nil
+	return f.mainConfig.RedisPeerManagement.Username
 }
 
 func (f *fileConfig) GetRedisPrefix() string {
@@ -614,18 +603,18 @@ func (f *fileConfig) GetRedisPrefix() string {
 	return f.mainConfig.RedisPeerManagement.Prefix
 }
 
-func (f *fileConfig) GetRedisPassword() (string, error) {
+func (f *fileConfig) GetRedisPassword() string {
 	f.mux.RLock()
 	defer f.mux.RUnlock()
 
-	return f.mainConfig.RedisPeerManagement.Password, nil
+	return f.mainConfig.RedisPeerManagement.Password
 }
 
-func (f *fileConfig) GetRedisAuthCode() (string, error) {
+func (f *fileConfig) GetRedisAuthCode() string {
 	f.mux.RLock()
 	defer f.mux.RUnlock()
 
-	return f.mainConfig.RedisPeerManagement.AuthCode, nil
+	return f.mainConfig.RedisPeerManagement.AuthCode
 }
 
 func (f *fileConfig) GetRedisDatabase() int {
@@ -635,39 +624,39 @@ func (f *fileConfig) GetRedisDatabase() int {
 	return f.mainConfig.RedisPeerManagement.Database
 }
 
-func (f *fileConfig) GetUseTLS() (bool, error) {
+func (f *fileConfig) GetUseTLS() bool {
 	f.mux.RLock()
 	defer f.mux.RUnlock()
 
-	return f.mainConfig.RedisPeerManagement.UseTLS, nil
+	return f.mainConfig.RedisPeerManagement.UseTLS
 }
 
-func (f *fileConfig) GetUseTLSInsecure() (bool, error) {
+func (f *fileConfig) GetUseTLSInsecure() bool {
 	f.mux.RLock()
 	defer f.mux.RUnlock()
 
-	return f.mainConfig.RedisPeerManagement.UseTLSInsecure, nil
+	return f.mainConfig.RedisPeerManagement.UseTLSInsecure
 }
 
-func (f *fileConfig) GetIdentifierInterfaceName() (string, error) {
+func (f *fileConfig) GetIdentifierInterfaceName() string {
 	f.mux.RLock()
 	defer f.mux.RUnlock()
 
-	return f.mainConfig.PeerManagement.IdentifierInterfaceName, nil
+	return f.mainConfig.PeerManagement.IdentifierInterfaceName
 }
 
-func (f *fileConfig) GetUseIPV6Identifier() (bool, error) {
+func (f *fileConfig) GetUseIPV6Identifier() bool {
 	f.mux.RLock()
 	defer f.mux.RUnlock()
 
-	return f.mainConfig.PeerManagement.UseIPV6Identifier, nil
+	return f.mainConfig.PeerManagement.UseIPV6Identifier
 }
 
-func (f *fileConfig) GetRedisIdentifier() (string, error) {
+func (f *fileConfig) GetRedisIdentifier() string {
 	f.mux.RLock()
 	defer f.mux.RUnlock()
 
-	return f.mainConfig.PeerManagement.Identifier, nil
+	return f.mainConfig.PeerManagement.Identifier
 }
 
 func (f *fileConfig) GetRedisMaxActive() int {
@@ -684,11 +673,11 @@ func (f *fileConfig) GetRedisMaxIdle() int {
 	return f.mainConfig.RedisPeerManagement.MaxIdle
 }
 
-func (f *fileConfig) GetHoneycombAPI() (string, error) {
+func (f *fileConfig) GetHoneycombAPI() string {
 	f.mux.RLock()
 	defer f.mux.RUnlock()
 
-	return f.mainConfig.Network.HoneycombAPI, nil
+	return f.mainConfig.Network.HoneycombAPI
 }
 
 func (f *fileConfig) GetLoggerLevel() Level {
@@ -698,33 +687,33 @@ func (f *fileConfig) GetLoggerLevel() Level {
 	return f.mainConfig.Logger.Level
 }
 
-func (f *fileConfig) GetLoggerType() (string, error) {
+func (f *fileConfig) GetLoggerType() string {
 	f.mux.RLock()
 	defer f.mux.RUnlock()
 
-	return f.mainConfig.Logger.Type, nil
+	return f.mainConfig.Logger.Type
 }
 
-func (f *fileConfig) GetHoneycombLoggerConfig() (HoneycombLoggerConfig, error) {
+func (f *fileConfig) GetHoneycombLoggerConfig() HoneycombLoggerConfig {
 	f.mux.RLock()
 	defer f.mux.RUnlock()
 
-	return f.mainConfig.HoneycombLogger, nil
+	return f.mainConfig.HoneycombLogger
 }
 
-func (f *fileConfig) GetStdoutLoggerConfig() (StdoutLoggerConfig, error) {
+func (f *fileConfig) GetStdoutLoggerConfig() StdoutLoggerConfig {
 	f.mux.RLock()
 	defer f.mux.RUnlock()
 
-	return f.mainConfig.StdoutLogger, nil
+	return f.mainConfig.StdoutLogger
 }
 
-func (f *fileConfig) GetAllSamplerRules() (*V2SamplerConfig, error) {
+func (f *fileConfig) GetAllSamplerRules() *V2SamplerConfig {
 	f.mux.RLock()
 	defer f.mux.RUnlock()
 
 	// This is probably good enough for debug; if not we can extend it.
-	return f.rulesConfig, nil
+	return f.rulesConfig
 }
 
 // GetSamplerConfigForDestName returns the sampler config for the given
@@ -752,11 +741,11 @@ func (f *fileConfig) GetSamplerConfigForDestName(destname string) (any, string, 
 	return cfg, name, err
 }
 
-func (f *fileConfig) GetCollectionConfig() (CollectionConfig, error) {
+func (f *fileConfig) GetCollectionConfig() CollectionConfig {
 	f.mux.RLock()
 	defer f.mux.RUnlock()
 
-	return f.mainConfig.Collection, nil
+	return f.mainConfig.Collection
 }
 
 func (f *fileConfig) GetLegacyMetricsConfig() LegacyMetricsConfig {
@@ -787,11 +776,11 @@ func (f *fileConfig) GetOTelTracingConfig() OTelTracingConfig {
 	return f.mainConfig.OTelTracing
 }
 
-func (f *fileConfig) GetSendDelay() (time.Duration, error) {
+func (f *fileConfig) GetSendDelay() time.Duration {
 	f.mux.RLock()
 	defer f.mux.RUnlock()
 
-	return time.Duration(f.mainConfig.Traces.SendDelay), nil
+	return time.Duration(f.mainConfig.Traces.SendDelay)
 }
 
 func (f *fileConfig) GetBatchTimeout() time.Duration {
@@ -801,11 +790,11 @@ func (f *fileConfig) GetBatchTimeout() time.Duration {
 	return time.Duration(f.mainConfig.Traces.BatchTimeout)
 }
 
-func (f *fileConfig) GetTraceTimeout() (time.Duration, error) {
+func (f *fileConfig) GetTraceTimeout() time.Duration {
 	f.mux.RLock()
 	defer f.mux.RUnlock()
 
-	return time.Duration(f.mainConfig.Traces.TraceTimeout), nil
+	return time.Duration(f.mainConfig.Traces.TraceTimeout)
 }
 
 func (f *fileConfig) GetMaxBatchSize() uint {
@@ -836,15 +825,11 @@ func (f *fileConfig) GetSendTickerValue() time.Duration {
 	return time.Duration(f.mainConfig.Traces.SendTicker)
 }
 
-func (f *fileConfig) GetDebugServiceAddr() (string, error) {
+func (f *fileConfig) GetDebugServiceAddr() string {
 	f.mux.RLock()
 	defer f.mux.RUnlock()
 
-	_, _, err := net.SplitHostPort(f.mainConfig.Debugging.DebugServiceAddr)
-	if err != nil {
-		return "", err
-	}
-	return f.mainConfig.Debugging.DebugServiceAddr, nil
+	return f.mainConfig.Debugging.DebugServiceAddr
 }
 
 func (f *fileConfig) GetIsDryRun() bool {

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -1355,7 +1355,7 @@ groups:
         summary: is the list of field names to use for the span ID.
         description: >
           The first field in the list that is present in an event will be used
-          as the span ID. 
+          as the span ID.
 
   - name: GRPCServerParameters
     title: "gRPC Server Parameters"
@@ -1761,7 +1761,7 @@ groups:
         firstVersion: v2.6
         type: duration
         valuetype: nondefault
-        default: 1s
+        default: 2s
         reload: true
         summary: is the duration of the delay before sending spans to the central store.
         description: >
@@ -1771,14 +1771,14 @@ groups:
           this value at the cost of greater latency and increased memory
           consumption in the central store.
 
-          NOTE: TODO this value is the same as SendDelay in the InMemCollector,
-          should they be unified?
-
       - name: TraceTimeout
         firstVersion: v2.6
         type: duration
         valuetype: nondefault
         default: 1m
+        validations:
+          - type: minimum
+            arg: 1s
         reload: true
         summary: is the maximum duration after which a trace is considered to have timed out.
         description: >

--- a/config/mock.go
+++ b/config/mock.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"fmt"
 	"sync"
 	"time"
 )
@@ -11,61 +10,42 @@ import (
 type MockConfig struct {
 	Callbacks                        []func()
 	IsAPIKeyValidFunc                func(string) bool
-	GetCollectorTypeErr              error
 	GetCollectorTypeVal              string
-	GetCollectionConfigErr           error
 	GetCollectionConfigVal           CollectionConfig
-	GetHoneycombAPIErr               error
 	GetHoneycombAPIVal               string
-	GetListenAddrErr                 error
 	GetListenAddrVal                 string
-	GetPeerListenAddrErr             error
 	GetPeerListenAddrVal             string
 	GetHTTPIdleTimeoutVal            time.Duration
 	GetCompressPeerCommunicationsVal bool
 	GetGRPCEnabledVal                bool
-	GetGRPCListenAddrErr             error
 	GetGRPCListenAddrVal             string
 	GetGRPCServerParameters          GRPCServerParameters
-	GetLoggerTypeErr                 error
 	GetLoggerTypeVal                 string
-	GetHoneycombLoggerConfigErr      error
 	GetHoneycombLoggerConfigVal      HoneycombLoggerConfig
-	GetStdoutLoggerConfigErr         error
 	GetStdoutLoggerConfigVal         StdoutLoggerConfig
 	GetLoggerLevelVal                Level
-	GetPeersErr                      error
 	GetPeersVal                      []string
-	GetRedisHostErr                  error
 	GetRedisHostVal                  string
-	GetRedisUsernameErr              error
 	GetRedisUsernameVal              string
-	GetRedisPasswordErr              error
 	GetRedisPasswordVal              string
-	GetRedisAuthCodeErr              error
 	GetRedisAuthCodeVal              string
 	GetRedisDatabaseVal              int
 	GetRedisPrefixVal                string
 	GetRedisMaxActiveVal             int
 	GetRedisMaxIdleVal               int
 	GetRedisTimeoutVal               time.Duration
-	GetUseTLSErr                     error
 	GetUseTLSVal                     bool
-	GetUseTLSInsecureErr             error
 	GetUseTLSInsecureVal             bool
-	GetSamplerTypeErr                error
+	GetSamplerTypeErr                error //keep
 	GetSamplerTypeName               string
 	GetSamplerTypeVal                interface{}
-	GetMetricsTypeErr                error
 	GetMetricsTypeVal                string
 	GetLegacyMetricsConfigVal        LegacyMetricsConfig
 	GetPrometheusMetricsConfigVal    PrometheusMetricsConfig
 	GetOTelMetricsConfigVal          OTelMetricsConfig
 	GetOTelTracingConfigVal          OTelTracingConfig
-	GetSendDelayErr                  error
 	GetSendDelayVal                  time.Duration
 	GetBatchTimeoutVal               time.Duration
-	GetTraceTimeoutErr               error
 	GetTraceTimeoutVal               time.Duration
 	GetMaxBatchSizeVal               uint
 	GetUpstreamBufferSizeVal         int
@@ -127,39 +107,39 @@ func (m *MockConfig) IsAPIKeyValid(key string) bool {
 	return m.IsAPIKeyValidFunc(key)
 }
 
-func (m *MockConfig) GetCollectorType() (string, error) {
+func (m *MockConfig) GetCollectorType() string {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
-	return m.GetCollectorTypeVal, m.GetCollectorTypeErr
+	return m.GetCollectorTypeVal
 }
 
-func (m *MockConfig) GetCollectionConfig() (CollectionConfig, error) {
+func (m *MockConfig) GetCollectionConfig() CollectionConfig {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
-	return m.GetCollectionConfigVal, m.GetCollectionConfigErr
+	return m.GetCollectionConfigVal
 }
 
-func (m *MockConfig) GetHoneycombAPI() (string, error) {
+func (m *MockConfig) GetHoneycombAPI() string {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
-	return m.GetHoneycombAPIVal, m.GetHoneycombAPIErr
+	return m.GetHoneycombAPIVal
 }
 
-func (m *MockConfig) GetListenAddr() (string, error) {
+func (m *MockConfig) GetListenAddr() string {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
-	return m.GetListenAddrVal, m.GetListenAddrErr
+	return m.GetListenAddrVal
 }
 
-func (m *MockConfig) GetPeerListenAddr() (string, error) {
+func (m *MockConfig) GetPeerListenAddr() string {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
-	return m.GetPeerListenAddrVal, m.GetPeerListenAddrErr
+	return m.GetPeerListenAddrVal
 }
 
 func (m *MockConfig) GetHTTPIdleTimeout() time.Duration {
@@ -182,32 +162,32 @@ func (m *MockConfig) GetGRPCEnabled() bool {
 	return m.GetGRPCEnabledVal
 }
 
-func (m *MockConfig) GetGRPCListenAddr() (string, error) {
+func (m *MockConfig) GetGRPCListenAddr() string {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
-	return m.GetGRPCListenAddrVal, m.GetGRPCListenAddrErr
+	return m.GetGRPCListenAddrVal
 }
 
-func (m *MockConfig) GetLoggerType() (string, error) {
+func (m *MockConfig) GetLoggerType() string {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
-	return m.GetLoggerTypeVal, m.GetLoggerTypeErr
+	return m.GetLoggerTypeVal
 }
 
-func (m *MockConfig) GetHoneycombLoggerConfig() (HoneycombLoggerConfig, error) {
+func (m *MockConfig) GetHoneycombLoggerConfig() HoneycombLoggerConfig {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
-	return m.GetHoneycombLoggerConfigVal, m.GetHoneycombLoggerConfigErr
+	return m.GetHoneycombLoggerConfigVal
 }
 
-func (m *MockConfig) GetStdoutLoggerConfig() (StdoutLoggerConfig, error) {
+func (m *MockConfig) GetStdoutLoggerConfig() StdoutLoggerConfig {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
-	return m.GetStdoutLoggerConfigVal, m.GetStdoutLoggerConfigErr
+	return m.GetStdoutLoggerConfigVal
 }
 
 func (m *MockConfig) GetLoggerLevel() Level {
@@ -217,39 +197,39 @@ func (m *MockConfig) GetLoggerLevel() Level {
 	return m.GetLoggerLevelVal
 }
 
-func (m *MockConfig) GetPeers() ([]string, error) {
+func (m *MockConfig) GetPeers() []string {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
-	return m.GetPeersVal, m.GetPeersErr
+	return m.GetPeersVal
 }
 
-func (m *MockConfig) GetRedisHost() (string, error) {
+func (m *MockConfig) GetRedisHost() string {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
-	return m.GetRedisHostVal, m.GetRedisHostErr
+	return m.GetRedisHostVal
 }
 
-func (m *MockConfig) GetRedisUsername() (string, error) {
+func (m *MockConfig) GetRedisUsername() string {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
-	return m.GetRedisUsernameVal, m.GetRedisUsernameErr
+	return m.GetRedisUsernameVal
 }
 
-func (m *MockConfig) GetRedisPassword() (string, error) {
+func (m *MockConfig) GetRedisPassword() string {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
-	return m.GetRedisPasswordVal, m.GetRedisPasswordErr
+	return m.GetRedisPasswordVal
 }
 
-func (m *MockConfig) GetRedisAuthCode() (string, error) {
+func (m *MockConfig) GetRedisAuthCode() string {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
-	return m.GetRedisAuthCodeVal, m.GetRedisAuthCodeErr
+	return m.GetRedisAuthCodeVal
 }
 
 func (m *MockConfig) GetRedisPrefix() string {
@@ -266,18 +246,18 @@ func (m *MockConfig) GetRedisDatabase() int {
 	return m.GetRedisDatabaseVal
 }
 
-func (m *MockConfig) GetUseTLS() (bool, error) {
+func (m *MockConfig) GetUseTLS() bool {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
-	return m.GetUseTLSVal, m.GetUseTLSErr
+	return m.GetUseTLSVal
 }
 
-func (m *MockConfig) GetUseTLSInsecure() (bool, error) {
+func (m *MockConfig) GetUseTLSInsecure() bool {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
-	return m.GetUseTLSInsecureVal, m.GetUseTLSInsecureErr
+	return m.GetUseTLSInsecureVal
 }
 
 func (m *MockConfig) GetRedisMaxActive() int {
@@ -329,11 +309,11 @@ func (m *MockConfig) GetOTelTracingConfig() OTelTracingConfig {
 	return m.GetOTelTracingConfigVal
 }
 
-func (m *MockConfig) GetSendDelay() (time.Duration, error) {
+func (m *MockConfig) GetSendDelay() time.Duration {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
-	return m.GetSendDelayVal, m.GetSendDelayErr
+	return m.GetSendDelayVal
 }
 
 func (m *MockConfig) GetBatchTimeout() time.Duration {
@@ -343,11 +323,11 @@ func (m *MockConfig) GetBatchTimeout() time.Duration {
 	return m.GetBatchTimeoutVal
 }
 
-func (m *MockConfig) GetTraceTimeout() (time.Duration, error) {
+func (m *MockConfig) GetTraceTimeout() time.Duration {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
-	return m.GetTraceTimeoutVal, m.GetTraceTimeoutErr
+	return m.GetTraceTimeoutVal
 }
 
 func (m *MockConfig) GetMaxBatchSize() uint {
@@ -367,7 +347,7 @@ func (m *MockConfig) GetSamplerConfigForDestName(dataset string) (interface{}, s
 
 // GetAllSamplerRules normally returns all dataset rules, including the default
 // In this mock, it returns only the rules for "dataset1" according to the type of the value field
-func (m *MockConfig) GetAllSamplerRules() (*V2SamplerConfig, error) {
+func (m *MockConfig) GetAllSamplerRules() *V2SamplerConfig {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
@@ -384,14 +364,14 @@ func (m *MockConfig) GetAllSamplerRules() (*V2SamplerConfig, error) {
 	case *TotalThroughputSamplerConfig:
 		choice.TotalThroughputSampler = sampler
 	default:
-		return nil, fmt.Errorf("unable to determine data format")
+		return nil
 	}
 
 	v := &V2SamplerConfig{
 		Samplers: map[string]*V2SamplerChoice{"dataset1": choice},
 	}
 
-	return v, m.GetSamplerTypeErr
+	return v
 }
 
 func (m *MockConfig) GetUpstreamBufferSize() int {
@@ -408,25 +388,25 @@ func (m *MockConfig) GetPeerBufferSize() int {
 	return m.GetPeerBufferSizeVal
 }
 
-func (m *MockConfig) GetIdentifierInterfaceName() (string, error) {
+func (m *MockConfig) GetIdentifierInterfaceName() string {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
-	return m.IdentifierInterfaceName, nil
+	return m.IdentifierInterfaceName
 }
 
-func (m *MockConfig) GetUseIPV6Identifier() (bool, error) {
+func (m *MockConfig) GetUseIPV6Identifier() bool {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
-	return m.UseIPV6Identifier, nil
+	return m.UseIPV6Identifier
 }
 
-func (m *MockConfig) GetRedisIdentifier() (string, error) {
+func (m *MockConfig) GetRedisIdentifier() string {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
-	return m.RedisIdentifier, nil
+	return m.RedisIdentifier
 }
 
 func (m *MockConfig) GetSendTickerValue() time.Duration {
@@ -436,18 +416,18 @@ func (m *MockConfig) GetSendTickerValue() time.Duration {
 	return m.SendTickerVal
 }
 
-func (m *MockConfig) GetPeerManagementType() (string, error) {
+func (m *MockConfig) GetPeerManagementType() string {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
-	return m.PeerManagementType, nil
+	return m.PeerManagementType
 }
 
-func (m *MockConfig) GetDebugServiceAddr() (string, error) {
+func (m *MockConfig) GetDebugServiceAddr() string {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
-	return m.DebugServiceAddr, nil
+	return m.DebugServiceAddr
 }
 
 func (m *MockConfig) GetIsDryRun() bool {

--- a/internal/peer/file.go
+++ b/internal/peer/file.go
@@ -17,11 +17,11 @@ func (p *filePeers) GetPeers() ([]string, error) {
 	// we never want to return an empty list of peers, so if the config
 	// returns an empty list, return a single peer. This keeps the sharding
 	// logic happy.
-	peers, err := p.c.GetPeers()
+	peers := p.c.GetPeers()
 	if len(peers) == 0 {
 		peers = []string{"http://127.0.0.1:8081"}
 	}
-	return peers, err
+	return peers, nil
 }
 
 func (p *filePeers) RegisterUpdatedPeersCallback(callback func()) {

--- a/internal/peer/peers.go
+++ b/internal/peer/peers.go
@@ -15,11 +15,7 @@ type Peers interface {
 }
 
 func NewPeers(ctx context.Context, c config.Config, done chan struct{}) (Peers, error) {
-	t, err := c.GetPeerManagementType()
-
-	if err != nil {
-		return nil, err
-	}
+	t := c.GetPeerManagementType()
 
 	switch t {
 	case "file":

--- a/internal/peer/redis.go
+++ b/internal/peer/redis.go
@@ -46,7 +46,7 @@ type redisPeers struct {
 
 // NewRedisPeers returns a peers collection backed by redis
 func newRedisPeers(ctx context.Context, c config.Config, done chan struct{}) (Peers, error) {
-	redisHost, _ := c.GetRedisHost()
+	redisHost := c.GetRedisHost()
 
 	if redisHost == "" {
 		redisHost = "localhost:6379"
@@ -72,7 +72,7 @@ func newRedisPeers(ctx context.Context, c config.Config, done chan struct{}) (Pe
 				case <-timeout:
 					return nil, err
 				default:
-					if authCode, _ := c.GetRedisAuthCode(); authCode != "" {
+					if authCode := c.GetRedisAuthCode(); authCode != "" {
 						conn, err = redis.Dial("tcp", redisHost, options...)
 						if err != nil {
 							return nil, err
@@ -81,9 +81,7 @@ func newRedisPeers(ctx context.Context, c config.Config, done chan struct{}) (Pe
 							conn.Close()
 							return nil, err
 						}
-						if err == nil {
-							return conn, nil
-						}
+						return conn, nil
 					} else {
 						conn, err = redis.Dial("tcp", redisHost, options...)
 						if err == nil {
@@ -242,18 +240,18 @@ func buildOptions(c config.Config) []redis.DialOption {
 		redis.DialDatabase(c.GetRedisDatabase()),
 	}
 
-	username, _ := c.GetRedisUsername()
+	username := c.GetRedisUsername()
 	if username != "" {
 		options = append(options, redis.DialUsername(username))
 	}
 
-	password, _ := c.GetRedisPassword()
+	password := c.GetRedisPassword()
 	if password != "" {
 		options = append(options, redis.DialPassword(password))
 	}
 
-	useTLS, _ := c.GetUseTLS()
-	tlsInsecure, _ := c.GetUseTLSInsecure()
+	useTLS := c.GetUseTLS()
+	tlsInsecure := c.GetUseTLSInsecure()
 	if useTLS {
 		tlsConfig := &tls.Config{
 			MinVersion: tls.VersionTLS12,
@@ -273,7 +271,7 @@ func buildOptions(c config.Config) []redis.DialOption {
 
 func publicAddr(c config.Config) (string, error) {
 	// compute the public version of my peer listen address
-	listenAddr, _ := c.GetPeerListenAddr()
+	listenAddr := c.GetPeerListenAddr()
 	_, port, err := net.SplitHostPort(listenAddr)
 
 	if err != nil {
@@ -283,7 +281,7 @@ func publicAddr(c config.Config) (string, error) {
 	var myIdentifier string
 
 	// If RedisIdentifier is set, use as identifier.
-	if redisIdentifier, _ := c.GetRedisIdentifier(); redisIdentifier != "" {
+	if redisIdentifier := c.GetRedisIdentifier(); redisIdentifier != "" {
 		myIdentifier = redisIdentifier
 		logrus.WithField("identifier", myIdentifier).Info("using specified RedisIdentifier from config")
 	} else {
@@ -302,7 +300,7 @@ func publicAddr(c config.Config) (string, error) {
 // Scan network interfaces to determine an identifier from either IP or hostname.
 func getIdentifierFromInterfaces(c config.Config) (string, error) {
 	myIdentifier, _ := os.Hostname()
-	identifierInterfaceName, _ := c.GetIdentifierInterfaceName()
+	identifierInterfaceName := c.GetIdentifierInterfaceName()
 
 	if identifierInterfaceName != "" {
 		ifc, err := net.InterfaceByName(identifierInterfaceName)
@@ -321,7 +319,7 @@ func getIdentifierFromInterfaces(c config.Config) (string, error) {
 		for _, addr := range addrs {
 			// ParseIP doesn't know what to do with the suffix
 			ip := net.ParseIP(strings.Split(addr.String(), "/")[0])
-			ipv6, _ := c.GetUseIPV6Identifier()
+			ipv6 := c.GetUseIPV6Identifier()
 			if ipv6 && ip.To16() != nil {
 				ipStr = fmt.Sprintf("[%s]", ip.String())
 				break

--- a/internal/redis/redis.go
+++ b/internal/redis/redis.go
@@ -117,18 +117,18 @@ func buildOptions(c config.Config) []redis.DialOption {
 		redis.DialDatabase(c.GetRedisDatabase()),
 	}
 
-	username, _ := c.GetRedisUsername()
+	username := c.GetRedisUsername()
 	if username != "" {
 		options = append(options, redis.DialUsername(username))
 	}
 
-	password, _ := c.GetRedisPassword()
+	password := c.GetRedisPassword()
 	if password != "" {
 		options = append(options, redis.DialPassword(password))
 	}
 
-	useTLS, _ := c.GetUseTLS()
-	tlsInsecure, _ := c.GetUseTLSInsecure()
+	useTLS := c.GetUseTLS()
+	tlsInsecure := c.GetUseTLSInsecure()
 	if useTLS {
 		tlsConfig := &tls.Config{
 			MinVersion: tls.VersionTLS12,
@@ -146,7 +146,7 @@ func buildOptions(c config.Config) []redis.DialOption {
 	return options
 }
 func (d *DefaultClient) Start() error {
-	redisHost, _ := d.Config.GetRedisHost()
+	redisHost := d.Config.GetRedisHost()
 
 	if redisHost == "" {
 		redisHost = "localhost:6379"
@@ -171,7 +171,7 @@ func (d *DefaultClient) Start() error {
 				case <-timeout:
 					return nil, err
 				default:
-					if authCode, _ := d.Config.GetRedisAuthCode(); authCode != "" {
+					if authCode := d.Config.GetRedisAuthCode(); authCode != "" {
 						conn, err = redis.Dial("tcp", redisHost, options...)
 						if err != nil {
 							return nil, err
@@ -180,9 +180,7 @@ func (d *DefaultClient) Start() error {
 							conn.Close()
 							return nil, err
 						}
-						if err == nil {
-							return conn, nil
-						}
+						return conn, nil
 					} else {
 						conn, err = redis.Dial("tcp", redisHost, options...)
 						if err == nil {

--- a/logger/honeycomb.go
+++ b/logger/honeycomb.go
@@ -40,10 +40,7 @@ func (h *HoneycombLogger) Start() error {
 	// preserve it.
 	// TODO: make LogLevel part of the HoneycombLogger/LogrusLogger sections?
 	h.level = h.Config.GetLoggerLevel()
-	loggerConfig, err := h.Config.GetHoneycombLoggerConfig()
-	if err != nil {
-		return err
-	}
+	loggerConfig := h.Config.GetHoneycombLoggerConfig()
 	h.loggerConfig = loggerConfig
 	var loggerTx transmission.Sender
 	if h.loggerConfig.APIKey == "" {
@@ -126,14 +123,7 @@ func (h *HoneycombLogger) reloadBuilder() {
 	h.Debug().Logf("reloading config for Honeycomb logger")
 	// preserve log level
 	h.level = h.Config.GetLoggerLevel()
-	loggerConfig, err := h.Config.GetHoneycombLoggerConfig()
-	if err != nil {
-		// complain about this both to STDOUT and to the previously configured
-		// honeycomb logger
-		fmt.Printf("failed to reload configs for Honeycomb logger: %+v\n", err)
-		h.Error().Logf("failed to reload configs for Honeycomb logger: %+v", err)
-		return
-	}
+	loggerConfig := h.Config.GetHoneycombLoggerConfig()
 	h.loggerConfig = loggerConfig
 	h.builder.APIHost = h.loggerConfig.APIHost
 	h.builder.WriteKey = h.loggerConfig.APIKey

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -29,11 +29,7 @@ type Entry interface {
 
 func GetLoggerImplementation(c config.Config) Logger {
 	var logger Logger
-	loggerType, err := c.GetLoggerType()
-	if err != nil {
-		fmt.Printf("unable to get logger type from config: %v\n", err)
-		os.Exit(1)
-	}
+	loggerType := c.GetLoggerType()
 	switch loggerType {
 	case "honeycomb":
 		logger = &HoneycombLogger{}

--- a/logger/logrus.go
+++ b/logger/logrus.go
@@ -25,31 +25,26 @@ type StdoutLogger struct {
 var _ = Logger((*StdoutLogger)(nil))
 
 type LogrusEntry struct {
-	entry *logrus.Entry
-	level logrus.Level
+	entry   *logrus.Entry
+	level   logrus.Level
 	sampler dynsampler.Sampler
 }
 
 func (l *StdoutLogger) Start() error {
 	l.logger = logrus.New()
 	l.logger.SetLevel(l.level)
-	cfg, err := l.Config.GetStdoutLoggerConfig()
-	if err != nil {
-		return err
-	}
-
+	cfg := l.Config.GetStdoutLoggerConfig()
 	if cfg.Structured {
 		l.logger.SetFormatter(&logrus.JSONFormatter{})
 	}
 
 	if cfg.SamplerEnabled {
 		l.sampler = &dynsampler.PerKeyThroughput{
-			ClearFrequencyDuration: 10*time.Second,
+			ClearFrequencyDuration: 10 * time.Second,
 			PerKeyThroughputPerSec: cfg.SamplerThroughput,
-			MaxKeys: 1000,
+			MaxKeys:                1000,
 		}
-		err = l.sampler.Start()
-		if err != nil {
+		if err := l.sampler.Start(); err != nil {
 			return err
 		}
 	}
@@ -63,8 +58,8 @@ func (l *StdoutLogger) Debug() Entry {
 	}
 
 	return &LogrusEntry{
-		entry: logrus.NewEntry(l.logger),
-		level: logrus.DebugLevel,
+		entry:   logrus.NewEntry(l.logger),
+		level:   logrus.DebugLevel,
 		sampler: l.sampler,
 	}
 }
@@ -75,8 +70,8 @@ func (l *StdoutLogger) Info() Entry {
 	}
 
 	return &LogrusEntry{
-		entry: logrus.NewEntry(l.logger),
-		level: logrus.InfoLevel,
+		entry:   logrus.NewEntry(l.logger),
+		level:   logrus.InfoLevel,
 		sampler: l.sampler,
 	}
 }
@@ -87,8 +82,8 @@ func (l *StdoutLogger) Warn() Entry {
 	}
 
 	return &LogrusEntry{
-		entry: logrus.NewEntry(l.logger),
-		level: logrus.WarnLevel,
+		entry:   logrus.NewEntry(l.logger),
+		level:   logrus.WarnLevel,
 		sampler: l.sampler,
 	}
 }
@@ -99,8 +94,8 @@ func (l *StdoutLogger) Error() Entry {
 	}
 
 	return &LogrusEntry{
-		entry: logrus.NewEntry(l.logger),
-		level: logrus.ErrorLevel,
+		entry:   logrus.NewEntry(l.logger),
+		level:   logrus.ErrorLevel,
 		sampler: l.sampler,
 	}
 }
@@ -120,24 +115,24 @@ func (l *StdoutLogger) SetLevel(level string) error {
 
 func (l *LogrusEntry) WithField(key string, value interface{}) Entry {
 	return &LogrusEntry{
-		entry: l.entry.WithField(key, value),
-		level: l.level,
+		entry:   l.entry.WithField(key, value),
+		level:   l.level,
 		sampler: l.sampler,
 	}
 }
 
 func (l *LogrusEntry) WithString(key string, value string) Entry {
 	return &LogrusEntry{
-		entry: l.entry.WithField(key, value),
-		level: l.level,
+		entry:   l.entry.WithField(key, value),
+		level:   l.level,
 		sampler: l.sampler,
 	}
 }
 
 func (l *LogrusEntry) WithFields(fields map[string]interface{}) Entry {
 	return &LogrusEntry{
-		entry: l.entry.WithFields(fields),
-		level: l.level,
+		entry:   l.entry.WithFields(fields),
+		level:   l.level,
 		sampler: l.sampler,
 	}
 }
@@ -148,8 +143,8 @@ func (l *LogrusEntry) Logf(f string, args ...interface{}) {
 		// this will give us a different sample rate for each level and format string
 		// and avoid high cardinality args making the throughput sampler less effective
 		rate := l.sampler.GetSampleRate(fmt.Sprintf("%s:%s", l.level, f))
-		if shouldDrop(uint(rate)){
-			return 
+		if shouldDrop(uint(rate)) {
+			return
 		}
 		l.entry.WithField("SampleRate", rate)
 	}

--- a/route/otlp_trace.go
+++ b/route/otlp_trace.go
@@ -78,11 +78,7 @@ func processTraceRequest(
 	apiKey string) error {
 
 	var requestID types.RequestIDContextKey
-	apiHost, err := router.Config.GetHoneycombAPI()
-	if err != nil {
-		router.Logger.Error().Logf("Unable to retrieve APIHost from config while processing OTLP batch")
-		return err
-	}
+	apiHost := router.Config.GetHoneycombAPI()
 
 	// get environment name - will be empty for legacy keys
 	environment, err := router.getEnvironmentName(apiKey)

--- a/route/proxy.go
+++ b/route/proxy.go
@@ -13,13 +13,7 @@ import (
 func (r *Router) proxy(w http.ResponseWriter, req *http.Request) {
 	r.Metrics.Increment(r.incomingOrPeer + "_router_proxied")
 	r.Logger.Debug().Logf("proxying request for %s", req.URL.Path)
-	upstreamTarget, err := r.Config.GetHoneycombAPI()
-	if err != nil {
-		w.WriteHeader(http.StatusServiceUnavailable)
-		io.WriteString(w, `{"error":"upstream target unavailable"}`)
-		r.Logger.Error().Logf("error getting honeycomb API config: %s", err)
-		return
-	}
+	upstreamTarget := r.Config.GetHoneycombAPI()
 	forwarded := req.Header.Get("X-Forwarded-For")
 	// let's copy the request over to a new one and
 	// dispatch it upstream

--- a/service/debug/debug_service.go
+++ b/service/debug/debug_service.go
@@ -61,7 +61,7 @@ func (s *DebugService) Start() error {
 	s.Publish("memstats", Func(memstats))
 
 	go func() {
-		configAddr, _ := s.Config.GetDebugServiceAddr()
+		configAddr := s.Config.GetDebugServiceAddr()
 		if configAddr != "" {
 			host, portStr, _ := net.SplitHostPort(configAddr)
 			addr := net.JoinHostPort(host, portStr)

--- a/sharder/deterministic.go
+++ b/sharder/deterministic.go
@@ -132,10 +132,7 @@ func (d *DeterministicSharder) Start() error {
 		}
 
 		// get my listen address for peer traffic for the Port number
-		listenAddr, err := d.Config.GetPeerListenAddr()
-		if err != nil {
-			return errors.Wrap(err, "failed to get listen addr config")
-		}
+		listenAddr := d.Config.GetPeerListenAddr()
 		_, localPort, err := net.SplitHostPort(listenAddr)
 		if err != nil {
 			return errors.Wrap(err, "failed to parse listen addr into host:port")
@@ -145,7 +142,7 @@ func (d *DeterministicSharder) Start() error {
 		var localIPs []string
 
 		// If RedisIdentifier is an IP, use as localIPs value.
-		if redisIdentifier, err := d.Config.GetRedisIdentifier(); err == nil && redisIdentifier != "" {
+		if redisIdentifier := d.Config.GetRedisIdentifier(); redisIdentifier != "" {
 			if ip := net.ParseIP(redisIdentifier); ip != nil {
 				d.Logger.Debug().Logf("Using RedisIdentifier as public IP: %s", redisIdentifier)
 				localIPs = []string{redisIdentifier}

--- a/transmit/transmit.go
+++ b/transmit/transmit.go
@@ -56,11 +56,7 @@ func (d *DefaultTransmission) Start() error {
 
 	// upstreamAPI doesn't get set when the client is initialized, because
 	// it can be reloaded from the config file while live
-	upstreamAPI, err := d.Config.GetHoneycombAPI()
-	if err != nil {
-		return err
-	}
-
+	upstreamAPI := d.Config.GetHoneycombAPI()
 	d.builder = d.LibhClient.NewBuilder()
 	d.builder.APIHost = upstreamAPI
 
@@ -85,11 +81,7 @@ func (d *DefaultTransmission) Start() error {
 
 func (d *DefaultTransmission) reloadTransmissionBuilder() {
 	d.Logger.Debug().Logf("reloading transmission config")
-	upstreamAPI, err := d.Config.GetHoneycombAPI()
-	if err != nil {
-		// log and skip reload
-		d.Logger.Error().Logf("Failed to reload Honeycomb API when reloading configs:", err)
-	}
+	upstreamAPI := d.Config.GetHoneycombAPI()
 	builder := d.LibhClient.NewBuilder()
 	builder.APIHost = upstreamAPI
 }


### PR DESCRIPTION

## Which problem is this PR solving?

- Since we introduced validation of configs, it's not really possible for there to be errors returned from the config getter functions. Most of them returned nil, or did pointless validation checks in the new regime.

## Short description of the changes

- Remove error from most return signatures for config getters
- Fix up all the normal getters
- Fix the mocks (and remove all the useless error mock values that weren't being checked anyway!)
- Fix all the places things were used

