### PR TITLE
fix: clean up metrics and logs

### DIFF
--- a/collect/stressRelief/stress_relief_redis.go
+++ b/collect/stressRelief/stress_relief_redis.go
@@ -110,6 +110,7 @@ func (s *StressRelief) Start() error {
 
 	s.RefineryMetrics.Register("cluster_stress_level", "gauge")
 	s.RefineryMetrics.Register("individual_stress_level", "gauge")
+	s.RefineryMetrics.Register("stress_relief_activated", "gauge")
 
 	if err := s.Gossip.Subscribe("stress_level", s.onStressLevelMessage); err != nil {
 		return err
@@ -256,6 +257,12 @@ func (s *StressRelief) Recalc() uint {
 				"instance_stress_level": level,
 			}).Logf("StressRelief has been deactivated")
 		}
+	}
+
+	if s.stressed {
+		s.RefineryMetrics.Gauge("stress_relief_activated", 1)
+	} else {
+		s.RefineryMetrics.Gauge("stress_relief_activated", 0)
 	}
 
 	return uint(level)

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -1838,15 +1838,15 @@ groups:
           bandwidth to the central store is sufficient.
 
       - name: WriteSpanBatchSize
-        firstVersion: v2.6
+        firstVersion: v3.0
         type: int
         valuetype: nondefault
         default: 20
         reload: true
         summary: is the maximum number of spans to be included for writing to basic store in a single request.
         description: >
-          This setting controls the number of spans sent to the basic store in
-          central store when Refinery is processing incoming spans.
+          This setting controls the number of spans sent to the basic store at
+          the same time when Refinery is processing incoming spans.
 
       - name: StateTicker
         firstVersion: v2.6


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

Logs that includes trace ids in its message body is noisy.
We are also missing stress activation metric

## Short description of the changes

- move trace/span IDs to log fields
- add stress_relief_activated metric

