### PR TITLE
fix: make sure to inject Health object as a pointer

### DIFF
--- a/cmd/refinery/main.go
+++ b/cmd/refinery/main.go
@@ -265,7 +265,7 @@ func main() {
 		{Value: version, Name: "version"},
 		{Value: samplerFactory},
 		{Value: stressRelief, Name: "stressRelief"},
-		{Value: health.Health{}},
+		{Value: &health.Health{}},
 		{Value: &a},
 	}
 	err = g.Provide(objects...)


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

Refinery panics on start
 
## Short description of the changes

- inject `Health` as a pointer

