### PR TITLE
fix: set health check to ready when receiving a message on the channel

### DIFF
--- a/internal/gossip/gossip_redis.go
+++ b/internal/gossip/gossip_redis.go
@@ -41,7 +41,7 @@ func (g *GossipRedis) Start() error {
 	g.done = make(chan struct{})
 	g.subscriptions = make(map[string][]chan []byte)
 
-	g.Health.Register(gossipRedisHealth, redis.HealthCheckPeriod*5)
+	g.Health.Register(gossipRedisHealth, redis.HealthCheckPeriod*2)
 
 	g.eg.Go(func() error {
 		for {
@@ -50,6 +50,8 @@ func (g *GossipRedis) Start() error {
 				return nil
 			default:
 				err := g.Redis.ListenPubSubChannels(nil, func(channel string, b []byte) {
+					g.Health.Ready(gossipRedisHealth, true)
+
 					msg := newMessageFromBytes(b)
 					g.lock.RLock()
 					chans := g.subscriptions[msg.key]


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

The healthcheck ping and pong message on the redis pubsub channel are sent on an interval. That interval is delaying the  start time for refinery. Mark gossiper to be ready when we receive a message on the pubsub channel as well so we are not only relying on the redis health check message 

## Short description of the changes

- mark gossip-redis to be ready whenever refinery receives a message from redis pubsub channel.
- reduce the timeout on the healthcheck since we should be able to get a ready check more often.

