### PR TITLE
fix: add injection tags for configwatcher

### DIFF
--- a/internal/configwatcher/watcher.go
+++ b/internal/configwatcher/watcher.go
@@ -23,8 +23,8 @@ const ConfigPubsubTopic = "cfg_update"
 // ConfigWatcher listens for configuration changes and publishes notice of them.
 // It avoids sending duplicate messages by comparing the hash of the configs.
 type ConfigWatcher struct {
-	Config  config.Config
-	PubSub  pubsub.PubSub
+	Config  config.Config   `inject:""`
+	PubSub  pubsub.PubSub   `inject:""`
 	Tracer  trace.Tracer    `inject:"tracer"`
 	Clock   clockwork.Clock `inject:""`
 	subscr  pubsub.Subscription


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

Config and PubSub needs injection tags for the injection framework

## Short description of the changes

- add injection tag

