### PR TITLE
fix: make sure we record critical errors

### DIFF
--- a/centralstore/redis_store.go
+++ b/centralstore/redis_store.go
@@ -434,7 +434,9 @@ func (r *RedisBasicStore) GetTracesNeedingDecision(ctx context.Context, n int) (
 	}
 
 	if len(traceIDs) == 0 {
-		return nil, errors.New("failed to get traces for needing decisions")
+		err := errors.New("failed to get traces for needing decisions")
+		span.RecordError(err)
+		return nil, err
 	}
 
 	return traceIDs, nil
@@ -1230,7 +1232,9 @@ func (t *traceStateProcessor) applyStateChange(ctx context.Context, conn redis.C
 	}
 
 	if len(result) == 0 {
-		return nil, fmt.Errorf("failed to apply state change %s for traces %v", stateChange.string(), traceIDs)
+		err := fmt.Errorf("failed to apply state change %s for traces %v", stateChange.string(), traceIDs)
+		span.RecordError(err)
+		return nil, err
 	}
 	otelutil.AddSpanFields(span, map[string]interface{}{
 		"result": result,

--- a/centralstore/smartwrapper.go
+++ b/centralstore/smartwrapper.go
@@ -139,7 +139,7 @@ func (w *SmartWrapper) processSpans(ctx context.Context) {
 		w.Metrics.Gauge("smartstore_write_span_batch_count", len(spans))
 		err := w.BasicStore.WriteSpans(ctx, spans)
 		if err != nil {
-			w.Logger.Debug().Logf("error writing span: %s", err)
+			w.Logger.Error().Logf("error writing span: %s", err)
 		}
 	}
 

--- a/collect/central_collector.go
+++ b/collect/central_collector.go
@@ -505,6 +505,7 @@ func (c *CentralCollector) makeDecisions(ctx context.Context) error {
 	defer span.End()
 	tracesIDs, err := c.Store.GetTracesNeedingDecision(ctx, c.Config.GetCollectionConfig().GetDeciderBatchSize())
 	if err != nil {
+		span.RecordError(err)
 		return err
 	}
 


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

When refinery has issue communicating with Redis, we need to record the error message to help with debugging issues.

## Short description of the changes

- record errors in span
- change log level to error for `WriteSpans`

