### PR TITLE
fix: Gossip channels are now bytes, no dropped messages

### DIFF
--- a/collect/central_collector.go
+++ b/collect/central_collector.go
@@ -108,8 +108,6 @@ const (
 	receiverHealth = "receiver"
 	deciderHealth  = "decider"
 	senderHealth   = "sender"
-	gossip_keep    = "keep"
-	gossip_drop    = "drop"
 )
 
 func (c *CentralCollector) Start() error {
@@ -218,8 +216,8 @@ func (c *CentralCollector) Start() error {
 	c.egAgg.SetLimit(maxConcurrency) // we want to limit the number of goroutines that are aggregating trace IDs
 
 	// subscribe to the Keep and Drop decisions
-	c.keepChan = c.Gossip.Subscribe(c.Gossip.GetChannel(gossip_keep), maxCount)
-	c.dropChan = c.Gossip.Subscribe(c.Gossip.GetChannel(gossip_drop), maxCount)
+	c.keepChan = c.Gossip.Subscribe(c.Gossip.GetChannel(gossip.ChannelKeep), maxCount)
+	c.dropChan = c.Gossip.Subscribe(c.Gossip.GetChannel(gossip.ChannelDrop), maxCount)
 
 	go c.aggregateTraceIDChannel(c.keepChan, c.keepTraces, maxTime, maxCount)
 	go c.aggregateTraceIDChannel(c.dropChan, c.dropTraces, maxTime, maxCount)
@@ -795,8 +793,8 @@ func (c *CentralCollector) makeDecisions(ctx context.Context) error {
 	ctxTraces, spanTraces := otelutil.StartSpanWith(ctx, c.Tracer, "CentralCollector.makeDecision.traceLoop", "num_traces", len(traces))
 	defer spanTraces.End()
 
-	gossip_keep_channel := c.Gossip.GetChannel(gossip_keep)
-	gossip_drop_channel := c.Gossip.GetChannel(gossip_drop)
+	gossip_keep_channel := c.Gossip.GetChannel(gossip.ChannelKeep)
+	gossip_drop_channel := c.Gossip.GetChannel(gossip.ChannelDrop)
 
 	for _, trace := range traces {
 		if trace == nil {

--- a/collect/central_collector.go
+++ b/collect/central_collector.go
@@ -218,8 +218,8 @@ func (c *CentralCollector) Start() error {
 	c.egAgg.SetLimit(maxConcurrency) // we want to limit the number of goroutines that are aggregating trace IDs
 
 	// subscribe to the Keep and Drop decisions
-	c.keepChan = c.Gossip.Subscribe(gossip_keep, maxCount)
-	c.dropChan = c.Gossip.Subscribe(gossip_drop, maxCount)
+	c.keepChan = c.Gossip.Subscribe(c.Gossip.GetChannel(gossip_keep), maxCount)
+	c.dropChan = c.Gossip.Subscribe(c.Gossip.GetChannel(gossip_drop), maxCount)
 
 	go c.aggregateTraceIDChannel(c.keepChan, c.keepTraces, maxTime, maxCount)
 	go c.aggregateTraceIDChannel(c.dropChan, c.dropTraces, maxTime, maxCount)
@@ -794,6 +794,10 @@ func (c *CentralCollector) makeDecisions(ctx context.Context) error {
 
 	ctxTraces, spanTraces := otelutil.StartSpanWith(ctx, c.Tracer, "CentralCollector.makeDecision.traceLoop", "num_traces", len(traces))
 	defer spanTraces.End()
+
+	gossip_keep_channel := c.Gossip.GetChannel(gossip_keep)
+	gossip_drop_channel := c.Gossip.GetChannel(gossip_drop)
+
 	for _, trace := range traces {
 		if trace == nil {
 			continue
@@ -885,10 +889,10 @@ func (c *CentralCollector) makeDecisions(ctx context.Context) error {
 		if shouldSend {
 			state = centralstore.DecisionKeep
 			status.KeepReason = reason
-			c.Gossip.Publish(gossip_keep, []byte(trace.TraceID))
+			c.Gossip.Publish(gossip_keep_channel, []byte(trace.TraceID))
 		} else {
 			state = centralstore.DecisionDrop
-			c.Gossip.Publish(gossip_drop, []byte(trace.TraceID))
+			c.Gossip.Publish(gossip_drop_channel, []byte(trace.TraceID))
 		}
 		status.State = state
 		status.Rate = rate

--- a/collect/stressRelief/stress_relief_redis.go
+++ b/collect/stressRelief/stress_relief_redis.go
@@ -57,6 +57,8 @@ type StressRelief struct {
 	stressLevels map[string]stressReport
 }
 
+const stressChannelName = "stress_health"
+
 func (s *StressRelief) Start() error {
 	s.Logger.Debug().Logf("Starting StressRelief system")
 	defer func() { s.Logger.Debug().Logf("Finished starting StressRelief system") }()
@@ -111,7 +113,7 @@ func (s *StressRelief) Start() error {
 	s.RefineryMetrics.Register("individual_stress_level", "gauge")
 	s.RefineryMetrics.Register("stress_relief_activated", "gauge")
 
-	s.stressGossipCh = s.Gossip.Subscribe("stress_level", 20)
+	s.stressGossipCh = s.Gossip.Subscribe(s.Gossip.GetChannel(stressChannelName), 20)
 	s.eg = &errgroup.Group{}
 	s.eg.Go(s.monitor)
 
@@ -121,6 +123,7 @@ func (s *StressRelief) Start() error {
 func (s *StressRelief) monitor() error {
 	tick := time.NewTicker(calculationInterval)
 	defer tick.Stop()
+	gossipchan := s.Gossip.GetChannel(stressChannelName)
 	for {
 		select {
 		case <-tick.C:
@@ -130,7 +133,7 @@ func (s *StressRelief) monitor() error {
 				level: currentLevel,
 				id:    s.identification,
 			}
-			err := s.Gossip.Publish("stress_level", msg.ToBytes())
+			err := s.Gossip.Publish(gossipchan, msg.ToBytes())
 			if err != nil {
 				s.Logger.Error().Logf("error publishing stress level: %s", err)
 			} else {

--- a/collect/stressRelief/stress_relief_redis.go
+++ b/collect/stressRelief/stress_relief_redis.go
@@ -57,8 +57,6 @@ type StressRelief struct {
 	stressLevels map[string]stressReport
 }
 
-const stressChannelName = "stress_health"
-
 func (s *StressRelief) Start() error {
 	s.Logger.Debug().Logf("Starting StressRelief system")
 	defer func() { s.Logger.Debug().Logf("Finished starting StressRelief system") }()
@@ -113,7 +111,7 @@ func (s *StressRelief) Start() error {
 	s.RefineryMetrics.Register("individual_stress_level", "gauge")
 	s.RefineryMetrics.Register("stress_relief_activated", "gauge")
 
-	s.stressGossipCh = s.Gossip.Subscribe(s.Gossip.GetChannel(stressChannelName), 20)
+	s.stressGossipCh = s.Gossip.Subscribe(s.Gossip.GetChannel(gossip.ChannelStress), 20)
 	s.eg = &errgroup.Group{}
 	s.eg.Go(s.monitor)
 
@@ -123,7 +121,7 @@ func (s *StressRelief) Start() error {
 func (s *StressRelief) monitor() error {
 	tick := time.NewTicker(calculationInterval)
 	defer tick.Stop()
-	gossipchan := s.Gossip.GetChannel(stressChannelName)
+	gossipchan := s.Gossip.GetChannel(gossip.ChannelStress)
 	for {
 		select {
 		case <-tick.C:

--- a/collect/stressRelief/stress_relief_test.go
+++ b/collect/stressRelief/stress_relief_test.go
@@ -107,7 +107,7 @@ func TestStressRelief_Peer(t *testing.T) {
 			level: 0,
 			id:    "peer",
 		}
-		require.NoError(t, sr.Gossip.Publish("stress_level", msg.ToBytes()))
+		require.NoError(t, sr.Gossip.Publish(sr.Gossip.GetChannel(stressChannelName), msg.ToBytes()))
 		clock.Advance(time.Second * 1)
 		return sr.Stressed()
 	}, 2*time.Second, 100*time.Millisecond, "stress relief should be false")
@@ -119,7 +119,7 @@ func TestStressRelief_Peer(t *testing.T) {
 			level: 5,
 			id:    "peer",
 		}
-		require.NoError(t, sr.Gossip.Publish("stress_level", msg.ToBytes()))
+		require.NoError(t, sr.Gossip.Publish(sr.Gossip.GetChannel(stressChannelName), msg.ToBytes()))
 
 		clock.Advance(time.Second * 1)
 		return !sr.Stressed()

--- a/collect/stressRelief/stress_relief_test.go
+++ b/collect/stressRelief/stress_relief_test.go
@@ -107,7 +107,7 @@ func TestStressRelief_Peer(t *testing.T) {
 			level: 0,
 			id:    "peer",
 		}
-		require.NoError(t, sr.Gossip.Publish(sr.Gossip.GetChannel(stressChannelName), msg.ToBytes()))
+		require.NoError(t, sr.Gossip.Publish(sr.Gossip.GetChannel(gossip.ChannelStress), msg.ToBytes()))
 		clock.Advance(time.Second * 1)
 		return sr.Stressed()
 	}, 2*time.Second, 100*time.Millisecond, "stress relief should be false")
@@ -119,7 +119,7 @@ func TestStressRelief_Peer(t *testing.T) {
 			level: 5,
 			id:    "peer",
 		}
-		require.NoError(t, sr.Gossip.Publish(sr.Gossip.GetChannel(stressChannelName), msg.ToBytes()))
+		require.NoError(t, sr.Gossip.Publish(sr.Gossip.GetChannel(gossip.ChannelStress), msg.ToBytes()))
 
 		clock.Advance(time.Second * 1)
 		return !sr.Stressed()

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ toolchain go1.21.8
 require (
 	github.com/agnivade/levenshtein v1.1.1
 	github.com/creasty/defaults v1.7.0
-	github.com/davecgh/go-spew v1.1.1
 	github.com/dgryski/go-wyhash v0.0.0-20191203203029-c4841ae36371
 	github.com/facebookgo/inject v0.0.0-20180706035515-f23751cae28b
 	github.com/facebookgo/startstop v0.0.0-20161013234910-bc158412526d
@@ -24,7 +23,6 @@ require (
 	github.com/klauspost/compress v1.17.8
 	github.com/panmari/cuckoofilter v1.0.3
 	github.com/pelletier/go-toml/v2 v2.2.2
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.19.0
 	github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0
 	github.com/sirupsen/logrus v1.9.3
@@ -47,6 +45,7 @@ require (
 
 require (
 	github.com/alicebob/gopher-json v0.0.0-20230218143504-906a9b012302 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20240408141607-282e7b5d6b74 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect

--- a/go.sum
+++ b/go.sum
@@ -108,8 +108,6 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/pelletier/go-toml/v2 v2.2.2 h1:aYUidT7k73Pcl9nb2gScu7NSrKCSHIDE89b3+6Wq+LM=
 github.com/pelletier/go-toml/v2 v2.2.2/go.mod h1:1t835xjRzz80PqgE6HHgN2JOsmgYu/h4qDAS4n929Rs=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=

--- a/internal/gossip/gossip.go
+++ b/internal/gossip/gossip.go
@@ -4,6 +4,14 @@ import (
 	"github.com/facebookgo/startstop"
 )
 
+const (
+	ChannelKeep   = "keep"
+	ChannelDrop   = "drop"
+	ChannelStress = "stress_health"
+	ChannelTest1  = "test1"
+	ChannelTest2  = "test2"
+)
+
 // Gossiper is an interface for broadcasting messages to all receivers
 // subscribed to a channel
 type Gossiper interface {

--- a/internal/gossip/gossip_inmem.go
+++ b/internal/gossip/gossip_inmem.go
@@ -62,7 +62,7 @@ func (g *InMemoryGossip) Start() error {
 			case value := <-g.gossipCh:
 				msg := Message(value)
 				g.mut.RLock()
-				chans := g.subscriptions[msg.Channel()]
+				chans := g.subscriptions[msg.Channel()][:] // copy the slice to avoid holding the lock while sending
 				g.mut.RUnlock()
 				// now start goroutines to send the message to all subscribers in parallel
 				// we don't want to block the Redis listener or other subscribers

--- a/internal/gossip/gossip_redis.go
+++ b/internal/gossip/gossip_redis.go
@@ -56,7 +56,7 @@ func (g *GossipRedis) Start() error {
 
 					msg := Message(b)
 					g.lock.RLock()
-					chans := g.subscriptions[msg.Channel()]
+					chans := g.subscriptions[msg.Channel()][:] // copy the slice to avoid holding the lock while sending
 					g.lock.RUnlock()
 					// now start goroutines to send the message to all subscribers in parallel
 					// we don't want to block the Redis listener or other subscribers
@@ -71,7 +71,6 @@ func (g *GossipRedis) Start() error {
 				if err != nil {
 					g.Logger.Warn().Logf("Error listening to refinery-gossip channel: %v", err)
 				}
-
 			}
 		}
 

--- a/internal/gossip/gossip_redis.go
+++ b/internal/gossip/gossip_redis.go
@@ -2,6 +2,7 @@ package gossip
 
 import (
 	"errors"
+	"fmt"
 	"sync"
 
 	"github.com/facebookgo/startstop"
@@ -55,6 +56,7 @@ func (g *GossipRedis) Start() error {
 					g.Health.Ready(gossipRedisHealth, true)
 
 					msg := Message(b)
+					fmt.Printf("Received message: channel %d, %s\n", msg.Channel(), string(msg.Data()))
 					g.lock.RLock()
 					chans := g.subscriptions[msg.Channel()][:] // copy the slice to avoid holding the lock while sending
 					g.lock.RUnlock()

--- a/internal/gossip/gossip_redis.go
+++ b/internal/gossip/gossip_redis.go
@@ -2,7 +2,6 @@ package gossip
 
 import (
 	"errors"
-	"fmt"
 	"sync"
 
 	"github.com/facebookgo/startstop"
@@ -69,7 +68,6 @@ func (g *GossipRedis) Start() error {
 					g.Health.Ready(gossipRedisHealth, true)
 
 					msg := Message(b)
-					fmt.Printf("Received message: channel %d, %s\n", msg.Channel(), string(msg.Data()))
 					g.lock.RLock()
 					chans := g.subscriptions[msg.Channel()][:] // copy the slice to avoid holding the lock while sending
 					g.lock.RUnlock()

--- a/internal/gossip/gossip_redis_test.go
+++ b/internal/gossip/gossip_redis_test.go
@@ -66,7 +66,6 @@ func TestRoundTripChanRedis(t *testing.T) {
 	require.NoError(t, g.Publish(chTest2, []byte("bye")))
 
 	require.Eventually(t, func() bool {
-		time.Sleep(100 * time.Millisecond)
 		return len(ch) == 1 && len(ch2) == 1
 	}, 5*time.Second, 200*time.Millisecond)
 

--- a/internal/gossip/gossip_redis_test.go
+++ b/internal/gossip/gossip_redis_test.go
@@ -40,11 +40,12 @@ func TestRoundTripChanRedis(t *testing.T) {
 	}
 
 	require.NoError(t, g.Start())
-	test1Name := "test1" + time.Now().String()
-	test2Name := "test2" + time.Now().String()
+	// these channel names should not be duplicated in any other test
+	test1Name := "testA"
+	test2Name := "testB"
 	chTest1 := g.GetChannel(test1Name)
 	chTest2 := g.GetChannel(test2Name)
-	chJunk := g.GetChannel("junk")
+	chJunk := g.GetChannel("testJ")
 
 	ch := g.Subscribe(chTest1, 10)
 	require.NotNil(t, ch)
@@ -93,7 +94,7 @@ func TestRoundTripChanInMem(t *testing.T) {
 
 	require.NoError(t, g.Start())
 
-	chTest := g.GetChannel("test")
+	chTest := g.GetChannel("test1")
 	chTest2 := g.GetChannel("test2")
 
 	ch := g.Subscribe(chTest, 10)

--- a/internal/gossip/gossip_redis_test.go
+++ b/internal/gossip/gossip_redis_test.go
@@ -40,19 +40,22 @@ func TestRoundTripChanRedis(t *testing.T) {
 	}
 
 	require.NoError(t, g.Start())
+	chTest := g.GetChannel("test")
+	chTest2 := g.GetChannel("test2")
+	chJunk := g.GetChannel("junk")
 
-	ch := g.Subscribe("test", 10)
+	ch := g.Subscribe(chTest, 10)
 	require.NotNil(t, ch)
 
-	ch2 := g.Subscribe("test2", 10)
+	ch2 := g.Subscribe(chTest2, 10)
 	require.NotNil(t, ch2)
 
 	// This test is flaky unless we throw away the first message
-	g.Publish("throwaway", []byte("nevermind"))
+	g.Publish(chJunk, []byte("nevermind"))
 
 	// Test that we can publish a message
-	require.NoError(t, g.Publish("test", []byte("hi")))
-	require.NoError(t, g.Publish("test2", []byte("bye")))
+	require.NoError(t, g.Publish(chTest, []byte("hi")))
+	require.NoError(t, g.Publish(chTest2, []byte("bye")))
 
 	require.Eventually(t, func() bool {
 		time.Sleep(100 * time.Millisecond)
@@ -81,15 +84,18 @@ func TestRoundTripChanInMem(t *testing.T) {
 
 	require.NoError(t, g.Start())
 
-	ch := g.Subscribe("test", 10)
+	chTest := g.GetChannel("test")
+	chTest2 := g.GetChannel("test2")
+
+	ch := g.Subscribe(chTest, 10)
 	require.NotNil(t, ch)
 
-	ch2 := g.Subscribe("test2", 10)
+	ch2 := g.Subscribe(chTest2, 10)
 	require.NotNil(t, ch2)
 
 	// Test that we can publish a message
-	require.NoError(t, g.Publish("test", []byte("hi")))
-	require.NoError(t, g.Publish("test2", []byte("bye")))
+	require.NoError(t, g.Publish(chTest, []byte("hi")))
+	require.NoError(t, g.Publish(chTest2, []byte("bye")))
 
 	assert.Eventually(t, func() bool {
 		time.Sleep(100 * time.Millisecond)

--- a/internal/gossip/gossip_redis_test.go
+++ b/internal/gossip/gossip_redis_test.go
@@ -41,11 +41,13 @@ func TestRoundTripChanRedis(t *testing.T) {
 	}
 
 	require.NoError(t, g.Start())
-	chTest := g.GetChannel("test")
-	chTest2 := g.GetChannel("test2")
+	test1Name := "test1" + time.Now().String()
+	test2Name := "test2" + time.Now().String()
+	chTest1 := g.GetChannel(test1Name)
+	chTest2 := g.GetChannel(test2Name)
 	chJunk := g.GetChannel("junk")
 
-	ch := g.Subscribe(chTest, 10)
+	ch := g.Subscribe(chTest1, 10)
 	require.NotNil(t, ch)
 
 	ch2 := g.Subscribe(chTest2, 10)
@@ -63,7 +65,7 @@ func TestRoundTripChanRedis(t *testing.T) {
 	}, 5*time.Second, 200*time.Millisecond)
 
 	// Test that we can publish messages
-	require.NoError(t, g.Publish(chTest, []byte("hi")))
+	require.NoError(t, g.Publish(chTest1, []byte("hi")))
 	require.NoError(t, g.Publish(chTest2, []byte("bye")))
 
 	require.Eventually(t, func() bool {

--- a/internal/gossip/gossip_redis_test.go
+++ b/internal/gossip/gossip_redis_test.go
@@ -1,6 +1,7 @@
 package gossip
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -66,6 +67,7 @@ func TestRoundTripChanRedis(t *testing.T) {
 	require.NoError(t, g.Publish(chTest2, []byte("bye")))
 
 	require.Eventually(t, func() bool {
+		fmt.Println("message counts", len(ch), len(ch2))
 		return len(ch) == 1 && len(ch2) == 1
 	}, 5*time.Second, 200*time.Millisecond)
 

--- a/internal/gossip/gossip_redis_test.go
+++ b/internal/gossip/gossip_redis_test.go
@@ -1,7 +1,6 @@
 package gossip
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -69,7 +68,6 @@ func TestRoundTripChanRedis(t *testing.T) {
 	require.NoError(t, g.Publish(chTest2, []byte("bye")))
 
 	require.Eventually(t, func() bool {
-		fmt.Println("message counts", len(ch), len(ch2))
 		return len(ch) == 1 && len(ch2) == 1
 	}, 5*time.Second, 200*time.Millisecond)
 


### PR DESCRIPTION
## Which problem is this PR solving?

- Gossip channels are arbitrary strings and don't really need to be; we have only a few of them. Instead, you can use your string name to create a numeric channel and put that on the messages. Because we need different instances to use the same channel IDs, we still use constants for the string IDs. We can build IDs on the fly (and do when we're standalone) but in Redis we expect the constants to be used. 

## Short description of the changes

- Define Channel type
- Adjust how messages are built and used
- Fix the places they were used
- Use constants
- Debug tests

