### PR TITLE
feat: add MetricsCycleRate config option for redis

### DIFF
--- a/centralstore/redis_store.go
+++ b/centralstore/redis_store.go
@@ -98,11 +98,13 @@ func (r *RedisBasicStore) Start() error {
 	r.Metrics.Register(metricsPrefixConnection+"wait", "gauge")
 	r.Metrics.Register(metricsPrefixConnection+"wait_duration_ms", "gauge")
 
-	// register metrics for memory stats
-	r.Metrics.Register(metricsPrefixMemory+"used_total", "gauge")
-	r.Metrics.Register(metricsPrefixMemory+"used_peak", "gauge")
-	r.Metrics.Register(metricsPrefixCount+"keys", "gauge")
-	r.Metrics.Register(metricsPrefixCount+"traces", "gauge")
+	if !r.Config.GetRedisDisableMetrics() {
+		// register metrics for memory stats
+		r.Metrics.Register(metricsPrefixMemory+"used_total", "gauge")
+		r.Metrics.Register(metricsPrefixMemory+"used_peak", "gauge")
+		r.Metrics.Register(metricsPrefixCount+"keys", "gauge")
+		r.Metrics.Register(metricsPrefixCount+"traces", "gauge")
+	}
 
 	return nil
 }
@@ -131,6 +133,10 @@ func (r *RedisBasicStore) RecordMetrics(ctx context.Context) error {
 	r.Metrics.Gauge(metricsPrefixConnection+"idle", connStats.IdleCount)
 	r.Metrics.Gauge(metricsPrefixConnection+"wait", connStats.WaitCount)
 	r.Metrics.Gauge(metricsPrefixConnection+"wait_duration_ms", connStats.WaitDuration.Milliseconds())
+
+	if r.Config.GetRedisDisableMetrics() {
+		return nil
+	}
 
 	conn := r.RedisClient.Get()
 	defer conn.Close()

--- a/centralstore/redis_store_test.go
+++ b/centralstore/redis_store_test.go
@@ -461,6 +461,8 @@ func TestRedisBasicStore_GetMetrics(t *testing.T) {
 	count, ok = store.Metrics.Get(metricsPrefixConnection + "wait_duration_ms")
 	require.True(t, ok)
 	assert.EqualValues(t, 0, count)
+
+	require.NotEmpty(t, store.lastMetricsRecorded)
 }
 
 func TestRedisBasicStore_ValidStateTransition(t *testing.T) {

--- a/collect/central_collector.go
+++ b/collect/central_collector.go
@@ -121,7 +121,7 @@ func (c *CentralCollector) Start() error {
 	c.samplersByDestination = make(map[string]sample.Sampler)
 
 	// The cycles manage a periodic task and also provide some test hooks
-	c.metricsCycle = NewCycle(c.Clock, c.Config.GetSendTickerValue(), c.done)
+	c.metricsCycle = NewCycle(c.Clock, 2*c.Config.GetSendTickerValue(), c.done)
 	c.senderCycle = NewCycle(c.Clock, collectorCfg.GetSenderCycleDuration(), c.done)
 	c.deciderCycle = NewCycle(c.Clock, collectorCfg.GetDeciderCycleDuration(), c.done)
 

--- a/collect/central_collector.go
+++ b/collect/central_collector.go
@@ -164,7 +164,6 @@ func (c *CentralCollector) Start() error {
 	c.eg.Go(c.decide)
 	c.eg.Go(func() error {
 		return c.metricsCycle.Run(context.Background(), func(ctx context.Context) error {
-			fmt.Println("metrics cycle running")
 			if err := c.Store.RecordMetrics(ctx); err != nil {
 				c.Logger.Error().Logf("error recording metrics: %s", err)
 			}
@@ -394,7 +393,6 @@ func (c *CentralCollector) receive() error {
 
 func (c *CentralCollector) send() error {
 	return c.senderCycle.Run(context.Background(), func(ctx context.Context) error {
-		fmt.Println("sender cycle running")
 		err := c.sendTraces(ctx)
 		if err != nil {
 			c.Logger.Error().Logf("error processing traces: %s", err)
@@ -459,7 +457,6 @@ func (c *CentralCollector) sendTraces(ctx context.Context) error {
 
 func (c *CentralCollector) decide() error {
 	return c.deciderCycle.Run(context.Background(), func(ctx context.Context) error {
-		fmt.Println("decider cycle running")
 		err := c.makeDecisions(ctx)
 		if err != nil {
 			c.Logger.Error().Logf("error making decision: %s", err)
@@ -656,7 +653,6 @@ func (c *CentralCollector) processSpan(sp *types.Span) error {
 		c.Metrics.Down("spans_waiting")
 	}()
 
-	fmt.Printf("processing span %s\n", sp.Data["trace.span_id"])
 	err := c.SpanCache.Set(sp)
 	if err != nil {
 		c.Logger.Error().WithField("trace_id", sp.TraceID).Logf("error adding span to cache: %s", err)

--- a/collect/central_collector.go
+++ b/collect/central_collector.go
@@ -121,7 +121,7 @@ func (c *CentralCollector) Start() error {
 	c.samplersByDestination = make(map[string]sample.Sampler)
 
 	// The cycles manage a periodic task and also provide some test hooks
-	c.metricsCycle = NewCycle(c.Clock, 2*c.Config.GetSendTickerValue(), c.done)
+	c.metricsCycle = NewCycle(c.Clock, c.Config.GetSendTickerValue(), c.done)
 	c.senderCycle = NewCycle(c.Clock, collectorCfg.GetSenderCycleDuration(), c.done)
 	c.deciderCycle = NewCycle(c.Clock, collectorCfg.GetDeciderCycleDuration(), c.done)
 

--- a/config/config.go
+++ b/config/config.go
@@ -92,7 +92,7 @@ type Config interface {
 
 	GetParallelism() int
 
-	GetRedisDisableMetrics() bool
+	GetRedisMetricsCycleRate() time.Duration
 
 	// GetHoneycombAPI returns the base URL (protocol, hostname, and port) of
 	// the upstream Honeycomb API server

--- a/config/config.go
+++ b/config/config.go
@@ -92,6 +92,8 @@ type Config interface {
 
 	GetParallelism() int
 
+	GetRedisDisableMetrics() bool
+
 	// GetHoneycombAPI returns the base URL (protocol, hostname, and port) of
 	// the upstream Honeycomb API server
 	GetHoneycombAPI() string

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -201,19 +201,19 @@ type PeerManagementConfig struct {
 }
 
 type RedisPeerManagementConfig struct {
-	Host           string   `yaml:"Host" cmdenv:"RedisHost"`
-	Username       string   `yaml:"Username" cmdenv:"RedisUsername"`
-	Password       string   `yaml:"Password" cmdenv:"RedisPassword"`
-	AuthCode       string   `yaml:"AuthCode" cmdenv:"RedisAuthCode"`
-	Database       int      `yaml:"Database"`
-	UseTLS         bool     `yaml:"UseTLS" `
-	UseTLSInsecure bool     `yaml:"UseTLSInsecure" `
-	Timeout        Duration `yaml:"Timeout" default:"5s"`
-	Prefix         string   `yaml:"Prefix" default:"refinery"`
-	MaxIdle        int      `yaml:"MaxIdle" default:"30"`
-	MaxActive      int      `yaml:"MaxActive" default:"30"`
-	Parallelism    int      `yaml:"Parallelism" default:"10"`
-	DisableMetrics bool     `yaml:"DisableMetrics"`
+	Host             string   `yaml:"Host" cmdenv:"RedisHost"`
+	Username         string   `yaml:"Username" cmdenv:"RedisUsername"`
+	Password         string   `yaml:"Password" cmdenv:"RedisPassword"`
+	AuthCode         string   `yaml:"AuthCode" cmdenv:"RedisAuthCode"`
+	Database         int      `yaml:"Database"`
+	UseTLS           bool     `yaml:"UseTLS" `
+	UseTLSInsecure   bool     `yaml:"UseTLSInsecure" `
+	Timeout          Duration `yaml:"Timeout" default:"5s"`
+	Prefix           string   `yaml:"Prefix" default:"refinery"`
+	MaxIdle          int      `yaml:"MaxIdle" default:"30"`
+	MaxActive        int      `yaml:"MaxActive" default:"30"`
+	Parallelism      int      `yaml:"Parallelism" default:"10"`
+	MetricsCycleRate Duration `yaml:"MetricsCycleRate" default:"1m`
 }
 
 type CollectionConfig struct {
@@ -671,11 +671,11 @@ func (f *fileConfig) GetParallelism() int {
 	return f.mainConfig.RedisPeerManagement.Parallelism
 }
 
-func (f *fileConfig) GetRedisDisableMetrics() bool {
+func (f *fileConfig) GetRedisMetricsCycleRate() time.Duration {
 	f.mux.RLock()
 	defer f.mux.RUnlock()
 
-	return f.mainConfig.RedisPeerManagement.DisableMetrics
+	return time.Duration(f.mainConfig.RedisPeerManagement.MetricsCycleRate)
 }
 
 func (f *fileConfig) GetIdentifierInterfaceName() string {

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -213,6 +213,7 @@ type RedisPeerManagementConfig struct {
 	MaxIdle        int      `yaml:"MaxIdle" default:"30"`
 	MaxActive      int      `yaml:"MaxActive" default:"30"`
 	Parallelism    int      `yaml:"Parallelism" default:"10"`
+	DisableMetrics bool     `yaml:"DisableMetrics"`
 }
 
 type CollectionConfig struct {
@@ -668,6 +669,13 @@ func (f *fileConfig) GetParallelism() int {
 	defer f.mux.RUnlock()
 
 	return f.mainConfig.RedisPeerManagement.Parallelism
+}
+
+func (f *fileConfig) GetRedisDisableMetrics() bool {
+	f.mux.RLock()
+	defer f.mux.RUnlock()
+
+	return f.mainConfig.RedisPeerManagement.DisableMetrics
 }
 
 func (f *fileConfig) GetIdentifierInterfaceName() string {

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -1068,6 +1068,19 @@ groups:
           This setting is used to control the number of parallel Redis
           connections use when communicating trace information to Redis. It may
           be useful to increase this value in high-throughput environments.
+      
+      - name: DisableMetrics
+        firstversion: v3.0
+        type: bool
+        valuetype: nondefault
+        default: false
+        reload: true
+        summary: disables the collection of metrics for the Redis server.
+        description: >
+          This setting is used to disable the collection of metrics for the Redis
+          server. It may be useful to disable this setting in environments
+          where metrics collection is not desired.
+
 
       - name: Strategy
         v1group: PeerManagement

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -1069,17 +1069,18 @@ groups:
           connections use when communicating trace information to Redis. It may
           be useful to increase this value in high-throughput environments.
       
-      - name: DisableMetrics
+      - name: MetricsCycleRate
         firstversion: v3.0
-        type: bool
+        type: duration
         valuetype: nondefault
-        default: false
+        default: 1m
         reload: true
-        summary: disables the collection of metrics for the Redis server.
+        summary: is the interval between retrieving metrics from Redis server.
         description: >
-          This setting is used to disable the collection of metrics for the Redis
-          server. It may be useful to disable this setting in environments
-          where metrics collection is not desired.
+          This setting is used to control the interval between retrieving
+          metrics from Redis server. It may be useful to increase this value in
+          high-throughput environments. By setting this value to 0, the metrics
+          retrieval will be disabled.
 
 
       - name: Strategy

--- a/config/mock.go
+++ b/config/mock.go
@@ -35,7 +35,7 @@ type MockConfig struct {
 	GetRedisMaxIdleVal               int
 	GetRedisTimeoutVal               time.Duration
 	GetParallelismVal                int
-	GetRedisDisableMetricsVal        bool
+	GetRedisMetricsCycleRateVal      time.Duration
 	GetUseTLSVal                     bool
 	GetUseTLSInsecureVal             bool
 	GetSamplerTypeErr                error //keep
@@ -292,11 +292,15 @@ func (m *MockConfig) GetParallelism() int {
 	return m.GetParallelismVal
 }
 
-func (m *MockConfig) GetRedisDisableMetrics() bool {
+func (m *MockConfig) GetRedisMetricsCycleRate() time.Duration {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
-	return m.GetRedisDisableMetricsVal
+	if m.GetRedisMetricsCycleRateVal == 0 {
+		return 1 * time.Second
+	}
+
+	return m.GetRedisMetricsCycleRateVal
 }
 
 func (m *MockConfig) GetLegacyMetricsConfig() LegacyMetricsConfig {

--- a/config/mock.go
+++ b/config/mock.go
@@ -35,6 +35,7 @@ type MockConfig struct {
 	GetRedisMaxIdleVal               int
 	GetRedisTimeoutVal               time.Duration
 	GetParallelismVal                int
+	GetRedisDisableMetricsVal        bool
 	GetUseTLSVal                     bool
 	GetUseTLSInsecureVal             bool
 	GetSamplerTypeErr                error //keep
@@ -289,6 +290,13 @@ func (m *MockConfig) GetParallelism() int {
 	defer m.Mux.RUnlock()
 
 	return m.GetParallelismVal
+}
+
+func (m *MockConfig) GetRedisDisableMetrics() bool {
+	m.Mux.RLock()
+	defer m.Mux.RUnlock()
+
+	return m.GetRedisDisableMetricsVal
 }
 
 func (m *MockConfig) GetLegacyMetricsConfig() LegacyMetricsConfig {


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

Through testing, we realized that getting metrics from redis causes network usage to go up. Adding a config value to allow different interval for retrieving redis metrics as we currently are not calculating stress level using any of these metrics.

## Short description of the changes

- add MetricsCycleRate option in config

