### PR TITLE
fix: persist keep reason to central store

### DIFF
--- a/collect/central_collector.go
+++ b/collect/central_collector.go
@@ -111,6 +111,7 @@ func (c *CentralCollector) Start() error {
 	c.Metrics.Register("collector_processor_batch_count", "histogram")
 	c.Metrics.Register("collector_decider_batch_count", "histogram")
 	c.Metrics.Register("trace_send_kept", "counter")
+	c.Metrics.Register("trace_send_kept_sample_rate", "histogram")
 	c.Metrics.Register("trace_duration_ms", "histogram")
 	c.Metrics.Register("trace_span_count", "histogram")
 	c.Metrics.Register("trace_decision_kept", "counter")

--- a/collect/central_collector.go
+++ b/collect/central_collector.go
@@ -233,6 +233,7 @@ func (c *CentralCollector) shutdown(ctx context.Context) error {
 			err := c.Store.WriteSpan(ctx, cs)
 			if err != nil {
 				c.Logger.Error().Logf("error sending span %s for trace %s during shutdown: %s", sp.ID, id, err)
+
 			}
 			sentCount++
 			// if the context deadline is exceeded, that means we are
@@ -467,8 +468,6 @@ func (c *CentralCollector) makeDecision(ctx context.Context) error {
 			c.Logger.Info().WithFields(logFields).Logf("Dropping trace because of sampling")
 		}
 		c.Metrics.Increment("trace_decision_kept")
-		// This will observe sample rate decisions only if the trace is kept
-		c.Metrics.Histogram("trace_kept_sample_rate", float64(rate))
 
 		// These meta data should be stored on the central trace status object
 		// so that it's synced across all refinery instances
@@ -493,6 +492,7 @@ func (c *CentralCollector) makeDecision(ctx context.Context) error {
 		var state centralstore.CentralTraceState
 		if shouldSend {
 			state = centralstore.DecisionKeep
+			status.KeepReason = reason
 		} else {
 			state = centralstore.DecisionDrop
 		}
@@ -664,9 +664,12 @@ func (c *CentralCollector) send(status *centralstore.CentralTraceStatus) {
 
 		if c.Config.GetAddRuleReasonToTrace() {
 			reason, ok := status.Metadata["meta.refinery.reason"]
+			if !ok {
+				reason = status.KeepReason
+			}
 			sendReason := status.Metadata["meta.refinery.send_reason"]
 			if sp.ArrivalTime.After(status.Timestamp) {
-				if !ok {
+				if reason == "" {
 					reason = "late arriving span"
 				} else {
 					reason = fmt.Sprintf("%s - late arriving span", reason)
@@ -678,7 +681,6 @@ func (c *CentralCollector) send(status *centralstore.CentralTraceStatus) {
 				sp.Data["meta.refinery.send_reason"] = sendReason
 			}
 		}
-
 		sp.Data["meta.span_event_count"] = int(status.SpanEventCount())
 		sp.Data["meta.span_link_count"] = int(status.SpanLinkCount())
 		sp.Data["meta.span_count"] = int(status.SpanCount())


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

If a trace is kept, we want to persist the reason in `KeepReason` field

## Short description of the changes

- set keep reason during making decision
- retrieve reason from `KeepReason` before sending a trace

