### PR TITLE
maint: change targeted arch to arm for local development Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ADD . .
 
 RUN CGO_ENABLED=0 \
     GOOS=linux \
-    GOARCH=amd64 \
+    GOARCH=arm64 \
     go build -ldflags "-X main.BuildID=${BUILD_ID}" \
     -o refinery \
     ./cmd/refinery


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

This dockerfile is used only for local development. Now most of us who are actively working on this project are on ARM machines. Let's make it easier to test refinery locally

## Short description of the changes

- Change targeted architecture to ARM

