### PR TITLE
Check for traces before apply state change

### DIFF
--- a/centralstore/redis_store_test.go
+++ b/centralstore/redis_store_test.go
@@ -153,6 +153,38 @@ func TestRedisBasicStore_GetTrace(t *testing.T) {
 	assert.EqualValues(t, testSpans[1], trace.Root)
 }
 
+func TestRedisBasicStore_applyStateChange_NoTraces(t *testing.T) {
+	ctx := context.Background()
+	testRedis := &redis.TestService{}
+	testRedis.Start()
+	defer testRedis.Stop()
+
+	ts := newTestTraceStateProcessor(t, testRedis, nil, noop.NewTracerProvider().Tracer("test"))
+	require.NoError(t, ts.init(testRedis))
+	defer ts.Stop()
+
+	conn := testRedis.Get()
+	defer conn.Close()
+
+	result, err := ts.applyStateChange(ctx, conn, stateChangeEvent{}, []string{})
+	require.Nil(t, err)
+	assert.Nil(t, result)
+
+	result, err = ts.applyStateChange(ctx, conn, stateChangeEvent{}, nil)
+	require.Nil(t, err)
+	assert.Nil(t, result)
+}
+
+func TestRedisBasicStore_ChangeTraceStatus_NoTraces(t *testing.T) {
+	ctx := context.Background()
+
+	store := NewTestRedisBasicStore(ctx, t)
+	defer store.Stop()
+
+	assert.NoError(t, store.ChangeTraceStatus(ctx, []string{}, Collecting, DecisionDelay))
+	assert.NoError(t, store.ChangeTraceStatus(ctx, nil, Collecting, DecisionDelay))
+}
+
 func TestRedisBasicStore_ChangeTraceStatus(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
## Which problem is this PR solving?

- Ensures that state change requests only happen if traceids are provided

## Short description of the changes

- Updates functions to check the length of the trace ids slice.
- Added unit tests

