### PR TITLE
fix: Update cache lookup to use read lock (#1145)

### DIFF
--- a/route/route.go
+++ b/route/route.go
@@ -782,10 +782,19 @@ type cacheItem struct {
 // get queries the cached items, returning cache hits that have not expired.
 // Cache missed use the configured getFn to populate the cache.
 func (c *environmentCache) get(key string) (string, error) {
+	var val string
+	// get read lock so that we don't attempt to read from the map
+	// while another routine has a write lock and is actively writing
+	// to the map.
+	c.mutex.RLock()
 	if item, ok := c.items[key]; ok {
 		if time.Now().Before(item.expiresAt) {
-			return item.value, nil
+			val = item.value
 		}
+	}
+	c.mutex.RUnlock()
+	if val != "" {
+		return val, nil
 	}
 
 	// get write lock early so we don't execute getFn in parallel so the


### PR DESCRIPTION
## Which problem is this PR solving?

- #1144 

## Short description of the changes

- Within the `get` method of an `environmentCache`, a read lock is added around read access to the `items` map within the environment cache. It is possible for one routine to hold a write lock within this function while another routine enters the function and attempts to read from the map while the other routine is writing to it.

*NOTE*: Copying commit into 2.x release branch