### PR TITLE
fix: do not exit from the processor and decider loop on first error

### DIFF
--- a/collect/central_collector_test.go
+++ b/collect/central_collector_test.go
@@ -1274,6 +1274,7 @@ func startCollector(t *testing.T, cfg *config.MockConfig, collector *CentralColl
 		cfg.GetTraceTimeoutVal = time.Duration(500 * time.Microsecond)
 	}
 
+	collector.isTest = true
 	basicStore := &centralstore.RedisBasicStore{}
 	decisionCache := &cache.CuckooSentCache{}
 	sw := &centralstore.SmartWrapper{}


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

We shouldn't exit on the first error returned from processor or decider since that can happen when redis is upgrading or in the process of leader election if redis is in cluster mode.

## Short description of the changes

- added a `isTest` flag to make sure we can still catch the error in tests

