### PR TITLE
fix: make central collector tests more reliable

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -96,7 +96,6 @@ func newStartedApp(
 	enableHostMetadata bool,
 ) (*App, inject.Graph, func()) {
 	c := &config.MockConfig{
-		GetSendDelayVal:          0,
 		GetTraceTimeoutVal:       10 * time.Millisecond,
 		GetMaxBatchSizeVal:       500,
 		GetSamplerTypeVal:        &config.DeterministicSamplerConfig{SampleRate: 1},
@@ -120,6 +119,7 @@ func newStartedApp(
 			BasicStoreType:  "redis",
 			SpanChannelSize: 10000,
 			SendDelay:       config.Duration(2 * time.Millisecond),
+			DecisionTimeout: config.Duration(100 * time.Millisecond),
 		},
 	}
 

--- a/centralstore/smartwrapper_record_metrics_test.go
+++ b/centralstore/smartwrapper_record_metrics_test.go
@@ -1,0 +1,138 @@
+//go:build all || !race
+
+package centralstore
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/honeycombio/refinery/redis"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecordMetrics(t *testing.T) {
+	store, stopper, err := getAndStartSmartWrapper(storeType, &redis.DefaultClient{})
+	require.NoError(t, err)
+	defer stopper()
+
+	ctx := context.Background()
+	numberOfTraces := 5
+	traceids := make([]string, 0)
+
+	for tr := 0; tr < numberOfTraces; tr++ {
+		tid := fmt.Sprintf("trace%02d", rand.Intn(1000))
+		traceids = append(traceids, tid)
+		// write 9 child spans to the store
+		for s := 1; s < 10; s++ {
+			span := &CentralSpan{
+				TraceID: tid,
+				SpanID:  fmt.Sprintf("span%d", s),
+				IsRoot:  false,
+			}
+			err = store.WriteSpan(ctx, span)
+			require.NoError(t, err)
+		}
+		// now write the root span
+		span := &CentralSpan{
+			TraceID: tid,
+			SpanID:  "span0",
+		}
+		err = store.WriteSpan(ctx, span)
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, numberOfTraces, len(traceids))
+	assert.Eventually(t, func() bool {
+		states, err := store.GetStatusForTraces(ctx, traceids)
+		return err == nil && len(states) == numberOfTraces
+	}, 1*time.Second, 100*time.Millisecond)
+
+	// wait for it to reach the Ready state
+	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+		states, err := store.GetStatusForTraces(ctx, traceids)
+		assert.NoError(collect, err)
+		assert.Equal(collect, numberOfTraces, len(states))
+		for _, state := range states {
+			assert.Equal(collect, ReadyToDecide, state.State)
+		}
+
+	}, 3*time.Second, 100*time.Millisecond)
+
+	// get the traces in the Ready state
+	toDecide, err := store.GetTracesNeedingDecision(ctx, numberOfTraces)
+	assert.NoError(t, err)
+	assert.Equal(t, numberOfTraces, len(toDecide))
+	sort.Strings(toDecide)
+	expected := traceids[:numberOfTraces]
+	sort.Strings(expected)
+	assert.EqualValues(t, expected, toDecide)
+
+	statuses := make([]*CentralTraceStatus, 0)
+	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+		statuses, err = store.GetStatusForTraces(ctx, toDecide)
+		assert.NoError(collect, err)
+		assert.Equal(collect, numberOfTraces, len(statuses))
+		for _, state := range statuses {
+			assert.Equal(collect, AwaitingDecision, state.State)
+		}
+		err = store.RecordMetrics(ctx)
+		require.NoError(t, err)
+		value, ok := store.Metrics.Get("redisstore_count_awaiting_decision")
+		require.True(t, ok)
+		assert.EqualValues(t, numberOfTraces, value)
+	}, 3*time.Second, 100*time.Millisecond)
+
+	for _, status := range statuses {
+		if status.TraceID == traceids[0] {
+			status.State = DecisionKeep
+			status.KeepReason = "because"
+		} else {
+			status.State = DecisionDrop
+		}
+	}
+	require.NotEmpty(t, statuses)
+	err = store.SetTraceStatuses(ctx, statuses)
+	assert.NoError(t, err)
+
+	// we need to give the dropped traces cache a chance to run or it might not process everything
+	time.Sleep(50 * time.Millisecond)
+	statuses, err = store.GetStatusForTraces(ctx, traceids)
+	assert.NoError(t, err)
+	assert.Equal(t, numberOfTraces, len(statuses))
+	for _, status := range statuses {
+		if status.TraceID == traceids[0] {
+			assert.Equal(t, DecisionKeep, status.State)
+			assert.Equal(t, "because", status.KeepReason)
+		} else {
+			assert.Equal(t, DecisionDrop, status.State)
+		}
+
+		err = store.RecordMetrics(ctx)
+		require.NoError(t, err)
+		_, ok := store.Metrics.Get("redisstore_count_traces")
+		require.True(t, ok)
+
+		err = store.RecordMetrics(ctx)
+		require.NoError(t, err)
+		count, ok := store.Metrics.Get("redisstore_count_awaiting_decision")
+		require.True(t, ok)
+		assert.Equal(t, float64(0), count)
+		count, ok = store.Metrics.Get("redisstore_count_traces")
+		require.True(t, ok)
+		assert.GreaterOrEqual(t, count, float64(numberOfTraces))
+		count, ok = store.Metrics.Get("redisstore_memory_used_total")
+		require.True(t, ok)
+		assert.Greater(t, count, float64(0))
+		count, ok = store.Metrics.Get("redisstore_memory_used_peak")
+		require.True(t, ok)
+		assert.Greater(t, count, float64(0))
+		count, ok = store.Metrics.Get("redisstore_count_keys")
+		require.True(t, ok)
+		assert.Greater(t, count, float64(0))
+	}
+}

--- a/centralstore/smartwrapper_test.go
+++ b/centralstore/smartwrapper_test.go
@@ -315,7 +315,7 @@ func TestSetTraceStatuses(t *testing.T) {
 	require.True(t, ok)
 
 	for tr := 0; tr < numberOfTraces; tr++ {
-		tid := fmt.Sprintf("trace%02d", tr)
+		tid := fmt.Sprintf("trace%02d", rand.Intn(1000))
 		traceids = append(traceids, tid)
 		// write 9 child spans to the store
 		for s := 1; s < 10; s++ {
@@ -358,7 +358,9 @@ func TestSetTraceStatuses(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, numberOfTraces, len(toDecide))
 	sort.Strings(toDecide)
-	assert.EqualValues(t, traceids[:numberOfTraces], toDecide)
+	expected := traceids[:numberOfTraces]
+	sort.Strings(expected)
+	assert.EqualValues(t, expected, toDecide)
 
 	statuses := make([]*CentralTraceStatus, 0)
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
@@ -408,7 +410,7 @@ func TestSetTraceStatuses(t *testing.T) {
 	assert.Equal(t, float64(0), count)
 	count, ok = store.Metrics.Get("redisstore_count_traces")
 	require.True(t, ok)
-	assert.Equal(t, float64(numberOfTraces), count)
+	assert.GreaterOrEqual(t, count, float64(numberOfTraces))
 	count, ok = store.Metrics.Get("redisstore_memory_used_total")
 	require.True(t, ok)
 	assert.Greater(t, count, float64(0))

--- a/centralstore/smartwrapper_test.go
+++ b/centralstore/smartwrapper_test.go
@@ -301,18 +301,13 @@ func TestReadyForDecisionLoop(t *testing.T) {
 }
 
 func TestSetTraceStatuses(t *testing.T) {
-	store, stopper, err := getAndStartSmartWrapper(storeType, &redis.DefaultClient{})
+	store, stopper, err := getAndStartSmartWrapper(storeType, nil)
 	require.NoError(t, err)
 	defer stopper()
 
 	ctx := context.Background()
 	numberOfTraces := 5
 	traceids := make([]string, 0)
-
-	err = store.RecordMetrics(ctx)
-	require.NoError(t, err)
-	_, ok := store.Metrics.Get("redisstore_count_traces")
-	require.True(t, ok)
 
 	for tr := 0; tr < numberOfTraces; tr++ {
 		tid := fmt.Sprintf("trace%02d", rand.Intn(1000))
@@ -402,24 +397,6 @@ func TestSetTraceStatuses(t *testing.T) {
 			assert.Equal(t, DecisionDrop, status.State)
 		}
 	}
-
-	err = store.RecordMetrics(ctx)
-	require.NoError(t, err)
-	count, ok := store.Metrics.Get("redisstore_count_awaiting_decision")
-	require.True(t, ok)
-	assert.Equal(t, float64(0), count)
-	count, ok = store.Metrics.Get("redisstore_count_traces")
-	require.True(t, ok)
-	assert.GreaterOrEqual(t, count, float64(numberOfTraces))
-	count, ok = store.Metrics.Get("redisstore_memory_used_total")
-	require.True(t, ok)
-	assert.Greater(t, count, float64(0))
-	count, ok = store.Metrics.Get("redisstore_memory_used_peak")
-	require.True(t, ok)
-	assert.Greater(t, count, float64(0))
-	count, ok = store.Metrics.Get("redisstore_count_keys")
-	require.True(t, ok)
-	assert.Greater(t, count, float64(0))
 }
 
 func BenchmarkStoreWriteSpan(b *testing.B) {

--- a/collect/central_collector.go
+++ b/collect/central_collector.go
@@ -50,10 +50,6 @@ const (
 const (
 	// TODO: these should be configurable
 	cacheEjectBatchSize         = 100
-	processTracesBatchSize      = 100
-	processTracesPauseDuration  = 200 * time.Microsecond
-	deciderPauseDuration        = 100 * time.Microsecond
-	deciderBatchSize            = 50
 	retryLimit                  = 5
 	concurrentTraceFetcherCount = 10
 )

--- a/collect/central_collector.go
+++ b/collect/central_collector.go
@@ -83,15 +83,15 @@ type CentralCollector struct {
 	incoming chan *types.Span
 	reload   chan struct{}
 
-	done chan struct{}
-	eg   *errgroup.Group
+	done           chan struct{}
+	eg             *errgroup.Group
+	processorCycle *Cycle
+	deciderCycle   *Cycle
 
 	hostname string
 
 	// test hooks
-	BlockOnAdd       bool
-	BlockOnDecider   bool
-	BlockOnProcessor bool
+	blockOnCollect bool
 }
 
 func (c *CentralCollector) Start() error {
@@ -106,6 +106,10 @@ func (c *CentralCollector) Start() error {
 	c.incoming = make(chan *types.Span, collectorCfg.GetIncomingQueueSize())
 	c.reload = make(chan struct{}, 1)
 	c.samplersByDestination = make(map[string]sample.Sampler)
+
+	// test hooks
+	c.processorCycle = NewCycle(c.Clock, collectorCfg.GetProcessTracesPauseDuration(), c.done)
+	c.deciderCycle = NewCycle(c.Clock, collectorCfg.GetDeciderPauseDuration(), c.done)
 
 	c.Metrics.Register("collector_processor_batch_count", "histogram")
 	c.Metrics.Register("collector_decider_batch_count", "histogram")
@@ -170,25 +174,26 @@ func (c *CentralCollector) add(sp *types.Span, ch chan<- *types.Span) error {
 	}
 }
 
-func (c *CentralCollector) collect() {
+func (c *CentralCollector) collect() error {
 	tickerDuration := c.Config.GetSendTickerValue()
 	ticker := c.Clock.NewTicker(tickerDuration)
 	defer ticker.Stop()
 
-	if c.BlockOnAdd {
-		c.Logger.Debug().Logf("blocking on add")
-		return
+	if c.blockOnCollect {
+		return nil
 	}
 
 	for {
 		select {
+		case <-c.done:
+			return nil
 		case <-ticker.Chan():
 			c.sendTracesForDecision()
 			c.checkAlloc()
 
 		case sp, ok := <-c.incoming:
 			if !ok {
-				return
+				return nil
 			}
 			err := c.processSpan(sp)
 			if err != nil {
@@ -202,38 +207,16 @@ func (c *CentralCollector) collect() {
 
 }
 
-func (c *CentralCollector) processor() {
-	for {
-		select {
-		case <-c.done:
-			return
-		default:
-
-			if c.BlockOnProcessor {
-			} else {
-				c.processTraces()
-			}
-
-		}
-
-		timer := c.Clock.NewTimer(processTracesPauseDuration)
-		select {
-		case <-c.done:
-			timer.Stop()
-			return
-		case <-timer.Chan():
-			timer.Stop()
-			continue
-		}
-	}
+func (c *CentralCollector) processor() error {
+	return c.processorCycle.Run(context.Background(), c.processTraces)
 }
 
-func (c *CentralCollector) processTraces() {
-	ids := c.SpanCache.GetTraceIDs(processTracesBatchSize)
+func (c *CentralCollector) processTraces(ctx context.Context) error {
+	ids := c.SpanCache.GetTraceIDs(c.Config.GetCollectionConfig().GetProcessTracesBatchSize())
 
 	c.Metrics.Histogram("collector_processor_batch_count", len(ids))
 	if len(ids) == 0 {
-		return
+		return nil
 	}
 
 	statuses, err := c.Store.GetStatusForTraces(context.Background(), ids)
@@ -252,38 +235,16 @@ func (c *CentralCollector) processTraces() {
 			c.Logger.Debug().Logf("trace %s is still pending", status.TraceID)
 		}
 	}
+
+	return nil
 }
 
-func (c *CentralCollector) decider() {
-	for {
-		select {
-		case <-c.done:
-			return
-		default:
-			// this is only ever true in test mode
-			if c.BlockOnDecider {
-			} else {
-				if err := c.makeDecision(); err != nil {
-					c.Logger.Error().Logf("error making decision: %s", err)
-				}
-			}
-
-			timer := c.Clock.NewTimer(deciderPauseDuration)
-			select {
-			case <-c.done:
-				timer.Stop()
-				return
-			case <-timer.Chan():
-				timer.Stop()
-				continue
-			}
-		}
-	}
+func (c *CentralCollector) decider() error {
+	return c.deciderCycle.Run(context.Background(), c.makeDecision)
 }
 
-func (c *CentralCollector) makeDecision() error {
-	ctx := context.Background()
-	tracesIDs, err := c.Store.GetTracesNeedingDecision(ctx, deciderBatchSize)
+func (c *CentralCollector) makeDecision(ctx context.Context) error {
+	tracesIDs, err := c.Store.GetTracesNeedingDecision(ctx, c.Config.GetCollectionConfig().GetDeciderBatchSize())
 	if err != nil {
 		return err
 	}

--- a/collect/central_collector_test.go
+++ b/collect/central_collector_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/rand"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -40,9 +41,11 @@ func TestCentralCollector_AddSpan(t *testing.T) {
 			CacheCapacity: 3,
 		},
 	}
-	coll := &CentralCollector{BlockOnDecider: true}
+	coll := &CentralCollector{}
 	stop := startCollector(t, conf, coll, nil, clockwork.NewFakeClock())
 	defer stop()
+
+	coll.processorCycle.pause <- struct{}{}
 
 	var traceID1 = "mytrace"
 
@@ -103,18 +106,20 @@ func TestCentralCollector_ProcessTraces(t *testing.T) {
 		SendTickerVal:      2 * time.Millisecond,
 		ParentIdFieldNames: []string{"trace.parent_id", "parentId"},
 		GetCollectionConfigVal: config.CollectionConfig{
-			CacheCapacity: 100,
+			CacheCapacity:              100,
+			ProcessTracesPauseDuration: config.Duration(1 * time.Second),
+			DeciderPauseDuration:       config.Duration(1 * time.Second),
 		},
 	}
 	transmission := &transmit.MockTransmission{}
 
-	collector := &CentralCollector{
-		BlockOnDecider:   true,
-		BlockOnProcessor: true,
-	}
+	collector := &CentralCollector{}
 	clock := clockwork.NewRealClock()
 	stop := startCollector(t, conf, collector, transmission, clock)
 	defer stop()
+
+	collector.processorCycle.pause <- struct{}{}
+	collector.deciderCycle.pause <- struct{}{}
 
 	numberOfTraces := 10
 	traceids := make([]string, 0, numberOfTraces)
@@ -134,7 +139,7 @@ func TestCentralCollector_ProcessTraces(t *testing.T) {
 					},
 				},
 			}
-			require.NoError(t, collector.processSpan(span))
+			require.NoError(t, collector.AddSpan(span))
 		}
 		// now write the root span
 		span := &types.Span{
@@ -142,15 +147,15 @@ func TestCentralCollector_ProcessTraces(t *testing.T) {
 			ID:      "span0",
 			IsRoot:  true,
 		}
-		require.NoError(t, collector.processSpan(span))
+		require.NoError(t, collector.AddSpan(span))
 	}
 
 	// wait for all traces to be processed
-	time.Sleep(2 * time.Second)
-	err := collector.makeDecision()
-	require.NoError(t, err)
+	waitUntilReadyToDecide(t, collector, traceids)
 
-	collector.processTraces()
+	collector.deciderCycle.RunOnce()
+
+	collector.processorCycle.RunOnce()
 
 	count, ok := collector.Metrics.Get("trace_send_kept")
 	require.True(t, ok)
@@ -163,15 +168,18 @@ func TestCentralCollector_Decider(t *testing.T) {
 		SendTickerVal:      2 * time.Millisecond,
 		ParentIdFieldNames: []string{"trace.parent_id", "parentId"},
 		GetCollectionConfigVal: config.CollectionConfig{
-			IncomingQueueSize: 100,
+			IncomingQueueSize:          100,
+			ProcessTracesPauseDuration: config.Duration(1 * time.Second),
+			DeciderPauseDuration:       config.Duration(1 * time.Second),
 		},
 	}
 	transmission := &transmit.MockTransmission{}
 
-	collector := &CentralCollector{BlockOnDecider: true}
+	collector := &CentralCollector{}
 	clock := clockwork.NewRealClock()
 	stop := startCollector(t, conf, collector, transmission, clock)
 	defer stop()
+	collector.deciderCycle.pause <- struct{}{}
 
 	numberOfTraces := 10
 	traceids := make([]string, 0, numberOfTraces)
@@ -204,16 +212,17 @@ func TestCentralCollector_Decider(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-		require.NoError(t, collector.makeDecision())
-		traces, err := collector.Store.GetStatusForTraces(context.Background(), traceids)
-		require.NoError(collect, err)
-		require.Equal(collect, numberOfTraces, len(traces))
-		for _, trace := range traces {
-			assert.Equal(collect, centralstore.DecisionKeep, trace.State)
-			assert.Equal(collect, "test", trace.SamplerKey)
-		}
-	}, 3*time.Second, 500*time.Millisecond)
+	waitUntilReadyToDecide(t, collector, traceids)
+
+	ctx := context.Background()
+	collector.deciderCycle.RunOnce()
+	traces, err := collector.Store.GetStatusForTraces(ctx, traceids)
+	require.NoError(t, err)
+	require.Equal(t, numberOfTraces, len(traces))
+	for _, trace := range traces {
+		assert.Equal(t, centralstore.DecisionKeep, trace.State)
+		assert.Equal(t, "test", trace.SamplerKey)
+	}
 }
 
 func TestCentralCollector_OriginalSampleRateIsNotedInMetaField(t *testing.T) {
@@ -229,7 +238,9 @@ func TestCentralCollector_OriginalSampleRateIsNotedInMetaField(t *testing.T) {
 		SendTickerVal:      2 * time.Millisecond,
 		ParentIdFieldNames: []string{"trace.parent_id", "parentId"},
 		GetCollectionConfigVal: config.CollectionConfig{
-			IncomingQueueSize: 100,
+			IncomingQueueSize:          10000,
+			DeciderPauseDuration:       config.Duration(1 * time.Second),
+			ProcessTracesPauseDuration: config.Duration(1 * time.Second),
 		},
 		SampleCache: config.SampleCacheConfig{
 			KeptSize:          100,
@@ -243,12 +254,14 @@ func TestCentralCollector_OriginalSampleRateIsNotedInMetaField(t *testing.T) {
 	stop := startCollector(t, conf, collector, transmission, clock)
 	defer stop()
 
+	collector.deciderCycle.pause <- struct{}{}
+	collector.processorCycle.pause <- struct{}{}
+
 	// Generate events until one is sampled and appears on the transmission queue for sending.
-	sendAttemptCount := 0
-	for getEventsLength(transmission) < 1 {
-		sendAttemptCount++
+	traceIDs := make([]string, 0, 10)
+	for i := 0; i < 10; i++ {
 		span := &types.Span{
-			TraceID: fmt.Sprintf("trace-%v", sendAttemptCount),
+			TraceID: fmt.Sprintf("trace-%v", i),
 			Event: types.Event{
 				Dataset:    "aoeu",
 				APIKey:     legacyAPIKey,
@@ -256,9 +269,15 @@ func TestCentralCollector_OriginalSampleRateIsNotedInMetaField(t *testing.T) {
 				Data:       make(map[string]interface{}),
 			},
 		}
-		_ = collector.AddSpan(span)
-		time.Sleep(time.Duration(conf.GetCentralStoreOptions().StateTicker) * 2)
+		traceIDs = append(traceIDs, span.TraceID)
+		require.NoError(t, collector.AddSpan(span))
 	}
+	waitUntilReadyToDecide(t, collector, traceIDs)
+	collector.deciderCycle.RunOnce()
+
+	waitForTraceDecision(t, collector, traceIDs)
+
+	collector.processorCycle.RunOnce()
 
 	transmission.Mux.RLock()
 	require.Greater(t, len(transmission.Events), 0,
@@ -272,8 +291,9 @@ func TestCentralCollector_OriginalSampleRateIsNotedInMetaField(t *testing.T) {
 		"sample rate for the event should be the original sample rate multiplied by the deterministic sample rate")
 
 	// Generate one more event with no upstream sampling applied.
+	traceID := fmt.Sprintf("trace-%v", 1000)
 	err := collector.AddSpan(&types.Span{
-		TraceID: fmt.Sprintf("trace-%v", 1000),
+		TraceID: traceID,
 		Event: types.Event{
 			Dataset:    "no-upstream-sampling",
 			APIKey:     legacyAPIKey,
@@ -282,17 +302,18 @@ func TestCentralCollector_OriginalSampleRateIsNotedInMetaField(t *testing.T) {
 		},
 	})
 	require.NoError(t, err, "must be able to add the span")
-	time.Sleep(time.Duration(conf.GetCentralStoreOptions().StateTicker) * 2)
+	waitUntilReadyToDecide(t, collector, []string{traceID})
+	collector.deciderCycle.RunOnce()
+	waitForTraceDecision(t, collector, []string{traceID})
 
+	collector.processorCycle.RunOnce()
 	// Find the Refinery-sampled-and-sent event that had no upstream sampling which
 	// should be the last event on the transmission queue.
 	var noUpstreamSampleRateEvent *types.Event
-	require.Eventually(t, func() bool {
-		transmission.Mux.RLock()
-		defer transmission.Mux.RUnlock()
-		noUpstreamSampleRateEvent = transmission.Events[len(transmission.Events)-1]
-		return noUpstreamSampleRateEvent.Dataset == "no-upstream-sampling"
-	}, 5*time.Second, time.Duration(conf.GetCentralStoreOptions().StateTicker)*2, "the event with no upstream sampling should have appeared in the transmission queue by now")
+	transmission.Mux.RLock()
+	noUpstreamSampleRateEvent = transmission.Events[len(transmission.Events)-1]
+	require.Equal(t, "no-upstream-sampling", noUpstreamSampleRateEvent.Dataset)
+	transmission.Mux.RUnlock()
 
 	assert.Nil(t, noUpstreamSampleRateEvent.Data["meta.refinery.original_sample_rate"],
 		"original sample rate should not be set in metadata when original sample rate is zero")
@@ -307,7 +328,9 @@ func TestCentralCollector_TransmittedSpansShouldHaveASampleRateOfAtLeastOne(t *t
 		GetTraceTimeoutVal: 60 * time.Second,
 		GetSamplerTypeVal:  &config.DeterministicSamplerConfig{SampleRate: 1},
 		GetCollectionConfigVal: config.CollectionConfig{
-			IncomingQueueSize: 100,
+			IncomingQueueSize:          100,
+			ProcessTracesPauseDuration: config.Duration(1 * time.Second),
+			DeciderPauseDuration:       config.Duration(1 * time.Second),
 		},
 		SendTickerVal:      2 * time.Millisecond,
 		ParentIdFieldNames: []string{"trace.parent_id", "parentId"},
@@ -323,6 +346,9 @@ func TestCentralCollector_TransmittedSpansShouldHaveASampleRateOfAtLeastOne(t *t
 	stop := startCollector(t, conf, coll, transmission, clock)
 	defer stop()
 
+	coll.deciderCycle.pause <- struct{}{}
+	coll.processorCycle.pause <- struct{}{}
+
 	span := &types.Span{
 		TraceID: fmt.Sprintf("trace-%v", 1),
 		Event: types.Event{
@@ -335,28 +361,28 @@ func TestCentralCollector_TransmittedSpansShouldHaveASampleRateOfAtLeastOne(t *t
 
 	err := coll.AddSpan(span)
 	require.NoError(t, err)
+	waitUntilReadyToDecide(t, coll, []string{span.TraceID})
+	coll.deciderCycle.RunOnce()
+	waitForTraceDecision(t, coll, []string{span.TraceID})
+	coll.processorCycle.RunOnce()
 
-	waitDur := time.Duration(conf.GetCentralStoreOptions().StateTicker)
-	require.Eventually(t, func() bool {
-		transmission.Mux.RLock()
-		defer transmission.Mux.RUnlock()
-		return len(transmission.Events) > 0
-	}, 2*time.Second, waitDur*2)
-
-	transmission.Mux.RLock()
+	require.Len(t, transmission.Events, 1)
 	assert.Equal(t, uint(1), transmission.Events[0].SampleRate,
 		"SampleRate should be reset to one after starting at zero")
-	transmission.Mux.RUnlock()
 }
 
 func TestCentralCollector_SampleConfigReload(t *testing.T) {
 	conf := &config.MockConfig{
-		GetSendDelayVal:        0,
-		GetTraceTimeoutVal:     60 * time.Second,
-		GetSamplerTypeVal:      &config.DeterministicSamplerConfig{SampleRate: 1},
-		SendTickerVal:          2 * time.Millisecond,
-		ParentIdFieldNames:     []string{"trace.parent_id", "parentId"},
-		GetCollectionConfigVal: config.CollectionConfig{CacheCapacity: 10},
+		GetSendDelayVal:    0,
+		GetTraceTimeoutVal: 60 * time.Second,
+		GetSamplerTypeVal:  &config.DeterministicSamplerConfig{SampleRate: 1},
+		SendTickerVal:      2 * time.Millisecond,
+		ParentIdFieldNames: []string{"trace.parent_id", "parentId"},
+		GetCollectionConfigVal: config.CollectionConfig{
+			CacheCapacity:              10,
+			ProcessTracesPauseDuration: config.Duration(1 * time.Second),
+			DeciderPauseDuration:       config.Duration(1 * time.Second),
+		},
 		SampleCache: config.SampleCacheConfig{
 			KeptSize:          100,
 			DroppedSize:       100,
@@ -370,10 +396,14 @@ func TestCentralCollector_SampleConfigReload(t *testing.T) {
 	stop := startCollector(t, conf, coll, transmission, clock)
 	defer stop()
 
+	coll.deciderCycle.pause <- struct{}{}
+	coll.processorCycle.pause <- struct{}{}
+
 	dataset := "aoeu"
 
 	span := &types.Span{
 		TraceID: "1",
+		ID:      "span1",
 		Event: types.Event{
 			Dataset: dataset,
 			APIKey:  legacyAPIKey,
@@ -383,13 +413,10 @@ func TestCentralCollector_SampleConfigReload(t *testing.T) {
 	err := coll.AddSpan(span)
 	require.NoError(t, err)
 
-	assert.Eventually(t, func() bool {
-		coll.mut.RLock()
-		defer coll.mut.RUnlock()
+	waitUntilReadyToDecide(t, coll, []string{span.TraceID})
 
-		_, ok := coll.samplersByDestination[dataset]
-		return ok
-	}, 2*time.Second, 20*time.Millisecond)
+	_, ok := coll.samplersByDestination[dataset]
+	require.True(t, ok)
 
 	conf.ReloadConfig()
 
@@ -411,14 +438,10 @@ func TestCentralCollector_SampleConfigReload(t *testing.T) {
 
 	err = coll.AddSpan(span)
 	require.NoError(t, err)
+	waitUntilReadyToDecide(t, coll, []string{span.TraceID})
 
-	assert.Eventually(t, func() bool {
-		coll.mut.RLock()
-		defer coll.mut.RUnlock()
-
-		_, ok := coll.samplersByDestination[dataset]
-		return ok
-	}, 2*time.Second, 20*time.Millisecond)
+	_, ok = coll.samplersByDestination[dataset]
+	require.True(t, ok)
 }
 
 func TestCentralCollector_StableMaxAlloc(t *testing.T) {
@@ -434,19 +457,27 @@ func TestCentralCollector_StableMaxAlloc(t *testing.T) {
 			SizeCheckInterval: config.Duration(1 * time.Second),
 		},
 		GetCollectionConfigVal: config.CollectionConfig{
-			IncomingQueueSize:      600,
-			ProcessTracesBatchSize: 500,
-			DeciderBatchSize:       100,
+			IncomingQueueSize:          600,
+			ProcessTracesBatchSize:     500,
+			DeciderBatchSize:           100,
+			ProcessTracesPauseDuration: config.Duration(1 * time.Second),
+			DeciderPauseDuration:       config.Duration(1 * time.Second),
+		},
+		StoreOptions: config.SmartWrapperOptions{
+			DecisionTimeout: config.Duration(1 * time.Minute),
 		},
 	}
 
 	transmission := &transmit.MockTransmission{}
 	clock := clockwork.NewRealClock()
-	coll := &CentralCollector{BlockOnDecider: true, BlockOnProcessor: true}
+	coll := &CentralCollector{}
 	stop := startCollector(t, conf, coll, transmission, clock)
 	defer stop()
 
-	totalTraceCount := 500
+	coll.deciderCycle.pause <- struct{}{}
+	coll.processorCycle.pause <- struct{}{}
+
+	totalTraceCount := 300
 	spandata := make([]map[string]interface{}, totalTraceCount)
 	for i := 0; i < totalTraceCount; i++ {
 		spandata[i] = map[string]interface{}{
@@ -457,11 +488,13 @@ func TestCentralCollector_StableMaxAlloc(t *testing.T) {
 		}
 	}
 
-	toRemoveTraceCount := 400
+	toRemoveTraceCount := 200
 	var memorySize uint64
+	traceIDs := make([]string, 0, totalTraceCount)
 	for i := 0; i < totalTraceCount; i++ {
 		span := &types.Span{
 			TraceID: strconv.Itoa(i),
+			ID:      fmt.Sprintf("span%d", i),
 			Event: types.Event{
 				Dataset: "aoeu",
 				Data:    spandata[i],
@@ -473,12 +506,10 @@ func TestCentralCollector_StableMaxAlloc(t *testing.T) {
 		if i < toRemoveTraceCount {
 			memorySize += uint64(span.GetDataSize())
 		}
+		traceIDs = append(traceIDs, span.TraceID)
 	}
 
-	waitDur := time.Duration(conf.GetCentralStoreOptions().StateTicker)
-	for len(coll.incoming) > 0 {
-		time.Sleep(2 * waitDur)
-	}
+	waitUntilReadyToDecide(t, coll, traceIDs)
 
 	// Now there should be 500 traces in the cache.
 	assert.Equal(t, totalTraceCount, coll.SpanCache.Len())
@@ -496,9 +527,9 @@ func TestCentralCollector_StableMaxAlloc(t *testing.T) {
 	// wait for the cache to take some action
 	var numOfTracesInCache int
 	for {
-		time.Sleep(2 * waitDur)
-		require.NoError(t, coll.makeDecision())
-		coll.processTraces()
+		time.Sleep(20 * time.Millisecond)
+		coll.deciderCycle.RunOnce()
+		coll.processorCycle.RunOnce()
 
 		numOfTracesInCache = coll.SpanCache.Len()
 		if numOfTracesInCache <= toRemoveTraceCount {
@@ -506,7 +537,7 @@ func TestCentralCollector_StableMaxAlloc(t *testing.T) {
 		}
 	}
 
-	assert.Less(t, numOfTracesInCache, 480, "should have sent some traces")
+	assert.Less(t, numOfTracesInCache, 280, "should have sent some traces")
 	assert.Greater(t, numOfTracesInCache, 100, "should have NOT sent some traces")
 
 	// We discarded the most costly spans, and sent them.
@@ -535,7 +566,9 @@ func TestCentralCollector_AddSpanNoBlock(t *testing.T) {
 
 	transmission := &transmit.MockTransmission{}
 	clock := clockwork.NewRealClock()
-	coll := &CentralCollector{BlockOnAdd: true}
+	coll := &CentralCollector{
+		blockOnCollect: true,
+	}
 	stop := startCollector(t, conf, coll, transmission, clock)
 	defer stop()
 
@@ -561,7 +594,7 @@ func TestCentralCollector_AddSpanNoBlock(t *testing.T) {
 // This test also makes sure that AddCountsToRoot overrides the AddSpanCountToRoot config.
 func TestCentralCollector_AddCountsToRoot(t *testing.T) {
 	conf := &config.MockConfig{
-		GetSendDelayVal:    0,
+		GetSendDelayVal:    10 * time.Millisecond,
 		GetTraceTimeoutVal: 60 * time.Second,
 		GetSamplerTypeVal:  &config.DeterministicSamplerConfig{SampleRate: 1},
 		SendTickerVal:      60 * time.Second,
@@ -574,15 +607,20 @@ func TestCentralCollector_AddCountsToRoot(t *testing.T) {
 			SizeCheckInterval: config.Duration(1 * time.Second),
 		},
 		GetCollectionConfigVal: config.CollectionConfig{
-			IncomingQueueSize: 100,
+			IncomingQueueSize:          100,
+			ProcessTracesPauseDuration: config.Duration(1 * time.Second),
+			DeciderPauseDuration:       config.Duration(1 * time.Second),
 		},
 	}
 
 	transmission := &transmit.MockTransmission{}
-	clock := clockwork.NewFakeClock()
-	coll := &CentralCollector{BlockOnProcessor: true, BlockOnDecider: true}
+	clock := clockwork.NewRealClock()
+	coll := &CentralCollector{}
 	stop := startCollector(t, conf, coll, transmission, clock)
 	defer stop()
+
+	coll.deciderCycle.pause <- struct{}{}
+	coll.processorCycle.pause <- struct{}{}
 
 	var traceID = "mytrace"
 	for i := 0; i < 4; i++ {
@@ -605,11 +643,14 @@ func TestCentralCollector_AddCountsToRoot(t *testing.T) {
 		}
 		require.NoError(t, coll.AddSpan(span))
 	}
-	time.Sleep(10 * time.Millisecond)
+	coll.deciderCycle.RunOnce()
+	coll.processorCycle.RunOnce()
+
 	trace := coll.SpanCache.Get(traceID)
 	require.NotNil(t, trace, "after adding the spans, we should have a trace in the cache")
 	assert.Equal(t, traceID, trace.TraceID, "after adding the span, we should have a trace in the cache with the right trace ID")
 	assert.Equal(t, 0, len(transmission.Events), "adding a non-root span should not yet send the span")
+
 	// ok now let's add the root span and verify that both got sent
 	rootSpan := &types.Span{
 		TraceID: traceID,
@@ -625,22 +666,11 @@ func TestCentralCollector_AddCountsToRoot(t *testing.T) {
 
 	// make sure all spans are processed and the trace is ready
 	// for decision
-	var processed bool
-	ctx := context.Background()
-	for !processed {
-		clock.Advance(1 * time.Second)
-		ids, err := coll.Store.GetTracesForState(ctx, centralstore.ReadyToDecide)
-		require.NoError(t, err)
-		if len(ids) > 0 {
-			trace, err := coll.Store.GetTrace(ctx, traceID)
-			require.NoError(t, err)
-			if len(trace.Spans) == 5 {
-				processed = true
-			}
-		}
-	}
-	require.NoError(t, coll.makeDecision())
-	coll.processTraces()
+	waitUntilReadyToDecide(t, coll, []string{traceID})
+	coll.deciderCycle.RunOnce()
+	waitForTraceDecision(t, coll, []string{traceID})
+	coll.processorCycle.RunOnce()
+
 	trace = coll.SpanCache.Get(traceID)
 	require.Nil(t, trace, "after adding a leaf and root span, it should be removed from the cache")
 
@@ -676,15 +706,20 @@ func TestCentralCollector_LateRootGetsCounts(t *testing.T) {
 			SizeCheckInterval: config.Duration(1 * time.Second),
 		},
 		GetCollectionConfigVal: config.CollectionConfig{
-			IncomingQueueSize: 100,
+			IncomingQueueSize:          100,
+			ProcessTracesPauseDuration: config.Duration(1 * time.Second),
+			DeciderPauseDuration:       config.Duration(1 * time.Second),
 		},
 	}
 
 	transmission := &transmit.MockTransmission{}
 	clock := clockwork.NewRealClock()
-	coll := &CentralCollector{BlockOnDecider: true, BlockOnProcessor: true}
+	coll := &CentralCollector{}
 	stop := startCollector(t, conf, coll, transmission, clock)
 	defer stop()
+
+	coll.deciderCycle.pause <- struct{}{}
+	coll.processorCycle.pause <- struct{}{}
 
 	var traceID = "mytrace"
 
@@ -710,19 +745,13 @@ func TestCentralCollector_LateRootGetsCounts(t *testing.T) {
 	}
 	// make sure all spans are processed and the trace is ready
 	// for decision
-	var processed bool
-	for !processed {
-		require.NoError(t, coll.makeDecision())
-		coll.processTraces()
-		trace := coll.SpanCache.Get(traceID)
-		if trace != nil {
-			continue
-		}
-		require.Nil(t, trace, "after adding the spans, we should have a trace in the cache")
-		time.Sleep(time.Duration(conf.GetCollectionConfigVal.ProcessTracesPauseDuration) * 5)
-		require.Equal(t, 4, len(transmission.Events), "adding a non-root span and waiting should send the span")
-		processed = true
-	}
+	waitUntilReadyToDecide(t, coll, []string{traceID})
+	coll.deciderCycle.RunOnce()
+	waitForTraceDecision(t, coll, []string{traceID})
+	coll.processorCycle.RunOnce()
+	trace := coll.SpanCache.Get(traceID)
+	require.Nil(t, trace, "trace should have been sent")
+	require.Equal(t, 4, len(transmission.Events), "adding a non-root span and waiting should send the span")
 
 	// now we add the root span and verify that both got sent and that the root span had the span count
 	rootSpan := &types.Span{
@@ -736,13 +765,14 @@ func TestCentralCollector_LateRootGetsCounts(t *testing.T) {
 		IsRoot: true,
 	}
 	require.NoError(t, coll.AddSpan(rootSpan))
+	// The trace decision is already made for the late root span
+	waitForTraceDecision(t, coll, []string{traceID})
+	coll.processorCycle.RunOnce()
 
-	require.NoError(t, coll.makeDecision())
-	coll.processTraces()
-
-	trace := coll.SpanCache.Get(traceID)
+	trace = coll.SpanCache.Get(traceID)
 	require.Nil(t, trace, "after adding a leaf and root span, it should be removed from the cache")
 	transmission.Mux.RLock()
+
 	assert.Equal(t, 5, len(transmission.Events), "adding a root span should send all spans in the trace")
 	assert.Equal(t, nil, transmission.Events[0].Data["meta.span_count"], "child span metadata should NOT be populated with span count")
 	assert.Equal(t, nil, transmission.Events[1].Data["meta.span_count"], "child span metadata should NOT be populated with span count")
@@ -775,7 +805,9 @@ func TestCentralCollector_LateSpanNotDecorated(t *testing.T) {
 			SizeCheckInterval: config.Duration(1 * time.Second),
 		},
 		GetCollectionConfigVal: config.CollectionConfig{
-			IncomingQueueSize: 10,
+			IncomingQueueSize:          10,
+			ProcessTracesPauseDuration: config.Duration(1 * time.Second),
+			DeciderPauseDuration:       config.Duration(1 * time.Second),
 		},
 	}
 
@@ -784,6 +816,9 @@ func TestCentralCollector_LateSpanNotDecorated(t *testing.T) {
 	coll := &CentralCollector{}
 	stop := startCollector(t, conf, coll, transmission, clock)
 	defer stop()
+
+	coll.deciderCycle.pause <- struct{}{}
+	coll.processorCycle.pause <- struct{}{}
 
 	var traceID = "traceABC"
 
@@ -799,6 +834,15 @@ func TestCentralCollector_LateSpanNotDecorated(t *testing.T) {
 		},
 	}
 	require.NoError(t, coll.AddSpan(span))
+	// make sure all spans are processed and the trace is ready
+	// for decision
+	waitUntilReadyToDecide(t, coll, []string{traceID})
+	coll.deciderCycle.RunOnce()
+	waitForTraceDecision(t, coll, []string{traceID})
+	coll.processorCycle.RunOnce()
+	trace := coll.SpanCache.Get(traceID)
+	require.Nil(t, trace, "trace should have been sent")
+	require.Equal(t, 1, len(transmission.Events), "adding a non-root span and waiting should send the span")
 
 	rootSpan := &types.Span{
 		TraceID: traceID,
@@ -811,15 +855,17 @@ func TestCentralCollector_LateSpanNotDecorated(t *testing.T) {
 		IsRoot: true,
 	}
 	require.NoError(t, coll.AddSpan(rootSpan))
+	// The trace decision is already made for the late root span
+	waitForTraceDecision(t, coll, []string{traceID})
+	coll.processorCycle.RunOnce()
 
-	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		transmission.Mux.RLock()
-		assert.Equal(c, 2, len(transmission.Events), "adding a root span should send all spans in the trace")
-		if len(transmission.Events) == 2 {
-			assert.Equal(c, nil, transmission.Events[1].Data["meta.refinery.reason"], "late span should not have meta.refinery.reason set to late")
-		}
-		transmission.Mux.RUnlock()
-	}, 5*time.Second, conf.SendTickerVal)
+	trace = coll.SpanCache.Get(traceID)
+	require.Nil(t, trace, "after adding a leaf and root span, it should be removed from the cache")
+
+	transmission.Mux.RLock()
+	assert.Equal(t, 2, len(transmission.Events), "adding a root span should send all spans in the trace")
+	assert.Equal(t, nil, transmission.Events[1].Data["meta.refinery.reason"], "late span should not have meta.refinery.reason set to late")
+	transmission.Mux.RUnlock()
 }
 
 func TestCentralCollector_AddAdditionalAttributes(t *testing.T) {
@@ -838,17 +884,19 @@ func TestCentralCollector_AddAdditionalAttributes(t *testing.T) {
 			SizeCheckInterval: config.Duration(1 * time.Second),
 		},
 		GetCollectionConfigVal: config.CollectionConfig{
-			IncomingQueueSize: 5,
+			IncomingQueueSize:          5,
+			ProcessTracesPauseDuration: config.Duration(1 * time.Second),
+			DeciderPauseDuration:       config.Duration(1 * time.Second),
 		},
 	}
 	transmission := &transmit.MockTransmission{}
 	clock := clockwork.NewRealClock()
-	coll := &CentralCollector{
-		BlockOnDecider:   true,
-		BlockOnProcessor: true,
-	}
+	coll := &CentralCollector{}
 	stop := startCollector(t, conf, coll, transmission, clock)
 	defer stop()
+
+	coll.deciderCycle.pause <- struct{}{}
+	coll.processorCycle.pause <- struct{}{}
 
 	var traceID = "trace123"
 
@@ -876,23 +924,11 @@ func TestCentralCollector_AddAdditionalAttributes(t *testing.T) {
 		IsRoot: true,
 	}
 	require.NoError(t, coll.AddSpan(rootSpan))
-	time.Sleep(time.Duration(conf.StoreOptions.StateTicker) * 5)
+	waitUntilReadyToDecide(t, coll, []string{traceID})
+	coll.deciderCycle.RunOnce()
+	waitForTraceDecision(t, coll, []string{traceID})
+	coll.processorCycle.RunOnce()
 
-	var processed bool
-	ctx := context.Background()
-	for !processed {
-		ids, err := coll.Store.GetTracesForState(ctx, centralstore.ReadyToDecide)
-		require.NoError(t, err)
-		if len(ids) > 0 {
-			trace, err := coll.Store.GetTrace(ctx, traceID)
-			require.NoError(t, err)
-			if len(trace.Spans) == 2 {
-				processed = true
-			}
-		}
-	}
-	require.NoError(t, coll.makeDecision())
-	coll.processTraces()
 	transmission.Mux.RLock()
 	assert.Equal(t, 2, len(transmission.Events), "should be some events transmitted")
 	assert.Equal(t, "foo", transmission.Events[0].Data["name"], "new attribute should appear in data")
@@ -1020,15 +1056,20 @@ func TestCentralCollector_SpanWithRuleReasons(t *testing.T) {
 			SizeCheckInterval: config.Duration(1 * time.Second),
 		},
 		GetCollectionConfigVal: config.CollectionConfig{
-			IncomingQueueSize: 100,
+			IncomingQueueSize:          100,
+			ProcessTracesPauseDuration: config.Duration(1 * time.Second),
+			DeciderPauseDuration:       config.Duration(1 * time.Second),
 		},
 	}
 
 	transmission := &transmit.MockTransmission{}
 	clock := clockwork.NewRealClock()
-	coll := &CentralCollector{BlockOnProcessor: true, BlockOnDecider: true}
+	coll := &CentralCollector{}
 	stop := startCollector(t, conf, coll, transmission, clock)
 	defer stop()
+
+	coll.deciderCycle.pause <- struct{}{}
+	coll.processorCycle.pause <- struct{}{}
 
 	traceIDs := []string{"trace1", "trace2"}
 
@@ -1054,27 +1095,11 @@ func TestCentralCollector_SpanWithRuleReasons(t *testing.T) {
 		}
 		require.NoError(t, coll.AddSpan(span))
 	}
-	time.Sleep(time.Duration(conf.StoreOptions.StateTicker) * 5)
-	var processed bool
-	count := len(traceIDs)
-	for !processed {
-		require.NoError(t, coll.makeDecision())
-		coll.processTraces()
-		for _, traceID := range traceIDs {
-			trace := coll.SpanCache.Get(traceID)
-			if trace != nil {
-				continue
-			}
-			count--
-			require.Nil(t, trace, "after adding the spans, we should have a trace in the cache")
-		}
-		if count != 0 {
-			continue
-		}
-		time.Sleep(time.Duration(conf.GetCollectionConfigVal.ProcessTracesPauseDuration) * 5)
-		require.Equal(t, 4, len(transmission.Events), "adding a non-root span and waiting should send the span")
-		processed = true
-	}
+	waitUntilReadyToDecide(t, coll, traceIDs)
+	coll.deciderCycle.RunOnce()
+	waitForTraceDecision(t, coll, traceIDs)
+	coll.processorCycle.RunOnce()
+	require.Equal(t, 4, len(transmission.Events), "adding a non-root span and waiting should send the span")
 
 	for i, traceID := range traceIDs {
 		rootSpan := &types.Span{
@@ -1097,10 +1122,10 @@ func TestCentralCollector_SpanWithRuleReasons(t *testing.T) {
 
 		require.NoError(t, coll.AddSpan(rootSpan))
 	}
-	// now we add the root span and verify that both got sent and that the root span had the span count
-	time.Sleep(time.Duration(conf.GetCollectionConfigVal.ProcessTracesPauseDuration) * 2)
-	require.NoError(t, coll.makeDecision())
-	coll.processTraces()
+
+	waitForTraceDecision(t, coll, traceIDs)
+	coll.processorCycle.RunOnce()
+
 	transmission.Mux.RLock()
 	assert.Equal(t, 6, len(transmission.Events), "adding a root span should send all spans in the trace")
 	for _, event := range transmission.Events {
@@ -1131,17 +1156,35 @@ func startCollector(t *testing.T, cfg *config.MockConfig, collector *CentralColl
 		transmission = &transmit.MockTransmission{}
 	}
 
-	cfg.StoreOptions = config.SmartWrapperOptions{
-		SpanChannelSize: 200,
-		StateTicker:     duration("50ms"),
-		SendDelay:       duration("200ms"),
-		TraceTimeout:    duration("500ms"),
-		DecisionTimeout: duration("500ms"),
+	if cfg.StoreOptions.SpanChannelSize == 0 {
+		cfg.StoreOptions.SpanChannelSize = 100
 	}
-	cfg.SampleCache = config.SampleCacheConfig{
-		KeptSize:          1000,
-		DroppedSize:       1000,
-		SizeCheckInterval: duration("1s"),
+
+	if cfg.StoreOptions.StateTicker == 0 {
+		cfg.StoreOptions.StateTicker = duration("50ms")
+	}
+
+	if cfg.StoreOptions.SendDelay == 0 {
+		cfg.StoreOptions.SendDelay = duration("200ms")
+	}
+
+	if cfg.StoreOptions.TraceTimeout == 0 {
+		cfg.StoreOptions.TraceTimeout = duration("500ms")
+	}
+
+	if cfg.StoreOptions.DecisionTimeout == 0 {
+		cfg.StoreOptions.DecisionTimeout = duration("500ms")
+	}
+
+	if cfg.SampleCache.KeptSize == 0 {
+		cfg.SampleCache.KeptSize = 1000
+	}
+	if cfg.SampleCache.DroppedSize == 0 {
+		cfg.SampleCache.DroppedSize = 1000
+	}
+
+	if cfg.SampleCache.SizeCheckInterval == 0 {
+		cfg.SampleCache.SizeCheckInterval = duration("1s")
 	}
 
 	if cfg.GetTraceTimeoutVal == 0 {
@@ -1194,9 +1237,39 @@ func duration(s string) config.Duration {
 	return config.Duration(d)
 }
 
-func getEventsLength(transmission *transmit.MockTransmission) int {
-	transmission.Mux.RLock()
-	defer transmission.Mux.RUnlock()
+func waitUntilReadyToDecide(t *testing.T, coll *CentralCollector, traceIDs []string) {
+	ctx := context.Background()
+	require.Eventually(t, func() bool {
+		ids, err := coll.Store.GetTracesForState(ctx, centralstore.ReadyToDecide)
+		require.NoError(t, err)
+		for _, id := range traceIDs {
+			if !slices.Contains(ids, id) {
+				return false
+			}
+		}
+		return true
+	}, 5*time.Second, 10*time.Millisecond)
+}
 
-	return len(transmission.Events)
+func waitForTraceDecision(t *testing.T, coll *CentralCollector, traceIDs []string) {
+	ctx := context.Background()
+	require.Eventually(t, func() bool {
+		statuses, err := coll.Store.GetStatusForTraces(ctx, traceIDs)
+		require.NoError(t, err)
+		var count int
+		for _, status := range statuses {
+			if !slices.Contains(traceIDs, status.TraceID) {
+				continue
+			}
+			switch status.State {
+			case centralstore.DecisionKeep:
+				count++
+			case centralstore.DecisionDrop:
+				count++
+			default:
+				fmt.Println("status", status.State)
+			}
+		}
+		return count == len(traceIDs)
+	}, 5*time.Second, 20*time.Millisecond)
 }

--- a/collect/central_collector_test.go
+++ b/collect/central_collector_test.go
@@ -45,7 +45,7 @@ func TestCentralCollector_AddSpan(t *testing.T) {
 	stop := startCollector(t, conf, coll, nil, clockwork.NewFakeClock())
 	defer stop()
 
-	coll.processorCycle.pause <- struct{}{}
+	coll.processorCycle.Pause()
 
 	var traceID1 = "mytrace"
 
@@ -118,8 +118,8 @@ func TestCentralCollector_ProcessTraces(t *testing.T) {
 	stop := startCollector(t, conf, collector, transmission, clock)
 	defer stop()
 
-	collector.processorCycle.pause <- struct{}{}
-	collector.deciderCycle.pause <- struct{}{}
+	collector.processorCycle.Pause()
+	collector.deciderCycle.Pause()
 
 	numberOfTraces := 10
 	traceids := make([]string, 0, numberOfTraces)
@@ -179,7 +179,7 @@ func TestCentralCollector_Decider(t *testing.T) {
 	clock := clockwork.NewRealClock()
 	stop := startCollector(t, conf, collector, transmission, clock)
 	defer stop()
-	collector.deciderCycle.pause <- struct{}{}
+	collector.deciderCycle.Pause()
 
 	numberOfTraces := 10
 	traceids := make([]string, 0, numberOfTraces)
@@ -254,8 +254,8 @@ func TestCentralCollector_OriginalSampleRateIsNotedInMetaField(t *testing.T) {
 	stop := startCollector(t, conf, collector, transmission, clock)
 	defer stop()
 
-	collector.deciderCycle.pause <- struct{}{}
-	collector.processorCycle.pause <- struct{}{}
+	collector.deciderCycle.Pause()
+	collector.processorCycle.Pause()
 
 	// Generate events until one is sampled and appears on the transmission queue for sending.
 	traceIDs := make([]string, 0, 10)
@@ -346,8 +346,8 @@ func TestCentralCollector_TransmittedSpansShouldHaveASampleRateOfAtLeastOne(t *t
 	stop := startCollector(t, conf, coll, transmission, clock)
 	defer stop()
 
-	coll.deciderCycle.pause <- struct{}{}
-	coll.processorCycle.pause <- struct{}{}
+	coll.deciderCycle.Pause()
+	coll.processorCycle.Pause()
 
 	span := &types.Span{
 		TraceID: fmt.Sprintf("trace-%v", 1),
@@ -396,8 +396,8 @@ func TestCentralCollector_SampleConfigReload(t *testing.T) {
 	stop := startCollector(t, conf, coll, transmission, clock)
 	defer stop()
 
-	coll.deciderCycle.pause <- struct{}{}
-	coll.processorCycle.pause <- struct{}{}
+	coll.deciderCycle.Pause()
+	coll.processorCycle.Pause()
 
 	dataset := "aoeu"
 
@@ -474,8 +474,8 @@ func TestCentralCollector_StableMaxAlloc(t *testing.T) {
 	stop := startCollector(t, conf, coll, transmission, clock)
 	defer stop()
 
-	coll.deciderCycle.pause <- struct{}{}
-	coll.processorCycle.pause <- struct{}{}
+	coll.deciderCycle.Pause()
+	coll.processorCycle.Pause()
 
 	totalTraceCount := 300
 	spandata := make([]map[string]interface{}, totalTraceCount)
@@ -619,8 +619,8 @@ func TestCentralCollector_AddCountsToRoot(t *testing.T) {
 	stop := startCollector(t, conf, coll, transmission, clock)
 	defer stop()
 
-	coll.deciderCycle.pause <- struct{}{}
-	coll.processorCycle.pause <- struct{}{}
+	coll.deciderCycle.Pause()
+	coll.processorCycle.Pause()
 
 	var traceID = "mytrace"
 	for i := 0; i < 4; i++ {
@@ -718,8 +718,8 @@ func TestCentralCollector_LateRootGetsCounts(t *testing.T) {
 	stop := startCollector(t, conf, coll, transmission, clock)
 	defer stop()
 
-	coll.deciderCycle.pause <- struct{}{}
-	coll.processorCycle.pause <- struct{}{}
+	coll.deciderCycle.Pause()
+	coll.processorCycle.Pause()
 
 	var traceID = "mytrace"
 
@@ -817,8 +817,8 @@ func TestCentralCollector_LateSpanNotDecorated(t *testing.T) {
 	stop := startCollector(t, conf, coll, transmission, clock)
 	defer stop()
 
-	coll.deciderCycle.pause <- struct{}{}
-	coll.processorCycle.pause <- struct{}{}
+	coll.deciderCycle.Pause()
+	coll.processorCycle.Pause()
 
 	var traceID = "traceABC"
 
@@ -895,8 +895,8 @@ func TestCentralCollector_AddAdditionalAttributes(t *testing.T) {
 	stop := startCollector(t, conf, coll, transmission, clock)
 	defer stop()
 
-	coll.deciderCycle.pause <- struct{}{}
-	coll.processorCycle.pause <- struct{}{}
+	coll.deciderCycle.Pause()
+	coll.processorCycle.Pause()
 
 	var traceID = "trace123"
 
@@ -1068,8 +1068,8 @@ func TestCentralCollector_SpanWithRuleReasons(t *testing.T) {
 	stop := startCollector(t, conf, coll, transmission, clock)
 	defer stop()
 
-	coll.deciderCycle.pause <- struct{}{}
-	coll.processorCycle.pause <- struct{}{}
+	coll.deciderCycle.Pause()
+	coll.processorCycle.Pause()
 
 	traceIDs := []string{"trace1", "trace2"}
 

--- a/collect/cycler.go
+++ b/collect/cycler.go
@@ -1,0 +1,90 @@
+package collect
+
+import (
+	"context"
+	"time"
+
+	"github.com/jonboulle/clockwork"
+)
+
+type Cycle struct {
+	clock       clockwork.Clock
+	interval    time.Duration
+	runOnce     chan message
+	pause       chan struct{}
+	continueRun chan struct{}
+	done        chan struct{}
+
+	runfinished chan struct{}
+}
+
+type message struct {
+	done chan struct{}
+}
+
+func NewCycle(clock clockwork.Clock, interval time.Duration, done chan struct{}) *Cycle {
+	return &Cycle{
+		clock:       clock,
+		interval:    interval,
+		runOnce:     make(chan message),
+		pause:       make(chan struct{}),
+		continueRun: make(chan struct{}),
+		done:        done,
+	}
+}
+
+func (c *Cycle) Run(ctx context.Context, fn func(ctx context.Context) error) error {
+	ticker := c.clock.NewTicker(c.interval)
+	defer ticker.Stop()
+
+	if err := fn(ctx); err != nil {
+		return err
+	}
+
+	for {
+		select {
+		case <-c.done:
+			return nil
+		case wait := <-c.runOnce:
+			if err := fn(ctx); err != nil {
+				return err
+			}
+
+			if wait.done != nil {
+				close(wait.done)
+			}
+
+		case <-c.pause:
+			ticker.Stop()
+
+			select {
+			case <-ticker.Chan():
+			default:
+			}
+		case <-c.continueRun:
+			ticker = c.clock.NewTicker(c.interval)
+		case <-ticker.Chan():
+			if err := fn(ctx); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func (c *Cycle) RunOnce() {
+	done := make(chan struct{})
+	select {
+	case c.runOnce <- message{done: done}:
+	case <-c.done:
+		close(done)
+		return
+	}
+
+	select {
+	case <-done:
+		return
+	case <-c.done:
+		close(done)
+		return
+	}
+}

--- a/collect/cycler.go
+++ b/collect/cycler.go
@@ -110,3 +110,13 @@ func (c *Cycle) RunOnce() {
 		return
 	}
 }
+
+// Pause pauses the cycle.
+func (c *Cycle) Pause() {
+	c.pause <- struct{}{}
+}
+
+// Continue resumes the cycle.
+func (c *Cycle) Continue() {
+	c.continueRun <- struct{}{}
+}

--- a/collect/cycler.go
+++ b/collect/cycler.go
@@ -7,21 +7,29 @@ import (
 	"github.com/jonboulle/clockwork"
 )
 
+// Cycle implements a controllable loop that can be paused, resumed, and run once.
+// It runs a function at a fixed interval and is stopped by closing the done channel
+// passed in by the caller.
 type Cycle struct {
-	clock       clockwork.Clock
-	interval    time.Duration
+	clock    clockwork.Clock
+	interval time.Duration
+	// shutdown the cycle by closing this channel
+	done chan struct{}
+
+	// The following channels are used to control the cycle
+	// these should only be used in tests
 	runOnce     chan message
 	pause       chan struct{}
 	continueRun chan struct{}
-	done        chan struct{}
-
-	runfinished chan struct{}
 }
 
+// message is a struct used to signal back to the caller
+// that the cycle has finished running once.
 type message struct {
 	done chan struct{}
 }
 
+// NewCycle creates a new Cycle instance.
 func NewCycle(clock clockwork.Clock, interval time.Duration, done chan struct{}) *Cycle {
 	return &Cycle{
 		clock:       clock,
@@ -33,6 +41,8 @@ func NewCycle(clock clockwork.Clock, interval time.Duration, done chan struct{})
 	}
 }
 
+// Run starts the cycle.
+// Every interval, the function passed in is called.
 func (c *Cycle) Run(ctx context.Context, fn func(ctx context.Context) error) error {
 	ticker := c.clock.NewTicker(c.interval)
 	defer ticker.Stop()
@@ -45,6 +55,9 @@ func (c *Cycle) Run(ctx context.Context, fn func(ctx context.Context) error) err
 		select {
 		case <-c.done:
 			return nil
+
+			// run the function once and wait for it to finish
+			// after it finishes, close the done channel to signal that it's done
 		case wait := <-c.runOnce:
 			if err := fn(ctx); err != nil {
 				return err
@@ -54,14 +67,18 @@ func (c *Cycle) Run(ctx context.Context, fn func(ctx context.Context) error) err
 				close(wait.done)
 			}
 
+			// stop the ticker so that no more cycle iterations are run
 		case <-c.pause:
 			ticker.Stop()
 
+			// drain the ticker channel to ensure we don't have ticks left
 			select {
 			case <-ticker.Chan():
 			default:
 			}
 		case <-c.continueRun:
+			// start the ticker again
+			ticker.Stop()
 			ticker = c.clock.NewTicker(c.interval)
 		case <-ticker.Chan():
 			if err := fn(ctx); err != nil {
@@ -71,20 +88,25 @@ func (c *Cycle) Run(ctx context.Context, fn func(ctx context.Context) error) err
 	}
 }
 
+// RunOnce runs the function passed in once.
+// It only returns after the function has finished running.
 func (c *Cycle) RunOnce() {
 	done := make(chan struct{})
 	select {
 	case c.runOnce <- message{done: done}:
+
+	// if the cycle has been stopped, return immediately
 	case <-c.done:
 		close(done)
 		return
 	}
 
+	// wait for the function to finish running
 	select {
 	case <-done:
 		return
+	// if the cycle has been stopped, return immediately
 	case <-c.done:
-		close(done)
 		return
 	}
 }

--- a/collect/panic_handler.go
+++ b/collect/panic_handler.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-func catchPanic(fn func()) (err error) {
+func catchPanic(fn func() error) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			err = fmt.Errorf("panic in central collector: %v\n%s", r, debug.Stack())

--- a/test1.log
+++ b/test1.log
@@ -1,0 +1,194 @@
+∅  cmd/refinery
+∅  cmd/test_redimem
+∅  cmd/test_stores
+∅  internal/otelutil
+∅  internal/redimem (1ms)
+✓  internal/peer (896ms)
+✓  generics (946ms)
+∅  service/debug
+✓  collect/cache (997ms)
+✓  logger (1.244s)
+✓  metrics (1.247s)
+✓  route (771ms)
+✓  redis (1.336s)
+✓  sample (1.166s)
+✓  app (2.164s)
+✓  tools/convert (949ms)
+✓  sharder (988ms)
+✓  types (873ms)
+✓  transmit (1.079s)
+✓  centralstore (4.1s)
+✓  config (7.255s)
+✖  collect (14.352s)
+
+=== Skipped
+=== SKIP: config TestGRPCListenAddrEnvVar (0.00s)
+    config_test.go:70: 
+
+=== SKIP: config TestRedisHostEnvVar (0.00s)
+    config_test.go:84: 
+
+=== SKIP: config TestDefaultSampler (0.00s)
+    config_test.go:576: This tests for a default sampler, but we are currently not requiring explicit default samplers.
+
+=== SKIP: config TestErrorReloading (0.00s)
+    config_test_reload_error_test.go:15: 
+
+=== SKIP: route TestOTLPHandler/creates_events_for_span_events (0.00s)
+    otlp_trace_test.go:107: need additional work to support inspecting outbound JSON
+
+=== SKIP: route TestOTLPHandler/creates_events_for_span_links (0.00s)
+    otlp_trace_test.go:153: need additional work to support inspecting outbound JSON
+
+=== SKIP: sample TestTotalThroughputClusterSize (0.00s)
+    sample_test.go:111: 
+
+=== SKIP: sample TestEMAThroughputClusterSize (0.00s)
+    sample_test.go:142: 
+
+=== SKIP: sample TestWindowedThroughputClusterSize (0.00s)
+    sample_test.go:173: 
+
+=== Failed
+=== FAIL: collect TestCentralCollector_StableMaxAlloc (5.02s)
+changing [0 1 2 3 4 5 6 7 8 9 10 11 12 13 14] traces from collecting to decision_delay
+changing [15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78] traces from collecting to decision_delay
+changing [79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 101 102 103 104 105 106 107 108 109 110 111 112 113 114 115 116 117 118 119 120 121 122 123 124 125 126 127 128 129 130 131 132 133 134 135 136 137 138 139 140 141 142 143 144 145 146 147] traces from collecting to decision_delay
+changing [148 149 150 151 152 153 154 155 156 157 158 159 160 161 162 163 164 165 166 167 168 169 170 171 172 173 174 175 176 177 178 179 180 181 182 183 184 185 186 187 188 189 190 191 192 193 194 195 196 197 198 199 200 373 348 306 296] traces from collecting to decision_delay
+changing [377 258 259 260 284 213 286 249 264 479 497 432 398 236 407 268 495 245 410 317] traces from collecting to decision_delay
+changing [9 4 8 14 5 7 6 13 12 2 3 10 0 1 11 58 55 22 32 75 24 36 61 54 57 45 21 43 65 76 15 73 44 59 48 33 39 77 23 74 52 18 60 20 49 41 29 46 62 31 40 67 72 27 56 70 28 34 25 37 38 64 51 26 17 66 71 53 78 69 50 35 68 16 30 42 63 19 47] traces from decision_delay to ready_to_decide
+changing [392 279 288 414 256 489 269 443 436 349] traces from collecting to decision_delay
+changing [460 487 206 224 324 209 231 225] traces from collecting to decision_delay
+changing [79 96 105 88 100 113 110 145 136 80 102 84 95 81 111 112 146 103 85 129 121 87 137 120 139 101 142 91 94 126 130 131 92 89 104 128 93 127 107 143 97 144 108 86 99 123 141 132 114 122 134 98 109 82 138 119 106 117 140 115 133 83 135 90 118 124 116 125 147] traces from decision_delay to ready_to_decide
+changing [305 475 386 445 203 281 417 490 367 454 233 208 420 263] traces from collecting to decision_delay
+changing [161 188 168 156 159 169 174 172 189 306 186 183 160 184 175 177 179 158 163 170 167 149 296 196 165 373 199 154 197 192 181 198 185 173 195 176 166 157 152 180 191 153 187 178 162 164 200 348 155 151 193 190 194 150 171 148 182] traces from decision_delay to ready_to_decide
+changing [300 257 340 252 298 254 396 376] traces from collecting to decision_delay
+changing [495 479 407 259 213 398 264 258 432 249 245 286 497 284 260 377 410 268 236 317] traces from decision_delay to ready_to_decide
+changing [312 255 292 483 262 297 343 215] traces from collecting to decision_delay
+changing [443 436 256 288 349 489 414 392 279 269] traces from decision_delay to ready_to_decide
+changing [423 351 204 331] traces from collecting to decision_delay
+changing [460 224 206 324 225 231 209 487] traces from decision_delay to ready_to_decide
+changing [337 418 222 427 399 452 468 315] traces from collecting to decision_delay
+changing [367 454 417 386 420 263 203 475 281 445 490 208 305 233] traces from decision_delay to ready_to_decide
+changing [421 218 267 437 361 370] traces from collecting to decision_delay
+changing [257 298 340 376 396 252 300 254] traces from decision_delay to ready_to_decide
+changing [480 287 345 325 247 476 316 458] traces from collecting to decision_delay
+changing [262 292 343 215 483 255 297 312] traces from decision_delay to ready_to_decide
+changing [435 448 484 205] traces from collecting to decision_delay
+changing [204 351 423 331] traces from decision_delay to ready_to_decide
+changing [304 431 314 221 461 277 280] traces from collecting to decision_delay
+changing [222 337 452 418 427 399 468 315] traces from decision_delay to ready_to_decide
+changing [241 346 338 393 477 449 467] traces from collecting to decision_delay
+changing [218 437 421 267 361 370] traces from decision_delay to ready_to_decide
+changing [492 270 455 358 223 426] traces from collecting to decision_delay
+changing [325 316 480 287 247 458 345 476] traces from decision_delay to ready_to_decide
+changing [422 234 464 474 219 365 357] traces from collecting to decision_delay
+changing [435 205 484 448] traces from decision_delay to ready_to_decide
+changing [381 389 405 251 416] traces from collecting to decision_delay
+changing [221 277 280 431 304 461 314] traces from decision_delay to ready_to_decide
+changing [275 488 329 400 327 211 313 311 293 246 326 463] traces from collecting to decision_delay
+changing [449 241 477 393 338 346 467] traces from decision_delay to ready_to_decide
+changing [229 425 462 403 450 471 380] traces from collecting to decision_delay
+changing [455 492 358 223 426 270] traces from decision_delay to ready_to_decide
+changing [352 496 411 388 395 408 271 240 239 242] traces from collecting to decision_delay
+changing [422 234 474 365 219 357 464] traces from decision_delay to ready_to_decide
+changing [409 456 368 387 441 319 364 328] traces from collecting to decision_delay
+changing [251 389 416 405 381] traces from decision_delay to ready_to_decide
+changing [356 482 285 369 442 244] traces from collecting to decision_delay
+changing [275 329 246 293 463 311 327 313 400 211 326 488] traces from decision_delay to ready_to_decide
+changing [419 202 318 282 424 232] traces from collecting to decision_delay
+changing [229 471 462 425 380 450 403] traces from decision_delay to ready_to_decide
+changing [336 212 333 347 466 430 248] traces from collecting to decision_delay
+changing [239 395 242 388 411 271 352 408 496 240] traces from decision_delay to ready_to_decide
+changing [323 406 379 453 294 253 372 214 385 335] traces from collecting to decision_delay
+changing [387 368 441 456 319 328 364 409] traces from decision_delay to ready_to_decide
+changing [321 210 359 363 273] traces from collecting to decision_delay
+changing [482 442 369 356 244 285] traces from decision_delay to ready_to_decide
+changing [383 439 350 404 308] traces from collecting to decision_delay
+changing [202 318 419 232 424 282] traces from decision_delay to ready_to_decide
+changing [375 309 261] traces from collecting to decision_delay
+changing [248 336 430 347 212 333 466] traces from decision_delay to ready_to_decide
+changing [354 382] traces from collecting to decision_delay
+changing [385 379 294 372 335 214 406 453 323 253] traces from decision_delay to ready_to_decide
+changing [207 303 216 322 301] traces from collecting to decision_delay
+changing [273 210 359 363 321] traces from decision_delay to ready_to_decide
+changing [493 378 440 447] traces from collecting to decision_delay
+changing [404 383 350 308 439] traces from decision_delay to ready_to_decide
+changing [470 371 290 295 353 478] traces from collecting to decision_delay
+changing [309 375 261] traces from decision_delay to ready_to_decide
+changing [302 362] traces from collecting to decision_delay
+changing [354 382] traces from decision_delay to ready_to_decide
+changing [217 465 434] traces from collecting to decision_delay
+changing [216 303 322 301 207] traces from decision_delay to ready_to_decide
+changing [237 459 341 402 276 278] traces from collecting to decision_delay
+changing [378 447 440 493 470 353 371 478 295 290] traces from decision_delay to ready_to_decide
+changing [457] traces from collecting to decision_delay
+changing [362 302] traces from decision_delay to ready_to_decide
+changing [394 391 469] traces from collecting to decision_delay
+changing [465 434 217] traces from decision_delay to ready_to_decide
+changing [384] traces from collecting to decision_delay
+changing [276 237 459 341 278 402] traces from decision_delay to ready_to_decide
+changing [485 307] traces from collecting to decision_delay
+changing [457] traces from decision_delay to ready_to_decide
+changing [473 238] traces from collecting to decision_delay
+changing [391 394 469] traces from decision_delay to ready_to_decide
+changing [384] traces from decision_delay to ready_to_decide
+changing [413 415 228] traces from collecting to decision_delay
+changing [307 485] traces from decision_delay to ready_to_decide
+changing [401] traces from collecting to decision_delay
+changing [238 473] traces from decision_delay to ready_to_decide
+changing [310 390 266 339] traces from collecting to decision_delay
+changing [451] traces from collecting to decision_delay
+changing [228 413 415] traces from decision_delay to ready_to_decide
+changing [344 250] traces from collecting to decision_delay
+changing [401] traces from decision_delay to ready_to_decide
+changing [230] traces from collecting to decision_delay
+changing [266 310 339 390] traces from decision_delay to ready_to_decide
+changing [491] traces from collecting to decision_delay
+changing [451] traces from decision_delay to ready_to_decide
+changing [472] traces from collecting to decision_delay
+changing [250 344] traces from decision_delay to ready_to_decide
+changing [374 498 360 274] traces from collecting to decision_delay
+changing [230] traces from decision_delay to ready_to_decide
+changing [412 320] traces from collecting to decision_delay
+changing [491] traces from decision_delay to ready_to_decide
+changing [472] traces from decision_delay to ready_to_decide
+changing [243 499 397] traces from collecting to decision_delay
+changing [374 274 360 498] traces from decision_delay to ready_to_decide
+changing [342] traces from collecting to decision_delay
+changing [320 412] traces from decision_delay to ready_to_decide
+changing [428 226 355] traces from collecting to decision_delay
+changing [332 235] traces from collecting to decision_delay
+changing [243 499 397] traces from decision_delay to ready_to_decide
+changing [283] traces from collecting to decision_delay
+changing [342] traces from decision_delay to ready_to_decide
+changing [444 438] traces from collecting to decision_delay
+changing [428 226 355] traces from decision_delay to ready_to_decide
+changing [220 486] traces from collecting to decision_delay
+changing [235 332] traces from decision_delay to ready_to_decide
+changing [283] traces from decision_delay to ready_to_decide
+changing [444 438] traces from decision_delay to ready_to_decide
+changing [220 486] traces from decision_delay to ready_to_decide
+changing [429] traces from collecting to decision_delay
+changing [291] traces from collecting to decision_delay
+changing [429] traces from decision_delay to ready_to_decide
+changing [494 433] traces from collecting to decision_delay
+changing [291] traces from decision_delay to ready_to_decide
+changing [299] traces from collecting to decision_delay
+changing [494 433] traces from decision_delay to ready_to_decide
+changing [299] traces from decision_delay to ready_to_decide
+changing [330] traces from collecting to decision_delay
+changing [330] traces from decision_delay to ready_to_decide
+changing [272] traces from collecting to decision_delay
+changing [289] traces from collecting to decision_delay
+changing [272] traces from decision_delay to ready_to_decide
+changing [289] traces from decision_delay to ready_to_decide
+changing [366] traces from collecting to decision_delay
+changing [201] traces from collecting to decision_delay
+    central_collector_test.go:1221: 
+        	Error Trace:	/Users/yingrongzhao/work/refinery/collect/central_collector_test.go:1221
+        	            				/Users/yingrongzhao/work/refinery/collect/central_collector_test.go:509
+        	Error:      	Condition never satisfied
+        	Test:       	TestCentralCollector_StableMaxAlloc
+
+DONE 625 tests, 9 skipped, 1 failure in 16.430s


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

Since processor and decider run concurrently, it's hard to manage the timing in tests. 

#1082 

## Short description of the changes

- implement a Cycle object to manage the goroutine so we can pause or restart it
- modify tests to use the new Cycle management interface

