### PR TITLE
fix: make sure we can retrieve trace decisions made during stress relief

### DIFF
--- a/centralstore/redis_store.go
+++ b/centralstore/redis_store.go
@@ -329,9 +329,7 @@ func (r *RedisBasicStore) GetStatusForTraces(ctx context.Context, traceIDs []str
 	for _, state := range statesToCheck {
 		validStates[state] = struct{}{}
 		// is any of the states we are looking for a decision state?
-		if (state == DecisionKeep || state == DecisionDrop) && !decisionMade {
-			decisionMade = true
-		}
+		decisionMade = decisionMade || state == DecisionKeep || state == DecisionDrop
 	}
 
 	statuses := make([]*CentralTraceStatus, 0, len(statusMapFromRedis))

--- a/centralstore/redis_store.go
+++ b/centralstore/redis_store.go
@@ -325,19 +325,52 @@ func (r *RedisBasicStore) GetStatusForTraces(ctx context.Context, traceIDs []str
 	}
 
 	validStates := make(map[CentralTraceState]struct{}, len(statesToCheck))
+	var decisionMade bool
 	for _, state := range statesToCheck {
 		validStates[state] = struct{}{}
+		if (state == DecisionKeep || state == DecisionDrop) && !decisionMade {
+			decisionMade = true
+		}
 	}
 
 	statuses := make([]*CentralTraceStatus, 0, len(statusMapFromRedis))
 	for _, status := range statusMapFromRedis {
-		// only include statuses that are in the statesToCheck list
+		// only include statuses that are in the statesToCheck list with one
+		// exception: if a trace decision is made during stress relief, we need to
+		// find the trace state from the decision cache instead of redis
 		_, ok := validStates[status.State]
 		if !ok {
+			if decisionMade {
+				//we still need to grab the trace state from decision cache since
+				// trace decisions are only stored in memory during stress relief
+				record, reason, found := r.DecisionCache.Test(status.TraceID)
+				if !found {
+					r.DecisionCache.Dropped(status.TraceID)
+					continue
+				}
+
+				if record.Kept() {
+					status.State = DecisionKeep
+					status.KeepReason = reason
+					status.Rate = record.Rate()
+					status.Count = uint32(record.DescendantCount())
+					status.EventCount = uint32(record.SpanEventCount())
+					status.LinkCount = uint32(record.SpanLinkCount())
+					statuses = append(statuses, status)
+				} else {
+					status.State = DecisionDrop
+					status.Count = uint32(record.DescendantCount())
+					status.EventCount = uint32(record.SpanEventCount())
+					status.LinkCount = uint32(record.SpanLinkCount())
+					statuses = append(statuses, status)
+				}
+
+			}
 			continue
 		}
 		statuses = append(statuses, status)
 	}
+
 	sort.SliceStable(statuses, func(i, j int) bool {
 		if statuses[i].Timestamp.IsZero() {
 			return false
@@ -514,11 +547,7 @@ func (r *RedisBasicStore) RecordTraceDecision(ctx context.Context, trace *Centra
 	_, span := r.Tracer.Start(ctx, "RecordTraceDecision")
 	defer span.End()
 
-	if keep {
-		r.DecisionCache.Record(trace, keep, reason)
-	} else {
-		r.DecisionCache.Dropped(trace.ID())
-	}
+	r.DecisionCache.Record(trace, keep, reason)
 
 	return nil
 }
@@ -783,7 +812,8 @@ func (t *tracesStore) getTraceStatuses(ctx context.Context, client redis.Client,
 			queries++
 			if err != nil {
 				if errors.Is(err, redis.ErrKeyNotFound) {
-					return nil
+					status.TraceID = traceID
+					return normalizeCentralTraceStatusRedis(status)
 				}
 				statusSpan.RecordError(err)
 				return nil

--- a/centralstore/redis_store.go
+++ b/centralstore/redis_store.go
@@ -328,6 +328,7 @@ func (r *RedisBasicStore) GetStatusForTraces(ctx context.Context, traceIDs []str
 	var decisionMade bool
 	for _, state := range statesToCheck {
 		validStates[state] = struct{}{}
+		// is any of the states we are looking for a decision state?
 		if (state == DecisionKeep || state == DecisionDrop) && !decisionMade {
 			decisionMade = true
 		}
@@ -335,8 +336,8 @@ func (r *RedisBasicStore) GetStatusForTraces(ctx context.Context, traceIDs []str
 
 	statuses := make([]*CentralTraceStatus, 0, len(statusMapFromRedis))
 	for _, status := range statusMapFromRedis {
-		// only include statuses that are in the statesToCheck list with one
-		// exception: if a trace decision is made during stress relief, we need to
+		// only include statuses that are in the statesToCheck list.
+		// exception: if a trace decision was made during stress relief, we need to
 		// find the trace state from the decision cache instead of redis
 		_, ok := validStates[status.State]
 		if !ok {

--- a/centralstore/redis_store_test.go
+++ b/centralstore/redis_store_test.go
@@ -149,6 +149,35 @@ func TestRedisBasicStore_GetTrace(t *testing.T) {
 	assert.EqualValues(t, testSpans[1], trace.Root)
 }
 
+func TestRedisBasicStore_GetStatusForTraces(t *testing.T) {
+	ctx := context.Background()
+	store := NewTestRedisBasicStore(ctx, t)
+	defer store.Stop()
+
+	traceID := "traceID0"
+
+	// before the trace is stored in redis, we should get no status
+	status, err := store.GetStatusForTraces(ctx, []string{traceID}, Collecting)
+	require.NoError(t, err)
+
+	require.Len(t, status, 0)
+
+	store.ensureInitialState(t, ctx, store.RedisClient.Get(), traceID, Collecting)
+
+	// after the trace is stored in redis, we should get the status for the state we expect
+	status, err = store.GetStatusForTraces(ctx, []string{traceID}, Collecting, AwaitingDecision)
+	require.NoError(t, err)
+	require.Len(t, status, 1)
+	assert.Equal(t, Collecting, status[0].State)
+	assert.Equal(t, traceID, status[0].TraceID)
+	assert.Equal(t, uint32(1), status[0].DescendantCount())
+
+	// when we ask for a state that the trace doesn't belong to, we should get no status
+	status, err = store.GetStatusForTraces(ctx, []string{traceID}, AwaitingDecision)
+	require.NoError(t, err)
+	require.Len(t, status, 0)
+}
+
 func TestRedisBasicStore_applyStateChange_NoTraces(t *testing.T) {
 	ctx := context.Background()
 	testRedis := &redis.TestService{}
@@ -463,6 +492,36 @@ func TestRedisBasicStore_GetMetrics(t *testing.T) {
 	assert.EqualValues(t, 0, count)
 
 	require.NotEmpty(t, store.lastMetricsRecorded)
+}
+
+func TestRedisBasicStore_RecordTraceDecision(t *testing.T) {
+	ctx := context.Background()
+	store := NewTestRedisBasicStore(ctx, t)
+	defer store.Stop()
+
+	keepTraceID := "traceID0"
+	dropTraceID := "traceID1"
+
+	err := store.RecordTraceDecision(ctx, &CentralTraceStatus{TraceID: keepTraceID, State: DecisionKeep, KeepReason: "test"}, true, "kept")
+	require.NoError(t, err)
+	err = store.RecordTraceDecision(ctx, &CentralTraceStatus{TraceID: dropTraceID, State: DecisionDrop}, false, "dropped")
+	require.NoError(t, err)
+
+	conn := store.RedisClient.Get()
+	defer conn.Close()
+
+	status, err := store.GetStatusForTraces(ctx, []string{keepTraceID, dropTraceID}, DecisionKeep, DecisionDrop)
+	require.NoError(t, err)
+	require.Len(t, status, 2)
+	for _, s := range status {
+		if s.TraceID == keepTraceID {
+			assert.Equal(t, DecisionKeep, s.State)
+			assert.Equal(t, "kept", s.KeepReason)
+		} else if s.TraceID == dropTraceID {
+			assert.Equal(t, DecisionDrop, s.State)
+		}
+	}
+
 }
 
 func TestRedisBasicStore_ValidStateTransition(t *testing.T) {

--- a/collect/central_collector.go
+++ b/collect/central_collector.go
@@ -309,10 +309,15 @@ func (c *CentralCollector) ProcessSpanImmediately(sp *types.Span) (bool, error) 
 	})
 
 	status := &centralstore.CentralTraceStatus{
-		TraceID:    sp.TraceID,
-		State:      centralstore.DecisionKeep,
-		Rate:       rate,
-		KeepReason: reason,
+		TraceID: sp.TraceID,
+	}
+
+	if keep {
+		status.State = centralstore.DecisionKeep
+		status.KeepReason = reason
+		status.Rate = rate
+	} else {
+		status.State = centralstore.DecisionDrop
 	}
 
 	err := c.Store.RecordTraceDecision(ctx, status, keep, reason)


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

When a late span comes in after stress relief made a decision for the trace it belongs to, we should still be able to make the same decision for that late span. 
This will only works if there's no restart between the stress relief decision is made and the late span arrival. 
## Short description of the changes

- Retrieve trace decision from decision cache in `GetStatusForTraces`
- Correctly record trace decision during stress relief
- add tests

