### PR TITLE
fix: break once we find parent ID field on a span

### DIFF
--- a/route/route.go
+++ b/route/route.go
@@ -534,8 +534,7 @@ func (r *Router) processEvent(ev *types.Event, reqID interface{}) error {
 
 	var isRoot bool
 	for _, parentIdFieldName := range r.Config.GetParentIdFieldNames() {
-		_, isRoot = ev.Data[parentIdFieldName]
-		if isRoot {
+		if _, isRoot = ev.Data[parentIdFieldName]; isRoot {
 			break
 		}
 	}

--- a/route/route.go
+++ b/route/route.go
@@ -535,6 +535,9 @@ func (r *Router) processEvent(ev *types.Event, reqID interface{}) error {
 	var isRoot bool
 	for _, parentIdFieldName := range r.Config.GetParentIdFieldNames() {
 		_, isRoot = ev.Data[parentIdFieldName]
+		if isRoot {
+			break
+		}
 	}
 
 	span := &types.Span{


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

once we find a valid parent id field, we should stop and recognize the span is a root span

## Short description of the changes

- break the loop once `isRoot` is true
