### PR TITLE
fix: gossip into channels instead of callbacks

### DIFF
--- a/collect/stressRelief/stress_relief_redis.go
+++ b/collect/stressRelief/stress_relief_redis.go
@@ -46,6 +46,7 @@ type StressRelief struct {
 	stayOnUntil        time.Time
 	minDuration        time.Duration
 	identification     string
+	stressGossipCh     chan []byte
 
 	eg *errgroup.Group
 
@@ -104,46 +105,59 @@ func (s *StressRelief) Start() error {
 	s.stressLevels = make(map[string]stressReport)
 	s.done = make(chan struct{})
 
-	s.eg = &errgroup.Group{}
-
 	s.Health.Register(stressReliefHealthSource, 5*calculationInterval)
 
 	s.RefineryMetrics.Register("cluster_stress_level", "gauge")
 	s.RefineryMetrics.Register("individual_stress_level", "gauge")
 	s.RefineryMetrics.Register("stress_relief_activated", "gauge")
 
-	if err := s.Gossip.Subscribe("stress_level", s.onStressLevelMessage); err != nil {
-		return err
-	}
-
-	// start our monitor goroutine that periodically calls recalc
-	s.eg.Go(func() error {
-		tick := time.NewTicker(calculationInterval)
-		defer tick.Stop()
-		for {
-			select {
-			case <-tick.C:
-				currentLevel := s.Recalc()
-				// publish the stress level to the rest of the cluster
-				msg := stressLevelMessage{
-					level: currentLevel,
-					id:    s.identification,
-				}
-				err := s.Gossip.Publish("stress_level", msg.ToBytes())
-				if err != nil {
-					s.Logger.Error().Logf("error publishing stress level: %s", err)
-				} else {
-					s.Health.Ready(stressReliefHealthSource, true)
-				}
-			case <-s.done:
-				s.Logger.Debug().Logf("Stopping StressRelief system")
-				return nil
-			}
-		}
-
-	})
+	s.stressGossipCh = s.Gossip.SubscribeChan("stress_level", 20)
+	s.eg = &errgroup.Group{}
+	s.eg.Go(s.monitor)
 
 	return nil
+}
+
+func (s *StressRelief) monitor() error {
+	tick := time.NewTicker(calculationInterval)
+	defer tick.Stop()
+	for {
+		select {
+		case <-tick.C:
+			currentLevel := s.Recalc()
+			// publish the stress level to the rest of the cluster
+			msg := stressLevelMessage{
+				level: currentLevel,
+				id:    s.identification,
+			}
+			err := s.Gossip.Publish("stress_level", msg.ToBytes())
+			if err != nil {
+				s.Logger.Error().Logf("error publishing stress level: %s", err)
+			} else {
+				s.Health.Ready(stressReliefHealthSource, true)
+			}
+
+		case data := <-s.stressGossipCh:
+			msg, err := newMessageFromBytes(data)
+			if err != nil {
+				s.Logger.Error().Logf("error parsing stress level message: %s", err)
+				continue
+			}
+
+			s.lock.Lock()
+			s.stressLevels[msg.id] = stressReport{
+				key:       msg.id,
+				level:     msg.level,
+				timestamp: s.Clock.Now(),
+			}
+			s.lock.Unlock()
+
+		case <-s.done:
+			s.Logger.Debug().Logf("Stopping StressRelief system")
+			return nil
+		}
+	}
+
 }
 
 func (s *StressRelief) Stop() error {
@@ -309,22 +323,6 @@ func (s *StressRelief) deterministicFraction() uint {
 
 	// round to the nearest integer
 	return uint(float64(s.overallStressLevel-s.activateLevel)/float64(100-s.activateLevel)*100 + 0.5)
-}
-
-func (s *StressRelief) onStressLevelMessage(data []byte) {
-	msg, err := newMessageFromBytes(data)
-	if err != nil {
-		s.Logger.Error().Logf("error parsing stress level message: %s", err)
-		return
-	}
-
-	s.lock.Lock()
-	s.stressLevels[msg.id] = stressReport{
-		key:       msg.id,
-		level:     msg.level,
-		timestamp: s.Clock.Now(),
-	}
-	s.lock.Unlock()
 }
 
 type stressReport struct {

--- a/collect/stressRelief/stress_relief_redis.go
+++ b/collect/stressRelief/stress_relief_redis.go
@@ -111,7 +111,7 @@ func (s *StressRelief) Start() error {
 	s.RefineryMetrics.Register("individual_stress_level", "gauge")
 	s.RefineryMetrics.Register("stress_relief_activated", "gauge")
 
-	s.stressGossipCh = s.Gossip.SubscribeChan("stress_level", 20)
+	s.stressGossipCh = s.Gossip.Subscribe("stress_level", 20)
 	s.eg = &errgroup.Group{}
 	s.eg.Go(s.monitor)
 

--- a/internal/gossip/gossip.go
+++ b/internal/gossip/gossip.go
@@ -2,10 +2,8 @@ package gossip
 
 import (
 	"bytes"
-	"errors"
 
 	"github.com/facebookgo/startstop"
-	"golang.org/x/sync/errgroup"
 )
 
 // Gossiper is an interface for broadcasting messages to all receivers
@@ -19,73 +17,6 @@ type Gossiper interface {
 
 	startstop.Starter
 	startstop.Stopper
-}
-
-var _ Gossiper = &InMemoryGossip{}
-
-// InMemoryGossip is a Gossiper that uses an in-memory channel
-type InMemoryGossip struct {
-	channel     chan []byte
-	subscribers map[string][]func(data []byte)
-
-	done chan struct{}
-	eg   *errgroup.Group
-}
-
-func (g *InMemoryGossip) Publish(channel string, value []byte) error {
-	msg := message{
-		key:  channel,
-		data: value,
-	}
-
-	select {
-	case <-g.done:
-		return errors.New("gossip has been stopped")
-	case g.channel <- msg.ToBytes():
-	default:
-	}
-	return nil
-}
-
-func (g *InMemoryGossip) Subscribe(channel string, callback func(data []byte)) error {
-	select {
-	case <-g.done:
-		return errors.New("gossip has been stopped")
-	default:
-	}
-
-	g.subscribers[channel] = append(g.subscribers[channel], callback)
-	return nil
-}
-
-func (g *InMemoryGossip) Start() error {
-	g.channel = make(chan []byte, 10)
-	g.eg = &errgroup.Group{}
-	g.subscribers = make(map[string][]func(data []byte))
-	g.done = make(chan struct{})
-
-	g.eg.Go(func() error {
-		for {
-			select {
-			case <-g.done:
-				return nil
-			case value := <-g.channel:
-				msg := newMessageFromBytes(value)
-				callbacks := g.subscribers[msg.key]
-
-				for _, cb := range callbacks {
-					cb(msg.data)
-				}
-			}
-		}
-	})
-
-	return nil
-}
-func (g *InMemoryGossip) Stop() error {
-	close(g.done)
-	close(g.channel)
-	return g.eg.Wait()
 }
 
 type message struct {

--- a/internal/gossip/gossip.go
+++ b/internal/gossip/gossip.go
@@ -12,10 +12,10 @@ type Gossiper interface {
 	// Publish sends a message to all peers listening on the channel
 	Publish(channel string, value []byte) error
 
-	// SubscribeChan returns a Go channel that will receive messages from the Gossip channel
+	// Subscribe returns a Go channel that will receive messages from the Gossip channel
 	// (Redis already called the thing we listen to a channel, so we have to live with that)
 	// The channel has a buffer of depth; if the buffer is full, messages will be dropped.
-	SubscribeChan(channel string, depth int) chan []byte
+	Subscribe(channel string, depth int) chan []byte
 
 	startstop.Starter
 	startstop.Stopper

--- a/internal/gossip/gossip.go
+++ b/internal/gossip/gossip.go
@@ -15,6 +15,11 @@ type Gossiper interface {
 	// Subscribe listens for messages on the channel
 	Subscribe(channel string, callback func(data []byte)) error
 
+	// SubscribeChan returns a Go channel that will receive messages from the Gossip channel
+	// (Redis already called the thing we listen to a channel, so we have to live with that)
+	// The channel has a buffer of depth; if the buffer is full, messages will be dropped.
+	SubscribeChan(channel string, depth int) chan []byte
+
 	startstop.Starter
 	startstop.Stopper
 }

--- a/internal/gossip/gossip.go
+++ b/internal/gossip/gossip.go
@@ -12,9 +12,6 @@ type Gossiper interface {
 	// Publish sends a message to all peers listening on the channel
 	Publish(channel string, value []byte) error
 
-	// Subscribe listens for messages on the channel
-	Subscribe(channel string, callback func(data []byte)) error
-
 	// SubscribeChan returns a Go channel that will receive messages from the Gossip channel
 	// (Redis already called the thing we listen to a channel, so we have to live with that)
 	// The channel has a buffer of depth; if the buffer is full, messages will be dropped.

--- a/internal/gossip/gossip_inmem.go
+++ b/internal/gossip/gossip_inmem.go
@@ -32,7 +32,7 @@ func (g *InMemoryGossip) Publish(channel string, value []byte) error {
 		return errors.New("gossip has been stopped")
 	case g.gossipCh <- msg.ToBytes():
 	default:
-		g.Logger.Debug().WithFields(map[string]interface{}{
+		g.Logger.Warn().WithFields(map[string]interface{}{
 			"channel": channel,
 			"msg":     string(value),
 		}).Logf("Unable to publish message")
@@ -73,7 +73,7 @@ func (g *InMemoryGossip) Start() error {
 					select {
 					case ch <- msg.data:
 					default:
-						g.Logger.Debug().WithFields(map[string]interface{}{
+						g.Logger.Warn().WithFields(map[string]interface{}{
 							"channel": msg.key,
 							"msg":     string(msg.data),
 						}).Logf("Unable to forward message")

--- a/internal/gossip/gossip_inmem.go
+++ b/internal/gossip/gossip_inmem.go
@@ -1,0 +1,74 @@
+package gossip
+
+import (
+	"errors"
+
+	"golang.org/x/sync/errgroup"
+)
+
+// InMemoryGossip is a Gossiper that uses an in-memory channel
+type InMemoryGossip struct {
+	channel     chan []byte
+	subscribers map[string][]func(data []byte)
+
+	done chan struct{}
+	eg   *errgroup.Group
+}
+
+var _ Gossiper = &InMemoryGossip{}
+
+func (g *InMemoryGossip) Publish(channel string, value []byte) error {
+	msg := message{
+		key:  channel,
+		data: value,
+	}
+
+	select {
+	case <-g.done:
+		return errors.New("gossip has been stopped")
+	case g.channel <- msg.ToBytes():
+	default:
+	}
+	return nil
+}
+
+func (g *InMemoryGossip) Subscribe(channel string, callback func(data []byte)) error {
+	select {
+	case <-g.done:
+		return errors.New("gossip has been stopped")
+	default:
+	}
+
+	g.subscribers[channel] = append(g.subscribers[channel], callback)
+	return nil
+}
+
+func (g *InMemoryGossip) Start() error {
+	g.channel = make(chan []byte, 10)
+	g.eg = &errgroup.Group{}
+	g.subscribers = make(map[string][]func(data []byte))
+	g.done = make(chan struct{})
+
+	g.eg.Go(func() error {
+		for {
+			select {
+			case <-g.done:
+				return nil
+			case value := <-g.channel:
+				msg := newMessageFromBytes(value)
+				callbacks := g.subscribers[msg.key]
+
+				for _, cb := range callbacks {
+					cb(msg.data)
+				}
+			}
+		}
+	})
+
+	return nil
+}
+func (g *InMemoryGossip) Stop() error {
+	close(g.done)
+	close(g.channel)
+	return g.eg.Wait()
+}

--- a/internal/gossip/gossip_redis.go
+++ b/internal/gossip/gossip_redis.go
@@ -2,7 +2,6 @@ package gossip
 
 import (
 	"errors"
-	"fmt"
 	"sync"
 
 	"github.com/facebookgo/startstop"
@@ -54,7 +53,10 @@ func (g *GossipRedis) Start() error {
 						select {
 						case ch <- msg.data:
 						default:
-							fmt.Println("dropped message", msg.key, string(msg.data))
+							g.Logger.Debug().WithFields(map[string]interface{}{
+								"channel": msg.key,
+								"msg":     string(msg.data),
+							}).Logf("Unable to forward message")
 						}
 					}
 				}, g.done, "refinery-gossip")

--- a/internal/gossip/gossip_redis.go
+++ b/internal/gossip/gossip_redis.go
@@ -53,7 +53,7 @@ func (g *GossipRedis) Start() error {
 						select {
 						case ch <- msg.data:
 						default:
-							g.Logger.Debug().WithFields(map[string]interface{}{
+							g.Logger.Warn().WithFields(map[string]interface{}{
 								"channel": msg.key,
 								"msg":     string(msg.data),
 							}).Logf("Unable to forward message")
@@ -61,7 +61,7 @@ func (g *GossipRedis) Start() error {
 					}
 				}, g.done, "refinery-gossip")
 				if err != nil {
-					g.Logger.Debug().Logf("Error listening to refinery-gossip channel: %v", err)
+					g.Logger.Warn().Logf("Error listening to refinery-gossip channel: %v", err)
 				}
 			}
 		}

--- a/internal/gossip/gossip_redis_test.go
+++ b/internal/gossip/gossip_redis_test.go
@@ -12,43 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestRoundTrip(t *testing.T) {
-	cfg := config.MockConfig{
-		GetRedisHostVal: "localhost:6379",
-	}
-	metric := &metrics.MockMetrics{}
-	metric.Start()
-	defer metric.Stop()
-	redis := &redis.DefaultClient{
-		Config:  &cfg,
-		Metrics: metric,
-	}
-	require.NoError(t, redis.Start())
-	defer redis.Stop()
-	g := &GossipRedis{
-		Redis:  redis,
-		Logger: &logger.NullLogger{},
-	}
-
-	require.NoError(t, g.Start())
-
-	// Test that we can register a handler
-	require.NoError(t, g.Subscribe("test", func(data []byte) {
-		require.Equal(t, "hi", string(data))
-	}))
-
-	require.NoError(t, g.Subscribe("test2", func(data []byte) {
-		require.Equal(t, "bye", string(data))
-	}))
-
-	// Test that we can publish a message
-	require.NoError(t, g.Publish("test", []byte("hi")))
-	require.NoError(t, g.Publish("test2", []byte("bye")))
-
-	require.NoError(t, g.Stop())
-}
-
-func TestRoundTripChan(t *testing.T) {
+func TestRoundTripChanRedis(t *testing.T) {
 	cfg := config.MockConfig{
 		GetRedisHostVal: "localhost:6379",
 	}
@@ -74,20 +38,68 @@ func TestRoundTripChan(t *testing.T) {
 	ch2 := g.SubscribeChan("test2", 10)
 	require.NotNil(t, ch2)
 
+	// This test is flaky unless we throw away the first message
+	g.Publish("throwaway", []byte("nevermind"))
+
 	// Test that we can publish a message
 	require.NoError(t, g.Publish("test", []byte("hi")))
 	require.NoError(t, g.Publish("test2", []byte("bye")))
 
-	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-		assert.Equal(t, 1, len(ch))
-		assert.Equal(t, 1, len(ch2))
-	}, 1*time.Second, 50*time.Millisecond)
+	assert.Eventually(t, func() bool {
+		time.Sleep(100 * time.Millisecond)
+		return len(ch) == 1 && len(ch2) == 1
+	}, 5*time.Second, 200*time.Millisecond)
 
-	hi := <-ch
-	assert.Equal(t, "hi", string(hi))
+	select {
+	case hi := <-ch:
+		require.Equal(t, "hi", string(hi))
+	default:
+		t.Fatal("expected to receive a message on channel 'test'")
+	}
 
-	bye := <-ch2
-	assert.Equal(t, "bye", string(bye))
+	select {
+	case bye := <-ch2:
+		require.Equal(t, "bye", string(bye))
+	default:
+		t.Fatal("expected to receive a message on channel 'test2'")
+	}
+
+	require.NoError(t, g.Stop())
+}
+
+func TestRoundTripChanInMem(t *testing.T) {
+	g := &InMemoryGossip{}
+
+	require.NoError(t, g.Start())
+
+	ch := g.SubscribeChan("test", 10)
+	require.NotNil(t, ch)
+
+	ch2 := g.SubscribeChan("test2", 10)
+	require.NotNil(t, ch2)
+
+	// Test that we can publish a message
+	require.NoError(t, g.Publish("test", []byte("hi")))
+	require.NoError(t, g.Publish("test2", []byte("bye")))
+
+	assert.Eventually(t, func() bool {
+		time.Sleep(100 * time.Millisecond)
+		return len(ch) == 1 && len(ch2) == 1
+	}, 5*time.Second, 200*time.Millisecond)
+
+	select {
+	case hi := <-ch:
+		require.Equal(t, "hi", string(hi))
+	default:
+		t.Fatal("expected to receive a message on channel 'test'")
+	}
+
+	select {
+	case bye := <-ch2:
+		require.Equal(t, "bye", string(bye))
+	default:
+		t.Fatal("expected to receive a message on channel 'test2'")
+	}
 
 	require.NoError(t, g.Stop())
 }

--- a/internal/gossip/gossip_redis_test.go
+++ b/internal/gossip/gossip_redis_test.go
@@ -32,10 +32,10 @@ func TestRoundTripChanRedis(t *testing.T) {
 
 	require.NoError(t, g.Start())
 
-	ch := g.SubscribeChan("test", 10)
+	ch := g.Subscribe("test", 10)
 	require.NotNil(t, ch)
 
-	ch2 := g.SubscribeChan("test2", 10)
+	ch2 := g.Subscribe("test2", 10)
 	require.NotNil(t, ch2)
 
 	// This test is flaky unless we throw away the first message
@@ -72,10 +72,10 @@ func TestRoundTripChanInMem(t *testing.T) {
 
 	require.NoError(t, g.Start())
 
-	ch := g.SubscribeChan("test", 10)
+	ch := g.Subscribe("test", 10)
 	require.NotNil(t, ch)
 
-	ch2 := g.SubscribeChan("test2", 10)
+	ch2 := g.Subscribe("test2", 10)
 	require.NotNil(t, ch2)
 
 	// Test that we can publish a message

--- a/internal/gossip/gossip_redis_test.go
+++ b/internal/gossip/gossip_redis_test.go
@@ -45,7 +45,7 @@ func TestRoundTripChanRedis(t *testing.T) {
 	require.NoError(t, g.Publish("test", []byte("hi")))
 	require.NoError(t, g.Publish("test2", []byte("bye")))
 
-	assert.Eventually(t, func() bool {
+	require.Eventually(t, func() bool {
 		time.Sleep(100 * time.Millisecond)
 		return len(ch) == 1 && len(ch2) == 1
 	}, 5*time.Second, 200*time.Millisecond)

--- a/internal/gossip/gossip_redis_test.go
+++ b/internal/gossip/gossip_redis_test.go
@@ -2,11 +2,13 @@ package gossip
 
 import (
 	"testing"
+	"time"
 
 	"github.com/honeycombio/refinery/config"
 	"github.com/honeycombio/refinery/logger"
 	"github.com/honeycombio/refinery/metrics"
 	"github.com/honeycombio/refinery/redis"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -42,6 +44,50 @@ func TestRoundTrip(t *testing.T) {
 	// Test that we can publish a message
 	require.NoError(t, g.Publish("test", []byte("hi")))
 	require.NoError(t, g.Publish("test2", []byte("bye")))
+
+	require.NoError(t, g.Stop())
+}
+
+func TestRoundTripChan(t *testing.T) {
+	cfg := config.MockConfig{
+		GetRedisHostVal: "localhost:6379",
+	}
+	metric := &metrics.MockMetrics{}
+	metric.Start()
+	defer metric.Stop()
+	redis := &redis.DefaultClient{
+		Config:  &cfg,
+		Metrics: metric,
+	}
+	require.NoError(t, redis.Start())
+	defer redis.Stop()
+	g := &GossipRedis{
+		Redis:  redis,
+		Logger: &logger.NullLogger{},
+	}
+
+	require.NoError(t, g.Start())
+
+	ch := g.SubscribeChan("test", 10)
+	require.NotNil(t, ch)
+
+	ch2 := g.SubscribeChan("test2", 10)
+	require.NotNil(t, ch2)
+
+	// Test that we can publish a message
+	require.NoError(t, g.Publish("test", []byte("hi")))
+	require.NoError(t, g.Publish("test2", []byte("bye")))
+
+	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+		assert.Equal(t, 1, len(ch))
+		assert.Equal(t, 1, len(ch2))
+	}, 1*time.Second, 50*time.Millisecond)
+
+	hi := <-ch
+	assert.Equal(t, "hi", string(hi))
+
+	bye := <-ch2
+	assert.Equal(t, "bye", string(bye))
 
 	require.NoError(t, g.Stop())
 }


### PR DESCRIPTION
## Which problem is this PR solving?

- Gossip uses callbacks. A callback approach adds extra code we don't need if we use channels. This is a refactoring to change it to channels. Each commit is standalone.

## Short description of the changes

- [x] Split the gossip interface file from the inmem implementation
- [x] Add a SubscribeChan function that lives beside the Subscribe function
- [x] Add test code for chan version
- [x] Convert stress relief to use the channel model
- [x] Remove callback code
- [x] Rename remaining functions to simpler names again

My desire is to merge this before #1158 and then fix that one (which does a bit more gossiping) to use channels.
