### PR TITLE
maint: let app_tests use all store types

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -234,15 +234,18 @@ func post(t testing.TB, req *http.Request) {
 	resp.Body.Close()
 }
 
-var storesToTest = []string{"redis", "local"}
+var storesToTest = []string{
+	"redis",
+	"local",
+}
 
 func TestAppIntegration(t *testing.T) {
 	port := 10500
 	redisDB := 2
 
-	sender := &transmission.MockSender{}
 	for _, storeType := range storesToTest {
 		t.Run(storeType, func(t *testing.T) {
+			sender := &transmission.MockSender{}
 			_, _, stop := newStartedApp(t, sender, port, redisDB, false, storeType)
 			defer stop()
 

--- a/collect/central_collector.go
+++ b/collect/central_collector.go
@@ -164,7 +164,6 @@ func (c *CentralCollector) Start() error {
 	c.eg.Go(c.decide)
 	c.eg.Go(func() error {
 		return c.metricsCycle.Run(context.Background(), func(ctx context.Context) error {
-			fmt.Println("metrics cycle running")
 			if err := c.Store.RecordMetrics(ctx); err != nil {
 				c.Logger.Error().Logf("error recording metrics: %s", err)
 			}
@@ -394,7 +393,6 @@ func (c *CentralCollector) receive() error {
 
 func (c *CentralCollector) send() error {
 	return c.senderCycle.Run(context.Background(), func(ctx context.Context) error {
-		fmt.Println("sender cycle running")
 		err := c.sendTraces(ctx)
 		if err != nil {
 			c.Logger.Error().Logf("error processing traces: %s", err)
@@ -459,7 +457,6 @@ func (c *CentralCollector) sendTraces(ctx context.Context) error {
 
 func (c *CentralCollector) decide() error {
 	return c.deciderCycle.Run(context.Background(), func(ctx context.Context) error {
-		fmt.Println("decider cycle running")
 		err := c.makeDecisions(ctx)
 		if err != nil {
 			c.Logger.Error().Logf("error making decision: %s", err)
@@ -656,7 +653,6 @@ func (c *CentralCollector) processSpan(sp *types.Span) error {
 		c.Metrics.Down("spans_waiting")
 	}()
 
-	fmt.Printf("processing span %s\n", sp.Data["trace.span_id"])
 	err := c.SpanCache.Set(sp)
 	if err != nil {
 		c.Logger.Error().WithField("trace_id", sp.TraceID).Logf("error adding span to cache: %s", err)


### PR DESCRIPTION

## Which problem is this PR solving?

- Our app_tests were only testing the redis store; this fixes them to test all the stores (currently redis and local)

## Short description of the changes

- Create a list of store types
- Add iteration over that list to test code

