### PR TITLE
fix: get trace decision from cache before asking redis

### DIFF
--- a/centralstore/centralstore.go
+++ b/centralstore/centralstore.go
@@ -197,7 +197,7 @@ type SmartStorer interface {
 	RecordMetrics(ctx context.Context) error
 
 	// RecordTraceDecision records the decision made by the trace decision engine.
-	RecordTraceDecision(ctx context.Context, trace *CentralTraceStatus, keep bool, reason string) error
+	RecordTraceDecision(ctx context.Context, trace *CentralTraceStatus) error
 }
 
 // Spec for the central store's internal behavior:
@@ -294,5 +294,5 @@ type BasicStorer interface {
 	RecordMetrics(ctx context.Context) error
 
 	//RecordTraceDecision records the decision made by the trace decision engine.
-	RecordTraceDecision(ctx context.Context, trace *CentralTraceStatus, keep bool, reason string) error
+	RecordTraceDecision(ctx context.Context, trace *CentralTraceStatus) error
 }

--- a/centralstore/redis_store_test.go
+++ b/centralstore/redis_store_test.go
@@ -579,6 +579,8 @@ func TestRedisBasicStore_RecordTraceDecision(t *testing.T) {
 	conn := store.RedisClient.Get()
 	defer conn.Close()
 
+	// give decision drop cache a chance to update
+	time.Sleep(10 * time.Millisecond)
 	status, err := store.GetStatusForTraces(ctx, []string{keepTraceID, dropTraceID}, DecisionKeep, DecisionDrop)
 	require.NoError(t, err)
 	require.Len(t, status, 2)

--- a/centralstore/smartwrapper.go
+++ b/centralstore/smartwrapper.go
@@ -323,6 +323,6 @@ func (w *SmartWrapper) RecordMetrics(ctx context.Context) error {
 	return w.BasicStore.RecordMetrics(ctx)
 }
 
-func (w *SmartWrapper) RecordTraceDecision(ctx context.Context, trace *CentralTraceStatus, keep bool, reason string) error {
-	return w.BasicStore.RecordTraceDecision(ctx, trace, keep, reason)
+func (w *SmartWrapper) RecordTraceDecision(ctx context.Context, trace *CentralTraceStatus) error {
+	return w.BasicStore.RecordTraceDecision(ctx, trace)
 }

--- a/centralstore/smartwrapper_test.go
+++ b/centralstore/smartwrapper_test.go
@@ -418,7 +418,7 @@ func TestSetTraceStatuses(t *testing.T) {
 					assert.Equal(t, DecisionKeep, status.State)
 					assert.Equal(t, "because", status.KeepReason)
 				} else {
-					assert.Equal(t, DecisionDrop, status.State)
+					assert.Equal(t, DecisionDrop, status.State, status.TraceID)
 				}
 			}
 		})

--- a/collect/central_collector.go
+++ b/collect/central_collector.go
@@ -379,7 +379,7 @@ func (c *CentralCollector) ProcessSpanImmediately(sp *types.Span) (bool, error) 
 		status.State = centralstore.DecisionDrop
 	}
 
-	err := c.Store.RecordTraceDecision(ctx, status, keep, reason)
+	err := c.Store.RecordTraceDecision(ctx, status)
 	if err != nil {
 		span.RecordError(err)
 		return true, err


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

During stress relief, more trace decisions are made through the deterministic sampler and their decisions are stored only in memory. It's wasteful to asking redis for those decisions that redis has no idea of. Refinery should check with the in-memory decision cache first before asking redis for a trace status

## Short description of the changes

- move the logic to check with the decision cache to the top of the `GetStatusForTraces` call
- make `RecordTraceDecision` signature to be more clear

