### PR TITLE
feat: track config hash on config reload

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -26,9 +26,36 @@ type App struct {
 // program will exit.
 func (a *App) Start() error {
 	a.Logger.Debug().Logf("Starting up App...")
+	a.Metrics.Register("config_hash", "gauge")
+	a.Metrics.Register("rule_config_hash", "gauge")
 
 	a.IncomingRouter.SetVersion(a.Version)
 	a.PeerRouter.SetVersion(a.Version)
+
+	a.Config.RegisterReloadCallback(func(configHash, rulesHash string) {
+		if a.Logger != nil {
+			a.Logger.Warn().WithFields(map[string]interface{}{
+				"configHash": configHash,
+				"rulesHash":  rulesHash,
+			}).Logf("configuration change was detected and the configuration was reloaded.")
+
+			cfgMetric, err := config.ConfigHashMetrics(configHash)
+			if err != nil {
+				a.Logger.Error().Logf("error calculating config hash metrics: %s", err)
+			} else {
+				a.Metrics.Gauge("config_hash", cfgMetric)
+			}
+
+			ruleMetric, err := config.ConfigHashMetrics(rulesHash)
+			if err != nil {
+				a.Logger.Error().Logf("error calculating config hash metrics: %s", err)
+			} else {
+				a.Metrics.Gauge("rule_config_hash", ruleMetric)
+			}
+
+		}
+
+	})
 
 	// launch our main routers to listen for incoming event traffic from both peers
 	// and external sources

--- a/app/app.go
+++ b/app/app.go
@@ -39,19 +39,11 @@ func (a *App) Start() error {
 				"rulesHash":  rulesHash,
 			}).Logf("configuration change was detected and the configuration was reloaded.")
 
-			cfgMetric, err := config.ConfigHashMetrics(configHash)
-			if err != nil {
-				a.Logger.Error().Logf("error calculating config hash metrics: %s", err)
-			} else {
-				a.Metrics.Gauge("config_hash", cfgMetric)
-			}
+			cfgMetric := config.ConfigHashMetrics(configHash)
+			ruleMetric := config.ConfigHashMetrics(rulesHash)
 
-			ruleMetric, err := config.ConfigHashMetrics(rulesHash)
-			if err != nil {
-				a.Logger.Error().Logf("error calculating config hash metrics: %s", err)
-			} else {
-				a.Metrics.Gauge("rule_config_hash", ruleMetric)
-			}
+			a.Metrics.Gauge("config_hash", cfgMetric)
+			a.Metrics.Gauge("rule_config_hash", ruleMetric)
 
 		}
 

--- a/cmd/refinery/main.go
+++ b/cmd/refinery/main.go
@@ -96,12 +96,6 @@ func main() {
 		fmt.Println("Config and Rules validated successfully.")
 		os.Exit(0)
 	}
-	c.RegisterReloadCallback(func() {
-		if a.Logger != nil {
-			a.Logger.Info().Logf("configuration change was detected and the configuration was reloaded")
-		}
-	})
-
 	// get desired implementation for each dependency to inject
 	lgr := logger.GetLoggerImplementation(c)
 	collector := collect.GetCollectorImplementation(c)

--- a/collect/collect.go
+++ b/collect/collect.go
@@ -141,7 +141,7 @@ func (i *InMemCollector) Start() error {
 }
 
 // sendReloadSignal will trigger the collector reloading its config, eventually.
-func (i *InMemCollector) sendReloadSignal() {
+func (i *InMemCollector) sendReloadSignal(cfgHash, ruleHash string) {
 	// non-blocking insert of the signal here so we don't leak goroutines
 	select {
 	case i.reload <- struct{}{}:

--- a/config/config.go
+++ b/config/config.go
@@ -21,7 +21,7 @@ type Config interface {
 	// consumers of configuration set config values on startup, they should
 	// check their values haven't changed and re-start anything that needs
 	// restarting with the new values.
-	RegisterReloadCallback(callback func())
+	RegisterReloadCallback(callback ConfigReloadCallback)
 
 	// GetListenAddr returns the address and port on which to listen for
 	// incoming events
@@ -190,6 +190,8 @@ type Config interface {
 
 	GetParentIdFieldNames() []string
 }
+
+type ConfigReloadCallback func(configHash, ruleCfgHash string)
 
 type ConfigMetadata struct {
 	Type     string `json:"type"`

--- a/config/configLoadHelpers.go
+++ b/config/configLoadHelpers.go
@@ -246,16 +246,16 @@ func readConfigInto(dest any, location string, opts *CmdEnv) (string, error) {
 // The decimal value is the last 4 characters of the config hash, converted to decimal.
 // If the config hash is too short, or if there is an error converting the hash to decimal,
 // an error is returned.
-func ConfigHashMetrics(hash string) (int64, error) {
+func ConfigHashMetrics(hash string) int64 {
 	// get last 4 characters of config hash
 	if len(hash) < 4 {
-		return 0, fmt.Errorf("config hash is too short: %s", hash)
+		return 0
 	}
 	suffix := hash[len(hash)-4:]
 	CfgDecimal, err := strconv.ParseInt(suffix, 16, 64)
 	if err != nil {
-		return 0, fmt.Errorf("error converting config hash to decimal: %v", err)
+		return 0
 	}
 
-	return CfgDecimal, nil
+	return CfgDecimal
 }

--- a/config/configLoadHelpers.go
+++ b/config/configLoadHelpers.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 
 	"github.com/creasty/defaults"
 	"github.com/pelletier/go-toml/v2"
@@ -239,4 +240,22 @@ func readConfigInto(dest any, location string, opts *CmdEnv) (string, error) {
 	}
 
 	return hash, nil
+}
+
+// ConfigHashMetrics takes a config hash and returns a decimal value for use in metrics.
+// The decimal value is the last 4 characters of the config hash, converted to decimal.
+// If the config hash is too short, or if there is an error converting the hash to decimal,
+// an error is returned.
+func ConfigHashMetrics(hash string) (int64, error) {
+	// get last 4 characters of config hash
+	if len(hash) < 4 {
+		return 0, fmt.Errorf("config hash is too short: %s", hash)
+	}
+	suffix := hash[len(hash)-4:]
+	CfgDecimal, err := strconv.ParseInt(suffix, 16, 64)
+	if err != nil {
+		return 0, fmt.Errorf("error converting config hash to decimal: %v", err)
+	}
+
+	return CfgDecimal, nil
 }

--- a/config/configLoadHelpers.go
+++ b/config/configLoadHelpers.go
@@ -242,10 +242,10 @@ func readConfigInto(dest any, location string, opts *CmdEnv) (string, error) {
 	return hash, nil
 }
 
-// ConfigHashMetrics takes a config hash and returns a decimal value for use in metrics.
-// The decimal value is the last 4 characters of the config hash, converted to decimal.
-// If the config hash is too short, or if there is an error converting the hash to decimal,
-// an error is returned.
+// ConfigHashMetrics takes a config hash and returns a integer value for use in metrics.
+// The value is the last 4 characters of the config hash, converted to an integer.
+// If the config hash is too short, or if there is an error converting the hash to an integer,
+// it returns 0.
 func ConfigHashMetrics(hash string) int64 {
 	// get last 4 characters of config hash
 	if len(hash) < 4 {

--- a/config/configLoadHelpers_test.go
+++ b/config/configLoadHelpers_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func Test_formatFromFilename(t *testing.T) {
@@ -123,6 +125,30 @@ func Test_loadMemsize(t *testing.T) {
 			}
 			if !reflect.DeepEqual(tt.into, tt.want) {
 				t.Errorf("load() = %#v, want %#v", tt.into, tt.want)
+			}
+		})
+	}
+}
+
+func Test_ConfigHashMetrics(t *testing.T) {
+	testcases := []struct {
+		name     string
+		hash     string
+		expected int64
+		hasError bool
+	}{
+		{name: "valid hash", hash: "7f1237f7db723f4e874a7a8269081a77", expected: 6775},
+		{name: "invalid length", hash: "1a8", hasError: true},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := ConfigHashMetrics(tc.hash)
+			if tc.hasError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expected, result)
 			}
 		})
 	}

--- a/config/configLoadHelpers_test.go
+++ b/config/configLoadHelpers_test.go
@@ -135,21 +135,15 @@ func Test_ConfigHashMetrics(t *testing.T) {
 		name     string
 		hash     string
 		expected int64
-		hasError bool
 	}{
 		{name: "valid hash", hash: "7f1237f7db723f4e874a7a8269081a77", expected: 6775},
-		{name: "invalid length", hash: "1a8", hasError: true},
+		{name: "invalid length", hash: "1a8", expected: 0},
 	}
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			result, err := ConfigHashMetrics(tc.hash)
-			if tc.hasError {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-				require.Equal(t, tc.expected, result)
-			}
+			result := ConfigHashMetrics(tc.hash)
+			require.Equal(t, tc.expected, result)
 		})
 	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -212,7 +212,7 @@ func TestReload(t *testing.T) {
 
 	ch := make(chan interface{}, 1)
 
-	c.RegisterReloadCallback(func() {
+	c.RegisterReloadCallback(func(cfgHash, ruleHash string) {
 		close(ch)
 	})
 

--- a/config/mock.go
+++ b/config/mock.go
@@ -9,7 +9,7 @@ import (
 // MockConfig will respond with whatever config it's set to do during
 // initialization
 type MockConfig struct {
-	Callbacks                        []func()
+	Callbacks                        []ConfigReloadCallback
 	IsAPIKeyValidFunc                func(string) bool
 	GetCollectorTypeErr              error
 	GetCollectorTypeVal              string
@@ -99,11 +99,11 @@ func (m *MockConfig) ReloadConfig() {
 	defer m.Mux.RUnlock()
 
 	for _, callback := range m.Callbacks {
-		callback()
+		callback("", "")
 	}
 }
 
-func (m *MockConfig) RegisterReloadCallback(callback func()) {
+func (m *MockConfig) RegisterReloadCallback(callback ConfigReloadCallback) {
 	m.Mux.Lock()
 	m.Callbacks = append(m.Callbacks, callback)
 	m.Mux.Unlock()

--- a/logger/honeycomb.go
+++ b/logger/honeycomb.go
@@ -122,7 +122,7 @@ func (h *HoneycombLogger) readResponses() {
 	}
 }
 
-func (h *HoneycombLogger) reloadBuilder() {
+func (h *HoneycombLogger) reloadBuilder(cfgHash, ruleHash string) {
 	h.Debug().Logf("reloading config for Honeycomb logger")
 	// preserve log level
 	h.level = h.Config.GetLoggerLevel()

--- a/metrics/legacy.go
+++ b/metrics/legacy.go
@@ -92,7 +92,7 @@ func (h *LegacyMetrics) Start() error {
 	return nil
 }
 
-func (h *LegacyMetrics) reloadBuilder() {
+func (h *LegacyMetrics) reloadBuilder(cfgHash, ruleHash string) {
 	h.Logger.Debug().Logf("reloading config for honeycomb metrics reporter")
 	mc := h.Config.GetLegacyMetricsConfig()
 	h.libhClient.Close()

--- a/transmit/transmit.go
+++ b/transmit/transmit.go
@@ -83,7 +83,7 @@ func (d *DefaultTransmission) Start() error {
 	return nil
 }
 
-func (d *DefaultTransmission) reloadTransmissionBuilder() {
+func (d *DefaultTransmission) reloadTransmissionBuilder(cfgHash, ruleHash string) {
 	d.Logger.Debug().Logf("reloading transmission config")
 	upstreamAPI, err := d.Config.GetHoneycombAPI()
 	if err != nil {


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

To provide better visibility of current configuration used in Refinery, this PR introduce two metrics, `config_hash` and `rule_config_hash`, for keeping track of configuration.

## Short description of the changes
- change config change log from `info` level to `warn`
- include full config hash value in config change log
- store the decimal number of the last 4 digit of config hash value as metrics


#967 
