### PR TITLE
maint: Add jitter to peer traffic, fix startup

### DIFF
--- a/cmd/refinery/main.go
+++ b/cmd/refinery/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/facebookgo/startstop"
 	libhoney "github.com/honeycombio/libhoney-go"
 	"github.com/honeycombio/libhoney-go/transmission"
+	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
 
 	"github.com/honeycombio/refinery/app"
@@ -121,8 +122,9 @@ func main() {
 	}
 	switch ptype {
 	case "file":
-		peers = &peer.FilePeers{Cfg: c}
-		// we know FilePeers doesn't need to be Started, so we can ask it how many peers we have.
+		// we want to use the file peers object to ask if we have only one peer, so we need to instantiate it
+		// with a dummy metrics object. we'll replace it with the real one later.
+		peers = &peer.FilePeers{Cfg: c, Metrics: &metrics.NullMetrics{}}
 		// if we only have one, we can use the local pubsub implementation.
 		peerList, err := peers.GetPeers()
 		if err != nil {
@@ -133,6 +135,8 @@ func main() {
 		} else {
 			pubsubber = &pubsub.GoRedisPubSub{}
 		}
+		// now erase the peers Metrics object so that it will get injected with the right one later
+		peers.(*peer.FilePeers).Metrics = nil
 	case "redis":
 		pubsubber = &pubsub.GoRedisPubSub{}
 		peers = &peer.RedisPubsubPeers{}
@@ -252,7 +256,7 @@ func main() {
 		{Value: promMetrics, Name: "promMetrics"},
 		{Value: oTelMetrics, Name: "otelMetrics"},
 		{Value: tracer, Name: "tracer"},
-
+		{Value: clockwork.NewRealClock()},
 		{Value: metricsSingleton, Name: "metrics"},
 		{Value: genericMetricsRecorder, Name: "genericMetrics"},
 		{Value: upstreamMetricsRecorder, Name: "upstreamMetrics"},


### PR DESCRIPTION
## Which problem is this PR solving?

- Add jitter to peer traffic so we don't get thundering herds
- Inject the right things for proper startup

