### PR TITLE
fix: FilePeers implies no Redis

### DIFF
--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -835,12 +835,15 @@ groups:
           Peer management is the mechanism by which Refinery locates its peers.
 
           `file` means that Refinery gets its peer list from the Peers list in
-          this config file.
+          this config file. It also prevents Refinery from using a publish/subscribe
+          mechanism to propagate peer lists, stress levels, and configuration changes.
 
           `redis` means that Refinery uses a Publish/Subscribe mechanism,
-          implemented on Redis, to propagate peer lists much more quickly than
-          the legacy mechanism. This is the recommended setting, especially for
-          new installations.
+          implemented on Redis, to propagate peer lists, stress levels, and
+          notification of configuration changes much more quickly than the
+          legacy mechanism. This is the recommended setting, especially for new
+          installations. If this is specified, fields in `RedisPeerManagement`
+          must also be set.
 
       - name: Identifier
         v1group: PeerManagement


### PR DESCRIPTION
## Which problem is this PR solving?

- If someone specified FilePeers, then we are assuming they don't want to run Redis.

## Short description of the changes

- Simplify logic; if FilePeers, no redis and only local pubsub.
- Update some of the documentation.

