### PR TITLE
feat: expire keys in redis based on TraceTimeout

### DIFF
--- a/centralstore/redis_store.go
+++ b/centralstore/redis_store.go
@@ -21,6 +21,9 @@ import (
 )
 
 const (
+	// if a new refinery is started after the trace has passed its trace retention time,
+	// a late span could be sent to the new refinery. The new refinery will not have the trace
+	// decision in memory, so it may make a different decision than the original refinery.
 	defaultTraceRetention  = 15 * time.Minute
 	defaultReaperBatchSize = 400
 	redigoTimestamp        = "2006-01-02 15:04:05.999999 -0700 MST"

--- a/centralstore/redis_store_test.go
+++ b/centralstore/redis_store_test.go
@@ -622,7 +622,6 @@ type TestRedisBasicStore struct {
 func NewTestRedisBasicStore(ctx context.Context, t *testing.T) *TestRedisBasicStore {
 	cfg := config.MockConfig{
 		StoreOptions: config.SmartWrapperOptions{
-			MaxTraceRetention: duration("1m"),
 			ReaperRunInterval: duration("1m"),
 		},
 		SampleCache: config.SampleCacheConfig{

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -241,7 +241,6 @@ type SmartWrapperOptions struct {
 	SendDelay          Duration `yaml:"SendDelay" default:"2s"`
 	TraceTimeout       Duration `yaml:"TraceTimeout" default:"60s"`
 	DecisionTimeout    Duration `yaml:"DecisionTimeout" default:"3s"`
-	MaxTraceRetention  Duration `yaml:"MaxTraceRetention" default:"24h"`
 	ReaperRunInterval  Duration `yaml:"ReaperRunInterval" default:"1h"`
 }
 

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -300,7 +300,7 @@ groups:
           the root span) arrive, they will be kept or dropped based on the
           original decision. 
 
-          When running Refinery with Redis as the central store, this timer is 
+          When running Refinery with Redis as the central store, this timer is
           also used to determine how long to keep trace decisions in Redis.
           Refinery will keep trace decisions in Redis for 10 times the value of
           this timer or 15 minutes, whichever is greater.

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -298,7 +298,12 @@ groups:
           After the trace decision has been made, Refinery retains a record of
           that decision for a period of time. When additional spans (including
           the root span) arrive, they will be kept or dropped based on the
-          original decision.
+          original decision. 
+
+          When running Refinery with Redis as the central store, this timer is 
+          also used to determine how long to keep trace decisions in Redis.
+          Refinery will keep trace decisions in Redis for 10 times the value of
+          this timer or 15 minutes, whichever is greater.
 
           If particularly long-lived traces are present in your data, then you
           should increase this timer. Note that this increase will also

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -1963,19 +1963,6 @@ groups:
           happen is if a Refinery crashes or is forcibly shut down. TODO: not
           sure we need to expose this.
 
-      - name: MaxTraceRetention
-        firstVersion: v2.6
-        type: duration
-        valuetype: nondefault
-        default: 24h
-        reload: true
-        summary: is the maximum duration for which a trace is retained in the central store.
-        description: >
-          This value determines how long traces are retained in the central
-          store as a hedge against a potential memory leak. Traces older than
-          this value will be deleted. Under normal operation, this timeout
-          should never be invoked. TODO: don't expose this?
-
       - name: ReaperRunInterval
         firstVersion: v2.6
         type: duration


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

Redis memory usage was growing faster than the rate of cleanup from refinery.

## Short description of the changes

- Set the expiration time for a key to be minimum 15 minutes or 10 times of user defined TraceTimeout

