### PR TITLE
fix: Fix docs formatting around list type

### DIFF
--- a/rules_conditions.md
+++ b/rules_conditions.md
@@ -61,10 +61,10 @@ Rules:
     - Name: Drop any big traces
       Drop: true
       Conditions:
-        Field: "?.NUM_DESCENDANTS"
-        Operator: ">"
-        Value: 1000
-        Datatype: int
+        - Field: "?.NUM_DESCENDANTS"
+          Operator: ">"
+          Value: 1000
+          Datatype: int
 
 ```
 


### PR DESCRIPTION
## Which problem is this PR solving?

- Fixes errors like `- rules.Samplers.__default__.RulesBasedSampler.Rules.0.Conditions: Invalid type. Expected: array, given: object` when copy-pasting from the README

## Short description of the changes

- Update README to show Conditions as a list rather than object

