### PR TITLE
fix: Clean up all the things, even if redis doesn't know about it

### DIFF
--- a/collect/central_collector.go
+++ b/collect/central_collector.go
@@ -165,6 +165,7 @@ func (c *CentralCollector) Start() error {
 	c.Metrics.Register("kept_from_stress", "counter")
 	c.Metrics.Register("collector_keep_trace", "counter")
 	c.Metrics.Register("collector_drop_trace", "counter")
+	c.Metrics.Register("collector_drop_old_trace", "counter")
 	c.Metrics.Register("collector_decide_trace", "counter")
 	c.Metrics.Register("decider_decided_per_second", "histogram")
 	c.Metrics.Register("decider_considered_per_second", "histogram")
@@ -693,9 +694,11 @@ func (c *CentralCollector) cleanupTraces(ctx context.Context) {
 			c.SpanCache.Remove(status.TraceID)
 			tracesConsidered++
 			c.Metrics.Increment("collector_drop_trace")
+
 		default:
-			// if we don't know what to we did with the trace, and it's already
-			// this old, we just need to drop it, but let's record that we did
+			// if we didn't find the trace, but it's already
+			// this old, we need to drop it so it doesn't live forever.
+			// but let's record that we did.
 			c.SpanCache.Remove(status.TraceID)
 			tracesConsidered++
 			c.Metrics.Increment("collector_drop_old_trace")

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -223,6 +223,7 @@ type CollectionConfig struct {
 	TraceFetcherConcurrency int        `yaml:"TraceFetcherConcurrency" default:"10"`
 	SenderBatchSize         int        `yaml:"SenderBatchSize" default:"1000"`
 	SenderCycleDuration     Duration   `yaml:"SenderCycleDuration" default:"100ms"`
+	CleanupCycleDuration    Duration   `yaml:"CleanupCycleDuration" default:"5s"`
 	DeciderCycleDuration    Duration   `yaml:"DeciderCycleDuration" default:"100ms"`
 	DeciderBatchSize        int        `yaml:"DeciderBatchSize" default:"1000"`
 	AvailableMemory         MemorySize `yaml:"AvailableMemory" cmdenv:"AvailableMemory"`
@@ -284,6 +285,10 @@ func (c CollectionConfig) GetSenderBatchSize() int {
 
 func (c CollectionConfig) GetSenderCycleDuration() time.Duration {
 	return time.Duration(c.SenderCycleDuration)
+}
+
+func (c CollectionConfig) GetCleanupCycleDuration() time.Duration {
+	return time.Duration(c.CleanupCycleDuration)
 }
 
 func (c CollectionConfig) GetDeciderCycleDuration() time.Duration {

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -1266,6 +1266,16 @@ groups:
           of trace decisions Refinery can make in one second. It is rarely
           necessary to adjust this value.
 
+      - name: CleanupCycleDuration
+        type: duration
+        valuetype: nondefault
+        default: 5s
+        reload: false
+        summary: is the duration between cleanup batches.
+        description: >
+          This setting controls the interval that Refinery uses for running the cleanup
+          cycle in its memory cache. It is rarely necessary to adjust this value.
+
       - name: SenderCycleDuration
         type: duration
         valuetype: nondefault


### PR DESCRIPTION

## Which problem is this PR solving?

- We saw refinery seemed to lose track of some traces and just leave them in the cache forever. This makes sure they can't hang around forever, and we'll track a metric for it 

## Short description of the changes

- Add CleanupCycleDuration config value
- Use it for the cleanup cycle
- Drop traces we can't find in redis

