### PR TITLE
fix: make sure send_reason is attached to span metadata

### DIFF
--- a/centralstore/redis_store.go
+++ b/centralstore/redis_store.go
@@ -636,6 +636,9 @@ func (t *tracesStore) addStatuses(ctx context.Context, conn redis.Conn, cspans [
 
 	commands := make([]redis.Command, 0, 3*len(cspans))
 	for _, span := range cspans {
+		if span.SpanID == "" {
+			continue
+		}
 
 		trace := &centralTraceStatusInit{
 			TraceID:    span.TraceID,

--- a/centralstore/redis_store.go
+++ b/centralstore/redis_store.go
@@ -646,6 +646,8 @@ func (t *tracesStore) addStatuses(ctx context.Context, conn redis.Conn, cspans [
 
 	commands := make([]redis.Command, 0, 3*len(cspans))
 	for _, span := range cspans {
+		// prevent storing signaling spans sent from central collector
+		// all actual spans should have a spanID
 		if span.SpanID == "" {
 			continue
 		}

--- a/collect/central_collector.go
+++ b/collect/central_collector.go
@@ -163,7 +163,6 @@ func (c *CentralCollector) Start() error {
 	c.eg.Go(c.decide)
 	c.eg.Go(func() error {
 		return c.metricsCycle.Run(context.Background(), func(ctx context.Context) error {
-			fmt.Println("metrics cycle running")
 			if err := c.Store.RecordMetrics(ctx); err != nil {
 				c.Logger.Error().Logf("error recording metrics: %s", err)
 			}
@@ -393,7 +392,6 @@ func (c *CentralCollector) receive() error {
 
 func (c *CentralCollector) send() error {
 	return c.senderCycle.Run(context.Background(), func(ctx context.Context) error {
-		fmt.Println("sender cycle running")
 		err := c.sendTraces(ctx)
 		if err != nil {
 			c.Logger.Error().Logf("error processing traces: %s", err)
@@ -458,7 +456,6 @@ func (c *CentralCollector) sendTraces(ctx context.Context) error {
 
 func (c *CentralCollector) decide() error {
 	return c.deciderCycle.Run(context.Background(), func(ctx context.Context) error {
-		fmt.Println("decider cycle running")
 		err := c.makeDecisions(ctx)
 		if err != nil {
 			c.Logger.Error().Logf("error making decision: %s", err)
@@ -653,7 +650,6 @@ func (c *CentralCollector) processSpan(sp *types.Span) error {
 		c.Metrics.Down("spans_waiting")
 	}()
 
-	fmt.Printf("processing span %s\n", sp.Data["trace.span_id"])
 	err := c.SpanCache.Set(sp)
 	if err != nil {
 		c.Logger.Error().WithField("trace_id", sp.TraceID).Logf("error adding span to cache: %s", err)

--- a/collect/central_collector.go
+++ b/collect/central_collector.go
@@ -731,6 +731,9 @@ func (c *CentralCollector) checkAlloc() {
 		}
 		totalDataSizeSent += trace.DataSize
 		numOfTracesSent++
+		// in order to eject a trace from refinery's cache, we pretend that its root span has
+		// arrived. This will force the trace to enter the decision-making process. Once a decision
+		// is made, the trace will be removed from the cache.
 		err := c.Store.WriteSpan(ctx, &centralstore.CentralSpan{TraceID: id, IsRoot: true})
 		if err != nil {
 			c.Logger.Error().WithField("trace_id", id).Logf("error sending trace for decision: %s", err)

--- a/collect/central_collector_test.go
+++ b/collect/central_collector_test.go
@@ -401,6 +401,7 @@ func TestCentralCollector_TransmittedSpansShouldHaveASampleRateOfAtLeastOne(t *t
 
 			span := &types.Span{
 				TraceID: fmt.Sprintf("trace-%v", 1),
+				ID:      "span1",
 				Event: types.Event{
 					Dataset:    "aoeu",
 					APIKey:     legacyAPIKey,

--- a/collect/central_collector_test.go
+++ b/collect/central_collector_test.go
@@ -304,6 +304,7 @@ func TestCentralCollector_OriginalSampleRateIsNotedInMetaField(t *testing.T) {
 			for i := 0; i < 10; i++ {
 				span := &types.Span{
 					TraceID: fmt.Sprintf("trace-%v", i),
+					ID:      fmt.Sprintf("span%d", i),
 					Event: types.Event{
 						Dataset:    "aoeu",
 						APIKey:     legacyAPIKey,
@@ -336,6 +337,7 @@ func TestCentralCollector_OriginalSampleRateIsNotedInMetaField(t *testing.T) {
 			traceID := fmt.Sprintf("trace-%v", 1000)
 			err := collector.AddSpan(&types.Span{
 				TraceID: traceID,
+				ID:      "span1000",
 				Event: types.Event{
 					Dataset:    "no-upstream-sampling",
 					APIKey:     legacyAPIKey,


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

`span.Metadata` is a `map[string]interface{}` type. We were checking the return value against an empty string, which is not always correct. That means if the `meta.refinery.send_reason` does not exist in the metadata map, we will never set the send_reason.

## Short description of the changes

- Properly check empty value returned from metadata map and set `send_reason`

