### PR TITLE
fix: Don’t consider log events as root spans

### DIFF
--- a/collect/collect.go
+++ b/collect/collect.go
@@ -575,6 +575,11 @@ func mergeTraceAndSpanSampleRates(sp *types.Span, traceSampleRate uint, dryRunMo
 }
 
 func (i *InMemCollector) isRootSpan(sp *types.Span) bool {
+	// log event should never be considered a root span, check for that first
+	if signalType, _ := sp.Data["meta.signal_type"]; signalType == "log" {
+		return false
+	}
+	// check if the event has a parent id using the configured parent id field names
 	for _, parentIdFieldName := range i.Config.GetParentIdFieldNames() {
 		parentId := sp.Data[parentIdFieldName]
 		if _, ok := parentId.(string); ok {


### PR DESCRIPTION
## Which problem is this PR solving?

Log events should never be considered root spans even though they do not contain a `trace.parent_id`. A log event that is part of a trace would mark the trace complete as if it's considered a root span.

This change updates the check for whether a span is considered a root span to also check for the meta field `meta.signal_type`. If the field exists and is set to "log", we return false.

## Short description of the changes
- Update `InMemoryCollector.isRootSpan` to check if `meta.signal_type` and has a value of "log"
- Add unit tests for InMemoryCollector to verify expected behaviour for isRootSpan