### PR TITLE
feat: record metrics on an interval in central store

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -93,6 +93,7 @@ func newStartedApp(
 	t testing.TB,
 	libhoneyT transmission.Sender,
 	basePort int,
+	redisDB int,
 	enableHostMetadata bool,
 ) (*App, inject.Graph, func()) {
 	c := &config.MockConfig{
@@ -102,12 +103,13 @@ func newStartedApp(
 		SendTickerVal:            200 * time.Microsecond,
 		PeerManagementType:       "file",
 		GetUpstreamBufferSizeVal: 10000,
+		AddRuleReasonToTrace:     true,
 		GetListenAddrVal:         "127.0.0.1:" + strconv.Itoa(basePort),
 		IsAPIKeyValidFunc:        func(k string) bool { return k == legacyAPIKey || k == nonLegacyAPIKey },
 		GetHoneycombAPIVal:       "http://api.honeycomb.io",
 		GetCollectionConfigVal: config.CollectionConfig{
 			CacheCapacity:              10000,
-			ProcessTracesPauseDuration: config.Duration(10 * time.Millisecond),
+			ProcessTracesPauseDuration: config.Duration(100 * time.Millisecond),
 			DeciderPauseDuration:       config.Duration(10 * time.Millisecond),
 			ShutdownDelay:              config.Duration(1 * time.Millisecond),
 		},
@@ -124,7 +126,7 @@ func newStartedApp(
 		},
 	}
 
-	c.GetRedisDatabaseVal = rand.Intn(16)
+	c.GetRedisDatabaseVal = redisDB
 	fmt.Println("Using Redis database", c.GetRedisDatabaseVal)
 
 	var err error
@@ -204,9 +206,10 @@ func post(t testing.TB, req *http.Request) {
 
 func TestAppIntegration(t *testing.T) {
 	port := 10500
+	redisDB := 2
 
 	sender := &transmission.MockSender{}
-	_, _, stop := newStartedApp(t, sender, port, false)
+	_, _, stop := newStartedApp(t, sender, port, redisDB, false)
 	defer stop()
 
 	// Send a root span, it should be sent in short order.
@@ -240,9 +243,10 @@ func TestAppIntegration(t *testing.T) {
 
 func TestAppIntegrationWithNonLegacyKey(t *testing.T) {
 	port := 10600
+	redisDB := 3
 
 	sender := &transmission.MockSender{}
-	a, _, stop := newStartedApp(t, sender, port, false)
+	a, _, stop := newStartedApp(t, sender, port, redisDB, false)
 	defer stop()
 	a.IncomingRouter.SetEnvironmentCache(time.Second, func(s string) (string, error) { return "test", nil })
 
@@ -278,9 +282,10 @@ func TestAppIntegrationWithNonLegacyKey(t *testing.T) {
 
 func TestAppIntegrationWithUnauthorizedKey(t *testing.T) {
 	port := 10700
+	redisDB := 4
 
 	sender := &transmission.MockSender{}
-	a, _, stop := newStartedApp(t, sender, port, false)
+	a, _, stop := newStartedApp(t, sender, port, redisDB, false)
 	defer stop()
 	a.IncomingRouter.SetEnvironmentCache(time.Second, func(s string) (string, error) { return "test", nil })
 
@@ -306,9 +311,10 @@ func TestAppIntegrationWithUnauthorizedKey(t *testing.T) {
 
 func TestHostMetadataSpanAdditions(t *testing.T) {
 	port := 14000
+	redisDB := 6
 
 	sender := &transmission.MockSender{}
-	_, _, stop := newStartedApp(t, sender, port, true)
+	_, _, stop := newStartedApp(t, sender, port, redisDB, true)
 	defer stop()
 
 	// Send a root span, it should be sent in short order.
@@ -346,11 +352,12 @@ func TestEventsEndpoint(t *testing.T) {
 	var apps [2]*App
 	var addrs [2]string
 	var senders [2]*transmission.MockSender
+	redisDB := 7
 	for i := range apps {
 		var stop func()
 		basePort := 13000 + (i * 2)
 		senders[i] = &transmission.MockSender{}
-		apps[i], _, stop = newStartedApp(t, senders[i], basePort, false)
+		apps[i], _, stop = newStartedApp(t, senders[i], basePort, redisDB, false)
 		defer stop()
 
 		addrs[i] = "localhost:" + strconv.Itoa(basePort)
@@ -408,7 +415,7 @@ func TestEventsEndpoint(t *testing.T) {
 		)
 	}, 5*time.Second, 200*time.Microsecond)
 
-	// Repeat, but deliver to host 1 on the peer channel, it should not be
+	// Repeat, but deliver to host 1, it should not be
 	// passed to host 0.
 
 	blob = blob[:0]
@@ -450,8 +457,8 @@ func TestEventsEndpoint(t *testing.T) {
 					"trace.trace_id":                     "1",
 					"foo":                                "bar",
 					"meta.refinery.original_sample_rate": uint(10),
-					"meta.event_count":                   1,
-					"meta.span_count":                    1,
+					"meta.event_count":                   2,
+					"meta.span_count":                    2,
 					"meta.span_event_count":              0,
 					"meta.span_link_count":               0,
 				},
@@ -472,10 +479,11 @@ func TestEventsEndpointWithNonLegacyKey(t *testing.T) {
 	var apps [2]*App
 	var addrs [2]string
 	var senders [2]*transmission.MockSender
+	redisDB := 9
 	for i := range apps {
 		basePort := 15000 + (i * 2)
 		senders[i] = &transmission.MockSender{}
-		app, _, stop := newStartedApp(t, senders[i], basePort, false)
+		app, _, stop := newStartedApp(t, senders[i], basePort, redisDB, false)
 		app.IncomingRouter.SetEnvironmentCache(time.Second, func(s string) (string, error) { return "test", nil })
 		apps[i] = app
 		defer stop()
@@ -483,8 +491,6 @@ func TestEventsEndpointWithNonLegacyKey(t *testing.T) {
 		addrs[i] = "localhost:" + strconv.Itoa(basePort)
 	}
 
-	// this traceID was chosen because it hashes to the appropriate shard for this
-	// test. You can't change it or the number of peers and still expect the test to pass.
 	traceID := "4"
 	traceData := []byte(fmt.Sprintf(`{"foo":"bar","trace.trace_id":"%s"}`, traceID))
 	// Deliver to host 1, it should be passed to host 0 and emitted there.
@@ -529,6 +535,7 @@ func TestEventsEndpointWithNonLegacyKey(t *testing.T) {
 					"meta.span_count":                    1,
 					"meta.span_event_count":              0,
 					"meta.span_link_count":               0,
+					"meta.refinery.reason":               "deterministic/always",
 				},
 				Metadata: map[string]any{
 					"api_host":    "http://api.honeycomb.io",
@@ -584,10 +591,12 @@ func TestEventsEndpointWithNonLegacyKey(t *testing.T) {
 					"trace.trace_id":                     traceID,
 					"foo":                                "bar",
 					"meta.refinery.original_sample_rate": uint(10),
-					"meta.event_count":                   1,
-					"meta.span_count":                    1,
+					"meta.event_count":                   2,
+					"meta.span_count":                    2,
 					"meta.span_event_count":              0,
 					"meta.span_link_count":               0,
+					"meta.refinery.reason":               "deterministic/always - late arriving span",
+					"meta.refinery.send_reason":          "trace_send_late_span",
 				},
 				Metadata: map[string]any{
 					"api_host":    "http://api.honeycomb.io",
@@ -662,7 +671,7 @@ func BenchmarkTraces(b *testing.B) {
 			W: io.Discard,
 		},
 	}
-	_, _, stop := newStartedApp(b, sender, 11000, false)
+	_, _, stop := newStartedApp(b, sender, 11000, 11, false)
 	defer stop()
 
 	req, err := http.NewRequest(
@@ -749,7 +758,7 @@ func BenchmarkDistributedTraces(b *testing.B) {
 	for i := range apps {
 		var stop func()
 		basePort := 12000 + (i * 2)
-		apps[i], _, stop = newStartedApp(b, sender, basePort, false)
+		apps[i], _, stop = newStartedApp(b, sender, basePort, 11, false)
 		defer stop()
 
 		addrs[i] = "localhost:" + strconv.Itoa(basePort)

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -392,6 +392,10 @@ func TestEventsEndpoint(t *testing.T) {
 					"trace.trace_id":                     "1",
 					"foo":                                "bar",
 					"meta.refinery.original_sample_rate": uint(10),
+					"meta.event_count":                   1,
+					"meta.span_count":                    1,
+					"meta.span_event_count":              0,
+					"meta.span_link_count":               0,
 				},
 				Metadata: map[string]any{
 					"api_host":    "http://api.honeycomb.io",
@@ -446,6 +450,10 @@ func TestEventsEndpoint(t *testing.T) {
 					"trace.trace_id":                     "1",
 					"foo":                                "bar",
 					"meta.refinery.original_sample_rate": uint(10),
+					"meta.event_count":                   1,
+					"meta.span_count":                    1,
+					"meta.span_event_count":              0,
+					"meta.span_link_count":               0,
 				},
 				Metadata: map[string]any{
 					"api_host":    "http://api.honeycomb.io",
@@ -517,6 +525,10 @@ func TestEventsEndpointWithNonLegacyKey(t *testing.T) {
 					"trace.trace_id":                     traceID,
 					"foo":                                "bar",
 					"meta.refinery.original_sample_rate": uint(10),
+					"meta.event_count":                   1,
+					"meta.span_count":                    1,
+					"meta.span_event_count":              0,
+					"meta.span_link_count":               0,
 				},
 				Metadata: map[string]any{
 					"api_host":    "http://api.honeycomb.io",
@@ -572,6 +584,10 @@ func TestEventsEndpointWithNonLegacyKey(t *testing.T) {
 					"trace.trace_id":                     traceID,
 					"foo":                                "bar",
 					"meta.refinery.original_sample_rate": uint(10),
+					"meta.event_count":                   1,
+					"meta.span_count":                    1,
+					"meta.span_event_count":              0,
+					"meta.span_link_count":               0,
 				},
 				Metadata: map[string]any{
 					"api_host":    "http://api.honeycomb.io",

--- a/centralstore/centralstore.go
+++ b/centralstore/centralstore.go
@@ -165,24 +165,6 @@ type SmartStorer interface {
 	// Stop should be called once at Refinery shutdown to shut things down.
 	Stop() error
 
-	// Register should be called once at Refinery startup to register itself
-	// with the central store. This is used to ensure that the central store
-	// knows about all the refineries that are running, and can make decisions
-	// about which refinery is responsible for which trace.
-	Register(context.Context) error
-
-	// Unregister should be called once at Refinery shutdown to unregister itself
-	// with the central store. Once it has been unregistered, the central store
-	// will no longer ask it to make decisions on any new traces. (Calls to
-	// GetTracesNeedingDecision will return an empty list.)
-	Unregister(context.Context) error
-
-	// SetKeyFields sets the fields that will be recorded in the central store;
-	// if they are changed live, inflight trace decisions may be affected.
-	// Certain fields are always recorded, such as the trace ID, span ID, and
-	// parent ID; listing them in keyFields is not necessary (but won't hurt).
-	SetKeyFields(ctx context.Context, keyFields []string) error
-
 	// WriteSpan writes one or more CentralSpans to the CentralStore.
 	// It is valid to write a span that has already been written; this can happen
 	// on shutdown, when a refinery forwards all its remaining spans to the central store.

--- a/centralstore/smartwrapper.go
+++ b/centralstore/smartwrapper.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/honeycombio/refinery/config"
+	"github.com/honeycombio/refinery/logger"
 	"github.com/honeycombio/refinery/metrics"
 	"github.com/jonboulle/clockwork"
 	"go.opentelemetry.io/otel/trace"
@@ -19,10 +20,10 @@ type statusMap map[string]*CentralTraceStatus
 type SmartWrapper struct {
 	Config         config.Config   `inject:""`
 	Metrics        metrics.Metrics `inject:"genericMetrics"`
+	Logger         logger.Logger   `inject:""`
 	BasicStore     BasicStorer     `inject:""`
 	Tracer         trace.Tracer    `inject:"tracer"`
 	Clock          clockwork.Clock `inject:""`
-	keyfields      []string
 	spanChan       chan *CentralSpan
 	stopped        chan struct{}
 	done           chan struct{}
@@ -51,6 +52,11 @@ func (w *SmartWrapper) Start() error {
 	w.done = make(chan struct{})
 	w.doneProcessing = make(chan struct{})
 
+	w.Metrics.Register("smartstore_span_queue", "histogram")
+	w.Metrics.Register("smartstore_span_queue_length", "gauge")
+
+	w.Metrics.Store("SPAN_CHANNEL_CAP", float64(opts.SpanChannelSize))
+
 	// start the span processor
 	go w.processSpans(context.Background())
 
@@ -67,34 +73,6 @@ func (w *SmartWrapper) Stop() error {
 	close(w.done)
 	// wait for the span processor to finish
 	<-w.doneProcessing
-	return nil
-}
-
-// Register should be called once at Refinery startup to register itself
-// with the central store. This is used to ensure that the central store
-// knows about all the refineries that are running, and can make decisions
-// about which refinery is responsible for which trace.
-// For an in-memory store, this is a no-op.
-func (w *SmartWrapper) Register(ctx context.Context) error {
-	return nil
-}
-
-// Unregister should be called once at Refinery shutdown to unregister itself
-// with the central store. Once it has been unregistered, the central store
-// will no longer ask it to make decisions on any new traces. (Calls to
-// GetTracesNeedingDecision will return an empty list.)
-// For an in-memory store, this is a no-op.
-func (w *SmartWrapper) Unregister(ctx context.Context) error {
-	return nil
-}
-
-// SetKeyFields sets the fields that will be recorded in the central store;
-// if they are changed live, inflight trace decisions may be affected.
-// Certain fields are always recorded, such as the trace ID, span ID, and
-// parent ID; listing them in keyFields is not necessary (but won't hurt).
-func (w *SmartWrapper) SetKeyFields(ctx context.Context, keyFields []string) error {
-	// someday maybe we compare new keyFields to old keyFields and do something
-	w.keyfields = keyFields
 	return nil
 }
 
@@ -116,7 +94,6 @@ func (w *SmartWrapper) WriteSpan(ctx context.Context, span *CentralSpan) error {
 	case <-w.done:
 		return fmt.Errorf("span channel closed")
 	case w.spanChan <- span:
-		// fmt.Println("span written")
 	default:
 		return fmt.Errorf("span queue full")
 	}
@@ -129,7 +106,7 @@ func (w *SmartWrapper) processSpans(ctx context.Context) {
 	for span := range w.spanChan {
 		err := w.BasicStore.WriteSpan(ctx, span)
 		if err != nil {
-			fmt.Println(err)
+			w.Logger.Debug().Logf("error writing span: %s", err)
 		}
 	}
 
@@ -139,7 +116,7 @@ func (w *SmartWrapper) processSpans(ctx context.Context) {
 // helper function for manageStates
 func (w *SmartWrapper) manageTimeouts(ctx context.Context, timeout time.Duration, fromState, toState CentralTraceState) error {
 	if w.BasicStore == nil {
-		fmt.Println("basicStore is nil")
+		return fmt.Errorf("basic store is nil")
 	}
 	st, err := w.BasicStore.GetTracesForState(ctx, fromState)
 	if err != nil {
@@ -159,7 +136,7 @@ func (w *SmartWrapper) manageTimeouts(ctx context.Context, timeout time.Duration
 		}
 	}
 	if len(traceIDsToChange) > 0 {
-		fmt.Println("changing", traceIDsToChange, "traces from", fromState, "to", toState)
+		w.Logger.Debug().Logf("changing %d traces from %s to %s", len(traceIDsToChange), fromState, toState)
 		err = w.BasicStore.ChangeTraceStatus(ctx, traceIDsToChange, fromState, toState)
 	}
 	return err
@@ -179,14 +156,20 @@ func (w *SmartWrapper) manageStates(ctx context.Context, options config.SmartWra
 			// the order of these is important!
 
 			// see if AwaitDecision traces have been waiting too long
-			w.manageTimeouts(ctx, time.Duration(options.DecisionTimeout), AwaitingDecision, ReadyToDecide)
+			if err := w.manageTimeouts(ctx, time.Duration(options.DecisionTimeout), AwaitingDecision, ReadyToDecide); err != nil {
+				w.Logger.Error().Logf("error managing timeouts for moving traces from awaiting decision to ready to decide: %s", err)
+			}
 
 			// traces that are past SendDelay should be moved to ready for decision
 			// the only errors can be syntax errors, so won't happen at runtime
-			w.manageTimeouts(ctx, time.Duration(options.SendDelay), DecisionDelay, ReadyToDecide)
+			if err := w.manageTimeouts(ctx, time.Duration(options.SendDelay), DecisionDelay, ReadyToDecide); err != nil {
+				w.Logger.Error().Logf("error managing timeouts for moving traces from decision delay to ready to decide: %s", err)
+			}
 
 			// trace that are past TraceTimeout should be moved to waiting to decide
-			w.manageTimeouts(ctx, time.Duration(options.TraceTimeout), Collecting, DecisionDelay)
+			if err := w.manageTimeouts(ctx, time.Duration(options.TraceTimeout), Collecting, DecisionDelay); err != nil {
+				w.Logger.Error().Logf("error managing timeouts for moving traces from collecting to decision delay: %s", err)
+			}
 		}
 	}
 }
@@ -266,8 +249,11 @@ func (w *SmartWrapper) SetTraceStatuses(ctx context.Context, statuses []*Central
 	return err
 }
 
-// RecordMetrics returns a map of metrics from the central store, accumulated
-// since the previous time this method was called.
+// RecordMetrics calls the RecordMetrics method on the BasicStore.
 func (w *SmartWrapper) RecordMetrics(ctx context.Context) error {
+	// record channel lengths as histogram but also as gauges
+	w.Metrics.Histogram("smartstore_incoming_queue", float64(len(w.spanChan)))
+	w.Metrics.Gauge("smartstore_incoming_queue_length", float64(len(w.spanChan)))
+
 	return w.BasicStore.RecordMetrics(ctx)
 }

--- a/centralstore/smartwrapper_test.go
+++ b/centralstore/smartwrapper_test.go
@@ -82,8 +82,10 @@ func getAndStartSmartWrapper(storetype string, redisClient redis.Client) (*Smart
 		if redisClient == nil {
 			redisClient = &redis.TestService{}
 		}
-		objects = append(objects, &inject.Object{Value: redisClient, Name: "redis"})
+
+		cfg.GetRedisDatabaseVal = 13
 		store = &RedisBasicStore{}
+		objects = append(objects, &inject.Object{Value: redisClient, Name: "redis"})
 	default:
 		return nil, nil, fmt.Errorf("unknown store type %s", storetype)
 	}
@@ -106,6 +108,9 @@ func getAndStartSmartWrapper(storetype string, redisClient redis.Client) (*Smart
 	}
 
 	stopper := func() {
+		conn := redisClient.Get()
+		conn.Do("FLUSHDB")
+		conn.Close()
 		startstop.Stop(g.Objects(), ststLogger)
 	}
 

--- a/collect/cache/span_cache_basic.go
+++ b/collect/cache/span_cache_basic.go
@@ -73,6 +73,10 @@ func (sc *SpanCache_basic) Get(traceID string) *types.Trace {
 }
 
 func (sc *SpanCache_basic) GetOldest(fract float64) []string {
+	if fract <= 0 {
+		return nil
+	}
+
 	type tidWithImpact struct {
 		id     string
 		impact int

--- a/collect/cache/span_cache_complex.go
+++ b/collect/cache/span_cache_complex.go
@@ -101,6 +101,10 @@ func (sc *SpanCache_complex) Get(traceID string) *types.Trace {
 // because it has to sort the traces by arrival time, but I couldn't find a
 // faster way to do it.
 func (sc *SpanCache_complex) GetOldest(fract float64) []string {
+	if fract <= 0 {
+		return nil
+	}
+
 	type tidWithImpact struct {
 		id     string
 		impact int

--- a/collect/central_collector.go
+++ b/collect/central_collector.go
@@ -112,7 +112,7 @@ func (c *CentralCollector) Start() error {
 	c.Metrics.Register("trace_send_kept", "counter")
 	c.Metrics.Register("trace_duration_ms", "histogram")
 	c.Metrics.Register("trace_span_count", "histogram")
-	c.Metrics.Register("trace_decision_ket", "counter")
+	c.Metrics.Register("trace_decision_kept", "counter")
 	c.Metrics.Register("trace_decision_dropped", "counter")
 	c.Metrics.Register("trace_decision_has_root", "counter")
 	c.Metrics.Register("trace_decision_no_root", "counter")

--- a/collect/central_collector_test.go
+++ b/collect/central_collector_test.go
@@ -461,7 +461,7 @@ func TestCentralCollector_StableMaxAlloc(t *testing.T) {
 			DeciderBatchSize:           200,
 			ProcessTracesPauseDuration: config.Duration(1 * time.Second),
 			DeciderPauseDuration:       config.Duration(1 * time.Second),
-			EjectionBatchSize:          79,
+			EjectionBatchSize:          0,
 		},
 		StoreOptions: config.SmartWrapperOptions{
 			SpanChannelSize: 500,
@@ -1328,7 +1328,7 @@ func waitUntilReadyToDecide(t *testing.T, coll *CentralCollector, traceIDs []str
 		require.NoError(t, err)
 		idMap.Add(ids...)
 		return len(idMap.Members()) == len(traceIDs)
-	}, 10*time.Second, 100*time.Millisecond)
+	}, 8*time.Second, 50*time.Millisecond)
 }
 
 func waitForTraceDecision(t *testing.T, coll *CentralCollector, traceIDs []string) {

--- a/collect/stressRelief.go
+++ b/collect/stressRelief.go
@@ -88,6 +88,8 @@ func (s *StressRelief) Start() error {
 		{Numerator: "collector_incoming_queue_length", Denominator: "INCOMING_CAP", Algorithm: "sqrt", Reason: "CacheCapacity (incoming)"},
 		{Numerator: "libhoney_upstream_queue_length", Denominator: "UPSTREAM_BUFFER_SIZE", Algorithm: "sqrt", Reason: "UpstreamBufferSize"},
 		{Numerator: "memory_heap_allocation", Denominator: "MEMORY_MAX_ALLOC", Algorithm: "sigmoid", Reason: "MaxAlloc"},
+		// TODO: what's the denominator for this one?
+		//{Numerator: "redisstore_memory_used_total", }
 	}
 
 	// start our monitor goroutine that periodically calls recalc
@@ -107,7 +109,7 @@ func (s *StressRelief) Start() error {
 	return nil
 }
 
-func (s *StressRelief) UpdateFromConfig(cfg config.StressReliefConfig) error {
+func (s *StressRelief) UpdateFromConfig(cfg config.StressReliefConfig) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
@@ -156,8 +158,6 @@ func (s *StressRelief) UpdateFromConfig(cfg config.StressReliefConfig) error {
 	// uint64. In the case where the sample rate is 1, this should sample every
 	// value.
 	s.upperBound = math.MaxUint64 / s.sampleRate
-
-	return nil
 }
 
 func clamp(f float64, min float64, max float64) float64 {

--- a/collect/stressRelief.go
+++ b/collect/stressRelief.go
@@ -14,7 +14,7 @@ import (
 
 type StressReliever interface {
 	Start() error
-	UpdateFromConfig(cfg config.StressReliefConfig) error
+	UpdateFromConfig(cfg config.StressReliefConfig)
 	Recalc()
 	StressLevel() uint
 	Stressed() bool
@@ -23,11 +23,11 @@ type StressReliever interface {
 
 type MockStressReliever struct{}
 
-func (m *MockStressReliever) Start() error                                         { return nil }
-func (m *MockStressReliever) UpdateFromConfig(cfg config.StressReliefConfig) error { return nil }
-func (m *MockStressReliever) Recalc()                                              {}
-func (m *MockStressReliever) StressLevel() uint                                    { return 0 }
-func (m *MockStressReliever) Stressed() bool                                       { return false }
+func (m *MockStressReliever) Start() error                                   { return nil }
+func (m *MockStressReliever) UpdateFromConfig(cfg config.StressReliefConfig) {}
+func (m *MockStressReliever) Recalc()                                        {}
+func (m *MockStressReliever) StressLevel() uint                              { return 0 }
+func (m *MockStressReliever) Stressed() bool                                 { return false }
 func (m *MockStressReliever) GetSampleRate(traceID string) (rate uint, keep bool, reason string) {
 	return 1, false, ""
 }
@@ -44,6 +44,8 @@ const (
 	Monitor
 	Always
 )
+
+var _ StressReliever = &StressRelief{}
 
 type StressRelief struct {
 	mode            StressReliefMode

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -217,7 +217,7 @@ type RedisPeerManagementConfig struct {
 type CollectionConfig struct {
 	CacheCapacity              int        `yaml:"CacheCapacity" default:"10_000"`
 	IncomingQueueSize          int        `yaml:"IncomingQueueSize"`
-	EjectionBatchSize          int        `yaml:"EjectionBatchSize" default:"100"`
+	EjectionBatchSize          float64    `yaml:"EjectionBatchSize" default:"0.1"`
 	TraceFetcherConcurrency    int        `yaml:"TraceFetcherConcurrency" default:"10"`
 	ProcessTracesBatchSize     int        `yaml:"ProcessTracesBatchSize" default:"50"`
 	ProcessTracesPauseDuration Duration   `yaml:"ProcessTracesPauseDuration" default:"1s"`
@@ -266,9 +266,9 @@ func (c CollectionConfig) GetIncomingQueueSize() int {
 	return c.IncomingQueueSize
 }
 
-func (c CollectionConfig) GetCacheEjectBatchSize() int {
+func (c CollectionConfig) GetCacheEjectBatchSize() float64 {
 	if c.EjectionBatchSize == 0 {
-		return 100
+		return 0.1
 	}
 	return c.EjectionBatchSize
 }

--- a/route/route.go
+++ b/route/route.go
@@ -517,25 +517,8 @@ func (r *Router) processEvent(ev *types.Event, reqID interface{}) error {
 	// we know we're a span, but we need to check if we're in Stress Relief mode;
 	// if we are, then we want to make an immediate, deterministic trace decision
 	// and either drop or send the trace without even trying to cache or forward it.
-	isProbe := false
 	if r.Collector.Stressed() {
-		rate, keep, reason := r.Collector.GetStressedSampleRate(traceID)
-
-		r.Collector.ProcessSpanImmediately(span, keep, rate, reason)
-
-		if !keep {
-			return nil
-		}
-		// If the span was kept, we want to generate a probe that we'll forward
-		// to a peer IF this span would have been forwarded.
-		ev.Data["meta.refinery.probe"] = true
-		isProbe = true
-	}
-
-	if isProbe {
-		// If we got here it's because the span we were using for a probe was
-		// intended for us, so just skip it.
-		return nil
+		// TODO: process span in stress relief mode
 	}
 
 	// we're supposed to handle it normally


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

Record central store metrics on an interval so we have metrics ready for stress level calculation

## Short description of the changes

- added metrics for smart wrapper, central collectors
- added metrics cycle to run `RecordMetrics` in an interval
- add span counts to all spans' metadata instead of only on root span
- removed unnecessary code
- inject StressRelief to central collector

