### PR TITLE
fix: add sender hostname in span metadata

### DIFF
--- a/collect/central_collector.go
+++ b/collect/central_collector.go
@@ -797,6 +797,10 @@ func (c *CentralCollector) send(status *centralstore.CentralTraceStatus) {
 			sp.Data[k] = v
 		}
 
+		if c.hostname != "" && c.Config.GetAddHostMetadataToTrace() {
+			sp.Data["meta.refinery.sender.local_hostname"] = c.hostname
+		}
+
 		// if the trace doesn't have a sample rate and is kept, it
 		traceSampleRate := status.SampleRate()
 		if traceSampleRate == 0 {


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

add metadata to every span regarding which refinery send it to upstream

## Short description of the changes

- add `meta.refinery.sender.local_hostname`

