### PR TITLE
fix: clean up a print line

### DIFF
--- a/sharder/deterministic.go
+++ b/sharder/deterministic.go
@@ -1,7 +1,6 @@
 package sharder
 
 import (
-	"fmt"
 	"sort"
 	"sync"
 	"time"
@@ -116,7 +115,6 @@ func (d *DeterministicSharder) Start() error {
 		// go through peer list, resolve each address, see if any of them match any
 		// local interface. Note that this assumes only one instance of Refinery per
 		// host can run.
-		fmt.Println("self", self)
 		self, err = d.Peers.GetInstanceID()
 		if err == nil {
 			for _, peerShard := range d.peers {


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

Accidentally left a print line from the previous PR

## Short description of the changes

remove `fmt.Println`

