### PR TITLE
fix: return when gossip channel is closed

### DIFF
--- a/internal/gossip/gossip_redis.go
+++ b/internal/gossip/gossip_redis.go
@@ -116,16 +116,13 @@ func (g *GossipRedis) Subscribe(channel Channel, depth int) chan []byte {
 
 // Publish sends a message to all subscribers of a given channel.
 func (g *GossipRedis) Publish(channel Channel, value []byte) error {
-	msg := NewMessage(channel, value)
-	if len(msg) == 0 {
-		return errors.New("empty message")
-	}
-
 	select {
 	case <-g.done:
 		return errors.New("gossip has been stopped")
 	default:
 	}
+
+	msg := NewMessage(channel, value)
 
 	conn := g.Redis.GetPubSubConn()
 	defer conn.Close()


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

Test are flaky when using in-memory gossiper due to race condition on shutdown.  

## Short description of the changes

- If the `g.gossipCh` is closed, Refinery should return instead of keep processing the value

