### PR TITLE
fix: reduce pub/sub messages from stress relief

### DIFF
--- a/collect/stressRelief.go
+++ b/collect/stressRelief.go
@@ -152,16 +152,32 @@ func (s *StressRelief) Start() error {
 	// start our monitor goroutine that periodically calls recalc
 	// and also reports that it's healthy
 	go func(s *StressRelief) {
+		// only publish stress level if it has changed or if it's been a while since the last publish
+		const maxTicksBetweenReports = 30
+		var (
+			lastLevel   uint = 0
+			tickCounter      = 0
+		)
+
 		tick := time.NewTicker(100 * time.Millisecond)
 		defer tick.Stop()
 		for {
 			select {
 			case <-tick.C:
 				currentLevel := s.Recalc()
-				err := s.PubSub.Publish(context.Background(), stressReliefTopic, newStressReliefMessage(currentLevel, s.hostID).String())
-				if err != nil {
-					s.Logger.Error().Logf("failed to publish stress level: %s", err)
+
+				if lastLevel != currentLevel || tickCounter == maxTicksBetweenReports {
+					err := s.PubSub.Publish(context.Background(), stressReliefTopic, newStressReliefMessage(currentLevel, s.hostID).String())
+					if err != nil {
+						s.Logger.Error().Logf("failed to publish stress level: %s", err)
+					}
+
+					lastLevel = currentLevel
+					tickCounter = 0
 				}
+
+				tickCounter++
+
 				s.Health.Ready(StressReliefHealthKey, true)
 			case <-s.Done:
 				s.Health.Unregister(StressReliefHealthKey)
@@ -174,8 +190,8 @@ func (s *StressRelief) Start() error {
 }
 
 type stressReliefMessage struct {
-	level  uint
 	peerID string
+	level  uint
 }
 
 func newStressReliefMessage(level uint, peerID string) *stressReliefMessage {


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

We don't need to publish stress level if it hasn't changed. This will help reduce the amount of pub/sub messages being transmitted in the cluster

## Short description of the changes

- made `stressReliefMessage` struct more memory efficient
- add a counter for tracking how long it has been since last stress level publish

