### PR TITLE
fix: Update cache lookup to use read lock

### DIFF
--- a/route/route.go
+++ b/route/route.go
@@ -769,17 +769,20 @@ type cacheItem struct {
 // get queries the cached items, returning cache hits that have not expired.
 // Cache missed use the configured getFn to populate the cache.
 func (c *environmentCache) get(key string) (string, error) {
+	var val string
 	// get read lock so that we don't attempt to read from the map
 	// while another routine has a write lock and is actively writing
 	// to the map.
 	c.mutex.RLock()
 	if item, ok := c.items[key]; ok {
 		if time.Now().Before(item.expiresAt) {
-			c.mutex.RUnlock()
-			return item.value, nil
+			val = item.value
 		}
 	}
 	c.mutex.RUnlock()
+	if val != "" {
+		return val, nil
+	}
 
 	// get write lock early so we don't execute getFn in parallel so the
 	// the result will be cached before the next lock is acquired to prevent


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- #1144 

## Short description of the changes

- Within the `get` method of an `environmentCache`, a read lock is added around read access to the `items` map within the environment cache. It is possible for one routine to hold a write lock within this function while another routine enters the function and attempts to read from the map while the other routine is writing to it.

