### PR TITLE
feat: implement graceful shutdown for central store

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -109,6 +109,7 @@ func newStartedApp(
 			CacheCapacity:              10000,
 			ProcessTracesPauseDuration: config.Duration(10 * time.Millisecond),
 			DeciderPauseDuration:       config.Duration(10 * time.Millisecond),
+			ShutdownDelay:              config.Duration(1 * time.Millisecond),
 		},
 		AddHostMetadataToTrace: enableHostMetadata,
 		TraceIdFieldNames:      []string{"trace.trace_id"},

--- a/centralstore/centralstore.go
+++ b/centralstore/centralstore.go
@@ -8,14 +8,6 @@ import (
 	"github.com/honeycombio/refinery/types"
 )
 
-type SpanType string
-
-const (
-	SpanTypeNormal SpanType = ""
-	SpanTypeLink   SpanType = "link"
-	SpanTypeEvent  SpanType = "span_event"
-)
-
 // CentralSpan is the subset of a span that is sent to the central store.
 // If AllFields is non-nil, it contains all the fields from the original span; this
 // is used when a refinery needs to shut down; it can forward all its spans to the central
@@ -26,13 +18,17 @@ type CentralSpan struct {
 	TraceID    string
 	SpanID     string // need access to this field for updating all fields
 	samplerKey string
-	Type       SpanType
+	Type       types.SpanType
 	KeyFields  map[string]interface{}
 	AllFields  map[string]interface{}
 	IsRoot     bool
 }
 
 func (s *CentralSpan) Fields() map[string]interface{} {
+	if s.KeyFields == nil {
+		return s.AllFields
+	}
+
 	return s.KeyFields
 }
 

--- a/centralstore/localremotestore.go
+++ b/centralstore/localremotestore.go
@@ -9,6 +9,7 @@ import (
 	"github.com/honeycombio/refinery/collect/cache"
 	"github.com/honeycombio/refinery/config"
 	"github.com/honeycombio/refinery/metrics"
+	"github.com/honeycombio/refinery/types"
 	"github.com/jonboulle/clockwork"
 )
 
@@ -162,9 +163,9 @@ func (lrs *LocalRemoteStore) WriteSpan(ctx context.Context, span *CentralSpan) e
 	// Add the span to the trace; this works even if the trace doesn't exist yet
 	lrs.traces[span.TraceID].Spans = append(lrs.traces[span.TraceID].Spans, span)
 	lrs.states[state][span.TraceID].Count++
-	if span.Type == SpanTypeLink {
+	if span.Type == types.SpanTypeLink {
 		lrs.states[state][span.TraceID].LinkCount++
-	} else if span.Type == SpanTypeEvent {
+	} else if span.Type == types.SpanTypeEvent {
 		lrs.states[state][span.TraceID].EventCount++
 	}
 

--- a/centralstore/redis_store.go
+++ b/centralstore/redis_store.go
@@ -13,6 +13,7 @@ import (
 	"github.com/honeycombio/refinery/internal/otelutil"
 	"github.com/honeycombio/refinery/metrics"
 	"github.com/honeycombio/refinery/redis"
+	"github.com/honeycombio/refinery/types"
 	"github.com/jonboulle/clockwork"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -780,7 +781,7 @@ func (t *tracesStore) storeSpan(ctx context.Context, conn redis.Conn, span *Cent
 	return conn.Exec(commands...)
 }
 
-func (t *tracesStore) incrementSpanCounts(ctx context.Context, conn redis.Conn, traceID string, spanType SpanType) error {
+func (t *tracesStore) incrementSpanCounts(ctx context.Context, conn redis.Conn, traceID string, spanType types.SpanType) error {
 	_, span := t.tracer.Start(ctx, "incrementSpanCounts")
 	defer span.End()
 
@@ -793,13 +794,13 @@ func (t *tracesStore) incrementSpanCounts(ctx context.Context, conn redis.Conn, 
 	return err
 }
 
-func (t *tracesStore) incrementSpanCountsCMD(traceID string, spanType SpanType) (redis.Command, error) {
+func (t *tracesStore) incrementSpanCountsCMD(traceID string, spanType types.SpanType) (redis.Command, error) {
 
 	var field string
 	switch spanType {
-	case SpanTypeEvent:
+	case types.SpanTypeEvent:
 		field = "EventCount"
-	case SpanTypeLink:
+	case types.SpanTypeLink:
 		field = "LinkCount"
 	default:
 		field = "Count"

--- a/centralstore/redis_store_test.go
+++ b/centralstore/redis_store_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/honeycombio/refinery/config"
 	"github.com/honeycombio/refinery/metrics"
 	"github.com/honeycombio/refinery/redis"
+	"github.com/honeycombio/refinery/types"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -57,7 +58,7 @@ func TestRedisBasicStore_TraceStatus(t *testing.T) {
 			span: &CentralSpan{
 				TraceID:   traceID,
 				SpanID:    "spanID1",
-				Type:      SpanTypeEvent,
+				Type:      types.SpanTypeEvent,
 				KeyFields: map[string]interface{}{"event": "bar"},
 				IsRoot:    false,
 			},
@@ -70,7 +71,7 @@ func TestRedisBasicStore_TraceStatus(t *testing.T) {
 			span: &CentralSpan{
 				TraceID:   traceID,
 				SpanID:    "spanID2",
-				Type:      SpanTypeLink,
+				Type:      types.SpanTypeLink,
 				KeyFields: map[string]interface{}{"link": "bar"},
 				IsRoot:    false,
 			},

--- a/centralstore/smartwrapper.go
+++ b/centralstore/smartwrapper.go
@@ -111,6 +111,8 @@ func (w *SmartWrapper) WriteSpan(ctx context.Context, span *CentralSpan) error {
 
 	// otherwise, put the span in the channel but don't block
 	select {
+	case <-ctx.Done():
+		return ctx.Err()
 	case <-w.done:
 		return fmt.Errorf("span channel closed")
 	case w.spanChan <- span:

--- a/cmd/test_stores/tracegen.go
+++ b/cmd/test_stores/tracegen.go
@@ -9,6 +9,7 @@ import (
 	"github.com/dgryski/go-wyhash"
 	"github.com/honeycombio/refinery/centralstore"
 	"github.com/honeycombio/refinery/internal/otelutil"
+	"github.com/honeycombio/refinery/types"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -145,7 +146,7 @@ func (t *traceGenerator) generateTrace(ctx context.Context, out chan *centralsto
 	rootSpan := &centralstore.CentralSpan{
 		TraceID:   trace.TraceID,
 		SpanID:    t.getSpanID(trace.TraceID),
-		Type:      centralstore.SpanTypeNormal,
+		Type:      types.SpanTypeNormal,
 		KeyFields: rootFields,
 		IsRoot:    true,
 	}
@@ -156,18 +157,18 @@ func (t *traceGenerator) generateTrace(ctx context.Context, out chan *centralsto
 		span := &centralstore.CentralSpan{
 			TraceID:   trace.TraceID,
 			SpanID:    t.getSpanID(trace.TraceID),
-			Type:      centralstore.SpanTypeNormal,
+			Type:      types.SpanTypeNormal,
 			KeyFields: t.getKeyFields(),
 		}
 		trace.Spans = append(trace.Spans, span)
 	}
 	// the first spans after the root span are the span events
 	for i := 0; i < spanEventCount; i++ {
-		trace.Spans[i+1].Type = centralstore.SpanTypeEvent
+		trace.Spans[i+1].Type = types.SpanTypeEvent
 	}
 	// the next spans are the span links
 	for i := spanEventCount; i < spanEventCount+spanLinkCount; i++ {
-		trace.Spans[i+1].Type = centralstore.SpanTypeLink
+		trace.Spans[i+1].Type = types.SpanTypeLink
 	}
 
 	// Now we have a trace, set up a timer to send all the spans in reverse

--- a/collect/cache/cuckooSentCache.go
+++ b/collect/cache/cuckooSentCache.go
@@ -88,10 +88,10 @@ func (t *keptTraceCacheEntry) SpanCount() uint {
 // Count records additional spans in the cache record.
 func (t *keptTraceCacheEntry) Count(s *types.Span) {
 	t.eventCount++
-	switch s.AnnotationType() {
-	case types.SpanAnnotationTypeSpanEvent:
+	switch s.Type() {
+	case types.SpanTypeEvent:
 		t.spanEventCount++
-	case types.SpanAnnotationTypeLink:
+	case types.SpanTypeLink:
 		t.spanLinkCount++
 	default:
 		t.spanCount++

--- a/collect/cycler.go
+++ b/collect/cycler.go
@@ -53,6 +53,8 @@ func (c *Cycle) Run(ctx context.Context, fn func(ctx context.Context) error) err
 
 	for {
 		select {
+		case <-ctx.Done():
+			return ctx.Err()
 		case <-c.done:
 			return nil
 

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -226,6 +226,7 @@ type CollectionConfig struct {
 	AvailableMemory            MemorySize `yaml:"AvailableMemory" cmdenv:"AvailableMemory"`
 	MaxMemoryPercentage        int        `yaml:"MaxMemoryPercentage" default:"75"`
 	MaxAlloc                   MemorySize `yaml:"MaxAlloc"`
+	ShutdownDelay              Duration   `yaml:"ShutdownDelay" default:"30s"`
 }
 
 type SmartWrapperOptions struct {
@@ -237,6 +238,13 @@ type SmartWrapperOptions struct {
 	DecisionTimeout   Duration `yaml:"DecisionTimeout" default:"3s"`
 	MaxTraceRetention Duration `yaml:"MaxTraceRetention" default:"24h"`
 	ReaperRunInterval Duration `yaml:"ReaperRunInterval" default:"1h"`
+}
+
+func (c CollectionConfig) GetShutdownDelay() time.Duration {
+	if c.ShutdownDelay == 0 {
+		return 30 * time.Second
+	}
+	return time.Duration(c.ShutdownDelay)
 }
 
 // GetMaxAlloc returns the maximum amount of memory to use for the cache.

--- a/types/event.go
+++ b/types/event.go
@@ -164,8 +164,8 @@ func (t *Trace) DescendantCount() uint32 {
 func (t *Trace) SpanCount() uint32 {
 	var count uint32
 	for _, s := range t.spans {
-		switch s.AnnotationType() {
-		case SpanAnnotationTypeSpanEvent, SpanAnnotationTypeLink:
+		switch s.Type() {
+		case SpanTypeEvent, SpanTypeLink:
 			continue
 		default:
 			count++
@@ -179,7 +179,7 @@ func (t *Trace) SpanCount() uint32 {
 func (t *Trace) SpanLinkCount() uint32 {
 	var count uint32
 	for _, s := range t.spans {
-		if s.AnnotationType() == SpanAnnotationTypeLink {
+		if s.Type() == SpanTypeLink {
 			count++
 		}
 	}
@@ -190,7 +190,7 @@ func (t *Trace) SpanLinkCount() uint32 {
 func (t *Trace) SpanEventCount() uint32 {
 	var count uint32
 	for _, s := range t.spans {
-		if s.AnnotationType() == SpanAnnotationTypeSpanEvent {
+		if s.Type() == SpanTypeEvent {
 			count++
 		}
 	}
@@ -251,28 +251,28 @@ func (sp *Span) GetDataSize() int {
 	return total
 }
 
-// SpanAnnotationType is an enum for the type of annotation this span is.
-type SpanAnnotationType int
+// SpanType is an enum for the type of annotation this span is.
+type SpanType int
 
 const (
-	// SpanAnnotationTypeUnknown is the default value for an unknown annotation type.
-	SpanAnnotationTypeUnknown SpanAnnotationType = iota
-	// SpanAnnotationTypeSpanEvent is the type for a span event.
-	SpanAnnotationTypeSpanEvent
-	// SpanAnnotationTypeLink is the type for a span link.
-	SpanAnnotationTypeLink
+	// SpanTypeNormal is the default value for an unknown annotation type.
+	SpanTypeNormal SpanType = iota
+	// SpanTypeEvent is the type for a span event.
+	SpanTypeEvent
+	// SpanTypeLink is the type for a span link.
+	SpanTypeLink
 )
 
-// AnnotationType returns the type of annotation this span is.
-func (sp *Span) AnnotationType() SpanAnnotationType {
+// Type returns the type of annotation this span is.
+func (sp *Span) Type() SpanType {
 	t := sp.Data["meta.annotation_type"]
 	switch t {
 	case "span_event":
-		return SpanAnnotationTypeSpanEvent
+		return SpanTypeEvent
 	case "link":
-		return SpanAnnotationTypeLink
+		return SpanTypeLink
 	default:
-		return SpanAnnotationTypeUnknown
+		return SpanTypeNormal
 	}
 }
 

--- a/types/event_test.go
+++ b/types/event_test.go
@@ -45,11 +45,11 @@ func TestSpan_AnnotationType(t *testing.T) {
 	tests := []struct {
 		name string
 		data map[string]any
-		want SpanAnnotationType
+		want SpanType
 	}{
-		{"unknown", map[string]any{}, SpanAnnotationTypeUnknown},
-		{"span_event", map[string]any{"meta.annotation_type": "span_event"}, SpanAnnotationTypeSpanEvent},
-		{"link", map[string]any{"meta.annotation_type": "link"}, SpanAnnotationTypeLink},
+		{"unknown", map[string]any{}, SpanTypeNormal},
+		{"span_event", map[string]any{"meta.annotation_type": "span_event"}, SpanTypeEvent},
+		{"link", map[string]any{"meta.annotation_type": "link"}, SpanTypeLink},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -58,7 +58,7 @@ func TestSpan_AnnotationType(t *testing.T) {
 					Data: tt.data,
 				},
 			}
-			if got := sp.AnnotationType(); got != tt.want {
+			if got := sp.Type(); got != tt.want {
 				t.Errorf("Span.AnnotationType() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

Drain in-flight spans during refinery shutdown
#1041

## Short description of the changes

- Run `process()` to monitor trace decisions for in-flight traces
- Stop accepting new spans immediately after receive shutdown signal
- Send remaining spans without a decision to central store
- consolidate `SpanType` constant

