### PR TITLE
feat: distribute workload for trace state management more efficiently

### DIFF
--- a/centralstore/centralstore.go
+++ b/centralstore/centralstore.go
@@ -185,7 +185,7 @@ type SmartStorer interface {
 	GetStatusForTraces(ctx context.Context, traceIDs []string, statesToCheck ...CentralTraceState) ([]*CentralTraceStatus, error)
 
 	// GetTracesForState returns a list of trace IDs that match the provided status.
-	GetTracesForState(ctx context.Context, state CentralTraceState) ([]string, error)
+	GetTracesForState(ctx context.Context, state CentralTraceState, n int) ([]string, error)
 
 	// GetTracesNeedingDecision returns a list of up to n trace IDs that are in the
 	// ReadyForDecision state. These IDs are moved to the AwaitingDecision state
@@ -281,7 +281,7 @@ type BasicStorer interface {
 	GetStatusForTraces(ctx context.Context, traceIDs []string, statesToCheck ...CentralTraceState) ([]*CentralTraceStatus, error)
 
 	// GetTracesForState returns a list of trace IDs that match the provided status.
-	GetTracesForState(ctx context.Context, state CentralTraceState) ([]string, error)
+	GetTracesForState(ctx context.Context, state CentralTraceState, n int) ([]string, error)
 
 	// GetTracesNeedingDecision returns a list of up to n trace IDs that are in the
 	// ReadyForDecision state. These IDs are moved to the AwaitingDecision state

--- a/centralstore/centralstore.go
+++ b/centralstore/centralstore.go
@@ -184,7 +184,8 @@ type SmartStorer interface {
 	// change the state of these traces after this call.
 	GetStatusForTraces(ctx context.Context, traceIDs []string, statesToCheck ...CentralTraceState) ([]*CentralTraceStatus, error)
 
-	// GetTracesForState returns a list of trace IDs that match the provided status.
+	// GetTracesForState returns a list of up to n trace IDs that match the provided status.
+	// If n is -1, return all matching traces.
 	GetTracesForState(ctx context.Context, state CentralTraceState, n int) ([]string, error)
 
 	// GetTracesNeedingDecision returns a list of up to n trace IDs that are in the

--- a/centralstore/local_store.go
+++ b/centralstore/local_store.go
@@ -297,7 +297,7 @@ func (lrs *LocalStore) GetStatusForTraces(ctx context.Context, traceIDs []string
 }
 
 // GetTracesForState returns a list of trace IDs that match the provided status.
-func (lrs *LocalStore) GetTracesForState(ctx context.Context, state CentralTraceState) ([]string, error) {
+func (lrs *LocalStore) GetTracesForState(ctx context.Context, state CentralTraceState, n int) ([]string, error) {
 	_, span := otelutil.StartSpan(ctx, lrs.Tracer, "LocalStore.GetTracesForState")
 	defer span.End()
 	lrs.mutex.RLock()

--- a/centralstore/redis_store.go
+++ b/centralstore/redis_store.go
@@ -351,6 +351,8 @@ func (r *RedisBasicStore) GetStatusForTraces(ctx context.Context, traceIDs []str
 
 }
 
+// GetTracesForState returns a list of up to n trace IDs that match the provided status.
+// If n is -1, returns all matching traces.
 func (r *RedisBasicStore) GetTracesForState(ctx context.Context, state CentralTraceState, n int) ([]string, error) {
 	ctx, span := r.Tracer.Start(ctx, "GetTracesForState")
 	defer span.End()

--- a/centralstore/redis_store.go
+++ b/centralstore/redis_store.go
@@ -74,9 +74,10 @@ func (r *RedisBasicStore) Start() error {
 	opt := r.Config.GetCentralStoreOptions()
 
 	stateProcessorCfg := traceStateProcessorConfig{
-		reaperRunInterval: time.Duration(opt.ReaperRunInterval),
-		maxTraceRetention: time.Duration(opt.MaxTraceRetention),
-		changeState:       r.RedisClient.NewScript(stateChangeKey, stateChangeScript),
+		reaperRunInterval:       time.Duration(opt.ReaperRunInterval),
+		maxTraceRetention:       time.Duration(opt.MaxTraceRetention),
+		changeState:             r.RedisClient.NewScript(stateChangeKey, stateChangeScript),
+		getTraceNeedingDecision: r.RedisClient.NewScript(tracesNeedingDecisionScriptKey, tracesNeedingDecisionScript),
 	}
 
 	stateProcessor := newTraceStateProcessor(stateProcessorCfg, r.Clock, r.Tracer)
@@ -382,21 +383,20 @@ func (r *RedisBasicStore) GetTracesNeedingDecision(ctx context.Context, n int) (
 	conn := r.RedisClient.Get()
 	defer conn.Close()
 
-	traceIDs, err := r.states.activeTraceIDsByState(ctx, conn, ReadyToDecide, n)
+	traceIDs, err := r.states.config.getTraceNeedingDecision.DoStrings(ctx, conn,
+		validStateChangeEventsKey, n, expirationForTraceState.Seconds(), time.Now().UnixMicro())
 	if err != nil {
+		if errors.Is(err, redis.ErrKeyNotFound) {
+			return nil, nil
+		}
 		return nil, err
 	}
 
 	if len(traceIDs) == 0 {
-		return nil, nil
+		return nil, errors.New("failed to get traces for needing decisions")
 	}
 
-	succeed, err := r.states.toNextState(ctx, conn, newTraceStateChangeEvent(ReadyToDecide, AwaitingDecision), traceIDs...)
-	if err != nil {
-		return nil, err
-	}
-
-	return succeed, nil
+	return traceIDs, nil
 
 }
 
@@ -925,9 +925,10 @@ func addToSpanHash(span *CentralSpan) (redis.Command, error) {
 // on it's current state.
 
 type traceStateProcessorConfig struct {
-	reaperRunInterval time.Duration
-	maxTraceRetention time.Duration
-	changeState       redis.Script
+	reaperRunInterval       time.Duration
+	maxTraceRetention       time.Duration
+	changeState             redis.Script
+	getTraceNeedingDecision redis.Script
 }
 
 type traceStateProcessor struct {
@@ -1220,6 +1221,40 @@ func (t *traceStateProcessor) applyStateChange(ctx context.Context, conn redis.C
 	return result, nil
 }
 
+const tracesNeedingDecisionScriptKey = 1
+const tracesNeedingDecisionScript = `
+		local possibleStateChangeEvents = KEYS[1]
+		local batchSize = ARGV[1]
+		local ttl = ARGV[2]
+		local timestamp = ARGV[3]
+		local result = {}
+		local previousState = "ready_to_decide"
+		local nextState = "awaiting_decision"
+
+	  	local traceIDs = redis.call('ZRANDMEMBER', "ready_to_decide:traces", batchSize)
+		if next(traceIDs) == nil then
+   			-- myTable is empty
+			return -1
+		end
+  -- iterate through the traceIDs and move them to the next state
+  for i, traceID in ipairs(traceIDs) do
+    -- unfortunately, Lua doesn't support "continue" statement in for loops.
+	-- even though, Lua 5.2+ supports "goto" statement, we can't use it here because
+	-- Redis only supports Lua 5.1.
+	-- The interior "repeat ... until true" is a way of creating a do-once loop, and "do break end" is a way to
+	-- spell "break" that indicates it's not just a normal break.
+	-- This is a common pattern to simulate "continue" in Lua versions before 5.2.
+  	repeat
+` + traceStateChangeScript + `
+	   -- add it to the result list
+	   table.insert(result, traceID)
+	until true
+  end
+
+
+		return result
+`
+
 // stateChangeScript is a lua script that atomically moves traces between states and returns
 // the trace IDs that has completed a state change.
 // It takes the following arguments:
@@ -1258,7 +1293,17 @@ const stateChangeScript = `
 	    if i < 5 then
 		  do break end
 		end
+` + traceStateChangeScript + `
+	   -- add it to the result list
+	   table.insert(result, traceID)
+	until true
+  end
 
+
+ return result
+`
+
+const traceStateChangeScript = `
 		--  get current state for the trace. If it doesn't exist yet, use the previous state
 		-- this formatting logic should match with the traceStatesKey function in the traceStateProcessor struct
 		local traceStateKey = string.format("%s:states", traceID)
@@ -1292,14 +1337,6 @@ const stateChangeScript = `
 	   local removed = redis.call('ZREM', string.format("%s:traces", currentState), traceID)
 
 	   local status = redis.call("HSET", string.format("%s:status", traceID), "State", nextState, "Timestamp", timestamp)
-
-	   -- add it to the result list
-	   table.insert(result, traceID)
-	until true
-  end
-
-
- return result
 `
 
 const validStateChangeEventsKey = "valid-state-change-events"

--- a/centralstore/smartwrapper.go
+++ b/centralstore/smartwrapper.go
@@ -158,9 +158,7 @@ func (w *SmartWrapper) manageTimeouts(ctx context.Context, timeout time.Duration
 	defer span.End()
 
 	// process up to 20% of the channel size
-	n := w.Config.GetCentralStoreOptions().SpanChannelSize * 20 / 100
-
-	st, err := w.BasicStore.GetTracesForState(ctx, fromState, n)
+	st, err := w.BasicStore.GetTracesForState(ctx, fromState, w.Config.GetCentralStoreOptions().StateBatchSize)
 	if err != nil {
 		span.RecordError(err)
 		return err

--- a/centralstore/smartwrapper.go
+++ b/centralstore/smartwrapper.go
@@ -157,7 +157,10 @@ func (w *SmartWrapper) manageTimeouts(ctx context.Context, timeout time.Duration
 	})
 	defer span.End()
 
-	st, err := w.BasicStore.GetTracesForState(ctx, fromState)
+	// process up to 20% of the channel size
+	n := w.Config.GetCentralStoreOptions().SpanChannelSize * 20 / 100
+
+	st, err := w.BasicStore.GetTracesForState(ctx, fromState, n)
 	if err != nil {
 		span.RecordError(err)
 		return err
@@ -255,8 +258,8 @@ func (w *SmartWrapper) GetStatusForTraces(ctx context.Context, traceIDs []string
 }
 
 // GetTracesForState returns a list of trace IDs that match the provided status.
-func (w *SmartWrapper) GetTracesForState(ctx context.Context, state CentralTraceState) ([]string, error) {
-	return w.BasicStore.GetTracesForState(ctx, state)
+func (w *SmartWrapper) GetTracesForState(ctx context.Context, state CentralTraceState, n int) ([]string, error) {
+	return w.BasicStore.GetTracesForState(ctx, state, n)
 }
 
 // GetTracesNeedingDecision returns a list of up to n trace IDs that are in the

--- a/centralstore/smartwrapper_test.go
+++ b/centralstore/smartwrapper_test.go
@@ -512,6 +512,6 @@ func BenchmarkStoreGetTracesForState(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		store.GetTracesForState(ctx, ReadyToDecide)
+		store.GetTracesForState(ctx, ReadyToDecide, -1)
 	}
 }

--- a/collect/central_collector_test.go
+++ b/collect/central_collector_test.go
@@ -1463,7 +1463,7 @@ func waitUntilReadyToDecide(t *testing.T, coll *CentralCollector, traceIDs []str
 	idMap := generics.NewSetWithCapacity[string](len(traceIDs))
 
 	require.Eventually(t, func() bool {
-		ids, err := coll.Store.GetTracesForState(ctx, centralstore.ReadyToDecide)
+		ids, err := coll.Store.GetTracesForState(ctx, centralstore.ReadyToDecide, 1000)
 		require.NoError(t, err)
 		idMap.Add(ids...)
 		return len(idMap.Members()) == len(traceIDs)

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -235,6 +235,7 @@ type SmartWrapperOptions struct {
 	SpanChannelSize    int      `yaml:"SpanChannelSize" default:"100"`
 	WriteSpanBatchSize int      `yaml:"WriteSpanBatchSize" default:"20"`
 	StateTicker        Duration `yaml:"StateTicker" default:"1s"`
+	StateBatchSize     int      `yaml:"StateBatchSize" default:"400"`
 	SendDelay          Duration `yaml:"SendDelay" default:"2s"`
 	TraceTimeout       Duration `yaml:"TraceTimeout" default:"60s"`
 	DecisionTimeout    Duration `yaml:"DecisionTimeout" default:"3s"`

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -1862,6 +1862,17 @@ groups:
           This setting controls the number of spans sent to the basic store at
           the same time when Refinery is processing incoming spans.
 
+      - name: StateBatchSize
+        firstVersion: v3.0
+        type: int
+        valuetype: nondefault
+        default: 400
+        reload: true
+        summary: is the maximum number of traces to be included for updating state of the central store in a single request.
+        description: >
+          This setting controls the number of traces sent to the central store at
+          the same time when Refinery is updating the state of the central store.
+
       - name: StateTicker
         firstVersion: v2.6
         type: duration

--- a/config/mock.go
+++ b/config/mock.go
@@ -580,5 +580,9 @@ func (f *MockConfig) GetCentralStoreOptions() SmartWrapperOptions {
 		f.StoreOptions.WriteSpanBatchSize = 20
 	}
 
+	if f.StoreOptions.StateBatchSize == 0 {
+		f.StoreOptions.StateBatchSize = 400
+	}
+
 	return f.StoreOptions
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

Currently, each refinery will retrieve all traces within a state to process them through the state machine in an interval. This approach creates a lot of duplicated work since multiple refineries can end up competing with each other on completing the task for the same trace ID.

## Short description of the changes

- Randomize the trace IDs handed to each refinery
- Process 20% of the total incoming traces on each state ticker
- make `GetTracesNeedingDecision` atomic through lua script

