### PR TITLE
feat: record decision and send rates

### DIFF
--- a/collect/central_collector.go
+++ b/collect/central_collector.go
@@ -146,6 +146,9 @@ func (c *CentralCollector) Start() error {
 	c.Metrics.Register("kept_from_stress", "counter")
 	c.Metrics.Register("collector_send_trace", "counter")
 	c.Metrics.Register("collector_decide_trace", "counter")
+	c.Metrics.Register("decider_decided_per_second", "histogram")
+	c.Metrics.Register("decider_considered_per_second", "histogram")
+	c.Metrics.Register("sender_considered_per_second", "histogram")
 
 	if c.Config.GetAddHostMetadataToTrace() {
 		if hostname, err := os.Hostname(); err == nil && hostname != "" {
@@ -413,6 +416,13 @@ func (c *CentralCollector) sendTraces(ctx context.Context) error {
 		return nil
 	}
 
+	var tracesConsidered float64
+	now := c.Clock.Now()
+	defer func() {
+		sendTime := c.Clock.Since(now)
+		c.Metrics.Histogram("sender_considered_per_second", tracesConsidered/sendTime.Seconds())
+	}()
+
 	statuses, err := c.Store.GetStatusForTraces(ctx, ids, centralstore.DecisionKeep, centralstore.DecisionDrop)
 	if err != nil {
 		return err
@@ -423,11 +433,16 @@ func (c *CentralCollector) sendTraces(ctx context.Context) error {
 		case centralstore.DecisionKeep:
 			c.sendSpans(status)
 			c.SpanCache.Remove(status.TraceID)
+			tracesConsidered++
 
 		case centralstore.DecisionDrop:
 			c.SpanCache.Remove(status.TraceID)
+			tracesConsidered++
 		default:
-			return fmt.Errorf("unexpected state %s for trace %s", status.State, status.TraceID)
+			// we don't want to send traces that are in any other state;
+			// it's also an error, but ending the loop is not what we want
+			c.Logger.Error().Logf("unexpected state %s for trace %s", status.State, status.TraceID)
+			continue
 		}
 		c.Metrics.Increment("collector_sender_trace")
 	}
@@ -437,7 +452,7 @@ func (c *CentralCollector) sendTraces(ctx context.Context) error {
 
 func (c *CentralCollector) decide() error {
 	return c.deciderCycle.Run(context.Background(), func(ctx context.Context) error {
-		err := c.makeDecision(ctx)
+		err := c.makeDecisions(ctx)
 		if err != nil {
 			c.Logger.Error().Logf("error making decision: %s", err)
 			if c.isTest {
@@ -450,7 +465,7 @@ func (c *CentralCollector) decide() error {
 	})
 }
 
-func (c *CentralCollector) makeDecision(ctx context.Context) error {
+func (c *CentralCollector) makeDecisions(ctx context.Context) error {
 	ctx, span := otelutil.StartSpan(ctx, c.Tracer, "CentralCollector.makeDecision")
 	defer span.End()
 	tracesIDs, err := c.Store.GetTracesNeedingDecision(ctx, c.Config.GetCollectionConfig().GetDeciderBatchSize())
@@ -463,6 +478,16 @@ func (c *CentralCollector) makeDecision(ctx context.Context) error {
 	if len(tracesIDs) == 0 {
 		return nil
 	}
+
+	var tracesDecided float64
+	var tracesConsidered float64
+	now := c.Clock.Now()
+	defer func() {
+		sendTime := c.Clock.Since(now)
+		c.Metrics.Histogram("decider_decided_per_second", tracesDecided/sendTime.Seconds())
+		c.Metrics.Histogram("decider_considered_per_second", tracesConsidered/sendTime.Seconds())
+	}()
+
 	statuses, err := c.Store.GetStatusForTraces(ctx, tracesIDs, centralstore.AwaitingDecision)
 	if err != nil {
 		span.RecordError(err)
@@ -514,6 +539,8 @@ func (c *CentralCollector) makeDecision(ctx context.Context) error {
 		if trace == nil {
 			continue
 		}
+		tracesConsidered++
+
 		_, span := otelutil.StartSpan(ctxTraces, c.Tracer, "CentralCollector.makeDecision.trace")
 
 		if trace.Root != nil {
@@ -562,6 +589,7 @@ func (c *CentralCollector) makeDecision(ctx context.Context) error {
 		}
 		// This will observe sample rate attempts even if the trace is dropped
 		c.Metrics.Histogram("trace_aggregate_sample_rate", float64(rate))
+		tracesDecided++
 
 		if !shouldSend {
 			c.Metrics.Increment("trace_decision_dropped")

--- a/collect/central_collector.go
+++ b/collect/central_collector.go
@@ -439,9 +439,13 @@ func (c *CentralCollector) sendTraces(ctx context.Context) error {
 			c.SpanCache.Remove(status.TraceID)
 			tracesConsidered++
 		default:
+			// this shouldn't happen, but we want to be safe about it.
 			// we don't want to send traces that are in any other state;
-			// it's also an error, but ending the loop is not what we want
-			c.Logger.Error().Logf("unexpected state %s for trace %s", status.State, status.TraceID)
+			// it's an error, but ending the loop is not what we want
+			c.Logger.Error().WithFields(logrus.Fields{
+				"trace_id": status.TraceID,
+				"state":    status.State,
+			}).Logf("unexpected state for trace")
 			continue
 		}
 		c.Metrics.Increment("collector_send_trace")


### PR DESCRIPTION
## Which problem is this PR solving?

- Record how fast the decider and the sender are actually operating

## Short description of the changes

- for each invocation of the decider and sender, record histograms of the number of traces actually considered (and for the decider, actually handled)

