### PR TITLE
feat: implement Gossiper interface

### DIFF
--- a/internal/gossip/gossip.go
+++ b/internal/gossip/gossip.go
@@ -1,0 +1,24 @@
+package gossip
+
+import "github.com/facebookgo/startstop"
+
+type Gossiper interface {
+	// Gossip sends a message to all peers that are listening on the channel
+	Publish(channel string, message Message) error
+
+	// Register a handler for messages on a channel
+	// The handler will be called for each message received on the channel
+	Register(channel string, handler func(Message)) error
+
+	startstop.Starter
+	startstop.Stopper
+}
+
+var _ Gossiper = &NullGossip{}
+
+type NullGossip struct{}
+
+func (g *NullGossip) Publish(channel string, message Message) error        { return nil }
+func (g *NullGossip) Register(channel string, handler func(Message)) error { return nil }
+func (g *NullGossip) Start() error                                         { return nil }
+func (g *NullGossip) Stop() error                                          { return nil }

--- a/internal/gossip/gossip.go
+++ b/internal/gossip/gossip.go
@@ -6,11 +6,10 @@ type Gossiper interface {
 	// Gossip sends a message to all peers that are listening on the channel
 	Publish(channel string, message []byte) error
 
-	// Register a handler for messages on a channel
-	// The handler will be called for each message received on the channel
-	Subscribe(channel string) error
+	// Subscribe listens for messages on the channel
+	Subscribe(channel ...string) error
 
-	Receive() []byte
+	Receive() (string, []byte)
 
 	startstop.Starter
 	startstop.Stopper
@@ -21,8 +20,8 @@ var _ Gossiper = &NullGossip{}
 type NullGossip struct{}
 
 func (g *NullGossip) Publish(channel string, message []byte) error { return nil }
-func (g *NullGossip) Subscribe(channel string) error               { return nil }
-func (g *NullGossip) Receive() []byte                              { return nil }
+func (g *NullGossip) Subscribe(channel ...string) error            { return nil }
+func (g *NullGossip) Receive() (string, []byte)                    { return "", nil }
 
 func (g *NullGossip) Start() error { return nil }
 func (g *NullGossip) Stop() error  { return nil }

--- a/internal/gossip/gossip.go
+++ b/internal/gossip/gossip.go
@@ -2,6 +2,7 @@ package gossip
 
 import (
 	"bytes"
+	"errors"
 
 	"github.com/facebookgo/startstop"
 	"golang.org/x/sync/errgroup"
@@ -39,12 +40,20 @@ func (g *InMemoryGossip) Publish(channel string, value []byte) error {
 
 	select {
 	case <-g.done:
+		return errors.New("gossip has been stopped")
 	case g.channel <- msg.ToBytes():
 	default:
 	}
 	return nil
 }
+
 func (g *InMemoryGossip) Subscribe(channel string, callback func(data []byte)) error {
+	select {
+	case <-g.done:
+		return errors.New("gossip has been stopped")
+	default:
+	}
+
 	g.subscribers[channel] = append(g.subscribers[channel], callback)
 	return nil
 }

--- a/internal/gossip/gossip.go
+++ b/internal/gossip/gossip.go
@@ -4,11 +4,13 @@ import "github.com/facebookgo/startstop"
 
 type Gossiper interface {
 	// Gossip sends a message to all peers that are listening on the channel
-	Publish(channel string, message Message) error
+	Publish(channel string, message []byte) error
 
 	// Register a handler for messages on a channel
 	// The handler will be called for each message received on the channel
-	Register(channel string, handler func(Message)) error
+	Subscribe(channel string) error
+
+	Receive() []byte
 
 	startstop.Starter
 	startstop.Stopper
@@ -18,7 +20,9 @@ var _ Gossiper = &NullGossip{}
 
 type NullGossip struct{}
 
-func (g *NullGossip) Publish(channel string, message Message) error        { return nil }
-func (g *NullGossip) Register(channel string, handler func(Message)) error { return nil }
-func (g *NullGossip) Start() error                                         { return nil }
-func (g *NullGossip) Stop() error                                          { return nil }
+func (g *NullGossip) Publish(channel string, message []byte) error { return nil }
+func (g *NullGossip) Subscribe(channel string) error               { return nil }
+func (g *NullGossip) Receive() []byte                              { return nil }
+
+func (g *NullGossip) Start() error { return nil }
+func (g *NullGossip) Stop() error  { return nil }

--- a/internal/gossip/gossip.go
+++ b/internal/gossip/gossip.go
@@ -59,6 +59,8 @@ func (g *InMemoryGossip) Subscribe(channel string, callback func(data []byte)) e
 }
 
 func (g *InMemoryGossip) Start() error {
+	g.channel = make(chan []byte, 10)
+
 	g.eg.Go(func() error {
 		for {
 			select {

--- a/internal/gossip/gossip_redis.go
+++ b/internal/gossip/gossip_redis.go
@@ -1,0 +1,103 @@
+package gossip
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/facebookgo/startstop"
+	"github.com/honeycombio/refinery/logger"
+	"github.com/honeycombio/refinery/redis"
+	"golang.org/x/sync/errgroup"
+)
+
+type GossipRedis struct {
+	Redis  redis.Client  `inject:"redis"`
+	Logger logger.Logger `inject:"logger"`
+	eg     *errgroup.Group
+
+	done chan struct{}
+
+	startstop.Stopper
+}
+
+func (g *GossipRedis) Start() error {
+	g.eg = &errgroup.Group{}
+	g.done = make(chan struct{})
+
+	return nil
+}
+
+func (g *GossipRedis) Stop() error {
+	close(g.done)
+	return g.eg.Wait()
+}
+
+func (g *GossipRedis) Register(channel string, handler func(msg Message)) error {
+	g.eg.Go(func() error {
+		for {
+			select {
+			case <-g.done:
+				return nil
+			default:
+				err := g.Redis.ListenPubSubChannels(nil, func(channel string, b []byte) {
+					message, err := newMessageFromString(string(b))
+					if err != nil {
+						g.Logger.Debug().Logf("Error parsing message: %s", err)
+						return
+					}
+					handler(message)
+				}, g.done, channel)
+				if err != nil {
+					g.Logger.Debug().Logf("Error listening to channel %s: %s", channel, err)
+				}
+			}
+		}
+
+	})
+
+	return nil
+}
+
+func (g *GossipRedis) Publish(channel string, message Message) error {
+	conn := g.Redis.GetPubSubConn()
+	defer conn.Close()
+
+	return conn.Publish(channel, message)
+}
+
+type Message struct {
+	Key   string
+	Value interface{}
+}
+
+func (m Message) String() string {
+	var value string
+	switch v := m.Value.(type) {
+	case string:
+		value = v
+	case []byte:
+		value = string(v)
+	case int:
+		value = strconv.Itoa(v)
+	case uint:
+		value = strconv.Itoa(int(v))
+	case float64:
+		value = strconv.FormatFloat(v, 'f', -1, 64)
+	default:
+		value = fmt.Sprintf("%v", v)
+	}
+	return m.Key + "/" + value
+}
+
+func newMessageFromString(str string) (Message, error) {
+	values := strings.Split(str, "/")
+	if len(values) != 2 {
+		return Message{}, fmt.Errorf("Received invalid stress_level message: %s", str)
+	}
+
+	return Message{
+		Key:   values[0],
+		Value: values[1],
+	}, nil
+}

--- a/internal/gossip/gossip_redis_test.go
+++ b/internal/gossip/gossip_redis_test.go
@@ -1,0 +1,46 @@
+package gossip
+
+import (
+	"testing"
+
+	"github.com/honeycombio/refinery/config"
+	"github.com/honeycombio/refinery/logger"
+	"github.com/honeycombio/refinery/metrics"
+	"github.com/honeycombio/refinery/redis"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRoundTrip(t *testing.T) {
+	cfg := config.MockConfig{
+		GetRedisHostVal: "localhost:6379",
+	}
+	metric := &metrics.MockMetrics{}
+	metric.Start()
+	defer metric.Stop()
+	redis := &redis.DefaultClient{
+		Config:  &cfg,
+		Metrics: metric,
+	}
+	require.NoError(t, redis.Start())
+	defer redis.Stop()
+	g := &GossipRedis{
+		Redis:  redis,
+		Logger: &logger.NullLogger{},
+	}
+
+	require.NoError(t, g.Start())
+
+	// Test that we can register a handler
+	require.NoError(t, g.Register("test", func(msg Message) {
+		require.Equal(t, "hi", msg.Key)
+		require.Equal(t, "hello", msg.Value)
+	}))
+
+	// Test that we can publish a message
+	require.NoError(t, g.Publish("test", Message{
+		Key:   "hi",
+		Value: "hello",
+	}))
+
+	require.NoError(t, g.Stop())
+}

--- a/internal/gossip/gossip_redis_test.go
+++ b/internal/gossip/gossip_redis_test.go
@@ -2,7 +2,6 @@ package gossip
 
 import (
 	"testing"
-	"time"
 
 	"github.com/honeycombio/refinery/config"
 	"github.com/honeycombio/refinery/logger"
@@ -32,28 +31,17 @@ func TestRoundTrip(t *testing.T) {
 	require.NoError(t, g.Start())
 
 	// Test that we can register a handler
-	require.NoError(t, g.Subscribe("test", "test2"))
+	require.NoError(t, g.Subscribe("test", func(data []byte) {
+		require.Equal(t, "hi", string(data))
+	}))
+
+	require.NoError(t, g.Subscribe("test2", func(data []byte) {
+		require.Equal(t, "bye", string(data))
+	}))
 
 	// Test that we can publish a message
 	require.NoError(t, g.Publish("test", []byte("hi")))
 	require.NoError(t, g.Publish("test2", []byte("bye")))
-
-	// Test that we can receive a message
-	var received []bool
-	require.Eventually(t, func() bool {
-		channel, data := g.Receive()
-		switch channel {
-		case "test":
-			if "hi" == string(data) {
-				received = append(received, true)
-			}
-		case "test2":
-			if "bye" == string(data) {
-				received = append(received, true)
-			}
-		}
-		return len(received) == 2
-	}, 3*time.Second, 100*time.Millisecond)
 
 	require.NoError(t, g.Stop())
 }

--- a/internal/gossip/gossip_redis_test.go
+++ b/internal/gossip/gossip_redis_test.go
@@ -2,6 +2,7 @@ package gossip
 
 import (
 	"testing"
+	"time"
 
 	"github.com/honeycombio/refinery/config"
 	"github.com/honeycombio/refinery/logger"
@@ -31,16 +32,16 @@ func TestRoundTrip(t *testing.T) {
 	require.NoError(t, g.Start())
 
 	// Test that we can register a handler
-	require.NoError(t, g.Register("test", func(msg Message) {
-		require.Equal(t, "hi", msg.Key)
-		require.Equal(t, "hello", msg.Value)
-	}))
+	require.NoError(t, g.Subscribe("test"))
 
 	// Test that we can publish a message
-	require.NoError(t, g.Publish("test", Message{
-		Key:   "hi",
-		Value: "hello",
-	}))
+	require.NoError(t, g.Publish("test", []byte("hi")))
+
+	// Test that we can receive a message
+	require.Eventually(t, func() bool {
+		msg := g.Receive()
+		return "hi" == string(msg)
+	}, 3*time.Second, 100*time.Millisecond)
 
 	require.NoError(t, g.Stop())
 }

--- a/internal/gossip/gossip_redis_test.go
+++ b/internal/gossip/gossip_redis_test.go
@@ -32,15 +32,27 @@ func TestRoundTrip(t *testing.T) {
 	require.NoError(t, g.Start())
 
 	// Test that we can register a handler
-	require.NoError(t, g.Subscribe("test"))
+	require.NoError(t, g.Subscribe("test", "test2"))
 
 	// Test that we can publish a message
 	require.NoError(t, g.Publish("test", []byte("hi")))
+	require.NoError(t, g.Publish("test2", []byte("bye")))
 
 	// Test that we can receive a message
+	var received []bool
 	require.Eventually(t, func() bool {
-		msg := g.Receive()
-		return "hi" == string(msg)
+		channel, data := g.Receive()
+		switch channel {
+		case "test":
+			if "hi" == string(data) {
+				received = append(received, true)
+			}
+		case "test2":
+			if "bye" == string(data) {
+				received = append(received, true)
+			}
+		}
+		return len(received) == 2
 	}, 3*time.Second, 100*time.Millisecond)
 
 	require.NoError(t, g.Stop())

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"slices"
 	"strconv"
 	"time"
 
@@ -30,6 +31,8 @@ type Client interface {
 	Get() Conn
 	GetContext(context.Context) (Conn, error)
 	NewScript(keyCount int, src string) Script
+	ListenPubSubChannels(func() error, func(string, []byte), <-chan struct{}, ...string) error
+	GetPubSubConn() PubSubConn
 	startstop.Starter
 	startstop.Stopper
 	Stats() redis.PoolStats
@@ -88,6 +91,33 @@ type Conn interface {
 	Do(string, ...any) (any, error)
 	Exec(...Command) error
 	MemoryStats() (map[string]any, error)
+}
+
+type PubSubConn interface {
+	Publish(channel string, message interface{}) error
+	Close() error
+}
+
+type DefaultPubSubConn struct {
+	channels []string
+	conn     redis.PubSubConn
+	metrics  metrics.Metrics
+	clock    clockwork.Clock
+}
+
+func (d *DefaultPubSubConn) Publish(channel string, message interface{}) error {
+	if !slices.Contains(d.channels, channel) {
+		return errors.New("channel not subscribed")
+	}
+	return d.conn.Conn.Send("PUBLISH", channel, message)
+}
+
+func (d *DefaultPubSubConn) Channels() []string {
+	return d.channels
+}
+
+func (d *DefaultPubSubConn) Close() error {
+	return d.conn.Close()
 }
 
 var _ Client = &DefaultClient{}
@@ -231,6 +261,93 @@ func (d *DefaultClient) GetContext(ctx context.Context) (Conn, error) {
 		metrics: d.Metrics,
 		Clock:   clockwork.NewRealClock(),
 	}, nil
+}
+
+func (d *DefaultClient) GetPubSubConn() PubSubConn {
+	return &DefaultPubSubConn{
+		conn: redis.PubSubConn{Conn: d.pool.Get()},
+	}
+
+}
+
+// listenPubSubChannels listens for messages on Redis pubsub channels. The
+// onStart function is called after the channels are subscribed. The onMessage
+// function is called for each message.
+func (d *DefaultClient) ListenPubSubChannels(onStart func() error,
+	onMessage func(channel string, data []byte), shutdown <-chan struct{},
+	channels ...string) error {
+	// A ping is set to the server with this period to test for the health of
+	// the connection and server.
+	const healthCheckPeriod = time.Minute
+
+	// Read timeout on server should be greater than ping period.
+	c := d.pool.Get()
+
+	psc := redis.PubSubConn{Conn: c}
+	defer func() { psc.Close() }()
+
+	if err := psc.Subscribe(redis.Args{}.AddFlat(channels)...); err != nil {
+		return err
+	}
+
+	done := make(chan error, 1)
+
+	// Start a goroutine to receive notifications from the server.
+	go func() {
+		for {
+			switch n := psc.Receive().(type) {
+			case error:
+				done <- n
+				return
+			case redis.Message:
+				onMessage(n.Channel, n.Data)
+			case redis.Subscription:
+				switch n.Count {
+				case len(channels):
+					// Notify application when all channels are subscribed.
+					if onStart == nil {
+						continue
+					}
+					if err := onStart(); err != nil {
+						done <- err
+						return
+					}
+				case 0:
+					// Return from the goroutine when all channels are unsubscribed.
+					done <- nil
+					return
+				}
+			}
+		}
+	}()
+
+	ticker := time.NewTicker(healthCheckPeriod)
+	defer ticker.Stop()
+loop:
+	for {
+		select {
+		case <-ticker.C:
+			// Send ping to test health of connection and server. If
+			// corresponding pong is not received, then receive on the
+			// connection will timeout and the receive goroutine will exit.
+			if err := psc.Ping(""); err != nil {
+				return err
+			}
+		case <-shutdown:
+			break loop
+		case err := <-done:
+			// Return error from the receive goroutine.
+			return err
+		}
+	}
+
+	// Signal the receiving goroutine to exit by unsubscribing from all channels.
+	if err := psc.Unsubscribe(); err != nil {
+		return err
+	}
+
+	// Wait for goroutine to complete.
+	return <-done
 }
 
 // NewScript returns a new script object that can be optionally registered with

--- a/redis/test_harness.go
+++ b/redis/test_harness.go
@@ -70,6 +70,18 @@ func (s *TestService) GetContext(ctx context.Context) (Conn, error) {
 	}, nil
 }
 
+func (s *TestService) GetPubSubConn() PubSubConn {
+	return &DefaultPubSubConn{
+		conn:    redis.PubSubConn{Conn: s.pool.Get()},
+		metrics: s.Metrics,
+		clock:   s.Clock,
+	}
+}
+
+func (s *TestService) ListenPubSubChannels(onStart func() error, onMessage func(string, []byte), shutdown <-chan struct{}, channels ...string) error {
+	return nil
+}
+
 func (s *TestService) NewScript(keyCount int, src string) Script {
 	return &DefaultScript{
 		script: redis.NewScript(keyCount, src),


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

When using Refinery with Redis, we need to let each Refinery in a cluster know about each other's stress level and config changes. This PR implements the communication protocol for such use case

## Short description of the changes

- Define a `Gossiper` interface
- Implement the `Gossiper` interface using Redis pub/sub

