### PR TITLE
feat: performance tweaks

### DIFF
--- a/centralstore/centralstore.go
+++ b/centralstore/centralstore.go
@@ -182,7 +182,7 @@ type SmartStorer interface {
 	// traces with a state of DecisionKeep or DecisionDrop should be considered
 	// to be final and appropriately disposed of; the central store will not
 	// change the state of these traces after this call.
-	GetStatusForTraces(ctx context.Context, traceIDs []string, statesToCheck []CentralTraceState) ([]*CentralTraceStatus, error)
+	GetStatusForTraces(ctx context.Context, traceIDs []string, statesToCheck ...CentralTraceState) ([]*CentralTraceStatus, error)
 
 	// GetTracesForState returns a list of trace IDs that match the provided status.
 	GetTracesForState(ctx context.Context, state CentralTraceState) ([]string, error)
@@ -278,7 +278,7 @@ type BasicStorer interface {
 	// traces with a state of DecisionKeep or DecisionDrop should be considered
 	// to be final and appropriately disposed of; the central store will not
 	// change the state of these traces after this call.
-	GetStatusForTraces(ctx context.Context, traceIDs []string, statesToCheck []CentralTraceState) ([]*CentralTraceStatus, error)
+	GetStatusForTraces(ctx context.Context, traceIDs []string, statesToCheck ...CentralTraceState) ([]*CentralTraceStatus, error)
 
 	// GetTracesForState returns a list of trace IDs that match the provided status.
 	GetTracesForState(ctx context.Context, state CentralTraceState) ([]string, error)

--- a/centralstore/centralstore.go
+++ b/centralstore/centralstore.go
@@ -175,15 +175,14 @@ type SmartStorer interface {
 	// its state will not be changed.
 	GetTrace(ctx context.Context, traceID string) (*CentralTrace, error)
 
-	// GetStatusForTraces returns the current state for a list of traces,
-	// including any reason information if the trace decision has been made and
-	// it was to keep the trace. If a trace is not found, it will be returned as
-	// Status:Unknown. This should be considered to be a bug in the central
-	// store, as the trace should have been created when the first span was
-	// added. Any traces with a state of DecisionKeep or DecisionDrop should be
-	// considered to be final and appropriately disposed of; the central store
-	// will not change the state of these traces after this call.
-	GetStatusForTraces(ctx context.Context, traceIDs []string) ([]*CentralTraceStatus, error)
+	// GetStatusForTraces returns the current state for a list of traces if they
+	// match any of the states passed in, including any reason information if
+	// the trace decision has been made and it was to keep the trace. If a trace
+	// is not found in any of the listed states, it will be not be returned. Any
+	// traces with a state of DecisionKeep or DecisionDrop should be considered
+	// to be final and appropriately disposed of; the central store will not
+	// change the state of these traces after this call.
+	GetStatusForTraces(ctx context.Context, traceIDs []string, statesToCheck []CentralTraceState) ([]*CentralTraceStatus, error)
 
 	// GetTracesForState returns a list of trace IDs that match the provided status.
 	GetTracesForState(ctx context.Context, state CentralTraceState) ([]string, error)
@@ -272,17 +271,14 @@ type BasicStorer interface {
 	// to make a trace decision.
 	GetTrace(ctx context.Context, traceID string) (*CentralTrace, error)
 
-	// GetStatusForTraces returns the current state for a list of trace IDs,
-	// including any reason information and trace counts if the trace decision
-	// has been made and it was to keep the trace. If a requested trace was not
-	// found, it will be returned as Status:Unknown. This should be considered
-	// to be a bug in the central store, as the trace should have been created
-	// when the first span was added. Any traces with a state of DecisionKeep or
-	// DecisionDrop should be considered to be final and appropriately disposed
-	// of; the central store will not change the decision state of these traces
-	// after this call (although kept spans will have counts updated when late
-	// spans arrive).
-	GetStatusForTraces(ctx context.Context, traceIDs []string) ([]*CentralTraceStatus, error)
+	// GetStatusForTraces returns the current state for a list of traces if they
+	// match any of the states passed in, including any reason information if
+	// the trace decision has been made and it was to keep the trace. If a trace
+	// is not found in any of the listed states, it will be not be returned. Any
+	// traces with a state of DecisionKeep or DecisionDrop should be considered
+	// to be final and appropriately disposed of; the central store will not
+	// change the state of these traces after this call.
+	GetStatusForTraces(ctx context.Context, traceIDs []string, statesToCheck []CentralTraceState) ([]*CentralTraceStatus, error)
 
 	// GetTracesForState returns a list of trace IDs that match the provided status.
 	GetTracesForState(ctx context.Context, state CentralTraceState) ([]string, error)

--- a/centralstore/local_store.go
+++ b/centralstore/local_store.go
@@ -219,7 +219,7 @@ func (lrs *LocalStore) GetTrace(ctx context.Context, traceID string) (*CentralTr
 // traces with a state of DecisionKeep or DecisionDrop should be considered
 // to be final and appropriately disposed of; the central store will not
 // change the state of these traces after this call.
-func (lrs *LocalStore) GetStatusForTraces(ctx context.Context, traceIDs []string, statesToCheck []CentralTraceState) ([]*CentralTraceStatus, error) {
+func (lrs *LocalStore) GetStatusForTraces(ctx context.Context, traceIDs []string, statesToCheck ...CentralTraceState) ([]*CentralTraceStatus, error) {
 	_, span := otelutil.StartSpan(ctx, lrs.Tracer, "LocalStore.GetStatusForTraces")
 	defer span.End()
 	lrs.mutex.RLock()

--- a/centralstore/redis_store.go
+++ b/centralstore/redis_store.go
@@ -279,7 +279,7 @@ func (r *RedisBasicStore) GetTrace(ctx context.Context, traceID string) (*Centra
 	}, errors.Join(errs...)
 }
 
-func (r *RedisBasicStore) GetStatusForTraces(ctx context.Context, traceIDs []string, statesToCheck []CentralTraceState) ([]*CentralTraceStatus, error) {
+func (r *RedisBasicStore) GetStatusForTraces(ctx context.Context, traceIDs []string, statesToCheck ...CentralTraceState) ([]*CentralTraceStatus, error) {
 	ctx, span := otelutil.StartSpanWith(ctx, r.Tracer, "GetStatusForTraces", "num_traces", len(traceIDs))
 	defer span.End()
 
@@ -801,8 +801,6 @@ func (t *tracesStore) getTraceStatuses(ctx context.Context, client redis.Client,
 				}
 				faninChan <- normalizeCentralTraceStatusRedis(status)
 				found++
-				// just to make sure we give all the goroutines a chance to run
-				time.Sleep(1 * time.Microsecond)
 			}
 			otelutil.AddSpanFields(span, map[string]interface{}{
 				"num_queries": queries,

--- a/centralstore/redis_store.go
+++ b/centralstore/redis_store.go
@@ -783,10 +783,14 @@ func (t *tracesStore) getTraceStatuses(ctx context.Context, client redis.Client,
 		}
 	}()
 
+	const (
+		maxConnections = 10
+		traceIDsPerGo  = 10
+	)
 	// determine the number of goroutines to use based on the number of traceIDs
-	numGoroutines := len(traceIDs)/10 + 1
-	if numGoroutines > 10 {
-		numGoroutines = 10
+	numGoroutines := len(traceIDs)/traceIDsPerGo + 1
+	if numGoroutines > maxConnections {
+		numGoroutines = maxConnections
 	}
 
 	// create workers to get the traceIDs and send their statuses to the fanin channel

--- a/centralstore/redis_store.go
+++ b/centralstore/redis_store.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"sort"
+	"sync"
 	"time"
 
 	"github.com/honeycombio/refinery/collect/cache"
@@ -277,7 +279,7 @@ func (r *RedisBasicStore) GetTrace(ctx context.Context, traceID string) (*Centra
 	}, errors.Join(errs...)
 }
 
-func (r *RedisBasicStore) GetStatusForTraces(ctx context.Context, traceIDs []string) ([]*CentralTraceStatus, error) {
+func (r *RedisBasicStore) GetStatusForTraces(ctx context.Context, traceIDs []string, statesToCheck []CentralTraceState) ([]*CentralTraceStatus, error) {
 	ctx, span := otelutil.StartSpanWith(ctx, r.Tracer, "GetStatusForTraces", "num_traces", len(traceIDs))
 	defer span.End()
 
@@ -315,12 +317,12 @@ func (r *RedisBasicStore) GetStatusForTraces(ctx context.Context, traceIDs []str
 		"num_of_cached_traces":  len(statusMap),
 	})
 
-	statusMapFromRedis, err := r.traces.getTraceStatuses(ctx, conn, traceIDs)
+	statusMapFromRedis, err := r.traces.getTraceStatuses(ctx, r.RedisClient, traceIDs)
 	if err != nil {
 		return nil, err
 	}
 
-	for _, state := range r.states.states {
+	for _, state := range statesToCheck {
 		if len(pendingTraceIDs) == 0 {
 			break
 		}
@@ -329,13 +331,12 @@ func (r *RedisBasicStore) GetStatusForTraces(ctx context.Context, traceIDs []str
 		if err != nil {
 			return nil, err
 		}
+		pendingTraceIDs = slices.DeleteFunc(pendingTraceIDs, func(id string) bool {
+			_, ok := timestampsByTraceIDs[id]
+			return ok
+		})
 
-		notExist := make([]string, 0, len(pendingTraceIDs))
 		for id, timestamp := range timestampsByTraceIDs {
-			if timestamp.IsZero() {
-				notExist = append(notExist, id)
-				continue
-			}
 			status, ok := statusMapFromRedis[id]
 			if !ok {
 				continue
@@ -345,16 +346,7 @@ func (r *RedisBasicStore) GetStatusForTraces(ctx context.Context, traceIDs []str
 			statusMap[id] = status
 		}
 
-		pendingTraceIDs = notExist
-	}
-
-	otelutil.AddSpanField(span, "num_of_unknown_traces", len(pendingTraceIDs))
-
-	for _, id := range pendingTraceIDs {
-		statusMap[id] = &CentralTraceStatus{
-			TraceID: id,
-			State:   Unknown,
-		}
+		otelutil.AddSpanField(span, "num_in_"+state.String(), len(timestampsByTraceIDs))
 	}
 
 	statuses := make([]*CentralTraceStatus, 0, len(statusMap))
@@ -438,7 +430,7 @@ func (r *RedisBasicStore) ChangeTraceStatus(ctx context.Context, traceIDs []stri
 	defer conn.Close()
 
 	if toState == DecisionDrop {
-		traces, err := r.traces.getTraceStatuses(ctx, conn, traceIDs)
+		traces, err := r.traces.getTraceStatuses(ctx, r.RedisClient, traceIDs)
 		if err != nil {
 			return err
 		}
@@ -745,7 +737,7 @@ func (t *tracesStore) keepTrace(ctx context.Context, conn redis.Conn, status []*
 	return nil
 }
 
-func (t *tracesStore) getTraceStatuses(ctx context.Context, conn redis.Conn, traceIDs []string) (map[string]*CentralTraceStatus, error) {
+func (t *tracesStore) getTraceStatuses(ctx context.Context, client redis.Client, traceIDs []string) (map[string]*CentralTraceStatus, error) {
 	_, statusSpan := otelutil.StartSpanWith(ctx, t.tracer, "getTraceStatuses", "num_ids", len(traceIDs))
 	defer statusSpan.End()
 
@@ -753,21 +745,81 @@ func (t *tracesStore) getTraceStatuses(ctx context.Context, conn redis.Conn, tra
 		return nil, nil
 	}
 
-	statuses := make(map[string]*CentralTraceStatus, len(traceIDs))
-	for _, traceID := range traceIDs {
-		status := &centralTraceStatusRedis{}
-		err := conn.GetStructHash(t.traceStatusKey(traceID), status)
-		if err != nil {
-			if errors.Is(err, redis.ErrKeyNotFound) {
-				continue
-			}
-			statusSpan.RecordError(err)
-			return nil, fmt.Errorf("failed to retrieve trace status for trace ID %s with error %s", traceID, err)
-		}
+	fanoutChan := make(chan string, 100)
+	faninChan := make(chan *CentralTraceStatus, 100)
 
-		statuses[traceID] = normalizeCentralTraceStatusRedis(status)
+	// send all the trace IDs to the fanout channel
+	wgFans := sync.WaitGroup{}
+	wgFans.Add(1)
+	go func() {
+		defer wgFans.Done()
+		defer close(fanoutChan)
+		for i := range traceIDs {
+			fanoutChan <- traceIDs[i]
+		}
+	}()
+
+	// collect the statuses from the fanin channel
+	statuses := make(map[string]*CentralTraceStatus, len(traceIDs))
+	wgFans.Add(1)
+	go func() {
+		defer wgFans.Done()
+		for status := range faninChan {
+			statuses[status.TraceID] = status
+		}
+	}()
+
+	// determine the number of goroutines to use based on the number of traceIDs
+	numGoroutines := len(traceIDs)/10 + 1
+	if numGoroutines > 10 {
+		numGoroutines = 10
 	}
 
+	// create workers to get the traceIDs and send their statuses to the fanin channel
+	// They will pull from the fanout channel and terminate when it closes
+	wgWorkers := sync.WaitGroup{}
+	for i := 0; i < numGoroutines; i++ {
+		wgWorkers.Add(1)
+		go func(i int) {
+			conn := client.Get()
+			defer conn.Close()
+			queries := 0
+			found := 0
+			_, span := otelutil.StartSpanWith(ctx, t.tracer, "getTraceStatusesWorker", "worker", i)
+			defer span.End()
+			defer wgWorkers.Done()
+			for traceID := range fanoutChan {
+				status := &centralTraceStatusRedis{}
+				err := conn.GetStructHash(t.traceStatusKey(traceID), status)
+				queries++
+				if err != nil {
+					if errors.Is(err, redis.ErrKeyNotFound) {
+						continue
+					}
+					statusSpan.RecordError(err)
+					continue
+				}
+				faninChan <- normalizeCentralTraceStatusRedis(status)
+				found++
+				// just to make sure we give all the goroutines a chance to run
+				time.Sleep(1 * time.Microsecond)
+			}
+			otelutil.AddSpanFields(span, map[string]interface{}{
+				"num_queries": queries,
+				"num_found":   found,
+			})
+		}(i)
+	}
+
+	// wait for the workers to finish
+	wgWorkers.Wait()
+	// now we can close the fanin channel and wait for the fanin goroutine to finish
+	// fanout should already be done but this makes sure we don't lose track of it
+	close(faninChan)
+	wgFans.Wait()
+
+	// and our result is ready
+	otelutil.AddSpanField(statusSpan, "num_statuses", len(statuses))
 	return statuses, nil
 }
 
@@ -898,10 +950,10 @@ func newTraceStateProcessor(cfg traceStateProcessorConfig, clock clockwork.Clock
 		states: []CentralTraceState{
 			DecisionKeep,
 			DecisionDrop,
+			Collecting,
+			DecisionDelay,
 			AwaitingDecision,
 			ReadyToDecide,
-			DecisionDelay,
-			Collecting,
 		},
 		config: cfg,
 		clock:  clock,
@@ -1015,7 +1067,7 @@ func (t *traceStateProcessor) traceIDsWithTimestamp(ctx context.Context, conn re
 	traces := make(map[string]time.Time, len(timestamps))
 	for i, value := range timestamps {
 		if value == 0 {
-			traces[traceIDs[i]] = time.Time{}
+			// it didn't exist, skip it
 			continue
 		}
 		traces[traceIDs[i]] = time.UnixMicro(value)

--- a/centralstore/redis_store_test.go
+++ b/centralstore/redis_store_test.go
@@ -28,11 +28,9 @@ func TestRedisBasicStore_TraceStatus(t *testing.T) {
 	store := NewTestRedisBasicStore(ctx, t)
 	defer store.Stop()
 
-	status, err := store.GetStatusForTraces(ctx, []string{traceID})
+	status, err := store.GetStatusForTraces(ctx, []string{traceID}, []CentralTraceState{Unknown})
 	require.NoError(t, err)
-	require.Len(t, status, 1)
-	require.NotNil(t, status[0])
-	assert.Equal(t, Unknown, status[0].State)
+	require.Len(t, status, 0)
 
 	testcases := []struct {
 		name               string
@@ -99,7 +97,7 @@ func TestRedisBasicStore_TraceStatus(t *testing.T) {
 	for i, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			require.NoError(t, store.WriteSpan(ctx, tc.span))
-			status, err := store.GetStatusForTraces(ctx, []string{tc.span.TraceID})
+			status, err := store.GetStatusForTraces(ctx, []string{tc.span.TraceID}, []CentralTraceState{tc.expectedState})
 			require.NoError(t, err)
 			require.Len(t, status, 1)
 			require.NotNil(t, status[0])
@@ -170,7 +168,7 @@ func TestRedisBasicStore_ChangeTraceStatus(t *testing.T) {
 
 	require.NoError(t, store.WriteSpan(ctx, span))
 
-	collectingStatus, err := store.GetStatusForTraces(ctx, []string{span.TraceID})
+	collectingStatus, err := store.GetStatusForTraces(ctx, []string{span.TraceID}, []CentralTraceState{Collecting})
 	require.NoError(t, err)
 	require.Len(t, collectingStatus, 1)
 	assert.Equal(t, Collecting, collectingStatus[0].State)
@@ -179,7 +177,7 @@ func TestRedisBasicStore_ChangeTraceStatus(t *testing.T) {
 
 	require.NoError(t, store.ChangeTraceStatus(ctx, []string{span.TraceID}, Collecting, DecisionDelay))
 
-	waitingStatus, err := store.GetStatusForTraces(ctx, []string{span.TraceID})
+	waitingStatus, err := store.GetStatusForTraces(ctx, []string{span.TraceID}, []CentralTraceState{DecisionDelay})
 	require.NoError(t, err)
 	require.Len(t, waitingStatus, 1)
 	assert.Equal(t, DecisionDelay, waitingStatus[0].State)
@@ -188,7 +186,7 @@ func TestRedisBasicStore_ChangeTraceStatus(t *testing.T) {
 	store.clock.Advance(time.Duration(1 * time.Second))
 	require.NoError(t, store.ChangeTraceStatus(ctx, []string{span.TraceID}, DecisionDelay, ReadyToDecide))
 
-	readyStatus, err := store.GetStatusForTraces(ctx, []string{span.TraceID})
+	readyStatus, err := store.GetStatusForTraces(ctx, []string{span.TraceID}, []CentralTraceState{ReadyToDecide})
 	require.NoError(t, err)
 	require.Len(t, readyStatus, 1)
 	assert.Equal(t, ReadyToDecide, readyStatus[0].State)
@@ -197,7 +195,7 @@ func TestRedisBasicStore_ChangeTraceStatus(t *testing.T) {
 	store.clock.Advance(time.Duration(1 * time.Second))
 	require.NoError(t, store.ChangeTraceStatus(ctx, []string{span.TraceID}, ReadyToDecide, AwaitingDecision))
 
-	awaitingStatus, err := store.GetStatusForTraces(ctx, []string{span.TraceID})
+	awaitingStatus, err := store.GetStatusForTraces(ctx, []string{span.TraceID}, []CentralTraceState{AwaitingDecision})
 	require.NoError(t, err)
 	require.Len(t, awaitingStatus, 1)
 	assert.Equal(t, AwaitingDecision, awaitingStatus[0].State)
@@ -206,7 +204,7 @@ func TestRedisBasicStore_ChangeTraceStatus(t *testing.T) {
 	store.clock.Advance(time.Duration(1 * time.Second))
 	require.NoError(t, store.ChangeTraceStatus(ctx, []string{span.TraceID}, AwaitingDecision, ReadyToDecide))
 
-	readyStatus, err = store.GetStatusForTraces(ctx, []string{span.TraceID})
+	readyStatus, err = store.GetStatusForTraces(ctx, []string{span.TraceID}, []CentralTraceState{ReadyToDecide})
 	require.NoError(t, err)
 	require.Len(t, readyStatus, 1)
 	assert.Equal(t, ReadyToDecide, readyStatus[0].State)
@@ -214,12 +212,12 @@ func TestRedisBasicStore_ChangeTraceStatus(t *testing.T) {
 
 	store.clock.Advance(time.Duration(1 * time.Second))
 	require.NoError(t, store.ChangeTraceStatus(ctx, []string{span.TraceID}, ReadyToDecide, AwaitingDecision))
-	awaitingStatus, err = store.GetStatusForTraces(ctx, []string{span.TraceID})
+	awaitingStatus, err = store.GetStatusForTraces(ctx, []string{span.TraceID}, []CentralTraceState{AwaitingDecision})
 	require.NoError(t, err)
 
 	require.NoError(t, store.KeepTraces(ctx, awaitingStatus))
 
-	keepStatus, err := store.GetStatusForTraces(ctx, []string{span.TraceID})
+	keepStatus, err := store.GetStatusForTraces(ctx, []string{span.TraceID}, []CentralTraceState{DecisionKeep})
 	require.NoError(t, err)
 	require.Len(t, keepStatus, 1)
 	assert.Equal(t, DecisionKeep, keepStatus[0].State)
@@ -264,7 +262,7 @@ func TestRedisBasicStore_KeepTraces(t *testing.T) {
 	defer conn.Close()
 
 	store.ensureInitialState(t, ctx, conn, traceID, AwaitingDecision)
-	status, err := store.GetStatusForTraces(ctx, []string{traceID})
+	status, err := store.GetStatusForTraces(ctx, []string{traceID}, []CentralTraceState{AwaitingDecision})
 	require.NoError(t, err)
 	require.NoError(t, store.KeepTraces(ctx, status))
 
@@ -274,7 +272,7 @@ func TestRedisBasicStore_KeepTraces(t *testing.T) {
 	require.Equal(t, uint(1), record.DescendantCount())
 
 	// make sure it's state is updated to keep
-	status, err = store.GetStatusForTraces(ctx, []string{traceID})
+	status, err = store.GetStatusForTraces(ctx, []string{traceID}, []CentralTraceState{DecisionKeep})
 	require.NoError(t, err)
 	require.Len(t, status, 1)
 	require.Equal(t, DecisionKeep, status[0].State)
@@ -300,7 +298,7 @@ func TestRedisBasicStore_ConcurrentStateChange(t *testing.T) {
 		IsRoot:    false,
 	}))
 
-	status, err := store.GetStatusForTraces(ctx, []string{traceID})
+	status, err := store.GetStatusForTraces(ctx, []string{traceID}, []CentralTraceState{Collecting})
 	require.NoError(t, err)
 	require.Len(t, status, 1)
 	require.Equal(t, Collecting, status[0].State)
@@ -333,14 +331,14 @@ func TestRedisBasicStore_ConcurrentStateChange(t *testing.T) {
 
 	require.False(t, store.states.exists(ctx, conn, Collecting, traceID))
 	decisionDelay := store.states.exists(ctx, conn, DecisionDelay, traceID)
-	status, err = store.GetStatusForTraces(ctx, []string{traceID})
+	status, err = store.GetStatusForTraces(ctx, []string{traceID}, []CentralTraceState{AwaitingDecision})
 	require.NoError(t, err)
 	require.Len(t, status, 1)
 	require.False(t, decisionDelay)
 	require.False(t, store.states.exists(ctx, conn, ReadyToDecide, traceID))
 	require.True(t, store.states.exists(ctx, conn, AwaitingDecision, traceID))
 
-	status, err = store.GetStatusForTraces(ctx, []string{traceID})
+	status, err = store.GetStatusForTraces(ctx, []string{traceID}, []CentralTraceState{AwaitingDecision})
 	require.NoError(t, err)
 	require.Len(t, status, 1)
 	assert.Equal(t, AwaitingDecision, status[0].State)

--- a/centralstore/redis_store_test.go
+++ b/centralstore/redis_store_test.go
@@ -28,7 +28,7 @@ func TestRedisBasicStore_TraceStatus(t *testing.T) {
 	store := NewTestRedisBasicStore(ctx, t)
 	defer store.Stop()
 
-	status, err := store.GetStatusForTraces(ctx, []string{traceID}, []CentralTraceState{Unknown})
+	status, err := store.GetStatusForTraces(ctx, []string{traceID}, Unknown)
 	require.NoError(t, err)
 	require.Len(t, status, 0)
 
@@ -97,7 +97,7 @@ func TestRedisBasicStore_TraceStatus(t *testing.T) {
 	for i, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			require.NoError(t, store.WriteSpan(ctx, tc.span))
-			status, err := store.GetStatusForTraces(ctx, []string{tc.span.TraceID}, []CentralTraceState{tc.expectedState})
+			status, err := store.GetStatusForTraces(ctx, []string{tc.span.TraceID}, tc.expectedState)
 			require.NoError(t, err)
 			require.Len(t, status, 1)
 			require.NotNil(t, status[0])
@@ -168,7 +168,7 @@ func TestRedisBasicStore_ChangeTraceStatus(t *testing.T) {
 
 	require.NoError(t, store.WriteSpan(ctx, span))
 
-	collectingStatus, err := store.GetStatusForTraces(ctx, []string{span.TraceID}, []CentralTraceState{Collecting})
+	collectingStatus, err := store.GetStatusForTraces(ctx, []string{span.TraceID}, Collecting)
 	require.NoError(t, err)
 	require.Len(t, collectingStatus, 1)
 	assert.Equal(t, Collecting, collectingStatus[0].State)
@@ -177,7 +177,7 @@ func TestRedisBasicStore_ChangeTraceStatus(t *testing.T) {
 
 	require.NoError(t, store.ChangeTraceStatus(ctx, []string{span.TraceID}, Collecting, DecisionDelay))
 
-	waitingStatus, err := store.GetStatusForTraces(ctx, []string{span.TraceID}, []CentralTraceState{DecisionDelay})
+	waitingStatus, err := store.GetStatusForTraces(ctx, []string{span.TraceID}, DecisionDelay)
 	require.NoError(t, err)
 	require.Len(t, waitingStatus, 1)
 	assert.Equal(t, DecisionDelay, waitingStatus[0].State)
@@ -186,7 +186,7 @@ func TestRedisBasicStore_ChangeTraceStatus(t *testing.T) {
 	store.clock.Advance(time.Duration(1 * time.Second))
 	require.NoError(t, store.ChangeTraceStatus(ctx, []string{span.TraceID}, DecisionDelay, ReadyToDecide))
 
-	readyStatus, err := store.GetStatusForTraces(ctx, []string{span.TraceID}, []CentralTraceState{ReadyToDecide})
+	readyStatus, err := store.GetStatusForTraces(ctx, []string{span.TraceID}, ReadyToDecide)
 	require.NoError(t, err)
 	require.Len(t, readyStatus, 1)
 	assert.Equal(t, ReadyToDecide, readyStatus[0].State)
@@ -195,7 +195,7 @@ func TestRedisBasicStore_ChangeTraceStatus(t *testing.T) {
 	store.clock.Advance(time.Duration(1 * time.Second))
 	require.NoError(t, store.ChangeTraceStatus(ctx, []string{span.TraceID}, ReadyToDecide, AwaitingDecision))
 
-	awaitingStatus, err := store.GetStatusForTraces(ctx, []string{span.TraceID}, []CentralTraceState{AwaitingDecision})
+	awaitingStatus, err := store.GetStatusForTraces(ctx, []string{span.TraceID}, AwaitingDecision)
 	require.NoError(t, err)
 	require.Len(t, awaitingStatus, 1)
 	assert.Equal(t, AwaitingDecision, awaitingStatus[0].State)
@@ -204,7 +204,7 @@ func TestRedisBasicStore_ChangeTraceStatus(t *testing.T) {
 	store.clock.Advance(time.Duration(1 * time.Second))
 	require.NoError(t, store.ChangeTraceStatus(ctx, []string{span.TraceID}, AwaitingDecision, ReadyToDecide))
 
-	readyStatus, err = store.GetStatusForTraces(ctx, []string{span.TraceID}, []CentralTraceState{ReadyToDecide})
+	readyStatus, err = store.GetStatusForTraces(ctx, []string{span.TraceID}, ReadyToDecide)
 	require.NoError(t, err)
 	require.Len(t, readyStatus, 1)
 	assert.Equal(t, ReadyToDecide, readyStatus[0].State)
@@ -212,12 +212,12 @@ func TestRedisBasicStore_ChangeTraceStatus(t *testing.T) {
 
 	store.clock.Advance(time.Duration(1 * time.Second))
 	require.NoError(t, store.ChangeTraceStatus(ctx, []string{span.TraceID}, ReadyToDecide, AwaitingDecision))
-	awaitingStatus, err = store.GetStatusForTraces(ctx, []string{span.TraceID}, []CentralTraceState{AwaitingDecision})
+	awaitingStatus, err = store.GetStatusForTraces(ctx, []string{span.TraceID}, AwaitingDecision)
 	require.NoError(t, err)
 
 	require.NoError(t, store.KeepTraces(ctx, awaitingStatus))
 
-	keepStatus, err := store.GetStatusForTraces(ctx, []string{span.TraceID}, []CentralTraceState{DecisionKeep})
+	keepStatus, err := store.GetStatusForTraces(ctx, []string{span.TraceID}, DecisionKeep)
 	require.NoError(t, err)
 	require.Len(t, keepStatus, 1)
 	assert.Equal(t, DecisionKeep, keepStatus[0].State)
@@ -262,7 +262,7 @@ func TestRedisBasicStore_KeepTraces(t *testing.T) {
 	defer conn.Close()
 
 	store.ensureInitialState(t, ctx, conn, traceID, AwaitingDecision)
-	status, err := store.GetStatusForTraces(ctx, []string{traceID}, []CentralTraceState{AwaitingDecision})
+	status, err := store.GetStatusForTraces(ctx, []string{traceID}, AwaitingDecision)
 	require.NoError(t, err)
 	require.NoError(t, store.KeepTraces(ctx, status))
 
@@ -272,7 +272,7 @@ func TestRedisBasicStore_KeepTraces(t *testing.T) {
 	require.Equal(t, uint(1), record.DescendantCount())
 
 	// make sure it's state is updated to keep
-	status, err = store.GetStatusForTraces(ctx, []string{traceID}, []CentralTraceState{DecisionKeep})
+	status, err = store.GetStatusForTraces(ctx, []string{traceID}, DecisionKeep)
 	require.NoError(t, err)
 	require.Len(t, status, 1)
 	require.Equal(t, DecisionKeep, status[0].State)
@@ -298,7 +298,7 @@ func TestRedisBasicStore_ConcurrentStateChange(t *testing.T) {
 		IsRoot:    false,
 	}))
 
-	status, err := store.GetStatusForTraces(ctx, []string{traceID}, []CentralTraceState{Collecting})
+	status, err := store.GetStatusForTraces(ctx, []string{traceID}, Collecting)
 	require.NoError(t, err)
 	require.Len(t, status, 1)
 	require.Equal(t, Collecting, status[0].State)
@@ -331,14 +331,14 @@ func TestRedisBasicStore_ConcurrentStateChange(t *testing.T) {
 
 	require.False(t, store.states.exists(ctx, conn, Collecting, traceID))
 	decisionDelay := store.states.exists(ctx, conn, DecisionDelay, traceID)
-	status, err = store.GetStatusForTraces(ctx, []string{traceID}, []CentralTraceState{AwaitingDecision})
+	status, err = store.GetStatusForTraces(ctx, []string{traceID}, AwaitingDecision)
 	require.NoError(t, err)
 	require.Len(t, status, 1)
 	require.False(t, decisionDelay)
 	require.False(t, store.states.exists(ctx, conn, ReadyToDecide, traceID))
 	require.True(t, store.states.exists(ctx, conn, AwaitingDecision, traceID))
 
-	status, err = store.GetStatusForTraces(ctx, []string{traceID}, []CentralTraceState{AwaitingDecision})
+	status, err = store.GetStatusForTraces(ctx, []string{traceID}, AwaitingDecision)
 	require.NoError(t, err)
 	require.Len(t, status, 1)
 	assert.Equal(t, AwaitingDecision, status[0].State)

--- a/centralstore/smartwrapper.go
+++ b/centralstore/smartwrapper.go
@@ -142,7 +142,7 @@ func (w *SmartWrapper) manageTimeouts(ctx context.Context, timeout time.Duration
 	if len(st) == 0 || st == nil {
 		return nil
 	}
-	statuses, err := w.BasicStore.GetStatusForTraces(ctx, st, []CentralTraceState{fromState})
+	statuses, err := w.BasicStore.GetStatusForTraces(ctx, st, fromState)
 	if err != nil {
 		span.RecordError(err)
 		return err
@@ -223,8 +223,8 @@ func (w *SmartWrapper) GetTrace(ctx context.Context, traceID string) (*CentralTr
 // added. Any traces with a state of DecisionKeep or DecisionDrop should be
 // considered to be final and appropriately disposed of; the central store
 // will not change the state of these traces after this call.
-func (w *SmartWrapper) GetStatusForTraces(ctx context.Context, traceIDs []string, statesToCheck []CentralTraceState) ([]*CentralTraceStatus, error) {
-	return w.BasicStore.GetStatusForTraces(ctx, traceIDs, statesToCheck)
+func (w *SmartWrapper) GetStatusForTraces(ctx context.Context, traceIDs []string, statesToCheck ...CentralTraceState) ([]*CentralTraceStatus, error) {
+	return w.BasicStore.GetStatusForTraces(ctx, traceIDs, statesToCheck...)
 }
 
 // GetTracesForState returns a list of trace IDs that match the provided status.

--- a/centralstore/smartwrapper.go
+++ b/centralstore/smartwrapper.go
@@ -142,7 +142,7 @@ func (w *SmartWrapper) manageTimeouts(ctx context.Context, timeout time.Duration
 	if len(st) == 0 || st == nil {
 		return nil
 	}
-	statuses, err := w.BasicStore.GetStatusForTraces(ctx, st)
+	statuses, err := w.BasicStore.GetStatusForTraces(ctx, st, []CentralTraceState{fromState})
 	if err != nil {
 		span.RecordError(err)
 		return err
@@ -223,8 +223,8 @@ func (w *SmartWrapper) GetTrace(ctx context.Context, traceID string) (*CentralTr
 // added. Any traces with a state of DecisionKeep or DecisionDrop should be
 // considered to be final and appropriately disposed of; the central store
 // will not change the state of these traces after this call.
-func (w *SmartWrapper) GetStatusForTraces(ctx context.Context, traceIDs []string) ([]*CentralTraceStatus, error) {
-	return w.BasicStore.GetStatusForTraces(ctx, traceIDs)
+func (w *SmartWrapper) GetStatusForTraces(ctx context.Context, traceIDs []string, statesToCheck []CentralTraceState) ([]*CentralTraceStatus, error) {
+	return w.BasicStore.GetStatusForTraces(ctx, traceIDs, statesToCheck)
 }
 
 // GetTracesForState returns a list of trace IDs that match the provided status.

--- a/centralstore/smartwrapper_record_metrics_test.go
+++ b/centralstore/smartwrapper_record_metrics_test.go
@@ -50,13 +50,13 @@ func TestRecordMetrics(t *testing.T) {
 
 	assert.Equal(t, numberOfTraces, len(traceids))
 	assert.Eventually(t, func() bool {
-		states, err := store.GetStatusForTraces(ctx, traceids, []CentralTraceState{Collecting, ReadyToDecide})
+		states, err := store.GetStatusForTraces(ctx, traceids, Collecting, ReadyToDecide)
 		return err == nil && len(states) == numberOfTraces
 	}, 1*time.Second, 100*time.Millisecond)
 
 	// wait for it to reach the Ready state
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-		states, err := store.GetStatusForTraces(ctx, traceids, []CentralTraceState{ReadyToDecide})
+		states, err := store.GetStatusForTraces(ctx, traceids, ReadyToDecide)
 		assert.NoError(collect, err)
 		assert.Equal(collect, numberOfTraces, len(states))
 		for _, state := range states {
@@ -76,7 +76,7 @@ func TestRecordMetrics(t *testing.T) {
 
 	statuses := make([]*CentralTraceStatus, 0)
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-		statuses, err = store.GetStatusForTraces(ctx, toDecide, []CentralTraceState{AwaitingDecision})
+		statuses, err = store.GetStatusForTraces(ctx, toDecide, AwaitingDecision)
 		assert.NoError(collect, err)
 		assert.Equal(collect, numberOfTraces, len(statuses))
 		for _, state := range statuses {
@@ -103,7 +103,7 @@ func TestRecordMetrics(t *testing.T) {
 
 	// we need to give the dropped traces cache a chance to run or it might not process everything
 	time.Sleep(50 * time.Millisecond)
-	statuses, err = store.GetStatusForTraces(ctx, traceids, []CentralTraceState{DecisionKeep, DecisionDrop})
+	statuses, err = store.GetStatusForTraces(ctx, traceids, DecisionKeep, DecisionDrop)
 	assert.NoError(t, err)
 	assert.Equal(t, numberOfTraces, len(statuses))
 	for _, status := range statuses {

--- a/centralstore/smartwrapper_record_metrics_test.go
+++ b/centralstore/smartwrapper_record_metrics_test.go
@@ -50,13 +50,13 @@ func TestRecordMetrics(t *testing.T) {
 
 	assert.Equal(t, numberOfTraces, len(traceids))
 	assert.Eventually(t, func() bool {
-		states, err := store.GetStatusForTraces(ctx, traceids)
+		states, err := store.GetStatusForTraces(ctx, traceids, []CentralTraceState{Collecting, ReadyToDecide})
 		return err == nil && len(states) == numberOfTraces
 	}, 1*time.Second, 100*time.Millisecond)
 
 	// wait for it to reach the Ready state
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-		states, err := store.GetStatusForTraces(ctx, traceids)
+		states, err := store.GetStatusForTraces(ctx, traceids, []CentralTraceState{ReadyToDecide})
 		assert.NoError(collect, err)
 		assert.Equal(collect, numberOfTraces, len(states))
 		for _, state := range states {
@@ -76,7 +76,7 @@ func TestRecordMetrics(t *testing.T) {
 
 	statuses := make([]*CentralTraceStatus, 0)
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-		statuses, err = store.GetStatusForTraces(ctx, toDecide)
+		statuses, err = store.GetStatusForTraces(ctx, toDecide, []CentralTraceState{AwaitingDecision})
 		assert.NoError(collect, err)
 		assert.Equal(collect, numberOfTraces, len(statuses))
 		for _, state := range statuses {
@@ -103,7 +103,7 @@ func TestRecordMetrics(t *testing.T) {
 
 	// we need to give the dropped traces cache a chance to run or it might not process everything
 	time.Sleep(50 * time.Millisecond)
-	statuses, err = store.GetStatusForTraces(ctx, traceids)
+	statuses, err = store.GetStatusForTraces(ctx, traceids, []CentralTraceState{DecisionKeep, DecisionDrop})
 	assert.NoError(t, err)
 	assert.Equal(t, numberOfTraces, len(statuses))
 	for _, status := range statuses {

--- a/centralstore/smartwrapper_test.go
+++ b/centralstore/smartwrapper_test.go
@@ -136,7 +136,7 @@ func TestSingleSpanGetsCollected(t *testing.T) {
 
 			// make sure that it arrived in the collecting state
 			assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-				states, err := store.GetStatusForTraces(ctx, []string{span.TraceID}, []CentralTraceState{Collecting})
+				states, err := store.GetStatusForTraces(ctx, []string{span.TraceID}, Collecting)
 				assert.NoError(collect, err)
 				assert.Equal(collect, 1, len(states))
 				if len(states) > 0 {
@@ -166,7 +166,7 @@ func TestSingleTraceOperation(t *testing.T) {
 
 			// make sure that it arrived in the collecting state
 			assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-				states, err := store.GetStatusForTraces(ctx, []string{span.TraceID}, []CentralTraceState{Collecting})
+				states, err := store.GetStatusForTraces(ctx, []string{span.TraceID}, Collecting)
 				assert.NoError(collect, err)
 				assert.Equal(collect, 1, len(states))
 				if len(states) > 0 {
@@ -177,7 +177,7 @@ func TestSingleTraceOperation(t *testing.T) {
 
 			// it should automatically time out to the Waiting state
 			assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-				states, err := store.GetStatusForTraces(ctx, []string{span.TraceID}, []CentralTraceState{DecisionDelay})
+				states, err := store.GetStatusForTraces(ctx, []string{span.TraceID}, DecisionDelay)
 				assert.NoError(collect, err)
 				assert.Equal(collect, 1, len(states))
 				if len(states) > 0 {
@@ -188,7 +188,7 @@ func TestSingleTraceOperation(t *testing.T) {
 
 			// and then to the Ready state
 			assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-				states, err := store.GetStatusForTraces(ctx, []string{span.TraceID}, []CentralTraceState{ReadyToDecide})
+				states, err := store.GetStatusForTraces(ctx, []string{span.TraceID}, ReadyToDecide)
 				assert.NoError(collect, err)
 				assert.Equal(collect, 1, len(states))
 				if len(states) > 0 {
@@ -235,13 +235,13 @@ func TestBasicStoreOperation(t *testing.T) {
 
 			assert.Equal(t, 10, len(traceids))
 			assert.Eventually(t, func() bool {
-				states, err := store.GetStatusForTraces(ctx, traceids, []CentralTraceState{Collecting, DecisionDelay, ReadyToDecide})
+				states, err := store.GetStatusForTraces(ctx, traceids, Collecting, DecisionDelay, ReadyToDecide)
 				return err == nil && len(states) == 10
 			}, 1*time.Second, 100*time.Millisecond)
 
 			// wait for it to reach the Ready state
 			assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-				states, err := store.GetStatusForTraces(ctx, traceids, []CentralTraceState{ReadyToDecide})
+				states, err := store.GetStatusForTraces(ctx, traceids, ReadyToDecide)
 				assert.NoError(collect, err)
 				assert.Equal(collect, 10, len(states))
 				for _, state := range states {
@@ -297,13 +297,13 @@ func TestReadyForDecisionLoop(t *testing.T) {
 
 			assert.Equal(t, numberOfTraces, len(traceids))
 			assert.Eventually(t, func() bool {
-				states, err := store.GetStatusForTraces(ctx, traceids, []CentralTraceState{Collecting, DecisionDelay, ReadyToDecide})
+				states, err := store.GetStatusForTraces(ctx, traceids, Collecting, DecisionDelay, ReadyToDecide)
 				return err == nil && len(states) == numberOfTraces
 			}, 1*time.Second, 100*time.Millisecond)
 
 			// wait for it to reach the Ready state
 			assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-				states, err := store.GetStatusForTraces(ctx, traceids, []CentralTraceState{ReadyToDecide})
+				states, err := store.GetStatusForTraces(ctx, traceids, ReadyToDecide)
 				assert.NoError(collect, err)
 				assert.Equal(collect, numberOfTraces, len(states))
 				for _, state := range states {
@@ -356,13 +356,13 @@ func TestSetTraceStatuses(t *testing.T) {
 
 			assert.Equal(t, numberOfTraces, len(traceids))
 			assert.Eventually(t, func() bool {
-				states, err := store.GetStatusForTraces(ctx, traceids, []CentralTraceState{Collecting, DecisionDelay, ReadyToDecide})
+				states, err := store.GetStatusForTraces(ctx, traceids, Collecting, DecisionDelay, ReadyToDecide)
 				return err == nil && len(states) == numberOfTraces
 			}, 1*time.Second, 100*time.Millisecond)
 
 			// wait for it to reach the Ready state
 			assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-				states, err := store.GetStatusForTraces(ctx, traceids, []CentralTraceState{ReadyToDecide})
+				states, err := store.GetStatusForTraces(ctx, traceids, ReadyToDecide)
 				assert.NoError(collect, err)
 				assert.Equal(collect, numberOfTraces, len(states))
 				for _, state := range states {
@@ -382,7 +382,7 @@ func TestSetTraceStatuses(t *testing.T) {
 
 			statuses := make([]*CentralTraceStatus, 0)
 			assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-				statuses, err = store.GetStatusForTraces(ctx, toDecide, []CentralTraceState{AwaitingDecision})
+				statuses, err = store.GetStatusForTraces(ctx, toDecide, AwaitingDecision)
 				assert.NoError(collect, err)
 				assert.Equal(collect, numberOfTraces, len(statuses))
 				for _, state := range statuses {
@@ -409,7 +409,7 @@ func TestSetTraceStatuses(t *testing.T) {
 
 			// we need to give the dropped traces cache a chance to run or it might not process everything
 			time.Sleep(50 * time.Millisecond)
-			statuses, err = store.GetStatusForTraces(ctx, traceids, []CentralTraceState{DecisionDrop, DecisionKeep})
+			statuses, err = store.GetStatusForTraces(ctx, traceids, DecisionDrop, DecisionKeep)
 			assert.NoError(t, err)
 			assert.Equal(t, numberOfTraces, len(statuses))
 			for _, status := range statuses {
@@ -463,7 +463,7 @@ func BenchmarkStoreGetStatus(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		store.GetStatusForTraces(ctx, []string{spans[i%100].TraceID}, states)
+		store.GetStatusForTraces(ctx, []string{spans[i%100].TraceID}, states...)
 	}
 }
 

--- a/centralstore/smartwrapper_test.go
+++ b/centralstore/smartwrapper_test.go
@@ -136,7 +136,7 @@ func TestSingleSpanGetsCollected(t *testing.T) {
 
 			// make sure that it arrived in the collecting state
 			assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-				states, err := store.GetStatusForTraces(ctx, []string{span.TraceID})
+				states, err := store.GetStatusForTraces(ctx, []string{span.TraceID}, []CentralTraceState{Collecting})
 				assert.NoError(collect, err)
 				assert.Equal(collect, 1, len(states))
 				if len(states) > 0 {
@@ -166,7 +166,7 @@ func TestSingleTraceOperation(t *testing.T) {
 
 			// make sure that it arrived in the collecting state
 			assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-				states, err := store.GetStatusForTraces(ctx, []string{span.TraceID})
+				states, err := store.GetStatusForTraces(ctx, []string{span.TraceID}, []CentralTraceState{Collecting})
 				assert.NoError(collect, err)
 				assert.Equal(collect, 1, len(states))
 				if len(states) > 0 {
@@ -177,7 +177,7 @@ func TestSingleTraceOperation(t *testing.T) {
 
 			// it should automatically time out to the Waiting state
 			assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-				states, err := store.GetStatusForTraces(ctx, []string{span.TraceID})
+				states, err := store.GetStatusForTraces(ctx, []string{span.TraceID}, []CentralTraceState{DecisionDelay})
 				assert.NoError(collect, err)
 				assert.Equal(collect, 1, len(states))
 				if len(states) > 0 {
@@ -188,7 +188,7 @@ func TestSingleTraceOperation(t *testing.T) {
 
 			// and then to the Ready state
 			assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-				states, err := store.GetStatusForTraces(ctx, []string{span.TraceID})
+				states, err := store.GetStatusForTraces(ctx, []string{span.TraceID}, []CentralTraceState{ReadyToDecide})
 				assert.NoError(collect, err)
 				assert.Equal(collect, 1, len(states))
 				if len(states) > 0 {
@@ -235,13 +235,13 @@ func TestBasicStoreOperation(t *testing.T) {
 
 			assert.Equal(t, 10, len(traceids))
 			assert.Eventually(t, func() bool {
-				states, err := store.GetStatusForTraces(ctx, traceids)
+				states, err := store.GetStatusForTraces(ctx, traceids, []CentralTraceState{Collecting, DecisionDelay, ReadyToDecide})
 				return err == nil && len(states) == 10
 			}, 1*time.Second, 100*time.Millisecond)
 
 			// wait for it to reach the Ready state
 			assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-				states, err := store.GetStatusForTraces(ctx, traceids)
+				states, err := store.GetStatusForTraces(ctx, traceids, []CentralTraceState{ReadyToDecide})
 				assert.NoError(collect, err)
 				assert.Equal(collect, 10, len(states))
 				for _, state := range states {
@@ -297,13 +297,13 @@ func TestReadyForDecisionLoop(t *testing.T) {
 
 			assert.Equal(t, numberOfTraces, len(traceids))
 			assert.Eventually(t, func() bool {
-				states, err := store.GetStatusForTraces(ctx, traceids)
+				states, err := store.GetStatusForTraces(ctx, traceids, []CentralTraceState{Collecting, DecisionDelay, ReadyToDecide})
 				return err == nil && len(states) == numberOfTraces
 			}, 1*time.Second, 100*time.Millisecond)
 
 			// wait for it to reach the Ready state
 			assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-				states, err := store.GetStatusForTraces(ctx, traceids)
+				states, err := store.GetStatusForTraces(ctx, traceids, []CentralTraceState{ReadyToDecide})
 				assert.NoError(collect, err)
 				assert.Equal(collect, numberOfTraces, len(states))
 				for _, state := range states {
@@ -356,13 +356,13 @@ func TestSetTraceStatuses(t *testing.T) {
 
 			assert.Equal(t, numberOfTraces, len(traceids))
 			assert.Eventually(t, func() bool {
-				states, err := store.GetStatusForTraces(ctx, traceids)
+				states, err := store.GetStatusForTraces(ctx, traceids, []CentralTraceState{Collecting, DecisionDelay, ReadyToDecide})
 				return err == nil && len(states) == numberOfTraces
 			}, 1*time.Second, 100*time.Millisecond)
 
 			// wait for it to reach the Ready state
 			assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-				states, err := store.GetStatusForTraces(ctx, traceids)
+				states, err := store.GetStatusForTraces(ctx, traceids, []CentralTraceState{ReadyToDecide})
 				assert.NoError(collect, err)
 				assert.Equal(collect, numberOfTraces, len(states))
 				for _, state := range states {
@@ -382,7 +382,7 @@ func TestSetTraceStatuses(t *testing.T) {
 
 			statuses := make([]*CentralTraceStatus, 0)
 			assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-				statuses, err = store.GetStatusForTraces(ctx, toDecide)
+				statuses, err = store.GetStatusForTraces(ctx, toDecide, []CentralTraceState{AwaitingDecision})
 				assert.NoError(collect, err)
 				assert.Equal(collect, numberOfTraces, len(statuses))
 				for _, state := range statuses {
@@ -409,7 +409,7 @@ func TestSetTraceStatuses(t *testing.T) {
 
 			// we need to give the dropped traces cache a chance to run or it might not process everything
 			time.Sleep(50 * time.Millisecond)
-			statuses, err = store.GetStatusForTraces(ctx, traceids)
+			statuses, err = store.GetStatusForTraces(ctx, traceids, []CentralTraceState{DecisionDrop, DecisionKeep})
 			assert.NoError(t, err)
 			assert.Equal(t, numberOfTraces, len(statuses))
 			for _, status := range statuses {
@@ -459,10 +459,11 @@ func BenchmarkStoreGetStatus(b *testing.B) {
 		spans = append(spans, span)
 		store.WriteSpan(ctx, spans[i%100])
 	}
+	states := []CentralTraceState{Collecting, DecisionDelay, ReadyToDecide}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		store.GetStatusForTraces(ctx, []string{spans[i%100].TraceID})
+		store.GetStatusForTraces(ctx, []string{spans[i%100].TraceID}, states)
 	}
 }
 

--- a/cmd/test_stores/fake_refinery.go
+++ b/cmd/test_stores/fake_refinery.go
@@ -101,7 +101,7 @@ func (fri *FakeRefineryInstance) runDecider(opts CmdLineOptions, nodeIndex int, 
 			}
 
 			statCtx, span2 := fri.Tracer.Start(ctx, "get_status_for_traces")
-			statuses, err := fri.Store.GetStatusForTraces(statCtx, traceIDs)
+			statuses, err := fri.Store.GetStatusForTraces(statCtx, traceIDs, []centralstore.CentralTraceState{centralstore.AwaitingDecision})
 			if err != nil {
 				otelutil.AddException(span2, err)
 			}
@@ -318,7 +318,8 @@ func (fri *FakeRefineryInstance) runProcessor(opts CmdLineOptions, nodeIndex int
 			}
 			statusCtx, span := fri.Tracer.Start(ctx, "get_status_for_traces")
 			otelutil.AddSpanField(span, "num_trace_ids", len(tids))
-			statuses, err := fri.Store.GetStatusForTraces(statusCtx, tids)
+			statuses, err := fri.Store.GetStatusForTraces(statusCtx, tids,
+				[]centralstore.CentralTraceState{centralstore.DecisionKeep, centralstore.DecisionDrop})
 			if err != nil {
 				otelutil.AddException(span, err)
 				span.End()

--- a/cmd/test_stores/fake_refinery.go
+++ b/cmd/test_stores/fake_refinery.go
@@ -101,7 +101,7 @@ func (fri *FakeRefineryInstance) runDecider(opts CmdLineOptions, nodeIndex int, 
 			}
 
 			statCtx, span2 := fri.Tracer.Start(ctx, "get_status_for_traces")
-			statuses, err := fri.Store.GetStatusForTraces(statCtx, traceIDs, []centralstore.CentralTraceState{centralstore.AwaitingDecision})
+			statuses, err := fri.Store.GetStatusForTraces(statCtx, traceIDs, centralstore.AwaitingDecision)
 			if err != nil {
 				otelutil.AddException(span2, err)
 			}
@@ -318,8 +318,7 @@ func (fri *FakeRefineryInstance) runProcessor(opts CmdLineOptions, nodeIndex int
 			}
 			statusCtx, span := fri.Tracer.Start(ctx, "get_status_for_traces")
 			otelutil.AddSpanField(span, "num_trace_ids", len(tids))
-			statuses, err := fri.Store.GetStatusForTraces(statusCtx, tids,
-				[]centralstore.CentralTraceState{centralstore.DecisionKeep, centralstore.DecisionDrop})
+			statuses, err := fri.Store.GetStatusForTraces(statusCtx, tids, centralstore.DecisionKeep, centralstore.DecisionDrop)
 			if err != nil {
 				otelutil.AddException(span, err)
 				span.End()

--- a/collect/central_collector.go
+++ b/collect/central_collector.go
@@ -48,8 +48,6 @@ const (
 	TraceSendEjectedFull    = "trace_send_ejected_full"
 	TraceSendEjectedMemsize = "trace_send_ejected_memsize"
 	TraceSendLateSpan       = "trace_send_late_span"
-
-	metricsCycleInterval = 1 * time.Second
 )
 
 type traceForDecision struct {
@@ -410,7 +408,8 @@ func (c *CentralCollector) processTraces(ctx context.Context) error {
 		return nil
 	}
 
-	statuses, err := c.Store.GetStatusForTraces(ctx, ids)
+	statuses, err := c.Store.GetStatusForTraces(ctx, ids,
+		[]centralstore.CentralTraceState{centralstore.DecisionKeep, centralstore.DecisionDrop})
 	if err != nil {
 		return err
 	}
@@ -459,7 +458,7 @@ func (c *CentralCollector) makeDecision(ctx context.Context) error {
 	if len(tracesIDs) == 0 {
 		return nil
 	}
-	statuses, err := c.Store.GetStatusForTraces(ctx, tracesIDs)
+	statuses, err := c.Store.GetStatusForTraces(ctx, tracesIDs, []centralstore.CentralTraceState{centralstore.AwaitingDecision})
 	if err != nil {
 		span.RecordError(err)
 		return err

--- a/collect/central_collector.go
+++ b/collect/central_collector.go
@@ -422,7 +422,7 @@ func (c *CentralCollector) processTraces(ctx context.Context) error {
 		case centralstore.DecisionDrop:
 			c.SpanCache.Remove(status.TraceID)
 		default:
-			c.Logger.Debug().Logf("trace %s is still pending", status.TraceID)
+			return fmt.Errorf("unexpected state %s for trace %s", status.State, status.TraceID)
 		}
 	}
 
@@ -477,8 +477,7 @@ func (c *CentralCollector) makeDecision(ctx context.Context) error {
 	for idx, status := range statuses {
 		// make a decision on each trace
 		if status.State != centralstore.AwaitingDecision {
-			// someone else got to it first
-			continue
+			return fmt.Errorf("unexpected state %s for trace %s", status.State, status.TraceID)
 		}
 		currentStatus, currentIdx := status, idx
 		stateMap[status.TraceID] = status

--- a/collect/central_collector.go
+++ b/collect/central_collector.go
@@ -408,8 +408,7 @@ func (c *CentralCollector) processTraces(ctx context.Context) error {
 		return nil
 	}
 
-	statuses, err := c.Store.GetStatusForTraces(ctx, ids,
-		[]centralstore.CentralTraceState{centralstore.DecisionKeep, centralstore.DecisionDrop})
+	statuses, err := c.Store.GetStatusForTraces(ctx, ids, centralstore.DecisionKeep, centralstore.DecisionDrop)
 	if err != nil {
 		return err
 	}
@@ -458,7 +457,7 @@ func (c *CentralCollector) makeDecision(ctx context.Context) error {
 	if len(tracesIDs) == 0 {
 		return nil
 	}
-	statuses, err := c.Store.GetStatusForTraces(ctx, tracesIDs, []centralstore.CentralTraceState{centralstore.AwaitingDecision})
+	statuses, err := c.Store.GetStatusForTraces(ctx, tracesIDs, centralstore.AwaitingDecision)
 	if err != nil {
 		span.RecordError(err)
 		return err

--- a/collect/central_collector_test.go
+++ b/collect/central_collector_test.go
@@ -236,7 +236,7 @@ func TestCentralCollector_Decider(t *testing.T) {
 
 			ctx := context.Background()
 			collector.deciderCycle.RunOnce()
-			traces, err := collector.Store.GetStatusForTraces(ctx, traceids)
+			traces, err := collector.Store.GetStatusForTraces(ctx, traceids, []centralstore.CentralTraceState{centralstore.DecisionKeep})
 			require.NoError(t, err)
 			require.Equal(t, numberOfTraces, len(traces))
 			for _, trace := range traces {
@@ -1444,7 +1444,8 @@ func waitUntilReadyToDecide(t *testing.T, coll *CentralCollector, traceIDs []str
 func waitForTraceDecision(t *testing.T, coll *CentralCollector, traceIDs []string) {
 	ctx := context.Background()
 	require.Eventually(t, func() bool {
-		statuses, err := coll.Store.GetStatusForTraces(ctx, traceIDs)
+		statuses, err := coll.Store.GetStatusForTraces(ctx, traceIDs,
+			[]centralstore.CentralTraceState{centralstore.DecisionKeep, centralstore.DecisionDrop})
 		require.NoError(t, err)
 		var count int
 		for _, status := range statuses {

--- a/collect/central_collector_test.go
+++ b/collect/central_collector_test.go
@@ -236,7 +236,7 @@ func TestCentralCollector_Decider(t *testing.T) {
 
 			ctx := context.Background()
 			collector.deciderCycle.RunOnce()
-			traces, err := collector.Store.GetStatusForTraces(ctx, traceids, []centralstore.CentralTraceState{centralstore.DecisionKeep})
+			traces, err := collector.Store.GetStatusForTraces(ctx, traceids, centralstore.DecisionKeep)
 			require.NoError(t, err)
 			require.Equal(t, numberOfTraces, len(traces))
 			for _, trace := range traces {
@@ -1444,8 +1444,7 @@ func waitUntilReadyToDecide(t *testing.T, coll *CentralCollector, traceIDs []str
 func waitForTraceDecision(t *testing.T, coll *CentralCollector, traceIDs []string) {
 	ctx := context.Background()
 	require.Eventually(t, func() bool {
-		statuses, err := coll.Store.GetStatusForTraces(ctx, traceIDs,
-			[]centralstore.CentralTraceState{centralstore.DecisionKeep, centralstore.DecisionDrop})
+		statuses, err := coll.Store.GetStatusForTraces(ctx, traceIDs, centralstore.DecisionKeep, centralstore.DecisionDrop)
 		require.NoError(t, err)
 		var count int
 		for _, status := range statuses {

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -210,8 +210,8 @@ type RedisPeerManagementConfig struct {
 	UseTLSInsecure bool     `yaml:"UseTLSInsecure" `
 	Timeout        Duration `yaml:"Timeout" default:"5s"`
 	Prefix         string   `yaml:"Prefix" default:"refinery"`
-	MaxIdle        int      `yaml:"MaxIdle" default:"3"`
-	MaxActive      int      `yaml:"MaxActive" default:"5"`
+	MaxIdle        int      `yaml:"MaxIdle" default:"15"`
+	MaxActive      int      `yaml:"MaxActive" default:"30"`
 }
 
 type CollectionConfig struct {


### PR DESCRIPTION
## Which problem is this PR solving?

- Addresses some performance issues with talking to Redis. Before these changes, some calls to GetStatusForTraces were taking 800ms when called with 5000 traceIDs. With this, 13000 traceIDs takes a little more than 100ms. I'm also seeing Refinery lasting quite a bit longer under heavy loads, although it still has problems; I have more ideas but I'd like to see this, plus #1108 and #1109 land first.
- This doesn't solve all performance issues, but it definitely helps. See me for links to HC queries that show it.

## Short description of the changes

- GetStatusForTraces now takes a list of the statuses it cares about, and only returns traces that have those values. This signature change needed to be made in all the CentralStore interfaces, and implemented in both redis and local stores.
- getTraceStatuses (which is called by GetStatusForTraces) now splits up its redis requests into multiple goroutines that run in parallel, using a fan-out/fan-in mechanism.
- Defaults for redis pool sizes have been increased to 15.
- Lots of tests have been fixed.

