### PR TITLE
fix: prevent data race when retrieve information about cuckoo cache

### DIFF
--- a/collect/cache/cuckoo.go
+++ b/collect/cache/cuckoo.go
@@ -161,3 +161,15 @@ func (c *CuckooTraceChecker) SetNextCapacity(capacity uint) {
 	defer c.mut.Unlock()
 	c.capacity = capacity
 }
+
+func (c *CuckooTraceChecker) Count() uint {
+	c.mut.RLock()
+	defer c.mut.RUnlock()
+	return c.current.Count()
+}
+
+func (c *CuckooTraceChecker) LoadFactor() float64 {
+	c.mut.RLock()
+	defer c.mut.RUnlock()
+	return c.current.LoadFactor()
+}

--- a/collect/cache/cuckooSentCache.go
+++ b/collect/cache/cuckooSentCache.go
@@ -298,8 +298,8 @@ func (c *CuckooSentCache) GetMetrics() (map[string]interface{}, error) {
 	metrics := map[string]interface{}{
 		"sent_cache_kept":             c.kept.Len(),
 		"sent_cache_kept_capacity":    cfg.KeptSize,
-		"sent_cache_dropped":          c.dropped.current.Count(),
-		"sent_cache_dropped_load":     c.dropped.current.LoadFactor(),
+		"sent_cache_dropped":          c.dropped.Count(),
+		"sent_cache_dropped_load":     c.dropped.LoadFactor(),
 		"sent_cache_dropped_capacity": cfg.DroppedSize,
 	}
 	return metrics, nil


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

In order to record metrics about dropped traces in cuckoo cache, we need to access the cuckoofilter object periodically in a goroutine. Since cuckoofilter itself is not concurrent safe, we need to add locks around accessing it.

## Short description of the changes

Add mutex when accessing cuckoofilter for current count and load factor