### PR TITLE
feat: add tracing to store

### DIFF
--- a/centralstore/local_store.go
+++ b/centralstore/local_store.go
@@ -8,9 +8,11 @@ import (
 
 	"github.com/honeycombio/refinery/collect/cache"
 	"github.com/honeycombio/refinery/config"
+	"github.com/honeycombio/refinery/internal/otelutil"
 	"github.com/honeycombio/refinery/metrics"
 	"github.com/honeycombio/refinery/types"
 	"github.com/jonboulle/clockwork"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // LocalStore is a basic store that is local to the Refinery process. This is
@@ -19,6 +21,7 @@ type LocalStore struct {
 	Config        config.Config        `inject:""`
 	DecisionCache cache.TraceSentCache `inject:""`
 	Metrics       metrics.Metrics      `inject:"genericMetrics"`
+	Tracer        trace.Tracer         `inject:"tracer"`
 	Clock         clockwork.Clock      `inject:""`
 	// states holds the current state of each trace in a map of the different states
 	// indexed by trace ID.
@@ -121,6 +124,9 @@ func (lrs *LocalStore) changeTraceState(traceID string, fromState, toState Centr
 // during shutdown. WriteSpan is expecting to be called from an asynchronous
 // process and will only return an error if the span could not be written.
 func (lrs *LocalStore) WriteSpan(ctx context.Context, span *CentralSpan) error {
+	_, spanWrite := otelutil.StartSpan(ctx, lrs.Tracer, "LocalStore.WriteSpan")
+	defer spanWrite.End()
+
 	lrs.mutex.Lock()
 	defer lrs.mutex.Unlock()
 
@@ -191,6 +197,8 @@ func (lrs *LocalStore) WriteSpan(ctx context.Context, span *CentralSpan) error {
 // populated. Normally this call will be made after Refinery has been asked
 // to make a trace decision.
 func (lrs *LocalStore) GetTrace(ctx context.Context, traceID string) (*CentralTrace, error) {
+	_, span := otelutil.StartSpan(ctx, lrs.Tracer, "LocalStore.GetTrace")
+	defer span.End()
 	lrs.mutex.RLock()
 	defer lrs.mutex.RUnlock()
 	if trace, ok := lrs.traces[traceID]; ok {
@@ -210,6 +218,8 @@ func (lrs *LocalStore) GetTrace(ctx context.Context, traceID string) (*CentralTr
 // after this call (although kept spans will have counts updated when late
 // spans arrive).
 func (lrs *LocalStore) GetStatusForTraces(ctx context.Context, traceIDs []string) ([]*CentralTraceStatus, error) {
+	_, span := otelutil.StartSpan(ctx, lrs.Tracer, "LocalStore.GetStatusForTraces")
+	defer span.End()
 	lrs.mutex.RLock()
 	defer lrs.mutex.RUnlock()
 	var statuses = make([]*CentralTraceStatus, 0, len(traceIDs))
@@ -225,6 +235,8 @@ func (lrs *LocalStore) GetStatusForTraces(ctx context.Context, traceIDs []string
 
 // GetTracesForState returns a list of trace IDs that match the provided status.
 func (lrs *LocalStore) GetTracesForState(ctx context.Context, state CentralTraceState) ([]string, error) {
+	_, span := otelutil.StartSpan(ctx, lrs.Tracer, "LocalStore.GetTracesForState")
+	defer span.End()
 	lrs.mutex.RLock()
 	defer lrs.mutex.RUnlock()
 	switch state {
@@ -247,6 +259,8 @@ func (lrs *LocalStore) GetTracesForState(ctx context.Context, state CentralTrace
 // ReadyForDecision state. These IDs are moved to the AwaitingDecision state
 // atomically, so that no other refinery will be assigned the same trace.
 func (lrs *LocalStore) GetTracesNeedingDecision(ctx context.Context, n int) ([]string, error) {
+	_, span := otelutil.StartSpan(ctx, lrs.Tracer, "LocalStore.GetTracesNeedingDecision")
+	defer span.End()
 	lrs.mutex.Lock()
 	defer lrs.mutex.Unlock()
 	// get the list of traces in the ReadyForDecision state
@@ -266,6 +280,8 @@ func (lrs *LocalStore) GetTracesNeedingDecision(ctx context.Context, n int) ([]s
 // atomically. This can be used for all trace states except transition to Keep.
 // If a traceID is not found in the fromState, this is not considered to be an error.
 func (lrs *LocalStore) ChangeTraceStatus(ctx context.Context, traceIDs []string, fromState, toState CentralTraceState) error {
+	_, span := otelutil.StartSpan(ctx, lrs.Tracer, "LocalStore.ChangeTraceStatus")
+	defer span.End()
 	lrs.mutex.Lock()
 	defer lrs.mutex.Unlock()
 	for _, traceID := range traceIDs {
@@ -289,6 +305,8 @@ func (lrs *LocalStore) ChangeTraceStatus(ctx context.Context, traceIDs []string,
 // Statuses should include Reason and Rate; do not include State as it will be ignored.
 // If a trace is not in the AwaitingDecision state, it will be ignored.
 func (lrs *LocalStore) KeepTraces(ctx context.Context, statuses []*CentralTraceStatus) error {
+	_, span := otelutil.StartSpan(ctx, lrs.Tracer, "LocalStore.KeepTraces")
+	defer span.End()
 	lrs.mutex.Lock()
 	defer lrs.mutex.Unlock()
 	for _, status := range statuses {
@@ -302,6 +320,8 @@ func (lrs *LocalStore) KeepTraces(ctx context.Context, statuses []*CentralTraceS
 }
 
 func (lrs *LocalStore) RecordTraceDecision(ctx context.Context, trace *CentralTraceStatus, keep bool, reason string) error {
+	_, span := otelutil.StartSpan(ctx, lrs.Tracer, "LocalStore.RecordTraceDecision")
+	defer span.End()
 	lrs.mutex.Lock()
 	defer lrs.mutex.Unlock()
 	if keep {
@@ -316,6 +336,8 @@ func (lrs *LocalStore) RecordTraceDecision(ctx context.Context, trace *CentralTr
 // RecordMetrics returns a map of metrics from the remote store, accumulated
 // since the previous time this method was called.
 func (lrs *LocalStore) RecordMetrics(ctx context.Context) error {
+	_, span := otelutil.StartSpan(ctx, lrs.Tracer, "LocalStore.RecordMetrics")
+	defer span.End()
 	lrs.mutex.RLock()
 	defer lrs.mutex.RUnlock()
 	m, err := lrs.DecisionCache.GetMetrics()

--- a/collect/central_collector.go
+++ b/collect/central_collector.go
@@ -14,6 +14,7 @@ import (
 	"github.com/honeycombio/refinery/collect/stressRelief"
 	"github.com/honeycombio/refinery/config"
 	"github.com/honeycombio/refinery/internal/health"
+	"github.com/honeycombio/refinery/internal/otelutil"
 	"github.com/honeycombio/refinery/logger"
 	"github.com/honeycombio/refinery/metrics"
 	"github.com/honeycombio/refinery/sample"
@@ -21,6 +22,7 @@ import (
 	"github.com/honeycombio/refinery/types"
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
+	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -68,6 +70,7 @@ type CentralCollector struct {
 	Transmission   transmit.Transmission       `inject:"upstreamTransmission"`
 	Logger         logger.Logger               `inject:""`
 	Metrics        metrics.Metrics             `inject:"genericMetrics"`
+	Tracer         trace.Tracer                `inject:"tracer"`
 	StressRelief   stressRelief.StressReliever `inject:"stressRelief"`
 	SamplerFactory *sample.SamplerFactory      `inject:""`
 	Health         health.Recorder             `inject:""`
@@ -199,7 +202,9 @@ func (c *CentralCollector) Stop() error {
 // other half is used for uploading the remaining traces.
 // If the shutdown process exceeds the shutdown delay, it will return an error.
 func (c *CentralCollector) shutdown(ctx context.Context) error {
-	// try to send the remaining traces to the cache
+	ctx, span := otelutil.StartSpan1(ctx, c.Tracer, "CentralCollector.shutdown", "span_cache_len", c.SpanCache.Len())
+	defer span.End()
+	// keep processing, hoping to send the remaining traces
 	interval := 1 * time.Second
 	done := make(chan struct{})
 	processCycle := NewCycle(c.Clock, interval, done)
@@ -232,10 +237,14 @@ func (c *CentralCollector) shutdown(ctx context.Context) error {
 	}
 	defer close(done)
 
+	ctxForward, spanForward := otelutil.StartSpan1(ctx, c.Tracer, "CentralCollector.shutdown.forward", "span_cache_len", c.SpanCache.Len())
+	defer spanForward.End()
+
 	// send the remaining traces to the central store
 	ids := c.SpanCache.GetTraceIDs(c.SpanCache.Len())
 	var sentCount int
-	defer c.Logger.Info().Logf("sending %d traces to central store during shutdown", sentCount)
+	defer otelutil.AddSpanField(spanForward, "sent_count", sentCount)
+	defer c.Logger.Info().Logf("sent %d traces to central store during shutdown", sentCount)
 
 	for _, id := range ids {
 		trace := c.SpanCache.Get(id)
@@ -251,8 +260,9 @@ func (c *CentralCollector) shutdown(ctx context.Context) error {
 			}
 
 			cs.SetSamplerSelector(trace.GetSamplerSelector(c.Config.GetDatasetPrefix()))
-			err := c.Store.WriteSpan(ctx, cs)
+			err := c.Store.WriteSpan(ctxForward, cs)
 			if err != nil {
+				spanForward.RecordError(err)
 				c.Logger.Error().Logf("error sending span %s for trace %s during shutdown: %s", sp.ID, id, err)
 
 			}
@@ -262,6 +272,7 @@ func (c *CentralCollector) shutdown(ctx context.Context) error {
 			// sending traces to the central store. Unfortunately, the
 			// remaining traces will be lost.
 			if errors.Is(err, context.DeadlineExceeded) {
+				spanForward.RecordError(err)
 				return err
 			}
 		}
@@ -274,11 +285,19 @@ func (c *CentralCollector) shutdown(ctx context.Context) error {
 // If it's part of the deterministic sample, the decision is written to the central store and
 // the span is enqueued for transmission.
 func (c *CentralCollector) ProcessSpanImmediately(sp *types.Span) (bool, error) {
+	ctx, span := otelutil.StartSpan1(context.Background(), c.Tracer, "CentralCollector.ProcessSpanImmediately", "trace_id", sp.TraceID)
+
 	if !c.StressRelief.ShouldSampleDeterministically(sp.TraceID) {
+		otelutil.AddSpanField(span, "nondeterministic", 1)
 		return false, nil
 	}
 
 	rate, keep, reason := c.StressRelief.GetSampleRate(sp.TraceID)
+	otelutil.AddSpanFields(span, map[string]interface{}{
+		"rate":   rate,
+		"keep":   keep,
+		"reason": reason,
+	})
 
 	status := &centralstore.CentralTraceStatus{
 		TraceID:    sp.TraceID,
@@ -287,8 +306,9 @@ func (c *CentralCollector) ProcessSpanImmediately(sp *types.Span) (bool, error) 
 		KeepReason: reason,
 	}
 
-	err := c.Store.RecordTraceDecision(context.Background(), status, keep, reason)
+	err := c.Store.RecordTraceDecision(ctx, status, keep, reason)
 	if err != nil {
+		span.RecordError(err)
 		return true, err
 	}
 
@@ -380,7 +400,10 @@ func (c *CentralCollector) process() error {
 }
 
 func (c *CentralCollector) processTraces(ctx context.Context) error {
+	ctx, span := otelutil.StartSpan(ctx, c.Tracer, "CentralCollector.processTraces")
+	defer span.End()
 	ids := c.SpanCache.GetTraceIDs(c.Config.GetCollectionConfig().GetProcessTracesBatchSize())
+	otelutil.AddSpanField(span, "num_ids", len(ids))
 
 	c.Metrics.Histogram("collector_processor_batch_count", len(ids))
 	if len(ids) == 0 {
@@ -424,6 +447,8 @@ func (c *CentralCollector) decide() error {
 }
 
 func (c *CentralCollector) makeDecision(ctx context.Context) error {
+	ctx, span := otelutil.StartSpan(ctx, c.Tracer, "CentralCollector.makeDecision")
+	defer span.End()
 	tracesIDs, err := c.Store.GetTracesNeedingDecision(ctx, c.Config.GetCollectionConfig().GetDeciderBatchSize())
 	if err != nil {
 		return err
@@ -436,6 +461,7 @@ func (c *CentralCollector) makeDecision(ctx context.Context) error {
 	}
 	statuses, err := c.Store.GetStatusForTraces(ctx, tracesIDs)
 	if err != nil {
+		span.RecordError(err)
 		return err
 	}
 
@@ -448,6 +474,7 @@ func (c *CentralCollector) makeDecision(ctx context.Context) error {
 		concurrency = 10
 	}
 	eg.SetLimit(concurrency)
+	otelutil.AddSpanField(span, "concurrency", concurrency)
 
 	for idx, status := range statuses {
 		// make a decision on each trace
@@ -459,6 +486,8 @@ func (c *CentralCollector) makeDecision(ctx context.Context) error {
 		stateMap[status.TraceID] = status
 
 		eg.Go(func() error {
+			ctx, span := otelutil.StartSpan(ctx, c.Tracer, "CentralCollector.makeDecision.getTrace")
+			defer span.End()
 			trace, err := c.Store.GetTrace(ctx, currentStatus.TraceID)
 			if err != nil {
 				return err
@@ -476,10 +505,13 @@ func (c *CentralCollector) makeDecision(ctx context.Context) error {
 		return err
 	}
 
+	ctxTraces, spanTraces := otelutil.StartSpan1(ctx, c.Tracer, "CentralCollector.makeDecision.traceLoop", "num_traces", len(traces))
+	defer spanTraces.End()
 	for _, trace := range traces {
 		if trace == nil {
 			continue
 		}
+		_, span := otelutil.StartSpan(ctxTraces, c.Tracer, "CentralCollector.makeDecision.trace")
 
 		if trace.Root != nil {
 			c.Metrics.Increment("trace_decision_has_root")
@@ -564,6 +596,7 @@ func (c *CentralCollector) makeDecision(ctx context.Context) error {
 		status.State = state
 		status.Rate = rate
 		stateMap[status.TraceID] = status
+		span.End()
 	}
 
 	updatedStatuses := make([]*centralstore.CentralTraceStatus, 0, len(stateMap))


### PR DESCRIPTION
## Which problem is this PR solving?

- We want to be able to watch performance of the store in detail; profiling is helpful but not enough. We had started to set up tracing already, this makes it work. It generates a lot of spans rather quickly, so it should definitely NOT be used in production.

## Short description of the changes

- Add tracers to a few key types
- Use them to generate spans and decorate them with useful data

