### PR TITLE
feat: add config for decider health check

### DIFF
--- a/collect/central_collector.go
+++ b/collect/central_collector.go
@@ -117,11 +117,11 @@ func (c *CentralCollector) Start() error {
 
 	// we're a health check reporter so register ourselves for each of our major routines
 	c.Health.Register(receiverHealth, time.Duration(5*collectorCfg.MemoryCycleDuration))
-	deciderHealthThreashold := collectorCfg.GetDeciderHealthThreshold()
-	if deciderHealthThreashold == 0 {
-		deciderHealthThreashold = 5 * collectorCfg.GetDeciderCycleDuration()
+	deciderHealthThreshold := collectorCfg.GetDeciderHealthThreshold()
+	if deciderHealthThreshold == 0 {
+		deciderHealthThreshold = 5 * collectorCfg.GetDeciderCycleDuration()
 	}
-	c.Health.Register(deciderHealth, deciderHealthThreashold)
+	c.Health.Register(deciderHealth, deciderHealthThreshold)
 
 	// the sender health check should only be run if we're using it
 	if !collectorCfg.UseDecisionGossip {

--- a/collect/central_collector.go
+++ b/collect/central_collector.go
@@ -117,7 +117,11 @@ func (c *CentralCollector) Start() error {
 
 	// we're a health check reporter so register ourselves for each of our major routines
 	c.Health.Register(receiverHealth, time.Duration(5*collectorCfg.MemoryCycleDuration))
-	c.Health.Register(deciderHealth, 5*collectorCfg.GetDeciderCycleDuration())
+	deciderHealthThreashold := collectorCfg.GetDeciderHealthThreshold()
+	if deciderHealthThreashold == 0 {
+		deciderHealthThreashold = 5 * collectorCfg.GetDeciderCycleDuration()
+	}
+	c.Health.Register(deciderHealth, deciderHealthThreashold)
 
 	// the sender health check should only be run if we're using it
 	if !collectorCfg.UseDecisionGossip {

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -226,6 +226,7 @@ type CollectionConfig struct {
 	CleanupCycleDuration    Duration   `yaml:"CleanupCycleDuration" default:"5s"`
 	DeciderCycleDuration    Duration   `yaml:"DeciderCycleDuration" default:"100ms"`
 	DeciderBatchSize        int        `yaml:"DeciderBatchSize" default:"1000"`
+	DeciderHealthThreshold  Duration   `yaml:"DeciderHealthThreshold" default:"2s"`
 	AvailableMemory         MemorySize `yaml:"AvailableMemory" cmdenv:"AvailableMemory"`
 	MaxMemoryPercentage     int        `yaml:"MaxMemoryPercentage" default:"75"`
 	MaxAlloc                MemorySize `yaml:"MaxAlloc"`
@@ -293,6 +294,9 @@ func (c CollectionConfig) GetCleanupCycleDuration() time.Duration {
 
 func (c CollectionConfig) GetDeciderCycleDuration() time.Duration {
 	return time.Duration(c.DeciderCycleDuration)
+}
+func (c CollectionConfig) GetDeciderHealthThreshold() time.Duration {
+	return time.Duration(c.DeciderHealthThreshold)
 }
 
 func (c CollectionConfig) GetDeciderBatchSize() int {

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -1271,7 +1271,7 @@ groups:
         valuetype: nondefault
         default: 2s
         reload: false
-        summary: is the threashold for the health check to consider the decider unhealthy.
+        summary: is the threshold for the health check to consider the decider unhealthy.
         description: >
           This setting controls the duration that Refinery uses for determining if the decider is unhealthy
           through the health check system.

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -1266,6 +1266,16 @@ groups:
           of trace decisions Refinery can make in one second. It is rarely
           necessary to adjust this value.
 
+      - name: DeciderHealthThreshold
+        type: duration
+        valuetype: nondefault
+        default: 2s
+        reload: false
+        summary: is the threashold for the health check to consider the decider unhealthy.
+        description: >
+          This setting controls the duration that Refinery uses for determining if the decider is unhealthy
+          through the health check system.
+
       - name: CleanupCycleDuration
         type: duration
         valuetype: nondefault


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

We have discovered that the decider can take much longer than 500ms to complete an iteration. In order to avoid health check being flappy, we need more control over the timeout value.

## Short description of the changes

- introduce a new config value for decider health check

