### PR TITLE
feat: add WriteSpanBatchSize to central store options as a configurable value

### DIFF
--- a/collect/central_collector.go
+++ b/collect/central_collector.go
@@ -429,7 +429,7 @@ func (c *CentralCollector) sendTraces(ctx context.Context) error {
 		default:
 			return fmt.Errorf("unexpected state %s for trace %s", status.State, status.TraceID)
 		}
-		c.Metrics.Increment("collector_sender_trace")
+		c.Metrics.Increment("collector_send_trace")
 	}
 
 	return nil

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -230,14 +230,15 @@ type CollectionConfig struct {
 }
 
 type SmartWrapperOptions struct {
-	BasicStoreType    string   `yaml:"Type" default:"local"`
-	SpanChannelSize   int      `yaml:"SpanChannelSize" default:"100"`
-	StateTicker       Duration `yaml:"StateTicker" default:"1s"`
-	SendDelay         Duration `yaml:"SendDelay" default:"2s"`
-	TraceTimeout      Duration `yaml:"TraceTimeout" default:"60s"`
-	DecisionTimeout   Duration `yaml:"DecisionTimeout" default:"3s"`
-	MaxTraceRetention Duration `yaml:"MaxTraceRetention" default:"24h"`
-	ReaperRunInterval Duration `yaml:"ReaperRunInterval" default:"1h"`
+	BasicStoreType     string   `yaml:"Type" default:"local"`
+	SpanChannelSize    int      `yaml:"SpanChannelSize" default:"100"`
+	WriteSpanBatchSize int      `yaml:"WriteSpanBatchSize" default:"20"`
+	StateTicker        Duration `yaml:"StateTicker" default:"1s"`
+	SendDelay          Duration `yaml:"SendDelay" default:"2s"`
+	TraceTimeout       Duration `yaml:"TraceTimeout" default:"60s"`
+	DecisionTimeout    Duration `yaml:"DecisionTimeout" default:"3s"`
+	MaxTraceRetention  Duration `yaml:"MaxTraceRetention" default:"24h"`
+	ReaperRunInterval  Duration `yaml:"ReaperRunInterval" default:"1h"`
 }
 
 func (c CollectionConfig) GetShutdownDelay() time.Duration {

--- a/config/mock.go
+++ b/config/mock.go
@@ -569,5 +569,9 @@ func (f *MockConfig) GetCentralStoreOptions() SmartWrapperOptions {
 	f.Mux.RLock()
 	defer f.Mux.RUnlock()
 
+	if f.StoreOptions.WriteSpanBatchSize == 0 {
+		f.StoreOptions.WriteSpanBatchSize = 20
+	}
+
 	return f.StoreOptions
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

Enable quick experiment with the batch size for writing spans to redis store

## Short description of the changes

- fixed an incorrect metric name for collector_send_trace
- add a new config value for WriteSpanBatchSize and default it to 20

