### PR TITLE
feat: Performance tuning, more telemetry

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -112,8 +112,8 @@ func newStartedApp(
 		GetHoneycombAPIVal:       "http://api.honeycomb.io",
 		GetCollectionConfigVal: config.CollectionConfig{
 			CacheCapacity:              10000,
-			ProcessTracesPauseDuration: config.Duration(100 * time.Millisecond),
-			DeciderPauseDuration:       config.Duration(10 * time.Millisecond),
+			ProcessTracesCycleDuration: config.Duration(100 * time.Millisecond),
+			DeciderCycleDuration:       config.Duration(10 * time.Millisecond),
 			ShutdownDelay:              config.Duration(1 * time.Millisecond),
 		},
 		AddHostMetadataToTrace: enableHostMetadata,

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -116,6 +116,8 @@ func newStartedApp(
 			DeciderCycleDuration:       config.Duration(10 * time.Millisecond),
 			ShutdownDelay:              config.Duration(1 * time.Millisecond),
 		},
+		GetRedisMaxActiveVal:   10,
+		GetRedisMaxIdleVal:     10,
 		AddHostMetadataToTrace: enableHostMetadata,
 		TraceIdFieldNames:      []string{"trace.trace_id"},
 		ParentIdFieldNames:     []string{"trace.parent_id"},

--- a/centralstore/redis_store.go
+++ b/centralstore/redis_store.go
@@ -790,6 +790,9 @@ func (t *tracesStore) getTraceStatuses(ctx context.Context, client redis.Client,
 	// for our maximum number of connections in the redis pool.
 	// It seems (after messing around) that adding a bit of randomness here helps with the performance.
 	maxGoroutines := t.config.GetRedisMaxActive()
+	if maxGoroutines <= 0 {
+		maxGoroutines = 1
+	}
 	randRange := maxGoroutines/4 + 1
 	numGoroutines := rand.Intn(randRange) + maxGoroutines - randRange
 	otelutil.AddSpanField(statusSpan, "num_goroutines", numGoroutines)

--- a/centralstore/redis_store.go
+++ b/centralstore/redis_store.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/rand"
 	"slices"
 	"sort"
 	"sync"
@@ -85,7 +86,7 @@ func (r *RedisBasicStore) Start() error {
 		return err
 	}
 
-	r.traces = newTraceStatusStore(r.Clock, r.Tracer, r.RedisClient.NewScript(keepTraceKey, keepTraceScript))
+	r.traces = newTraceStatusStore(r.Clock, r.Tracer, r.RedisClient.NewScript(keepTraceKey, keepTraceScript), r.Config)
 	r.states = stateProcessor
 
 	// register metrics for each state
@@ -616,13 +617,15 @@ type tracesStore struct {
 	clock           clockwork.Clock
 	tracer          trace.Tracer
 	keepTraceScript redis.Script
+	config          config.Config
 }
 
-func newTraceStatusStore(clock clockwork.Clock, tracer trace.Tracer, keepTraceScript redis.Script) *tracesStore {
+func newTraceStatusStore(clock clockwork.Clock, tracer trace.Tracer, keepTraceScript redis.Script, cfg config.Config) *tracesStore {
 	return &tracesStore{
 		clock:           clock,
 		tracer:          tracer,
 		keepTraceScript: keepTraceScript,
+		config:          cfg,
 	}
 }
 
@@ -783,15 +786,13 @@ func (t *tracesStore) getTraceStatuses(ctx context.Context, client redis.Client,
 		}
 	}()
 
-	const (
-		maxConnections = 10
-		traceIDsPerGo  = 10
-	)
-	// determine the number of goroutines to use based on the number of traceIDs
-	numGoroutines := len(traceIDs)/traceIDsPerGo + 1
-	if numGoroutines > maxConnections {
-		numGoroutines = maxConnections
-	}
+	// Randomly select the number of goroutines to use, using most of what we've been given
+	// for our maximum number of connections in the redis pool.
+	// It seems (after messing around) that adding a bit of randomness here helps with the performance.
+	maxGoroutines := t.config.GetRedisMaxActive()
+	randRange := maxGoroutines/4 + 1
+	numGoroutines := rand.Intn(randRange) + maxGoroutines - randRange
+	otelutil.AddSpanField(statusSpan, "num_goroutines", numGoroutines)
 
 	// create workers to get the traceIDs and send their statuses to the fanin channel
 	// They will pull from the fanout channel and terminate when it closes

--- a/centralstore/redis_store_test.go
+++ b/centralstore/redis_store_test.go
@@ -561,6 +561,8 @@ func NewTestRedisBasicStore(ctx context.Context, t *testing.T) *TestRedisBasicSt
 			DroppedSize:       1000,
 			SizeCheckInterval: duration("1s"),
 		},
+		GetRedisMaxActiveVal: 10,
+		GetRedisMaxIdleVal:   10,
 	}
 	decisionCache := &cache.CuckooSentCache{}
 	clock := clockwork.NewFakeClock()

--- a/centralstore/smartwrapper.go
+++ b/centralstore/smartwrapper.go
@@ -57,6 +57,8 @@ func (w *SmartWrapper) Start() error {
 
 	w.Metrics.Register("smartstore_span_queue", "histogram")
 	w.Metrics.Register("smartstore_span_queue_length", "gauge")
+	w.Metrics.Register("smartstore_span_queue_in", "count")
+	w.Metrics.Register("smartstore_span_queue_out", "count")
 
 	w.Metrics.Store("SPAN_CHANNEL_CAP", float64(opts.SpanChannelSize))
 
@@ -104,6 +106,7 @@ func (w *SmartWrapper) WriteSpan(ctx context.Context, span *CentralSpan) error {
 	case <-w.done:
 		return fmt.Errorf("span channel closed")
 	case w.spanChan <- span:
+		w.Metrics.Increment("smartstore_span_queue_in")
 	default:
 		err := fmt.Errorf("span queue full")
 		spanWrite.RecordError(err)
@@ -126,6 +129,7 @@ func (w *SmartWrapper) processSpans(ctx context.Context) {
 				if !ok {
 					break Remaining
 				}
+				w.Metrics.Increment("smartstore_span_queue_out")
 
 				spans = append(spans, span)
 			default:

--- a/centralstore/smartwrapper.go
+++ b/centralstore/smartwrapper.go
@@ -57,8 +57,8 @@ func (w *SmartWrapper) Start() error {
 
 	w.Metrics.Register("smartstore_span_queue", "histogram")
 	w.Metrics.Register("smartstore_span_queue_length", "gauge")
-	w.Metrics.Register("smartstore_span_queue_in", "count")
-	w.Metrics.Register("smartstore_span_queue_out", "count")
+	w.Metrics.Register("smartstore_span_queue_in", "counter")
+	w.Metrics.Register("smartstore_span_queue_out", "counter")
 
 	w.Metrics.Store("SPAN_CHANNEL_CAP", float64(opts.SpanChannelSize))
 

--- a/centralstore/smartwrapper_test.go
+++ b/centralstore/smartwrapper_test.go
@@ -55,6 +55,8 @@ func getAndStartSmartWrapper(storetype string, redisClient redis.Client) (*Smart
 			DroppedSize:       1000,
 			SizeCheckInterval: duration("1s"),
 		},
+		GetRedisMaxActiveVal: 10,
+		GetRedisMaxIdleVal:   10,
 	}
 
 	decisionCache := &cache.CuckooSentCache{}

--- a/collect/cache/span_cache_test.go
+++ b/collect/cache/span_cache_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/facebookgo/startstop"
 	"github.com/honeycombio/refinery/config"
+	"github.com/honeycombio/refinery/metrics"
 	"github.com/honeycombio/refinery/types"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
@@ -24,8 +25,9 @@ func getCache(typ string, clock clockwork.Clock) SpanCache {
 	switch typ {
 	case "basic":
 		return &SpanCache_basic{
-			Cfg:   cfg,
-			Clock: clock,
+			Cfg:     cfg,
+			Clock:   clock,
+			Metrics: &metrics.NullMetrics{},
 		}
 	case "complex":
 		return &SpanCache_complex{

--- a/collect/central_collector.go
+++ b/collect/central_collector.go
@@ -107,8 +107,8 @@ func (c *CentralCollector) Start() error {
 
 	// we're a health check reporter so register ourselves for each of our major routines
 	c.Health.Register(receiverHealth, 2*c.Config.GetSendTickerValue())
-	c.Health.Register(deciderHealth, 2*collectorCfg.GetDeciderPauseDuration())
-	c.Health.Register(processorHealth, 2*collectorCfg.GetProcessTracesPauseDuration())
+	c.Health.Register(deciderHealth, 2*collectorCfg.GetDeciderCycleDuration())
+	c.Health.Register(processorHealth, 2*collectorCfg.GetProcessTracesCycleDuration())
 
 	c.done = make(chan struct{})
 
@@ -122,8 +122,8 @@ func (c *CentralCollector) Start() error {
 
 	// test hooks
 	c.metricsCycle = NewCycle(c.Clock, c.Config.GetSendTickerValue(), c.done)
-	c.processorCycle = NewCycle(c.Clock, collectorCfg.GetProcessTracesPauseDuration(), c.done)
-	c.deciderCycle = NewCycle(c.Clock, collectorCfg.GetDeciderPauseDuration(), c.done)
+	c.processorCycle = NewCycle(c.Clock, collectorCfg.GetProcessTracesCycleDuration(), c.done)
+	c.deciderCycle = NewCycle(c.Clock, collectorCfg.GetDeciderCycleDuration(), c.done)
 
 	c.Metrics.Register("collector_processor_batch_count", "histogram")
 	c.Metrics.Register("collector_decider_batch_count", "histogram")
@@ -142,6 +142,8 @@ func (c *CentralCollector) Start() error {
 	c.Metrics.Register("span_received", "counter")
 	c.Metrics.Register("span_processed", "counter")
 	c.Metrics.Register("spans_waiting", "updown")
+	c.Metrics.Register("collector_process_trace", "counter")
+	c.Metrics.Register("collector_decide_trace", "counter")
 
 	if c.Config.GetAddHostMetadataToTrace() {
 		if hostname, err := os.Hostname(); err == nil && hostname != "" {
@@ -424,6 +426,7 @@ func (c *CentralCollector) processTraces(ctx context.Context) error {
 		default:
 			return fmt.Errorf("unexpected state %s for trace %s", status.State, status.TraceID)
 		}
+		c.Metrics.Increment("collector_process_trace")
 	}
 
 	return nil
@@ -593,6 +596,7 @@ func (c *CentralCollector) makeDecision(ctx context.Context) error {
 		status.State = state
 		status.Rate = rate
 		stateMap[status.TraceID] = status
+		c.Metrics.Increment("collector_decide_trace")
 		span.End()
 	}
 

--- a/collect/central_collector_test.go
+++ b/collect/central_collector_test.go
@@ -116,9 +116,11 @@ func TestCentralCollector_ProcessTraces(t *testing.T) {
 	for _, storeType := range storeTypes {
 		t.Run(storeType, func(t *testing.T) {
 			conf := &config.MockConfig{
-				GetSamplerTypeVal:  &config.DeterministicSamplerConfig{SampleRate: 1},
-				SendTickerVal:      2 * time.Millisecond,
-				ParentIdFieldNames: []string{"trace.parent_id", "parentId"},
+				GetSamplerTypeVal:    &config.DeterministicSamplerConfig{SampleRate: 1},
+				SendTickerVal:        2 * time.Millisecond,
+				ParentIdFieldNames:   []string{"trace.parent_id", "parentId"},
+				GetRedisMaxActiveVal: 10,
+				GetRedisMaxIdleVal:   10,
 				GetCollectionConfigVal: config.CollectionConfig{
 					CacheCapacity:              100,
 					ProcessTracesCycleDuration: config.Duration(1 * time.Second),
@@ -183,9 +185,11 @@ func TestCentralCollector_Decider(t *testing.T) {
 	for _, storeType := range storeTypes {
 		t.Run(storeType, func(t *testing.T) {
 			conf := &config.MockConfig{
-				GetSamplerTypeVal:  &config.DeterministicSamplerConfig{SampleRate: 1},
-				SendTickerVal:      2 * time.Millisecond,
-				ParentIdFieldNames: []string{"trace.parent_id", "parentId"},
+				GetSamplerTypeVal:    &config.DeterministicSamplerConfig{SampleRate: 1},
+				SendTickerVal:        2 * time.Millisecond,
+				ParentIdFieldNames:   []string{"trace.parent_id", "parentId"},
+				GetRedisMaxActiveVal: 10,
+				GetRedisMaxIdleVal:   10,
 				GetCollectionConfigVal: config.CollectionConfig{
 					IncomingQueueSize:          100,
 					ProcessTracesCycleDuration: config.Duration(1 * time.Second),
@@ -255,11 +259,13 @@ func TestCentralCollector_OriginalSampleRateIsNotedInMetaField(t *testing.T) {
 			const originalSampleRate = uint(50)
 
 			conf := &config.MockConfig{
-				GetSendDelayVal:    0,
-				GetTraceTimeoutVal: 60 * time.Second,
-				GetSamplerTypeVal:  &config.DeterministicSamplerConfig{SampleRate: expectedDeterministicSampleRate},
-				SendTickerVal:      2 * time.Millisecond,
-				ParentIdFieldNames: []string{"trace.parent_id", "parentId"},
+				GetSendDelayVal:      0,
+				GetTraceTimeoutVal:   60 * time.Second,
+				GetSamplerTypeVal:    &config.DeterministicSamplerConfig{SampleRate: expectedDeterministicSampleRate},
+				SendTickerVal:        2 * time.Millisecond,
+				ParentIdFieldNames:   []string{"trace.parent_id", "parentId"},
+				GetRedisMaxActiveVal: 10,
+				GetRedisMaxIdleVal:   10,
 				GetCollectionConfigVal: config.CollectionConfig{
 					IncomingQueueSize:          10000,
 					DeciderCycleDuration:       config.Duration(1 * time.Second),
@@ -367,6 +373,8 @@ func TestCentralCollector_TransmittedSpansShouldHaveASampleRateOfAtLeastOne(t *t
 					DroppedSize:       100,
 					SizeCheckInterval: config.Duration(1 * time.Second),
 				},
+				GetRedisMaxActiveVal: 10,
+				GetRedisMaxIdleVal:   10,
 			}
 			transmission := &transmit.MockTransmission{}
 			coll := &CentralCollector{
@@ -406,11 +414,13 @@ func TestCentralCollector_SampleConfigReload(t *testing.T) {
 	for _, storeType := range storeTypes {
 		t.Run(storeType, func(t *testing.T) {
 			conf := &config.MockConfig{
-				GetSendDelayVal:    0,
-				GetTraceTimeoutVal: 60 * time.Second,
-				GetSamplerTypeVal:  &config.DeterministicSamplerConfig{SampleRate: 1},
-				SendTickerVal:      2 * time.Millisecond,
-				ParentIdFieldNames: []string{"trace.parent_id", "parentId"},
+				GetSendDelayVal:      0,
+				GetTraceTimeoutVal:   60 * time.Second,
+				GetSamplerTypeVal:    &config.DeterministicSamplerConfig{SampleRate: 1},
+				SendTickerVal:        2 * time.Millisecond,
+				ParentIdFieldNames:   []string{"trace.parent_id", "parentId"},
+				GetRedisMaxActiveVal: 10,
+				GetRedisMaxIdleVal:   10,
 				GetCollectionConfigVal: config.CollectionConfig{
 					CacheCapacity:              10,
 					ProcessTracesCycleDuration: config.Duration(1 * time.Second),
@@ -647,11 +657,13 @@ func TestCentralCollector_AddCountsToRoot(t *testing.T) {
 	for _, storeType := range storeTypes {
 		t.Run(storeType, func(t *testing.T) {
 			conf := &config.MockConfig{
-				GetSendDelayVal:    10 * time.Millisecond,
-				GetTraceTimeoutVal: 60 * time.Second,
-				GetSamplerTypeVal:  &config.DeterministicSamplerConfig{SampleRate: 1},
-				SendTickerVal:      60 * time.Second,
-				ParentIdFieldNames: []string{"trace.parent_id", "parentId"},
+				GetSendDelayVal:      10 * time.Millisecond,
+				GetTraceTimeoutVal:   60 * time.Second,
+				GetSamplerTypeVal:    &config.DeterministicSamplerConfig{SampleRate: 1},
+				SendTickerVal:        60 * time.Second,
+				ParentIdFieldNames:   []string{"trace.parent_id", "parentId"},
+				GetRedisMaxActiveVal: 10,
+				GetRedisMaxIdleVal:   10,
 				SampleCache: config.SampleCacheConfig{
 					KeptSize:          100,
 					DroppedSize:       100,
@@ -754,6 +766,8 @@ func TestCentralCollector_LateRootGetsCounts(t *testing.T) {
 				SendTickerVal:        2 * time.Millisecond,
 				ParentIdFieldNames:   []string{"trace.parent_id", "parentId"},
 				AddRuleReasonToTrace: true,
+				GetRedisMaxActiveVal: 10,
+				GetRedisMaxIdleVal:   10,
 				SampleCache: config.SampleCacheConfig{
 					KeptSize:          100,
 					DroppedSize:       100,
@@ -854,11 +868,13 @@ func TestCentralCollector_LateSpanNotDecorated(t *testing.T) {
 	for _, storeType := range storeTypes {
 		t.Run(storeType, func(t *testing.T) {
 			conf := &config.MockConfig{
-				GetSendDelayVal:    0,
-				GetTraceTimeoutVal: 5 * time.Minute,
-				GetSamplerTypeVal:  &config.DeterministicSamplerConfig{SampleRate: 1},
-				SendTickerVal:      2 * time.Millisecond,
-				ParentIdFieldNames: []string{"trace.parent_id", "parentId"},
+				GetSendDelayVal:      0,
+				GetTraceTimeoutVal:   5 * time.Minute,
+				GetSamplerTypeVal:    &config.DeterministicSamplerConfig{SampleRate: 1},
+				SendTickerVal:        2 * time.Millisecond,
+				ParentIdFieldNames:   []string{"trace.parent_id", "parentId"},
+				GetRedisMaxActiveVal: 10,
+				GetRedisMaxIdleVal:   10,
 				SampleCache: config.SampleCacheConfig{
 					KeptSize:          100,
 					DroppedSize:       100,
@@ -935,10 +951,12 @@ func TestCentralCollector_AddAdditionalAttributes(t *testing.T) {
 	for _, storeType := range storeTypes {
 		t.Run(storeType, func(t *testing.T) {
 			conf := &config.MockConfig{
-				GetSendDelayVal:    0,
-				GetTraceTimeoutVal: 60 * time.Second,
-				GetSamplerTypeVal:  &config.DeterministicSamplerConfig{SampleRate: 1},
-				SendTickerVal:      2 * time.Millisecond,
+				GetSendDelayVal:      0,
+				GetTraceTimeoutVal:   60 * time.Second,
+				GetSamplerTypeVal:    &config.DeterministicSamplerConfig{SampleRate: 1},
+				SendTickerVal:        2 * time.Millisecond,
+				GetRedisMaxActiveVal: 10,
+				GetRedisMaxIdleVal:   10,
 				AdditionalAttributes: map[string]string{
 					"name":  "foo",
 					"other": "bar",
@@ -1008,8 +1026,10 @@ func TestCentralCollector_SpanWithRuleReasons(t *testing.T) {
 	for _, storeType := range storeTypes {
 		t.Run(storeType, func(t *testing.T) {
 			conf := &config.MockConfig{
-				GetSendDelayVal:    0,
-				GetTraceTimeoutVal: 5 * time.Millisecond,
+				GetSendDelayVal:      0,
+				GetTraceTimeoutVal:   5 * time.Millisecond,
+				GetRedisMaxActiveVal: 10,
+				GetRedisMaxIdleVal:   10,
 				GetSamplerTypeVal: &config.RulesBasedSamplerConfig{
 					Rules: []*config.RulesBasedSamplerRule{
 						{
@@ -1155,9 +1175,11 @@ func TestCentralCollector_Shutdown(t *testing.T) {
 	for _, storeType := range storeTypes {
 		t.Run(storeType, func(t *testing.T) {
 			conf := &config.MockConfig{
-				GetSamplerTypeVal:  &config.DeterministicSamplerConfig{SampleRate: 2},
-				SendTickerVal:      2 * time.Millisecond,
-				ParentIdFieldNames: []string{"trace.parent_id", "parentId"},
+				GetSamplerTypeVal:    &config.DeterministicSamplerConfig{SampleRate: 2},
+				SendTickerVal:        2 * time.Millisecond,
+				ParentIdFieldNames:   []string{"trace.parent_id", "parentId"},
+				GetRedisMaxActiveVal: 10,
+				GetRedisMaxIdleVal:   10,
 				GetCollectionConfigVal: config.CollectionConfig{
 					CacheCapacity:              100,
 					ProcessTracesCycleDuration: config.Duration(1 * time.Second),

--- a/collect/central_collector_test.go
+++ b/collect/central_collector_test.go
@@ -121,8 +121,8 @@ func TestCentralCollector_ProcessTraces(t *testing.T) {
 				ParentIdFieldNames: []string{"trace.parent_id", "parentId"},
 				GetCollectionConfigVal: config.CollectionConfig{
 					CacheCapacity:              100,
-					ProcessTracesPauseDuration: config.Duration(1 * time.Second),
-					DeciderPauseDuration:       config.Duration(1 * time.Second),
+					ProcessTracesCycleDuration: config.Duration(1 * time.Second),
+					DeciderCycleDuration:       config.Duration(1 * time.Second),
 				},
 			}
 			transmission := &transmit.MockTransmission{}
@@ -188,8 +188,8 @@ func TestCentralCollector_Decider(t *testing.T) {
 				ParentIdFieldNames: []string{"trace.parent_id", "parentId"},
 				GetCollectionConfigVal: config.CollectionConfig{
 					IncomingQueueSize:          100,
-					ProcessTracesPauseDuration: config.Duration(1 * time.Second),
-					DeciderPauseDuration:       config.Duration(1 * time.Second),
+					ProcessTracesCycleDuration: config.Duration(1 * time.Second),
+					DeciderCycleDuration:       config.Duration(1 * time.Second),
 				},
 			}
 			transmission := &transmit.MockTransmission{}
@@ -262,8 +262,8 @@ func TestCentralCollector_OriginalSampleRateIsNotedInMetaField(t *testing.T) {
 				ParentIdFieldNames: []string{"trace.parent_id", "parentId"},
 				GetCollectionConfigVal: config.CollectionConfig{
 					IncomingQueueSize:          10000,
-					DeciderPauseDuration:       config.Duration(1 * time.Second),
-					ProcessTracesPauseDuration: config.Duration(1 * time.Second),
+					DeciderCycleDuration:       config.Duration(1 * time.Second),
+					ProcessTracesCycleDuration: config.Duration(1 * time.Second),
 				},
 				SampleCache: config.SampleCacheConfig{
 					KeptSize:          100,
@@ -357,8 +357,8 @@ func TestCentralCollector_TransmittedSpansShouldHaveASampleRateOfAtLeastOne(t *t
 				GetSamplerTypeVal:  &config.DeterministicSamplerConfig{SampleRate: 1},
 				GetCollectionConfigVal: config.CollectionConfig{
 					IncomingQueueSize:          100,
-					ProcessTracesPauseDuration: config.Duration(1 * time.Second),
-					DeciderPauseDuration:       config.Duration(1 * time.Second),
+					ProcessTracesCycleDuration: config.Duration(1 * time.Second),
+					DeciderCycleDuration:       config.Duration(1 * time.Second),
 				},
 				SendTickerVal:      2 * time.Millisecond,
 				ParentIdFieldNames: []string{"trace.parent_id", "parentId"},
@@ -413,8 +413,8 @@ func TestCentralCollector_SampleConfigReload(t *testing.T) {
 				ParentIdFieldNames: []string{"trace.parent_id", "parentId"},
 				GetCollectionConfigVal: config.CollectionConfig{
 					CacheCapacity:              10,
-					ProcessTracesPauseDuration: config.Duration(1 * time.Second),
-					DeciderPauseDuration:       config.Duration(1 * time.Second),
+					ProcessTracesCycleDuration: config.Duration(1 * time.Second),
+					DeciderCycleDuration:       config.Duration(1 * time.Second),
 				},
 				SampleCache: config.SampleCacheConfig{
 					KeptSize:          100,
@@ -498,8 +498,8 @@ func TestCentralCollector_StableMaxAlloc(t *testing.T) {
 					IncomingQueueSize:          600,
 					ProcessTracesBatchSize:     500,
 					DeciderBatchSize:           200,
-					ProcessTracesPauseDuration: config.Duration(1 * time.Second),
-					DeciderPauseDuration:       config.Duration(1 * time.Second),
+					ProcessTracesCycleDuration: config.Duration(1 * time.Second),
+					DeciderCycleDuration:       config.Duration(1 * time.Second),
 				},
 				StoreOptions: config.SmartWrapperOptions{
 					SpanChannelSize: 500,
@@ -608,8 +608,8 @@ func TestCentralCollector_AddSpanNoBlock(t *testing.T) {
 				},
 				GetCollectionConfigVal: config.CollectionConfig{
 					IncomingQueueSize:          3,
-					DeciderPauseDuration:       config.Duration(1 * time.Second),
-					ProcessTracesPauseDuration: config.Duration(1 * time.Second),
+					DeciderCycleDuration:       config.Duration(1 * time.Second),
+					ProcessTracesCycleDuration: config.Duration(1 * time.Second),
 				},
 			}
 
@@ -659,8 +659,8 @@ func TestCentralCollector_AddCountsToRoot(t *testing.T) {
 				},
 				GetCollectionConfigVal: config.CollectionConfig{
 					IncomingQueueSize:          100,
-					ProcessTracesPauseDuration: config.Duration(1 * time.Second),
-					DeciderPauseDuration:       config.Duration(1 * time.Second),
+					ProcessTracesCycleDuration: config.Duration(1 * time.Second),
+					DeciderCycleDuration:       config.Duration(1 * time.Second),
 				},
 			}
 
@@ -761,8 +761,8 @@ func TestCentralCollector_LateRootGetsCounts(t *testing.T) {
 				},
 				GetCollectionConfigVal: config.CollectionConfig{
 					IncomingQueueSize:          100,
-					ProcessTracesPauseDuration: config.Duration(1 * time.Second),
-					DeciderPauseDuration:       config.Duration(1 * time.Second),
+					ProcessTracesCycleDuration: config.Duration(1 * time.Second),
+					DeciderCycleDuration:       config.Duration(1 * time.Second),
 				},
 			}
 
@@ -866,8 +866,8 @@ func TestCentralCollector_LateSpanNotDecorated(t *testing.T) {
 				},
 				GetCollectionConfigVal: config.CollectionConfig{
 					IncomingQueueSize:          10,
-					ProcessTracesPauseDuration: config.Duration(1 * time.Second),
-					DeciderPauseDuration:       config.Duration(1 * time.Second),
+					ProcessTracesCycleDuration: config.Duration(1 * time.Second),
+					DeciderCycleDuration:       config.Duration(1 * time.Second),
 				},
 			}
 
@@ -950,8 +950,8 @@ func TestCentralCollector_AddAdditionalAttributes(t *testing.T) {
 				},
 				GetCollectionConfigVal: config.CollectionConfig{
 					IncomingQueueSize:          5,
-					ProcessTracesPauseDuration: config.Duration(1 * time.Second),
-					DeciderPauseDuration:       config.Duration(1 * time.Second),
+					ProcessTracesCycleDuration: config.Duration(1 * time.Second),
+					DeciderCycleDuration:       config.Duration(1 * time.Second),
 				},
 			}
 			transmission := &transmit.MockTransmission{}
@@ -1058,8 +1058,8 @@ func TestCentralCollector_SpanWithRuleReasons(t *testing.T) {
 				},
 				GetCollectionConfigVal: config.CollectionConfig{
 					IncomingQueueSize:          100,
-					ProcessTracesPauseDuration: config.Duration(1 * time.Second),
-					DeciderPauseDuration:       config.Duration(1 * time.Second),
+					ProcessTracesCycleDuration: config.Duration(1 * time.Second),
+					DeciderCycleDuration:       config.Duration(1 * time.Second),
 				},
 			}
 
@@ -1160,8 +1160,8 @@ func TestCentralCollector_Shutdown(t *testing.T) {
 				ParentIdFieldNames: []string{"trace.parent_id", "parentId"},
 				GetCollectionConfigVal: config.CollectionConfig{
 					CacheCapacity:              100,
-					ProcessTracesPauseDuration: config.Duration(1 * time.Second),
-					DeciderPauseDuration:       config.Duration(1 * time.Second),
+					ProcessTracesCycleDuration: config.Duration(1 * time.Second),
+					DeciderCycleDuration:       config.Duration(1 * time.Second),
 					ShutdownDelay:              config.Duration(500 * time.Millisecond),
 				},
 			}
@@ -1211,7 +1211,7 @@ func TestCentralCollector_Shutdown(t *testing.T) {
 
 			// start the decider again to mock trace decision process
 			collector.deciderCycle.Continue()
-			time.Sleep(conf.GetCollectionConfigVal.GetDeciderPauseDuration() * 3)
+			time.Sleep(conf.GetCollectionConfigVal.GetDeciderCycleDuration() * 3)
 
 			waitForTraceDecision(t, collector, traceids)
 
@@ -1237,8 +1237,8 @@ func TestCentralCollector_ProcessSpanImmediately(t *testing.T) {
 				ParentIdFieldNames: []string{"trace.parent_id", "parentId"},
 				GetCollectionConfigVal: config.CollectionConfig{
 					IncomingQueueSize:          100,
-					ProcessTracesPauseDuration: config.Duration(1 * time.Second),
-					DeciderPauseDuration:       config.Duration(1 * time.Second),
+					ProcessTracesCycleDuration: config.Duration(1 * time.Second),
+					DeciderCycleDuration:       config.Duration(1 * time.Second),
 				},
 				StressRelief: config.StressReliefConfig{
 					SamplingRate: 1,

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -218,10 +218,10 @@ type CollectionConfig struct {
 	CacheCapacity              int        `yaml:"CacheCapacity" default:"10_000"`
 	IncomingQueueSize          int        `yaml:"IncomingQueueSize"`
 	TraceFetcherConcurrency    int        `yaml:"TraceFetcherConcurrency" default:"10"`
-	ProcessTracesBatchSize     int        `yaml:"ProcessTracesBatchSize" default:"50"`
-	ProcessTracesPauseDuration Duration   `yaml:"ProcessTracesPauseDuration" default:"1s"`
-	DeciderPauseDuration       Duration   `yaml:"DeciderPauseDuration" default:"1s"`
-	DeciderBatchSize           int        `yaml:"DeciderBatchSize" default:"50"`
+	ProcessTracesBatchSize     int        `yaml:"ProcessTracesBatchSize" default:"1000"`
+	ProcessTracesCycleDuration Duration   `yaml:"ProcessTracesCycleDuration" default:"100ms"`
+	DeciderCycleDuration       Duration   `yaml:"DeciderCycleDuration" default:"100ms"`
+	DeciderBatchSize           int        `yaml:"DeciderBatchSize" default:"1000"`
 	AvailableMemory            MemorySize `yaml:"AvailableMemory" cmdenv:"AvailableMemory"`
 	MaxMemoryPercentage        int        `yaml:"MaxMemoryPercentage" default:"75"`
 	MaxAlloc                   MemorySize `yaml:"MaxAlloc"`
@@ -272,12 +272,12 @@ func (c CollectionConfig) GetProcessTracesBatchSize() int {
 	return c.ProcessTracesBatchSize
 }
 
-func (c CollectionConfig) GetProcessTracesPauseDuration() time.Duration {
-	return time.Duration(c.ProcessTracesPauseDuration)
+func (c CollectionConfig) GetProcessTracesCycleDuration() time.Duration {
+	return time.Duration(c.ProcessTracesCycleDuration)
 }
 
-func (c CollectionConfig) GetDeciderPauseDuration() time.Duration {
-	return time.Duration(c.DeciderPauseDuration)
+func (c CollectionConfig) GetDeciderCycleDuration() time.Duration {
+	return time.Duration(c.DeciderCycleDuration)
 }
 
 func (c CollectionConfig) GetDeciderBatchSize() int {

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -1029,7 +1029,7 @@ groups:
         firstversion: v2.6
         type: int
         valuetype: nondefault
-        default: 3
+        default: 15
         reload: false
         validations:
           - type: minimum
@@ -1043,15 +1043,13 @@ groups:
         firstversion: v2.6
         type: int
         valuetype: nondefault
-        default: 5
+        default: 30
         reload: false
         summary: is the maximum number of active connections in the Redis connection pool.
         description: >
           This setting is used to control the maximum number of active
           connections to Redis in the Redis connection pool. It may be useful to
-          increase this value in high-throughput environments. Setting it
-          to 0 imposes no connection limit, but this may be risky in
-          a burst of traffic. TODO: default to a much higher number?
+          increase this value in high-throughput environments.
 
       - name: Strategy
         v1group: PeerManagement
@@ -1190,47 +1188,53 @@ groups:
           supported. See `MaxMemoryPercentage` for more details. If set,
           `Collections.AvailableMemory` must not be defined.
 
-      - name: DeciderPauseDuration
+      - name: DeciderCycleDuration
         type: duration
         valuetype: nondefault
-        default: 100us
+        default: 100ms
         reload: false
-        summary: is the duration to pause between processing trace batches.
+        summary: is the cycle time used for processing batches of traces.
         description: >
-          This setting controls the duration that Refinery waits between
-          processing trace batches. It is rarely necessary to adjust this value.
+          This setting controls the duration that Refinery uses for processing
+          trace batches. It is rarely necessary to adjust this value.
 
       - name: DeciderBatchSize
         type: int
         valuetype: nondefault
-        default: 100
+        default: 1000
         reload: true
         summary: is the maximum number of traces retrieved by the decision processor in a single request.
         description: >
-          This setting controls the number of traces that are returned from the
-          central store when Refinery is making trace decisions. It is rarely
+          This setting controls the number of traces that are requested from the
+          central store when Refinery is making trace decisions. Refinery's
+          trace throughput is limited by
+          `DeciderBatchSize*DeciderCycleDuration`, which is the maximum number
+          of trace decisions Refinery can make in one second. It is rarely
           necessary to adjust this value.
 
-      - name: ProcessTracesBatchSize
-        type: int
-        valuetype: nondefault
-        default: 100
-        reload: false
-        summary: is the number of traces evaluated for sending in a single request.
-        description: >
-          This setting controls the number of trace IDs processed when refinery
-          is considering which spans to send or drop. It is rarely necessary to
-          adjust this value.
-
-      - name: ProcessTracesPauseDuration
+      - name: ProcessTracesCycleDuration
         type: duration
         valuetype: nondefault
-        default: 200us
+        default: 100ms
         reload: false
         summary: is the duration to pause between processing trace batches.
         description: >
           This setting controls the duration that Refinery waits between
           processing trace batches. It is rarely necessary to adjust this value.
+
+      - name: ProcessTracesBatchSize
+        type: int
+        valuetype: nondefault
+        default: 1000
+        reload: false
+        summary: is the number of traces evaluated for sending in a single request.
+        description: >
+          This setting controls the number of trace IDs processed when refinery
+          is considering which spans to send or drop. Refinery's trace
+          throughput is limited by
+          `ProcessTracesBatchSize*ProcessTracesCycleDuration`, which is the
+          maximum number of traces that can be processed in one second. It is
+          rarely necessary to adjust this value.
 
       - name: TraceFetcherConcurrency
         type: int

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -37,7 +37,7 @@ type Metrics interface {
 	Register(name string, metricType string)
 	Increment(name string)                  // for counters
 	Gauge(name string, val interface{})     // for gauges
-	Count(name string, n interface{})       // for counters
+	Count(name string, n interface{})       // for counters and updowns
 	Histogram(name string, obs interface{}) // for histogram
 	Up(name string)                         // for updown
 	Down(name string)                       // for updown

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -109,6 +109,12 @@ func (p *PromMetrics) Count(name string, n interface{}) {
 			counter.Add(f)
 			p.values[name] += f
 		}
+	} else if gaugeIface, ok := p.metrics[name]; ok {
+		if gauge, ok := gaugeIface.(prometheus.Gauge); ok {
+			f := ConvertNumeric(n)
+			gauge.Add(f)
+			p.values[name] += f
+		}
 	}
 }
 func (p *PromMetrics) Gauge(name string, val interface{}) {


### PR DESCRIPTION
## Which problems is this PR solving?

Along the route to tuning performance, this:
- Renames Pause->Cycle in a couple config values, as Pause was inaccurate
- Updates the Count function in metrics to work with updowns as well as counters, so that we can count up/down by more than 1
- Adds some metrics to the spanstore as well as to the redis store
- Uses config to define the number of goroutines used to talk to redis in a chatty subroutine

