### PR TITLE
fix: allow a single node to activate stress relief mode during significant load increase

### DIFF
--- a/collect/stressRelief.go
+++ b/collect/stressRelief.go
@@ -35,8 +35,8 @@ var _ StressReliever = &MockStressReliever{}
 type MockStressReliever struct {
 	IsStressed              bool
 	SampleDeterministically bool
-	SampleRate              uint
 	ShouldKeep              bool
+	SampleRate              uint
 }
 
 func (m *MockStressReliever) Start() error                                   { return nil }
@@ -99,6 +99,8 @@ type StressRelief struct {
 
 	lock         sync.RWMutex
 	stressLevels map[string]stressReport
+	// only used in tests
+	disableStressLevelReport bool
 }
 
 const StressReliefHealthKey = "stress_relief"
@@ -152,8 +154,12 @@ func (s *StressRelief) Start() error {
 
 	// start our monitor goroutine that periodically calls recalc
 	// and also reports that it's healthy
+
 	go func(s *StressRelief) {
 		// only publish stress level if it has changed or if it's been a while since the last publish
+		if s.disableStressLevelReport {
+			return
+		}
 		const maxTicksBetweenReports = 30
 		var (
 			lastLevel   uint = 0

--- a/collect/stressRelief.go
+++ b/collect/stressRelief.go
@@ -160,11 +160,11 @@ func (s *StressRelief) Start() error {
 			tickCounter      = 0
 		)
 
-		tick := time.NewTicker(100 * time.Millisecond)
+		tick := s.Clock.NewTicker(100 * time.Millisecond)
 		defer tick.Stop()
 		for {
 			select {
-			case <-tick.C:
+			case <-tick.Chan():
 				currentLevel := s.Recalc()
 
 				if lastLevel != currentLevel || tickCounter == maxTicksBetweenReports {

--- a/collect/stressRelief.go
+++ b/collect/stressRelief.go
@@ -425,7 +425,13 @@ func (s *StressRelief) Recalc() uint {
 		// If it's off, should we activate it?
 		if !s.stressed && s.overallStressLevel >= s.activateLevel {
 			s.stressed = true
-			s.Logger.Warn().WithField("stress_level", s.overallStressLevel).WithField("stress_formula", s.formula).WithField("reason", s.reason).Logf("StressRelief has been activated")
+			s.Logger.Warn().WithFields(map[string]interface{}{
+				"individual_stress_level": localLevel,
+				"cluster_stress_level":    clusterStressLevel,
+				"stress_level":            s.overallStressLevel,
+				"stress_formula":          s.formula,
+				"reason":                  s.reason,
+			}).Logf("StressRelief has been activated")
 		}
 		// We want make sure that stress relief is below the deactivate level
 		// for a minimum time after the last time we said it should be, so
@@ -436,7 +442,11 @@ func (s *StressRelief) Recalc() uint {
 		// If it's on, should we deactivate it?
 		if s.stressed && s.overallStressLevel < s.deactivateLevel && s.Clock.Now().After(s.stayOnUntil) {
 			s.stressed = false
-			s.Logger.Warn().WithField("stress_level", s.overallStressLevel).Logf("StressRelief has been deactivated")
+			s.Logger.Warn().WithFields(map[string]interface{}{
+				"individual_stress_level": localLevel,
+				"cluster_stress_level":    clusterStressLevel,
+				"stress_level":            s.overallStressLevel,
+			}).Logf("StressRelief has been deactivated")
 		}
 	}
 

--- a/collect/stress_relief_test.go
+++ b/collect/stress_relief_test.go
@@ -117,7 +117,7 @@ func TestStressRelief_Peer(t *testing.T) {
 
 	// now the peer has reported valid stress level
 	// it should be taken into account for the overall stress level
-	sr.RefineryMetrics.Gauge("collector_incoming_queue_length", 10)
+	sr.RefineryMetrics.Gauge("collector_incoming_queue_length", 5)
 	require.Eventually(t, func() bool {
 		msg := stressReliefMessage{
 			level:  10,


### PR DESCRIPTION

<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

Without resolving trace locality issue, a single peer can receive a large trace that significantly raise its stress level than the rest of the cluster. To address this issue, we can allow individual refineries to go into stress relief mode if their own stress is too high, even if the cluster's isn't.

## Short description of the changes

- use the max of the individual stress level and the cluster stress level as the overall stress level when calculating stress relief activation and deactivation
- record the stress level that determined stress relief activation as `stress_level` metric
- add tests

