### PR TITLE
feat: RedisMetricsRecorder

### DIFF
--- a/centralstore/redis_metrics_recorder.go
+++ b/centralstore/redis_metrics_recorder.go
@@ -66,6 +66,7 @@ func (r *RedisMetricsRecorder) monitor() {
 			conn.SetHashTTL("Refinery_Metrics_"+r.prefix, allmetrics, r.reportingFreq*2)
 			conn.Close()
 		case <-r.done:
+			ticker.Stop()
 			return
 		}
 	}

--- a/centralstore/redis_metrics_recorder.go
+++ b/centralstore/redis_metrics_recorder.go
@@ -1,0 +1,69 @@
+package centralstore
+
+import (
+	"time"
+
+	"github.com/honeycombio/refinery/config"
+	"github.com/honeycombio/refinery/internal/redis"
+	"github.com/honeycombio/refinery/logger"
+	"github.com/honeycombio/refinery/metrics"
+	"github.com/jonboulle/clockwork"
+)
+
+// RedisMetricsRecorder reads from its injected metrics object and stores its
+// most current data in Redis where it can be read and aggregated by a separate
+// process. This is intended to allow a custom Kubernetes metrics reporter to
+// serve metrics data to Kubernetes for autoscaling purposes. The data we report
+// is the same data made available to stress relief (which doesn't include
+// histograms).
+type RedisMetricsRecorder struct {
+	Config      config.Config         `inject:""`
+	Logger      logger.Logger         `inject:""`
+	Clock       clockwork.Clock       `inject:""`
+	Metrics     *metrics.MultiMetrics `inject:"metrics"`
+	Version     string                `inject:"version"`
+	RedisClient redis.Client          `inject:"redis"`
+
+	//reportingFreq is the interval with which to report statistics
+	reportingFreq time.Duration
+	prefix        string
+	done          chan struct{}
+}
+
+func NewRedisReporter(prefix string) *RedisMetricsRecorder {
+	return &RedisMetricsRecorder{
+		prefix: prefix,
+	}
+}
+
+func (r *RedisMetricsRecorder) Start() error {
+	r.reportingFreq = 30 * time.Second // TODO: make this configurable
+	r.done = make(chan struct{})
+	go r.monitor()
+	return nil
+}
+
+func (r *RedisMetricsRecorder) Stop() error {
+	close(r.done)
+	return nil
+}
+
+// We store the metrics in Redis as a hash with the prefix "Refinery_Metrics_" +
+// r.prefix, which should be made unique to this instance of refinery. The hash
+// is stored with an expiration time of 2 times the reporting frequency. The
+// hash will be removed automatically once the refinery instance stops. It is
+// expected that the metrics reporter will iterate the prefixes and aggregate them.
+func (r *RedisMetricsRecorder) monitor() {
+	ticker := r.Clock.NewTicker(r.reportingFreq)
+	for {
+		select {
+		case <-ticker.Chan():
+			allmetrics := r.Metrics.GetAll()
+			conn := r.RedisClient.Get()
+			conn.SetHashTTL("Refinery_Metrics_"+r.prefix, allmetrics, r.reportingFreq*2)
+			conn.Close()
+		case <-r.done:
+			return
+		}
+	}
+}

--- a/centralstore/redis_metrics_recorder.go
+++ b/centralstore/redis_metrics_recorder.go
@@ -1,6 +1,8 @@
 package centralstore
 
 import (
+	"fmt"
+	"os"
 	"time"
 
 	"github.com/honeycombio/refinery/config"
@@ -30,13 +32,14 @@ type RedisMetricsRecorder struct {
 	done          chan struct{}
 }
 
-func NewRedisReporter(prefix string) *RedisMetricsRecorder {
-	return &RedisMetricsRecorder{
-		prefix: prefix,
-	}
-}
-
 func (r *RedisMetricsRecorder) Start() error {
+	// use the hostname if we have one, if not, use the timestamp
+	if hostname, err := os.Hostname(); err == nil && hostname != "" {
+		r.prefix = hostname
+	} else {
+		r.prefix = fmt.Sprintf("%d", r.Clock.Now().UnixMicro())
+	}
+
 	r.reportingFreq = 30 * time.Second // TODO: make this configurable
 	r.done = make(chan struct{})
 	go r.monitor()

--- a/metrics/multi_metrics.go
+++ b/metrics/multi_metrics.go
@@ -127,3 +127,16 @@ func (m *MultiMetrics) Store(name string, val float64) { // for storing a rarely
 	defer m.lock.Unlock()
 	m.values[name] = val
 }
+
+// GetAll isn't part of the Metrics API but is used by the RedisMetricsRecorder
+// to get all the metrics at once.
+func (m *MultiMetrics) GetAll() map[string]float64 {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+	// copy the map so the caller can't mess with the values
+	ret := make(map[string]float64)
+	for name, v := range m.values {
+		ret[name] = float64(v)
+	}
+	return ret
+}


### PR DESCRIPTION
This is the Refinery side of recording metrics to a central place in Redis so that we can make it available for autoscaling.

This will be followed up with the central metrics reporting app.

## Which problem is this PR solving?

- We want to record metrics centrally so we can scale with them.

## Short description of the changes

- Add GetAll to the MultiMetrics object so that we can fetch and send them all at once
- Send them to Redis with an expiration time so that they'll clean themselves up
- Use the hostname if it exists, otherwise the time, as a differentiator


