### PR TITLE
feat: Add new ticker for memory check cycle

### DIFF
--- a/collect/central_collector.go
+++ b/collect/central_collector.go
@@ -363,6 +363,9 @@ func (c *CentralCollector) AddSpan(span *types.Span) error {
 
 func (c *CentralCollector) receive() error {
 	tickerDuration := time.Duration(c.Config.GetCollectionConfig().MemoryCycleDuration)
+	if tickerDuration <= 0 {
+		tickerDuration = 1 * time.Second
+	}
 	memTicker := c.Clock.NewTicker(tickerDuration)
 	defer memTicker.Stop()
 

--- a/collect/central_collector.go
+++ b/collect/central_collector.go
@@ -362,9 +362,9 @@ func (c *CentralCollector) AddSpan(span *types.Span) error {
 }
 
 func (c *CentralCollector) receive() error {
-	tickerDuration := c.Config.GetSendTickerValue()
-	ticker := c.Clock.NewTicker(tickerDuration)
-	defer ticker.Stop()
+	tickerDuration := time.Duration(c.Config.GetCollectionConfig().MemoryCycleDuration)
+	memTicker := c.Clock.NewTicker(tickerDuration)
+	defer memTicker.Stop()
 
 	if c.blockOnCollect {
 		return nil
@@ -380,7 +380,7 @@ func (c *CentralCollector) receive() error {
 		select {
 		case <-c.done:
 			return nil
-		case <-ticker.Chan():
+		case <-memTicker.Chan():
 			c.checkAlloc()
 
 		case sp, ok := <-c.incoming:

--- a/collect/central_collector_test.go
+++ b/collect/central_collector_test.go
@@ -1403,6 +1403,10 @@ func startCollector(t *testing.T, cfg *config.MockConfig, collector *CentralColl
 		cfg.GetTraceTimeoutVal = time.Duration(500 * time.Microsecond)
 	}
 
+	if cfg.GetCollectionConfigVal.MemoryCycleDuration == 0 {
+		cfg.GetCollectionConfigVal.MemoryCycleDuration = duration("1s")
+	}
+
 	collector.isTest = true
 	var basicStore centralstore.BasicStorer
 	switch storeType {

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -229,6 +229,7 @@ type CollectionConfig struct {
 	MaxMemoryPercentage     int        `yaml:"MaxMemoryPercentage" default:"75"`
 	MaxAlloc                MemorySize `yaml:"MaxAlloc"`
 	ShutdownDelay           Duration   `yaml:"ShutdownDelay" default:"30s"`
+	MemoryCycleDuration     Duration   `yaml:"MemoryCycleDuration" default:"10s"`
 }
 
 type SmartWrapperOptions struct {

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -1317,6 +1317,8 @@ groups:
         type: duration
         valuetype: nondefault
         default: 10s
+        validations:
+          - type: nonzero
         reload: false
         summary: is the cycle time between memory checks.
         description: >

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -1313,6 +1313,18 @@ groups:
           normal timeout period for shutting down without forcibly terminating
           the process.
 
+      - name: MemoryCycleDuration
+        type: duration
+        valuetype: nondefault
+        default: 10s
+        reload: false
+        summary: is the cycle time between memory checks.
+        description: >
+          This setting controls the amount of time that Refinery waits between
+          checking its memory usage. This is somewhat expensive, so it's best
+          not to do it too often, but in situations where bursts of traffic can
+          cause memory pressure, it can be useful to check more frequently.
+
   - name: BufferSizes
     title: "Buffer Sizes"
     description: >

--- a/config/mock.go
+++ b/config/mock.go
@@ -121,6 +121,10 @@ func (m *MockConfig) GetCollectionConfig() CollectionConfig {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
+	v := m.GetCollectionConfigVal
+	if v.MemoryCycleDuration == 0 {
+		v.MemoryCycleDuration = Duration(1 * time.Second)
+	}
 	return m.GetCollectionConfigVal
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?

- The memory checker is running runtime.GC() very frequently (many times per second). We think this may be causing problems.

## Short description of the changes

- Create a new configuration to split off the memory checker's cycle time to a new config value
- Set it to 10s by default
- Document the setting
- Make sure it's nonzero

