### PR TITLE
fix: decrease network traffic from redis

### DIFF
--- a/centralstore/redis_store_test.go
+++ b/centralstore/redis_store_test.go
@@ -729,7 +729,9 @@ func newTestTraceStateProcessor(_ *testing.T, redisClient redis.Client, clock cl
 	}
 	ts := &testTraceStateProcessor{
 		traceStateProcessor: newTraceStateProcessor(traceStateProcessorConfig{
-			changeState: redisClient.NewScript(stateChangeKey, stateChangeScript),
+			changeState:             redisClient.NewScript(stateChangeKey, stateChangeScript),
+			getTraceNeedingDecision: redisClient.NewScript(tracesNeedingDecisionScriptKey, tracesNeedingDecisionScript),
+			removeExpiredTraces:     redisClient.NewScript(removeExpiredTracesKey, removeExpiredTracesScript),
 		}, clock, tracer),
 		clock: clock,
 	}

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -241,7 +241,8 @@ type SmartWrapperOptions struct {
 	SendDelay          Duration `yaml:"SendDelay" default:"2s"`
 	TraceTimeout       Duration `yaml:"TraceTimeout" default:"60s"`
 	DecisionTimeout    Duration `yaml:"DecisionTimeout" default:"3s"`
-	ReaperRunInterval  Duration `yaml:"ReaperRunInterval" default:"1h"`
+	ReaperRunInterval  Duration `yaml:"ReaperRunInterval" default:"10s"`
+	ReaperBatchSize    int      `yaml:"ReaperBatchSize" default:"500"`
 }
 
 func (c CollectionConfig) GetShutdownDelay() time.Duration {

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -1981,7 +1981,7 @@ groups:
         type: duration
         valuetype: nondefault
         default: 500
-        reload: false
+        reload: true
         summary: is the maximum number of traces to be included for deleting expired traces in a single request.
         description: >
           This value determines how many traces the reaper will delete in a single

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -298,7 +298,7 @@ groups:
           After the trace decision has been made, Refinery retains a record of
           that decision for a period of time. When additional spans (including
           the root span) arrive, they will be kept or dropped based on the
-          original decision. 
+          original decision.
 
           When running Refinery with Redis as the central store, this timer is
           also used to determine how long to keep trace decisions in Redis.
@@ -1104,7 +1104,6 @@ groups:
           metrics from Redis server. It may be useful to increase this value in
           high-throughput environments. By setting this value to 0, the metrics
           retrieval will be disabled.
-
 
       - name: Strategy
         v1group: PeerManagement
@@ -1970,9 +1969,20 @@ groups:
         firstVersion: v2.6
         type: duration
         valuetype: nondefault
-        default: 1h
+        default: 10s
         reload: true
         summary: is the interval at which the reaper runs to clean up expired traces.
         description: >
           This value determines how often the reaper runs to clean up expired traces
           in the central store. TODO: don't expose this?
+
+      - name: ReaperBatchSize
+        firstVersion: v3.0
+        type: duration
+        valuetype: nondefault
+        default: 500
+        reload: false
+        summary: is the maximum number of traces to be included for deleting expired traces in a single request.
+        description: >
+          This value determines how many traces the reaper will delete in a single
+          request.

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -1957,7 +1957,7 @@ groups:
         type: duration
         valuetype: nondefault
         default: 3s
-        reload: true
+        reload: false
         summary: is the time the central store will wait to receive a trace decision from Refinery
         description: >
           This value controls how long the central store will wait for a trace
@@ -1970,7 +1970,7 @@ groups:
         type: duration
         valuetype: nondefault
         default: 10s
-        reload: true
+        reload: false
         summary: is the interval at which the reaper runs to clean up expired traces.
         description: >
           This value determines how often the reaper runs to clean up expired traces
@@ -1981,7 +1981,7 @@ groups:
         type: duration
         valuetype: nondefault
         default: 500
-        reload: true
+        reload: false
         summary: is the maximum number of traces to be included for deleting expired traces in a single request.
         description: >
           This value determines how many traces the reaper will delete in a single


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

Turns out transmitting trace IDs back and forth between redis and refinery is very expensive.

## Short description of the changes

- Use `ZCOUNT` to get the amount of traces in a given state list instead of `ZRANGE` so that we are only returning a integer value from redis
- Use lua script for deleting expired traces in state lists to avoid returning trace IDs from redis to refinery during cleanup

