### PR TITLE
fix: allow sending otel tracing to honeycomb classic environment

### DIFF
--- a/internal/otelutil/otel_tracing.go
+++ b/internal/otelutil/otel_tracing.go
@@ -97,7 +97,8 @@ func SetupTracing(cfg config.OTelTracingConfig, resourceLibrary string, resource
 			otelconfig.WithTracesEnabled(true),
 			otelconfig.WithSampler(samplers.TraceIDRatioBased(sampleRatio)),
 			otelconfig.WithHeaders(map[string]string{
-				"x-honeycomb-team": cfg.APIKey,
+				"x-honeycomb-team":    cfg.APIKey,
+				"x-honeycomb-dataset": cfg.Dataset,
 			}),
 		)
 		if err != nil {


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

Refinery's traces wasn't getting send to honeycomb classic environment

## Short description of the changes

- add dataset header to otel tracing config

