### PR TITLE
fix: register gossip-redis health before start pubsub

### DIFF
--- a/internal/gossip/gossip_redis.go
+++ b/internal/gossip/gossip_redis.go
@@ -41,6 +41,8 @@ func (g *GossipRedis) Start() error {
 	g.done = make(chan struct{})
 	g.subscriptions = make(map[string][]chan []byte)
 
+	g.Health.Register(gossipRedisHealth, redis.HealthCheckPeriod*5)
+
 	g.eg.Go(func() error {
 		for {
 			select {
@@ -68,7 +70,6 @@ func (g *GossipRedis) Start() error {
 					g.Logger.Warn().Logf("Error listening to refinery-gossip channel: %v", err)
 				}
 
-				g.Health.Register(gossipRedisHealth, redis.HealthCheckPeriod*5)
 			}
 		}
 


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

the health check should happen before the pubsub goroutine


