### PR TITLE
maint: clean up redis interface

### DIFF
--- a/centralstore/redis_store_test.go
+++ b/centralstore/redis_store_test.go
@@ -711,7 +711,7 @@ func (ts *testTraceStateProcessor) ensureInitialState(t *testing.T, ctx context.
 	for _, state := range ts.states {
 		require.NoError(t, ts.remove(ctx, conn, state, traceID))
 	}
-	_, err := conn.Del(ts.traceStatesKey(traceID))
+	_, err := conn.Del(ts.traceStatesKey(traceID)).Do()
 	require.NoError(t, err)
 
 	newSpan := []string{traceID}

--- a/redis/redis_test.go
+++ b/redis/redis_test.go
@@ -127,63 +127,6 @@ func TestAcquireLockWithRetriesTTLExceeded(t *testing.T) {
 	require.NoError(t, clearLock3())
 }
 
-func Test_MGetSetings(t *testing.T) {
-	ctx := context.Background()
-
-	h := NewRedisTestHarness(ctx, t)
-	defer h.Stop(ctx)
-
-	redis := h.Redis.Client.Get()
-	defer redis.Close()
-
-	redis.SetString("foo", "fooval")
-	redis.SetString("bar", "barval")
-
-	vals, err := redis.MGetStrings("foo", "bar", "baz")
-	require.NoError(t, err)
-	require.EqualValues(t, []string{"fooval", "barval", ""}, vals)
-}
-
-func Test_SetStringTTL(t *testing.T) {
-	ctx := context.Background()
-
-	h := NewRedisTestHarness(ctx, t)
-	defer h.Stop(ctx)
-
-	redis := h.Redis.Client.Get()
-	defer redis.Close()
-
-	ttlDays := 30
-	ttl := time.Duration(ttlDays*24) * time.Hour
-
-	_, err := redis.SetStringTTL(ctx, "foo", "fooval", ttl)
-	require.NoError(t, err)
-
-	val, err := redis.GetString(ctx, "foo")
-	require.NoError(t, err)
-	require.Equal(t, "fooval", val)
-}
-
-func Test_SetStringsTTL(t *testing.T) {
-	ctx := context.Background()
-
-	h := NewRedisTestHarness(ctx, t)
-	defer h.Stop(ctx)
-
-	redis := h.Redis.Client.Get()
-	defer redis.Close()
-
-	ttlDays := 30
-	ttl := time.Duration(ttlDays*24) * time.Hour
-
-	_, err := redis.SetStringsTTL([]string{"foo", "bar"}, []string{"fooval", "barval"}, ttl)
-	require.NoError(t, err)
-
-	vals, err := redis.GetStrings("foo", "bar", "baz")
-	require.NoError(t, err)
-	require.EqualValues(t, []string{"fooval", "barval", ""}, vals)
-}
-
 func createArbitraryUniqueKey() string {
 	return uuid.Must(uuid.NewV4()).String()
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

We have converted a lot of code to use pipelining pattern for communication with Redis. This PR is to allow the caller of the redis package to have an easier time to use the pattern

## Short description of the changes

- return a command object from each redis call so that the caller has control whether to buffer or send a query to redis
- remove unused code

