### PR TITLE
fix: make sure stress relief pub/sub topic is consistent

### DIFF
--- a/collect/stressRelief.go
+++ b/collect/stressRelief.go
@@ -19,6 +19,8 @@ import (
 	"github.com/jonboulle/clockwork"
 )
 
+const stressReliefTopic = "refinery-stress-relief"
+
 type StressReliever interface {
 	Start() error
 	UpdateFromConfig(cfg config.StressReliefConfig)
@@ -145,7 +147,7 @@ func (s *StressRelief) Start() error {
 
 	// Subscribe to the stress relief topic so we can react to stress level
 	// changes in the cluster.
-	s.PubSub.Subscribe(context.Background(), "refinery-stress-level", s.onStressLevelUpdate)
+	s.PubSub.Subscribe(context.Background(), stressReliefTopic, s.onStressLevelUpdate)
 
 	// start our monitor goroutine that periodically calls recalc
 	// and also reports that it's healthy
@@ -156,7 +158,7 @@ func (s *StressRelief) Start() error {
 			select {
 			case <-tick.C:
 				currentLevel := s.Recalc()
-				err := s.PubSub.Publish(context.Background(), "refinery-stress-relief", newStressReliefMessage(currentLevel, s.hostID).String())
+				err := s.PubSub.Publish(context.Background(), stressReliefTopic, newStressReliefMessage(currentLevel, s.hostID).String())
 				if err != nil {
 					s.Logger.Error().Logf("failed to publish stress level: %s", err)
 				}

--- a/collect/stress_relief_test.go
+++ b/collect/stress_relief_test.go
@@ -109,7 +109,7 @@ func TestStressRelief_Peer(t *testing.T) {
 			level:  90,
 			peerID: "peer1",
 		}
-		require.NoError(t, channel.Publish(context.Background(), "refinery-stress-level", msg.String()))
+		require.NoError(t, channel.Publish(context.Background(), stressReliefTopic, msg.String()))
 		clock.Advance(time.Second * 1)
 		return sr.Stressed()
 	}, 2*time.Second, 100*time.Millisecond, "stress relief should be false")
@@ -121,7 +121,7 @@ func TestStressRelief_Peer(t *testing.T) {
 			level:  10,
 			peerID: "peer1",
 		}
-		require.NoError(t, channel.Publish(context.Background(), "refinery-stress-level", msg.String()))
+		require.NoError(t, channel.Publish(context.Background(), stressReliefTopic, msg.String()))
 
 		clock.Advance(time.Second * 1)
 		return !sr.Stressed()


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

Make sure subscriber and publisher uses the same channel for stress relief

## Short description of the changes

- define a constant for stress relief pub/sub topic
- use the constant in test and stress relief code

