### PR TITLE
fix: make sure we clean up data in redis for late spans

### DIFF
--- a/centralstore/centralstore.go
+++ b/centralstore/centralstore.go
@@ -24,7 +24,7 @@ type CentralSpan struct {
 	IsRoot          bool
 }
 
-// can you come up with another name for this fucntion?
+// Trace returns the trace ID of the span.
 func (s *CentralSpan) Trace() string {
 	return s.TraceID
 }

--- a/centralstore/centralstore.go
+++ b/centralstore/centralstore.go
@@ -47,6 +47,10 @@ func (s *CentralSpan) SetSamplerSelector(key string) {
 
 type CentralTraceState string
 
+// AllTraceStates is a list of all possible trace states.
+var AllTraceStates = []CentralTraceState{DecisionKeep, DecisionDrop, Unknown, Collecting,
+	DecisionDelay, ReadyToDecide, AwaitingDecision}
+
 const (
 	Unknown          CentralTraceState = "unknown"
 	Collecting       CentralTraceState = "collecting"

--- a/centralstore/centralstore.go
+++ b/centralstore/centralstore.go
@@ -24,6 +24,15 @@ type CentralSpan struct {
 	IsRoot          bool
 }
 
+// can you come up with another name for this fucntion?
+func (s *CentralSpan) Trace() string {
+	return s.TraceID
+}
+
+func (s *CentralSpan) SpanType() types.SpanType {
+	return s.Type
+}
+
 func (s *CentralSpan) Fields() map[string]interface{} {
 	if s.KeyFields == nil {
 		return s.AllFields

--- a/centralstore/redis_store.go
+++ b/centralstore/redis_store.go
@@ -205,15 +205,10 @@ func (r *RedisBasicStore) WriteSpans(ctx context.Context, spans []*CentralSpan) 
 	})
 	defer writespan.End()
 
-	states := make(map[string]CentralTraceState, len(spans))
-	for _, span := range spans {
-		states[span.TraceID] = Unknown
-	}
-
 	conn := r.RedisClient.Get()
 	defer conn.Close()
 
-	err := r.getTraceStates(ctx, conn, states)
+	states, err := r.getTraceStates(ctx, conn, spans)
 	if err != nil {
 		return err
 	}
@@ -461,13 +456,8 @@ func (r *RedisBasicStore) GetTracesNeedingDecision(ctx context.Context, n int) (
 	conn := r.RedisClient.Get()
 	defer conn.Close()
 
-	expirationDuration := time.Duration(r.Config.GetCentralStoreOptions().TraceTimeout)
-	if expirationDuration < defaultTraceRetention {
-		expirationDuration = defaultTraceRetention
-	}
-
 	traceIDs, err := r.states.config.getTraceNeedingDecision.DoStrings(ctx, conn,
-		validStateChangeEventsKey, n, expirationDuration.Seconds(), time.Now().UnixMicro())
+		validStateChangeEventsKey, n, r.traces.traceExpirationDuration().Seconds(), r.Clock.Now().UnixMicro())
 	if err != nil {
 		if errors.Is(err, redis.ErrKeyNotFound) {
 			return nil, nil
@@ -627,43 +617,45 @@ func (r *RedisBasicStore) RecordTraceDecision(ctx context.Context, trace *Centra
 	return nil
 }
 
-func (r *RedisBasicStore) getTraceStates(ctx context.Context, conn redis.Conn, states map[string]CentralTraceState) error {
+func (r *RedisBasicStore) getTraceStates(ctx context.Context, conn redis.Conn, spans []*CentralSpan) (map[string]CentralTraceState, error) {
 	ctx, span := r.Tracer.Start(ctx, "getTraceStates")
 	defer span.End()
 
 	var cacheHitCount int
-	notFound := make([]string, 0, len(states))
-	for traceID := range states {
-		tracerec, _, found := r.DecisionCache.Test(traceID)
+	notFound := make([]string, 0)
+	states := make(map[string]CentralTraceState, len(spans))
+	for _, span := range spans {
+		states[span.TraceID] = Unknown
+		tracerec, _, found := r.DecisionCache.Check(span)
 		if !found {
 			// if the trace is not in the cache, we need to retrieve its state from redis
-			notFound = append(notFound, traceID)
+			notFound = append(notFound, span.TraceID)
 			continue
 		}
 
 		cacheHitCount++
 		if tracerec.Kept() {
-			states[traceID] = DecisionKeep
+			states[span.TraceID] = DecisionKeep
 		} else {
-			states[traceID] = DecisionDrop
+			states[span.TraceID] = DecisionDrop
 		}
 	}
 	otelutil.AddSpanField(span, "cache_hit_count", cacheHitCount)
 
 	if cacheHitCount == len(states) {
-		return nil
+		return states, nil
 	}
 
 	results, err := r.traces.getTraceStates(ctx, conn, notFound)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	for id, state := range results {
 		states[id] = state
 	}
 
-	return nil
+	return states, nil
 }
 
 // TraceStore stores trace state status and spans.
@@ -741,19 +733,23 @@ func normalizeCentralTraceStatusRedis(status *centralTraceStatusRedis) *CentralT
 	}
 }
 
-func (t *tracesStore) addStatuses(ctx context.Context, conn redis.Conn, cspans []*CentralSpan) error {
-	_, spanStatus := otelutil.StartSpanMulti(ctx, t.tracer, "addStatus", map[string]interface{}{
-		"numSpans": len(cspans),
-		"isScript": true,
-	})
-	defer spanStatus.End()
-
+func (t *tracesStore) traceExpirationDuration() time.Duration {
 	// default trace retention is 2x the trace timeout + send delay
 	// this should be the same as the timeout for spanCache.GetOldTraceIDs
 	expirationDuration := time.Duration(2 * (t.config.GetCentralStoreOptions().TraceTimeout + t.config.GetCentralStoreOptions().SendDelay))
 	if expirationDuration < defaultTraceRetention {
 		expirationDuration = defaultTraceRetention
 	}
+
+	return expirationDuration
+}
+
+func (t *tracesStore) addStatuses(ctx context.Context, conn redis.Conn, cspans []*CentralSpan) error {
+	_, spanStatus := otelutil.StartSpanMulti(ctx, t.tracer, "addStatus", map[string]interface{}{
+		"numSpans": len(cspans),
+		"isScript": true,
+	})
+	defer spanStatus.End()
 
 	commands := make([]redis.Command, 0, 3*len(cspans))
 	for _, span := range cspans {
@@ -772,7 +768,7 @@ func (t *tracesStore) addStatuses(ctx context.Context, conn redis.Conn, cspans [
 		args := redis.Args().AddFlat(trace)
 
 		commands = append(commands, redis.NewMultiSetHashCommand(traceStatusKey, args))
-		commands = append(commands, redis.NewExpireCommand(traceStatusKey, expirationDuration.Seconds()))
+		commands = append(commands, redis.NewExpireCommand(traceStatusKey, t.traceExpirationDuration().Seconds()))
 		commands = append(commands, redis.NewINCRCommand(traceStatusCountKey))
 	}
 
@@ -895,6 +891,7 @@ func (t *tracesStore) getTraceStatuses(ctx context.Context, client redis.Client,
 			status := &centralTraceStatusRedis{}
 			err := conn.GetStructHash(t.traceStatusKey(traceID), status)
 			queries++
+
 			if err != nil {
 				if errors.Is(err, redis.ErrKeyNotFound) {
 					status.TraceID = traceID
@@ -954,16 +951,17 @@ func (t *tracesStore) storeSpans(ctx context.Context, conn redis.Conn, spans []*
 	})
 	defer spanStore.End()
 
-	commands := make([]redis.Command, 2*len(spans))
-	for i := 0; i < len(commands); i += 2 {
+	commands := make([]redis.Command, 3*len(spans))
+	for i := 0; i < len(commands); i += 3 {
 		var err error
-		span := spans[i/2]
+		span := spans[i/3]
 		commands[i], err = addToSpanHash(span)
 		if err != nil {
 			return err
 		}
 
-		commands[i+1] = t.incrementSpanCountsCMD(span.TraceID, span.Type)
+		commands[i+1] = redis.NewExpireCommand(spansHashByTraceIDKey(span.TraceID), t.traceExpirationDuration().Seconds())
+		commands[i+2] = t.incrementSpanCountsCMD(span.TraceID, span.Type)
 	}
 
 	err := conn.Exec(commands...)
@@ -984,12 +982,14 @@ func (t *tracesStore) incrementSpanCounts(ctx context.Context, conn redis.Conn, 
 	})
 	defer spanInc.End()
 
-	cmds := make([]redis.Command, len(spans))
-	for i, s := range spans {
-		cmds[i] = t.incrementSpanCountsCMD(s.TraceID, s.Type)
+	commands := make([]redis.Command, 2*len(spans))
+	for i := 0; i < len(commands); i += 2 {
+		span := spans[i/2]
+		commands[i] = t.incrementSpanCountsCMD(span.TraceID, span.Type)
+		commands[i+1] = redis.NewExpireCommand(t.traceStatusKey(span.TraceID), t.traceExpirationDuration().Seconds())
 	}
 
-	err := conn.Exec(cmds...)
+	err := conn.Exec(commands...)
 	if err != nil {
 		spanInc.RecordError(err)
 	}

--- a/centralstore/redis_store.go
+++ b/centralstore/redis_store.go
@@ -895,6 +895,9 @@ func (t *tracesStore) getTraceStatuses(ctx context.Context, client redis.Client,
 			if err != nil {
 				if errors.Is(err, redis.ErrKeyNotFound) {
 					status.TraceID = traceID
+					status.State = Unknown.String()
+					status.Timestamp = t.clock.Now().UnixMicro()
+
 					return normalizeCentralTraceStatusRedis(status)
 				}
 				statusSpan.RecordError(err)

--- a/centralstore/redis_store_test.go
+++ b/centralstore/redis_store_test.go
@@ -30,7 +30,9 @@ func TestRedisBasicStore_TraceStatus(t *testing.T) {
 
 	status, err := store.GetStatusForTraces(ctx, []string{traceID}, Unknown)
 	require.NoError(t, err)
-	require.Len(t, status, 0)
+	require.Len(t, status, 1)
+	require.Equal(t, Unknown, status[0].State)
+	require.Equal(t, traceID, status[0].TraceID)
 
 	testcases := []struct {
 		name               string

--- a/collect/cache/cuckooSentCache.go
+++ b/collect/cache/cuckooSentCache.go
@@ -42,7 +42,7 @@ type KeptTrace interface {
 	SentReason() uint
 }
 
-type Span interface {
+type SpanRecorder interface {
 	Trace() string
 	SpanType() types.SpanType
 }
@@ -91,7 +91,7 @@ func (t *keptTraceCacheEntry) SpanCount() uint {
 }
 
 // Count records additional spans in the cache record.
-func (t *keptTraceCacheEntry) Count(s Span) {
+func (t *keptTraceCacheEntry) Count(s SpanRecorder) {
 	t.eventCount++
 	switch s.SpanType() {
 	case types.SpanTypeEvent:
@@ -134,7 +134,7 @@ func (t *cuckooDroppedRecord) SpanCount() uint {
 	return 0
 }
 
-func (t *cuckooDroppedRecord) Count(Span) {
+func (t *cuckooDroppedRecord) Count(SpanRecorder) {
 }
 
 func (t *cuckooDroppedRecord) Reason() uint {
@@ -227,7 +227,7 @@ func (c *CuckooSentCache) Dropped(traceID string) bool {
 	return c.dropped.Check(traceID)
 }
 
-func (c *CuckooSentCache) Check(span Span) (TraceSentRecord, string, bool) {
+func (c *CuckooSentCache) Check(span SpanRecorder) (TraceSentRecord, string, bool) {
 	// was it dropped?
 	if c.dropped.Check(span.Trace()) {
 		// we recognize it as dropped, so just say so; there's nothing else to do

--- a/collect/cache/cuckooSentCache.go
+++ b/collect/cache/cuckooSentCache.go
@@ -42,8 +42,11 @@ type KeptTrace interface {
 	SentReason() uint
 }
 
+// SpanRecorder is an interface for a span that can be recorded in the CuckooSentCache.
 type SpanRecorder interface {
+	// Trace returns the trace ID of the span.
 	Trace() string
+	// SpanType returns the type of the span.
 	SpanType() types.SpanType
 }
 

--- a/collect/cache/traceSentCache.go
+++ b/collect/cache/traceSentCache.go
@@ -18,7 +18,7 @@ type TraceSentRecord interface {
 	// SpanCount returns the count of child spans in the trace.
 	SpanCount() uint
 	// Count records additional spans in the totals
-	Count(Span)
+	Count(SpanRecorder)
 }
 
 type TraceSentCache interface {
@@ -30,7 +30,7 @@ type TraceSentCache interface {
 	// found, it returns the appropriate TraceSentRecord, the keep reason, and
 	// true, else nil and "" and false. If the trace was kept, it will modify
 	// the record to include count information about the span.
-	Check(span Span) (TraceSentRecord, string, bool)
+	Check(span SpanRecorder) (TraceSentRecord, string, bool)
 	// Test if a trace is in the cache; if found, it returns the appropriate TraceSentRecord and true, else nil and false.
 	// It does not modify the count information.
 	Test(traceID string) (TraceSentRecord, string, bool)

--- a/collect/cache/traceSentCache.go
+++ b/collect/cache/traceSentCache.go
@@ -2,7 +2,6 @@ package cache
 
 import (
 	"github.com/honeycombio/refinery/config"
-	"github.com/honeycombio/refinery/types"
 )
 
 type TraceSentRecord interface {
@@ -19,7 +18,7 @@ type TraceSentRecord interface {
 	// SpanCount returns the count of child spans in the trace.
 	SpanCount() uint
 	// Count records additional spans in the totals
-	Count(*types.Span)
+	Count(Span)
 }
 
 type TraceSentCache interface {
@@ -31,7 +30,7 @@ type TraceSentCache interface {
 	// found, it returns the appropriate TraceSentRecord, the keep reason, and
 	// true, else nil and "" and false. If the trace was kept, it will modify
 	// the record to include count information about the span.
-	Check(span *types.Span) (TraceSentRecord, string, bool)
+	Check(span Span) (TraceSentRecord, string, bool)
 	// Test if a trace is in the cache; if found, it returns the appropriate TraceSentRecord and true, else nil and false.
 	// It does not modify the count information.
 	Test(traceID string) (TraceSentRecord, string, bool)

--- a/collect/central_collector.go
+++ b/collect/central_collector.go
@@ -668,17 +668,6 @@ func (c *CentralCollector) cleanupTraces(ctx context.Context) {
 	if len(ids) == 0 {
 		return
 	}
-	for _, t := range ids {
-		trace := c.SpanCache.Get(t)
-		if trace == nil {
-			continue
-		}
-		data := make(map[string]interface{}, 0)
-		data["trace_id"] = t
-		data["arrival_time"] = trace.ArrivalTime
-		data["span_coutn"] = len(trace.GetSpans())
-		c.Logger.Info().WithFields(data).Logf("old traces")
-	}
 
 	var tracesConsidered float64
 	now := c.Clock.Now()

--- a/collect/central_collector.go
+++ b/collect/central_collector.go
@@ -676,7 +676,10 @@ func (c *CentralCollector) cleanupTraces(ctx context.Context) {
 		c.Metrics.Histogram("sender_considered_per_second", tracesConsidered/sendTime.Seconds())
 	}()
 
-	statuses, err := c.Store.GetStatusForTraces(ctx, ids, centralstore.DecisionKeep, centralstore.DecisionDrop)
+	allStates := []centralstore.CentralTraceState{centralstore.DecisionKeep, centralstore.DecisionDrop, centralstore.Unknown, centralstore.Collecting,
+		centralstore.DecisionDelay, centralstore.ReadyToDecide}
+
+	statuses, err := c.Store.GetStatusForTraces(ctx, ids, allStates...)
 	if err != nil {
 		span.RecordError(err)
 		c.Logger.Error().Logf("error getting status for traces in cleanupTraces: %s", err)

--- a/collect/central_collector.go
+++ b/collect/central_collector.go
@@ -668,6 +668,17 @@ func (c *CentralCollector) cleanupTraces(ctx context.Context) {
 	if len(ids) == 0 {
 		return
 	}
+	for _, t := range ids {
+		trace := c.SpanCache.Get(t)
+		if trace == nil {
+			continue
+		}
+		data := make(map[string]interface{}, 0)
+		data["trace_id"] = t
+		data["arrival_time"] = trace.ArrivalTime
+		data["span_coutn"] = len(trace.GetSpans())
+		c.Logger.Info().WithFields(data).Logf("old traces")
+	}
 
 	var tracesConsidered float64
 	now := c.Clock.Now()
@@ -704,6 +715,7 @@ func (c *CentralCollector) cleanupTraces(ctx context.Context) {
 			// but let's record that we did.
 			c.SpanCache.Remove(status.TraceID)
 			tracesConsidered++
+			c.Logger.Info().WithField("trace_id", status.TraceID).Logf("dropping old trace")
 			c.Metrics.Increment("collector_drop_old_trace")
 			continue
 		}

--- a/collect/central_collector.go
+++ b/collect/central_collector.go
@@ -687,10 +687,7 @@ func (c *CentralCollector) cleanupTraces(ctx context.Context) {
 		c.Metrics.Histogram("sender_considered_per_second", tracesConsidered/sendTime.Seconds())
 	}()
 
-	allStates := []centralstore.CentralTraceState{centralstore.DecisionKeep, centralstore.DecisionDrop, centralstore.Unknown, centralstore.Collecting,
-		centralstore.DecisionDelay, centralstore.ReadyToDecide}
-
-	statuses, err := c.Store.GetStatusForTraces(ctx, ids, allStates...)
+	statuses, err := c.Store.GetStatusForTraces(ctx, ids, centralstore.AllTraceStates...)
 	if err != nil {
 		span.RecordError(err)
 		c.Logger.Error().Logf("error getting status for traces in cleanupTraces: %s", err)

--- a/collect/central_collector_test.go
+++ b/collect/central_collector_test.go
@@ -186,7 +186,7 @@ func TestCentralCollector_ProcessTraces(t *testing.T) {
 				assert.Equal(t, numberOfTraces*10, len(transmission.Events))
 				assert.Equal(t, "aoeu", transmission.Events[0].Dataset)
 				assert.Equal(t, "test", transmission.Events[0].Environment)
-				assert.Equal(t, TraceSendGotRoot, transmission.Events[0].Data["meta.refinery.send_reason"])
+				assert.Equal(t, TraceSendGotRoot, transmission.Events[0].Data["meta.refinery.send_reason"], transmission.Events[0])
 				assert.Equal(t, "deterministic/always", transmission.Events[0].Data["meta.refinery.reason"])
 				transmission.Mux.RUnlock()
 			}, 5*time.Second, 100*time.Millisecond)

--- a/collect/central_collector_test.go
+++ b/collect/central_collector_test.go
@@ -186,7 +186,7 @@ func TestCentralCollector_ProcessTraces(t *testing.T) {
 				assert.Equal(t, numberOfTraces*10, len(transmission.Events))
 				assert.Equal(t, "aoeu", transmission.Events[0].Dataset)
 				assert.Equal(t, "test", transmission.Events[0].Environment)
-				assert.Equal(t, TraceSendGotRoot, transmission.Events[0].Data["meta.refinery.send_reason"], transmission.Events[0])
+				assert.Equal(t, TraceSendGotRoot, transmission.Events[0].Data["meta.refinery.send_reason"])
 				assert.Equal(t, "deterministic/always", transmission.Events[0].Data["meta.refinery.reason"])
 				transmission.Mux.RUnlock()
 			}, 5*time.Second, 100*time.Millisecond)


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

This PR fixes multiple issues when dealing with late spans.
- updating late span counts in decision cache
- make sure late span data in redis gets cleaned up
- make sure key span list in redis is cleaned up if the trace decision is made through stress relief
-  make sure expired traces in span cache is cleaned up regardless their state

## Short description of the changes
- create `SpanRecorder` interface so that both `types.Span` and `centralstore.Span` can be recorded in cuckoo cache
- add expiration time for `addStatus`, `storeSpans`, and `incrementSpanCount` queries
- make sure `cleanupTraces` retrieves state for a trace in spancache regardless which state the trace is in

-

