### PR TITLE
maint: Remove SpanIDFieldNames; we don't need it.

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -126,7 +126,6 @@ func newStartedApp(
 		AddHostMetadataToTrace: enableHostMetadata,
 		TraceIdFieldNames:      []string{"trace.trace_id"},
 		ParentIdFieldNames:     []string{"trace.parent_id"},
-		SpanIdFieldNames:       []string{"trace.span_id"},
 		SampleCache:            config.SampleCacheConfig{KeptSize: 10000, DroppedSize: 100000, SizeCheckInterval: config.Duration(10 * time.Second)},
 		StoreOptions: config.SmartWrapperOptions{
 			StateTicker:     config.Duration(50 * time.Millisecond),

--- a/config/config.go
+++ b/config/config.go
@@ -201,8 +201,6 @@ type Config interface {
 
 	GetParentIdFieldNames() []string
 
-	GetSpanIdFieldNames() []string
-
 	GetCentralStoreOptions() SmartWrapperOptions
 }
 

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -213,7 +213,7 @@ type RedisPeerManagementConfig struct {
 	MaxIdle          int      `yaml:"MaxIdle" default:"30"`
 	MaxActive        int      `yaml:"MaxActive" default:"30"`
 	Parallelism      int      `yaml:"Parallelism" default:"10"`
-	MetricsCycleRate Duration `yaml:"MetricsCycleRate" default:"1m`
+	MetricsCycleRate Duration `yaml:"MetricsCycleRate" default:"1m"`
 }
 
 type CollectionConfig struct {
@@ -968,13 +968,6 @@ func (f *fileConfig) GetParentIdFieldNames() []string {
 	defer f.mux.RUnlock()
 
 	return f.mainConfig.IDFieldNames.ParentNames
-}
-
-func (f *fileConfig) GetSpanIdFieldNames() []string {
-	f.mux.RLock()
-	defer f.mux.RUnlock()
-
-	return f.mainConfig.IDFieldNames.SpanNames
 }
 
 func (f *fileConfig) GetConfigMetadata() []ConfigMetadata {

--- a/config/mock.go
+++ b/config/mock.go
@@ -75,7 +75,6 @@ type MockConfig struct {
 	AdditionalAttributes             map[string]string
 	TraceIdFieldNames                []string
 	ParentIdFieldNames               []string
-	SpanIdFieldNames                 []string
 	CfgMetadata                      []ConfigMetadata
 	StoreOptions                     SmartWrapperOptions
 
@@ -557,13 +556,6 @@ func (f *MockConfig) GetParentIdFieldNames() []string {
 		f.ParentIdFieldNames = []string{"trace.parent_id", "parent_id"}
 	}
 	return f.ParentIdFieldNames
-}
-
-func (f *MockConfig) GetSpanIdFieldNames() []string {
-	f.Mux.RLock()
-	defer f.Mux.RUnlock()
-
-	return f.SpanIdFieldNames
 }
 
 func (f *MockConfig) GetConfigMetadata() []ConfigMetadata {

--- a/route/route.go
+++ b/route/route.go
@@ -520,17 +520,9 @@ func (r *Router) processEvent(ev *types.Event, reqID interface{}) error {
 		r.UpstreamTransmission.EnqueueEvent(ev)
 		return nil
 	}
-	var spanID string
-	for _, spanIdFieldName := range r.Config.GetSpanIdFieldNames() {
-		if spID, ok := ev.Data[spanIdFieldName]; ok {
-			spanID = spID.(string)
-			break
-		}
-	}
-	if spanID == "" {
-		spanID = types.GenerateSpanID()
-	}
-	debugLog = debugLog.WithString("trace_id", traceID)
+
+	uniqueID := types.GenerateSpanID()
+	debugLog = debugLog.WithString("trace_id", traceID).WithString("unique_id", uniqueID)
 
 	// check if this is a root span; if we can't find a parent ID, it is.
 	isRoot := true
@@ -544,7 +536,7 @@ func (r *Router) processEvent(ev *types.Event, reqID interface{}) error {
 	span := &types.Span{
 		Event:   *ev,
 		TraceID: traceID,
-		ID:      spanID,
+		ID:      uniqueID,
 		IsRoot:  isRoot,
 	}
 


### PR DESCRIPTION
## Which problem is this PR solving?

- We had "SpanIDFieldNames" to mimic the parentID one, but we don't need it and don't want it.

## Short description of the changes

- Always generate a unique ID for spans when we receive them
- Delete the search for a spanID and all its configuration code

