### PR TITLE
fix: ReaperBatchSize should be a int type

### DIFF
--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -1978,7 +1978,7 @@ groups:
 
       - name: ReaperBatchSize
         firstVersion: v3.0
-        type: duration
+        type: int
         valuetype: nondefault
         default: 500
         reload: false


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- the configMeta type for ReaperBatchSize was wrong

## Short description of the changes

-

