### PR TITLE
fix: no need to store decisions in a list in redis

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.22
+golang 1.22.3


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

A trace state is stored in two data structures in redis currently, one in a hash table with the rest of the `CentralTraceStatus` information, another one in a sorted set. The sorted set is used for `GetTracesForState` so that Refinery can quickly get all trace IDs within a state. Refinery never retrieves a list of trace IDs that has their sampling decisions already made. Therefore, we actually don't need to store than in a sorted set form anymore

This should further reduce our Redis memory usage.

## Short description of the changes

- don't store trace IDs in a state if it's decision is already made

