### PR TITLE
feat: add metrics for alive and ready

### DIFF
--- a/collect/central_collector.go
+++ b/collect/central_collector.go
@@ -105,9 +105,9 @@ func (c *CentralCollector) Start() error {
 	collectorCfg := c.Config.GetCollectionConfig()
 
 	// we're a health check reporter so register ourselves for each of our major routines
-	c.Health.Register(receiverHealth, 2*c.Config.GetSendTickerValue())
-	c.Health.Register(deciderHealth, 2*collectorCfg.GetDeciderCycleDuration())
-	c.Health.Register(senderHealth, 2*collectorCfg.GetSenderCycleDuration())
+	c.Health.Register(receiverHealth, 5*c.Config.GetSendTickerValue())
+	c.Health.Register(deciderHealth, 5*collectorCfg.GetDeciderCycleDuration())
+	c.Health.Register(senderHealth, 5*collectorCfg.GetSenderCycleDuration())
 
 	c.done = make(chan struct{})
 
@@ -148,6 +148,9 @@ func (c *CentralCollector) Start() error {
 	c.Metrics.Register("decider_decided_per_second", "histogram")
 	c.Metrics.Register("decider_considered_per_second", "histogram")
 	c.Metrics.Register("sender_considered_per_second", "histogram")
+	c.Metrics.Register("collector_receiver_runs", "counter")
+	c.Metrics.Register("collector_sender_runs", "counter")
+	c.Metrics.Register("collector_decider_runs", "counter")
 
 	if c.Config.GetAddHostMetadataToTrace() {
 		if hostname, err := os.Hostname(); err == nil && hostname != "" {
@@ -366,6 +369,7 @@ func (c *CentralCollector) receive() error {
 		// record channel lengths as histogram but also as gauges
 		c.Metrics.Histogram("collector_incoming_queue", float64(len(c.incoming)))
 		c.Metrics.Gauge("collector_incoming_queue_length", float64(len(c.incoming)))
+		c.Metrics.Increment("collector_receiver_runs")
 		c.Health.Ready(receiverHealth, true)
 
 		select {
@@ -384,7 +388,6 @@ func (c *CentralCollector) receive() error {
 			}
 		case <-c.reload:
 			c.reloadConfig()
-			// reload config
 		}
 	}
 
@@ -400,6 +403,7 @@ func (c *CentralCollector) send() error {
 			}
 		}
 		c.Health.Ready(senderHealth, true)
+		c.Metrics.Increment("collector_sender_runs")
 
 		return nil
 	})
@@ -464,6 +468,7 @@ func (c *CentralCollector) decide() error {
 			}
 		}
 		c.Health.Ready(deciderHealth, true)
+		c.Metrics.Increment("collector_decider_runs")
 
 		return nil
 	})
@@ -587,6 +592,13 @@ func (c *CentralCollector) makeDecisions(ctx context.Context) error {
 
 		// make sampling decision and update the trace
 		rate, shouldSend, reason, key := sampler.GetSampleRate(tr)
+		otelutil.AddSpanFields(span, map[string]interface{}{
+			"trace_id": trace.TraceID,
+			"rate":     rate,
+			"keep":     shouldSend,
+			"reason":   reason,
+			"key":      key,
+		})
 		logFields["reason"] = reason
 		if key != "" {
 			logFields["sample_key"] = key

--- a/collect/stressRelief/stress_relief_redis.go
+++ b/collect/stressRelief/stress_relief_redis.go
@@ -106,7 +106,7 @@ func (s *StressRelief) Start() error {
 
 	s.eg = &errgroup.Group{}
 
-	s.Health.Register(stressReliefHealthSource, 2*calculationInterval)
+	s.Health.Register(stressReliefHealthSource, 5*calculationInterval)
 
 	s.RefineryMetrics.Register("cluster_stress_level", "gauge")
 	s.RefineryMetrics.Register("individual_stress_level", "gauge")

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -64,6 +64,13 @@ type Health struct {
 }
 
 func (h *Health) Start() error {
+	// if we don't have a logger or metrics object, we'll use the null ones (makes testing easier)
+	if h.Logger == nil {
+		h.Logger = &logger.NullLogger{}
+	}
+	if h.Metrics == nil {
+		h.Metrics = &metrics.NullMetrics{}
+	}
 	h.timeouts = make(map[string]time.Duration)
 	h.timeLeft = make(map[string]time.Duration)
 	h.readies = make(map[string]bool)

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/honeycombio/refinery/logger"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
 )
@@ -12,7 +13,8 @@ func TestHealthStartup(t *testing.T) {
 	// Create a new Health object
 	cl := clockwork.NewFakeClock()
 	h := &Health{
-		Clock: cl,
+		Logger: &logger.NullLogger{},
+		Clock:  cl,
 	}
 	// Start the Health object
 	h.Start()
@@ -28,7 +30,8 @@ func TestHealthRegistrationNotReady(t *testing.T) {
 	// Create a new Health object
 	cl := clockwork.NewFakeClock()
 	h := &Health{
-		Clock: cl,
+		Logger: &logger.NullLogger{},
+		Clock:  cl,
 	}
 	// Start the Health object
 	h.Start()
@@ -57,7 +60,8 @@ func TestHealthRegistrationAndReady(t *testing.T) {
 	// Create a new Health object
 	cl := clockwork.NewFakeClock()
 	h := &Health{
-		Clock: cl,
+		Logger: &logger.NullLogger{},
+		Clock:  cl,
 	}
 	// Start the Health object
 	h.Start()
@@ -94,7 +98,8 @@ func TestHealthReadyFalse(t *testing.T) {
 	// Create a new Health object
 	cl := clockwork.NewFakeClock()
 	h := &Health{
-		Clock: cl,
+		Logger: &logger.NullLogger{},
+		Clock:  cl,
 	}
 	// Start the Health object
 	h.Start()
@@ -121,7 +126,8 @@ func TestNotReadyFromOneService(t *testing.T) {
 	// Create a new Health object
 	cl := clockwork.NewFakeClock()
 	h := &Health{
-		Clock: cl,
+		Logger: &logger.NullLogger{},
+		Clock:  cl,
 	}
 	// Start the Health object
 	h.Start()

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/honeycombio/refinery/logger"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
 )
@@ -13,8 +12,7 @@ func TestHealthStartup(t *testing.T) {
 	// Create a new Health object
 	cl := clockwork.NewFakeClock()
 	h := &Health{
-		Logger: &logger.NullLogger{},
-		Clock:  cl,
+		Clock: cl,
 	}
 	// Start the Health object
 	h.Start()
@@ -30,8 +28,7 @@ func TestHealthRegistrationNotReady(t *testing.T) {
 	// Create a new Health object
 	cl := clockwork.NewFakeClock()
 	h := &Health{
-		Logger: &logger.NullLogger{},
-		Clock:  cl,
+		Clock: cl,
 	}
 	// Start the Health object
 	h.Start()
@@ -60,8 +57,7 @@ func TestHealthRegistrationAndReady(t *testing.T) {
 	// Create a new Health object
 	cl := clockwork.NewFakeClock()
 	h := &Health{
-		Logger: &logger.NullLogger{},
-		Clock:  cl,
+		Clock: cl,
 	}
 	// Start the Health object
 	h.Start()
@@ -98,8 +94,7 @@ func TestHealthReadyFalse(t *testing.T) {
 	// Create a new Health object
 	cl := clockwork.NewFakeClock()
 	h := &Health{
-		Logger: &logger.NullLogger{},
-		Clock:  cl,
+		Clock: cl,
 	}
 	// Start the Health object
 	h.Start()
@@ -126,8 +121,7 @@ func TestNotReadyFromOneService(t *testing.T) {
 	// Create a new Health object
 	cl := clockwork.NewFakeClock()
 	h := &Health{
-		Logger: &logger.NullLogger{},
-		Clock:  cl,
+		Clock: cl,
 	}
 	// Start the Health object
 	h.Start()

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -75,6 +75,11 @@ func ConvertNumeric(val interface{}) float64 {
 		return n
 	case float32:
 		return float64(n)
+	case bool:
+		if n {
+			return 1
+		}
+		return 0
 	default:
 		return 0
 	}

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -1,1 +1,33 @@
 package metrics
+
+import "testing"
+
+func TestConvertNumeric(t *testing.T) {
+	tests := []struct {
+		name string
+		val  any
+		want float64
+	}{
+		{"int", int(17), 17},
+		{"uint", uint(17), 17},
+		{"int64", int64(17), 17},
+		{"uint64", uint64(17), 17},
+		{"int32", int32(17), 17},
+		{"uint32", uint32(17), 17},
+		{"int16", int16(17), 17},
+		{"uint16", uint16(17), 17},
+		{"int8", int8(17), 17},
+		{"uint8", uint8(17), 17},
+		{"float64", float64(17), 17},
+		{"float32", float32(17), 17},
+		{"bool", true, 1},
+		{"bool", false, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ConvertNumeric(tt.val); got != tt.want {
+				t.Errorf("ConvertNumeric() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/route/route.go
+++ b/route/route.go
@@ -256,14 +256,9 @@ func (r *Router) Stop() error {
 
 func (r *Router) alive(w http.ResponseWriter, req *http.Request) {
 	r.iopLogger.Debug().Logf("answered /alive check")
+
 	alive := r.Health.IsAlive()
-
-	isalive := 0
-	if alive {
-		isalive = 1
-	}
-	r.Metrics.Gauge("is_alive", isalive)
-
+	r.Metrics.Gauge("is_alive", alive)
 	if !alive {
 		w.WriteHeader(http.StatusServiceUnavailable)
 		r.marshalToFormat(w, map[string]interface{}{"source": "refinery", "alive": "no"}, "json")
@@ -274,14 +269,9 @@ func (r *Router) alive(w http.ResponseWriter, req *http.Request) {
 
 func (r *Router) ready(w http.ResponseWriter, req *http.Request) {
 	r.iopLogger.Debug().Logf("answered /ready check")
+
 	ready := r.Health.IsReady()
-
-	isready := 0
-	if ready {
-		isready = 1
-	}
-	r.Metrics.Gauge("is_ready", isready)
-
+	r.Metrics.Gauge("is_ready", ready)
 	if !ready {
 		w.WriteHeader(http.StatusServiceUnavailable)
 		r.marshalToFormat(w, map[string]interface{}{"source": "refinery", "ready": "no"}, "json")


### PR DESCRIPTION
## Which problem is this PR solving?

- Refinery has endpoints for liveness and readiness, but wasn't putting those in metrics so we can see it in telemetry.

## Short description of the changes

- Add metrics for `is_alive` and `is_ready`
- Update those metrics both on hitting the endpoint and whenever we update the health
- Change `ConvertNumeric` function to accept bools, and add tests for it
- Adjust timing of health system internal ticker -- it needs to run more often than health check updates
- Add some logging to health system when things change, or when configuration errors occur

