### PR TITLE
refactor: Remove error returns from config functions, fix tests.

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -96,7 +96,7 @@ func newStartedApp(
 	enableHostMetadata bool,
 ) (*App, inject.Graph) {
 	c := &config.MockConfig{
-		GetSendDelayVal:          0,
+		GetSendDelayVal:          1 * time.Millisecond,
 		GetTraceTimeoutVal:       10 * time.Millisecond,
 		GetMaxBatchSizeVal:       500,
 		GetSamplerTypeVal:        &config.DeterministicSamplerConfig{SampleRate: 1},

--- a/cmd/refinery/main.go
+++ b/cmd/refinery/main.go
@@ -119,10 +119,7 @@ func main() {
 	// set up the peer management and pubsub implementations
 	var peers peer.Peers
 	var pubsubber pubsub.PubSub
-	ptype, err := c.GetPeerManagementType()
-	if err != nil {
-		panic(err)
-	}
+	ptype := c.GetPeerManagementType()
 	switch ptype {
 	case "file":
 		// In the case of file peers, we do not use Redis for anything, including pubsub, so

--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -59,7 +59,7 @@ func newTestCollector(conf config.Config, transmission transmit.Transmission) *I
 // the cache and that that trace gets sent
 func TestAddRootSpan(t *testing.T) {
 	conf := &config.MockConfig{
-		GetSendDelayVal:    0,
+		GetSendDelayVal:    1 * time.Millisecond,
 		GetTraceTimeoutVal: 60 * time.Second,
 		GetSamplerTypeVal:  &config.DeterministicSamplerConfig{SampleRate: 1},
 		SendTickerVal:      2 * time.Millisecond,
@@ -135,7 +135,7 @@ func TestOriginalSampleRateIsNotedInMetaField(t *testing.T) {
 	const originalSampleRate = uint(50)
 
 	conf := &config.MockConfig{
-		GetSendDelayVal:    0,
+		GetSendDelayVal:    1 * time.Millisecond,
 		GetTraceTimeoutVal: 60 * time.Second,
 		GetSamplerTypeVal:  &config.DeterministicSamplerConfig{SampleRate: expectedDeterministicSampleRate},
 		SendTickerVal:      2 * time.Millisecond,
@@ -217,7 +217,7 @@ func TestOriginalSampleRateIsNotedInMetaField(t *testing.T) {
 // set instead of inferred
 func TestTransmittedSpansShouldHaveASampleRateOfAtLeastOne(t *testing.T) {
 	conf := &config.MockConfig{
-		GetSendDelayVal:    0,
+		GetSendDelayVal:    1 * time.Millisecond,
 		GetTraceTimeoutVal: 60 * time.Second,
 		GetSamplerTypeVal:  &config.DeterministicSamplerConfig{SampleRate: 1},
 		SendTickerVal:      2 * time.Millisecond,
@@ -276,7 +276,7 @@ func getEventsLength(transmission *transmit.MockTransmission) int {
 // cache
 func TestAddSpan(t *testing.T) {
 	conf := &config.MockConfig{
-		GetSendDelayVal:    0,
+		GetSendDelayVal:    1 * time.Millisecond,
 		GetTraceTimeoutVal: 60 * time.Second,
 		GetSamplerTypeVal:  &config.DeterministicSamplerConfig{SampleRate: 1},
 		SendTickerVal:      2 * time.Millisecond,
@@ -335,7 +335,7 @@ func TestAddSpan(t *testing.T) {
 // sampling decision is marked on each span in the trace
 func TestDryRunMode(t *testing.T) {
 	conf := &config.MockConfig{
-		GetSendDelayVal:    0,
+		GetSendDelayVal:    1 * time.Millisecond,
 		GetTraceTimeoutVal: 60 * time.Second,
 		GetSamplerTypeVal: &config.DeterministicSamplerConfig{
 			SampleRate: 10,
@@ -460,7 +460,7 @@ func TestDryRunMode(t *testing.T) {
 
 func TestCacheSizeReload(t *testing.T) {
 	conf := &config.MockConfig{
-		GetSendDelayVal:    0,
+		GetSendDelayVal:    1 * time.Millisecond,
 		GetTraceTimeoutVal: 10 * time.Minute,
 		GetSamplerTypeVal:  &config.DeterministicSamplerConfig{SampleRate: 1},
 		SendTickerVal:      2 * time.Millisecond,
@@ -534,7 +534,7 @@ func TestCacheSizeReload(t *testing.T) {
 
 func TestSampleConfigReload(t *testing.T) {
 	conf := &config.MockConfig{
-		GetSendDelayVal:        0,
+		GetSendDelayVal:        1 * time.Millisecond,
 		GetTraceTimeoutVal:     60 * time.Second,
 		GetSamplerTypeVal:      &config.DeterministicSamplerConfig{SampleRate: 1},
 		SendTickerVal:          2 * time.Millisecond,
@@ -606,7 +606,7 @@ func TestSampleConfigReload(t *testing.T) {
 
 func TestStableMaxAlloc(t *testing.T) {
 	conf := &config.MockConfig{
-		GetSendDelayVal:    0,
+		GetSendDelayVal:    1 * time.Millisecond,
 		GetTraceTimeoutVal: 10 * time.Minute,
 		GetSamplerTypeVal:  &config.DeterministicSamplerConfig{SampleRate: 1},
 		SendTickerVal:      2 * time.Millisecond,
@@ -698,7 +698,7 @@ func TestStableMaxAlloc(t *testing.T) {
 
 func TestAddSpanNoBlock(t *testing.T) {
 	conf := &config.MockConfig{
-		GetSendDelayVal:    0,
+		GetSendDelayVal:    1 * time.Millisecond,
 		GetTraceTimeoutVal: 10 * time.Minute,
 		GetSamplerTypeVal:  &config.DeterministicSamplerConfig{},
 		SendTickerVal:      2 * time.Millisecond,
@@ -768,7 +768,7 @@ func TestDependencyInjection(t *testing.T) {
 // This test also makes sure that AddCountsToRoot overrides the AddSpanCountToRoot config.
 func TestAddCountsToRoot(t *testing.T) {
 	conf := &config.MockConfig{
-		GetSendDelayVal:    0,
+		GetSendDelayVal:    1 * time.Millisecond,
 		GetTraceTimeoutVal: 60 * time.Second,
 		GetSamplerTypeVal:  &config.DeterministicSamplerConfig{SampleRate: 1},
 		SendTickerVal:      2 * time.Millisecond,
@@ -846,7 +846,7 @@ func TestAddCountsToRoot(t *testing.T) {
 // even if the trace had already been sent
 func TestLateRootGetsCounts(t *testing.T) {
 	conf := &config.MockConfig{
-		GetSendDelayVal:      0,
+		GetSendDelayVal:      1 * time.Millisecond,
 		GetTraceTimeoutVal:   5 * time.Millisecond,
 		GetSamplerTypeVal:    &config.DeterministicSamplerConfig{SampleRate: 1},
 		SendTickerVal:        2 * time.Millisecond,
@@ -929,7 +929,7 @@ func TestLateRootGetsCounts(t *testing.T) {
 // the cache and that that trace gets span count added to it
 func TestAddSpanCount(t *testing.T) {
 	conf := &config.MockConfig{
-		GetSendDelayVal:    0,
+		GetSendDelayVal:    1 * time.Millisecond,
 		GetTraceTimeoutVal: 60 * time.Second,
 		GetSamplerTypeVal:  &config.DeterministicSamplerConfig{SampleRate: 1},
 		SendTickerVal:      2 * time.Millisecond,
@@ -991,7 +991,7 @@ func TestAddSpanCount(t *testing.T) {
 // even if the trace had already been sent
 func TestLateRootGetsSpanCount(t *testing.T) {
 	conf := &config.MockConfig{
-		GetSendDelayVal:      0,
+		GetSendDelayVal:      1 * time.Millisecond,
 		GetTraceTimeoutVal:   5 * time.Millisecond,
 		GetSamplerTypeVal:    &config.DeterministicSamplerConfig{SampleRate: 1},
 		SendTickerVal:        2 * time.Millisecond,
@@ -1057,7 +1057,7 @@ func TestLateRootGetsSpanCount(t *testing.T) {
 // if the AddRuleReasonToTrace attribute not set in config
 func TestLateSpanNotDecorated(t *testing.T) {
 	conf := &config.MockConfig{
-		GetSendDelayVal:    0,
+		GetSendDelayVal:    1 * time.Millisecond,
 		GetTraceTimeoutVal: 5 * time.Minute,
 		GetSamplerTypeVal:  &config.DeterministicSamplerConfig{SampleRate: 1},
 		SendTickerVal:      2 * time.Millisecond,
@@ -1116,7 +1116,7 @@ func TestLateSpanNotDecorated(t *testing.T) {
 
 func TestAddAdditionalAttributes(t *testing.T) {
 	conf := &config.MockConfig{
-		GetSendDelayVal:    0,
+		GetSendDelayVal:    1 * time.Millisecond,
 		GetTraceTimeoutVal: 60 * time.Second,
 		GetSamplerTypeVal:  &config.DeterministicSamplerConfig{SampleRate: 1},
 		SendTickerVal:      2 * time.Millisecond,
@@ -1178,7 +1178,7 @@ func TestAddAdditionalAttributes(t *testing.T) {
 // StressReliefMode is active
 func TestStressReliefDecorateHostname(t *testing.T) {
 	conf := &config.MockConfig{
-		GetSendDelayVal:    0,
+		GetSendDelayVal:    1 * time.Millisecond,
 		GetTraceTimeoutVal: 5 * time.Minute,
 		GetSamplerTypeVal:  &config.DeterministicSamplerConfig{SampleRate: 1},
 		SendTickerVal:      2 * time.Millisecond,
@@ -1242,7 +1242,7 @@ func TestStressReliefDecorateHostname(t *testing.T) {
 
 func TestSpanWithRuleReasons(t *testing.T) {
 	conf := &config.MockConfig{
-		GetSendDelayVal:    0,
+		GetSendDelayVal:    1 * time.Millisecond,
 		GetTraceTimeoutVal: 5 * time.Millisecond,
 		GetSamplerTypeVal: &config.RulesBasedSamplerConfig{
 			Rules: []*config.RulesBasedSamplerRule{

--- a/config/config.go
+++ b/config/config.go
@@ -31,11 +31,11 @@ type Config interface {
 
 	// GetListenAddr returns the address and port on which to listen for
 	// incoming events
-	GetListenAddr() (string, error)
+	GetListenAddr() string
 
 	// GetPeerListenAddr returns the address and port on which to listen for
 	// peer traffic
-	GetPeerListenAddr() (string, error)
+	GetPeerListenAddr() string
 
 	// GetHTTPIdleTimeout returns the idle timeout for refinery's HTTP server
 	GetHTTPIdleTimeout() time.Duration
@@ -49,7 +49,7 @@ type Config interface {
 
 	// GetGRPCListenAddr returns the address and port on which to listen for
 	// incoming events over gRPC
-	GetGRPCListenAddr() (string, error)
+	GetGRPCListenAddr() string
 
 	// Returns the entire GRPC config block
 	GetGRPCConfig() GRPCServerParameters
@@ -58,25 +58,25 @@ type Config interface {
 	IsAPIKeyValid(key string) bool
 
 	// GetPeers returns a list of other servers participating in this proxy cluster
-	GetPeers() ([]string, error)
+	GetPeers() []string
 
-	GetPeerManagementType() (string, error)
+	GetPeerManagementType() string
 
 	// GetRedisHost returns the address of a Redis instance to use for peer
 	// management.
-	GetRedisHost() (string, error)
+	GetRedisHost() string
 
 	// GetRedisUsername returns the username of a Redis instance to use for peer
 	// management.
-	GetRedisUsername() (string, error)
+	GetRedisUsername() string
 
 	// GetRedisPassword returns the password of a Redis instance to use for peer
 	// management.
-	GetRedisPassword() (string, error)
+	GetRedisPassword() string
 
 	// GetRedisAuthCode returns the AUTH string to use for connecting to a Redis
 	// instance to use for peer management
-	GetRedisAuthCode() (string, error)
+	GetRedisAuthCode() string
 
 	// GetRedisPrefix returns the prefix string used in the keys for peer
 	// management.
@@ -87,18 +87,18 @@ type Config interface {
 
 	// GetUseTLS returns true when TLS must be enabled to dial the Redis instance to
 	// use for peer management.
-	GetUseTLS() (bool, error)
+	GetUseTLS() bool
 
 	// UseTLSInsecure returns true when certificate checks are disabled
-	GetUseTLSInsecure() (bool, error)
+	GetUseTLSInsecure() bool
 
 	// GetHoneycombAPI returns the base URL (protocol, hostname, and port) of
 	// the upstream Honeycomb API server
-	GetHoneycombAPI() (string, error)
+	GetHoneycombAPI() string
 
 	// GetSendDelay returns the number of seconds to pause after a trace is
 	// complete before sending it, to allow stragglers to arrive
-	GetSendDelay() (time.Duration, error)
+	GetSendDelay() time.Duration
 
 	// GetBatchTimeout returns how often to send off batches in seconds
 	GetBatchTimeout() time.Duration
@@ -106,33 +106,33 @@ type Config interface {
 	// GetTraceTimeout is how long to wait before sending a trace even if it's
 	// not complete. This should be longer than the longest expected trace
 	// duration.
-	GetTraceTimeout() (time.Duration, error)
+	GetTraceTimeout() time.Duration
 
 	// GetMaxBatchSize is the number of events to be included in the batch for sending
 	GetMaxBatchSize() uint
 
 	// GetLoggerType returns the type of the logger to use. Valid types are in
 	// the logger package
-	GetLoggerType() (string, error)
+	GetLoggerType() string
 
 	// GetLoggerLevel returns the level of the logger to use.
 	GetLoggerLevel() Level
 
 	// GetHoneycombLoggerConfig returns the config specific to the HoneycombLogger
-	GetHoneycombLoggerConfig() (HoneycombLoggerConfig, error)
+	GetHoneycombLoggerConfig() HoneycombLoggerConfig
 
 	// GetStdoutLoggerConfig returns the config specific to the StdoutLogger
-	GetStdoutLoggerConfig() (StdoutLoggerConfig, error)
+	GetStdoutLoggerConfig() StdoutLoggerConfig
 
 	// GetCollectionConfig returns the config specific to the InMemCollector
-	GetCollectionConfig() (CollectionConfig, error)
+	GetCollectionConfig() CollectionConfig
 
 	// GetSamplerConfigForDestName returns the sampler type and name to use for
 	// the given destination (environment, or dataset in classic)
-	GetSamplerConfigForDestName(string) (interface{}, string, error)
+	GetSamplerConfigForDestName(string) (interface{}, string)
 
 	// GetAllSamplerRules returns all rules in a single map, including the default rules
-	GetAllSamplerRules() (*V2SamplerConfig, error)
+	GetAllSamplerRules() *V2SamplerConfig
 
 	// GetGeneralConfig returns the config specific to General
 	GetGeneralConfig() GeneralConfig
@@ -153,20 +153,20 @@ type Config interface {
 	// libhoney client
 	GetPeerBufferSize() int
 
-	GetIdentifierInterfaceName() (string, error)
+	GetIdentifierInterfaceName() string
 
 	GetOTelTracingConfig() OTelTracingConfig
 
-	GetUseIPV6Identifier() (bool, error)
+	GetUseIPV6Identifier() bool
 
-	GetRedisIdentifier() (string, error)
+	GetRedisIdentifier() string
 
 	// GetSendTickerValue returns the duration to use to check for traces to send
 	GetSendTickerValue() time.Duration
 
 	// GetDebugServiceAddr sets the IP and port the debug service will run on (you must provide the
 	// command line flag -d to start the debug service)
-	GetDebugServiceAddr() (string, error)
+	GetDebugServiceAddr() string
 
 	GetIsDryRun() bool
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -77,7 +77,7 @@ func TestGRPCListenAddrEnvVar(t *testing.T) {
 	c, err := getConfig([]string{"--no-validate", "--config", "../config.yaml", "--rules_config", "../rules.yaml"})
 	assert.NoError(t, err)
 
-	if a, _ := c.GetGRPCListenAddr(); a != address {
+	if a := c.GetGRPCListenAddr(); a != address {
 		t.Error("received", a, "expected", address)
 	}
 }
@@ -90,7 +90,7 @@ func TestRedisHostEnvVar(t *testing.T) {
 	c, err := getConfig([]string{"--no-validate", "--config", "../config.yaml", "--rules_config", "../rules.yaml"})
 	assert.NoError(t, err)
 
-	if d, _ := c.GetRedisHost(); d != host {
+	if d := c.GetRedisHost(); d != host {
 		t.Error("received", d, "expected", host)
 	}
 }
@@ -103,7 +103,7 @@ func TestRedisUsernameEnvVar(t *testing.T) {
 	c, err := getConfig([]string{"--no-validate", "--config", "../config.yaml", "--rules_config", "../rules.yaml"})
 	assert.NoError(t, err)
 
-	if d, _ := c.GetRedisUsername(); d != username {
+	if d := c.GetRedisUsername(); d != username {
 		t.Error("received", d, "expected", username)
 	}
 }
@@ -116,7 +116,7 @@ func TestRedisPasswordEnvVar(t *testing.T) {
 	c, err := getConfig([]string{"--no-validate", "--config", "../config.yaml", "--rules_config", "../rules.yaml"})
 	assert.NoError(t, err)
 
-	if d, _ := c.GetRedisPassword(); d != password {
+	if d := c.GetRedisPassword(); d != password {
 		t.Error("received", d, "expected", password)
 	}
 }
@@ -129,7 +129,7 @@ func TestRedisAuthCodeEnvVar(t *testing.T) {
 	c, err := getConfig([]string{"--no-validate", "--config", "../config.yaml", "--rules_config", "../rules.yaml"})
 	assert.NoError(t, err)
 
-	if d, _ := c.GetRedisAuthCode(); d != authCode {
+	if d := c.GetRedisAuthCode(); d != authCode {
 		t.Error("received", d, "expected", authCode)
 	}
 }
@@ -219,7 +219,7 @@ func TestReload(t *testing.T) {
 	watcher.Start()
 	defer watcher.Stop()
 
-	if d, _ := c.GetListenAddr(); d != "0.0.0.0:8080" {
+	if d := c.GetListenAddr(); d != "0.0.0.0:8080" {
 		t.Error("received", d, "expected", "0.0.0.0:8080")
 	}
 
@@ -266,7 +266,7 @@ func TestReload(t *testing.T) {
 
 	wg.Wait()
 
-	if d, _ := c.GetListenAddr(); d != "0.0.0.0:9000" {
+	if d := c.GetListenAddr(); d != "0.0.0.0:9000" {
 		t.Error("received", d, "expected", "0.0.0.0:9000")
 	}
 
@@ -281,7 +281,7 @@ func TestReloadDisabled(t *testing.T) {
 	c, err := getConfig([]string{"--no-validate", "--config", cfg, "--rules_config", rules})
 	assert.NoError(t, err)
 
-	if d, _ := c.GetListenAddr(); d != "0.0.0.0:8080" {
+	if d := c.GetListenAddr(); d != "0.0.0.0:8080" {
 		t.Error("received", d, "expected", "0.0.0.0:8080")
 	}
 
@@ -294,7 +294,7 @@ func TestReloadDisabled(t *testing.T) {
 
 	time.Sleep(5 * time.Second)
 
-	if d, _ := c.GetListenAddr(); d != "0.0.0.0:8080" {
+	if d := c.GetListenAddr(); d != "0.0.0.0:8080" {
 		t.Error("received", d, "expected", "0.0.0.0:8080")
 	}
 }
@@ -303,11 +303,11 @@ func TestReadDefaults(t *testing.T) {
 	c, err := getConfig([]string{"--no-validate", "--config", "../config.yaml", "--rules_config", "../rules.yaml"})
 	assert.NoError(t, err)
 
-	if d, _ := c.GetSendDelay(); d != 2*time.Second {
+	if d := c.GetSendDelay(); d != 2*time.Second {
 		t.Error("received", d, "expected", 2*time.Second)
 	}
 
-	if d, _ := c.GetTraceTimeout(); d != 60*time.Second {
+	if d := c.GetTraceTimeout(); d != 60*time.Second {
 		t.Error("received", d, "expected", 60*time.Second)
 	}
 
@@ -315,11 +315,11 @@ func TestReadDefaults(t *testing.T) {
 		t.Error("received", d, "expected", 100*time.Millisecond)
 	}
 
-	if d, _ := c.GetPeerManagementType(); d != "file" {
+	if d := c.GetPeerManagementType(); d != "file" {
 		t.Error("received", d, "expected", "file")
 	}
 
-	if d, _ := c.GetUseIPV6Identifier(); d != false {
+	if d := c.GetUseIPV6Identifier(); d != false {
 		t.Error("received", d, "expected", false)
 	}
 
@@ -335,8 +335,7 @@ func TestReadDefaults(t *testing.T) {
 		t.Error("received", d, "expected", time.Hour)
 	}
 
-	d, name, err := c.GetSamplerConfigForDestName("dataset-doesnt-exist")
-	assert.NoError(t, err)
+	d, name := c.GetSamplerConfigForDestName("dataset-doesnt-exist")
 	assert.IsType(t, &config.DeterministicSamplerConfig{}, d)
 	assert.Equal(t, "DeterministicSampler", name)
 }
@@ -345,18 +344,15 @@ func TestReadRulesConfig(t *testing.T) {
 	c, err := getConfig([]string{"--no-validate", "--config", "../config.yaml", "--rules_config", "../rules_complete.yaml"})
 	assert.NoError(t, err)
 
-	d, name, err := c.GetSamplerConfigForDestName("doesnt-exist")
-	assert.NoError(t, err)
+	d, name := c.GetSamplerConfigForDestName("doesnt-exist")
 	assert.IsType(t, &config.DeterministicSamplerConfig{}, d)
 	assert.Equal(t, "DeterministicSampler", name)
 
-	d, name, err = c.GetSamplerConfigForDestName("env1")
-	assert.NoError(t, err)
+	d, name = c.GetSamplerConfigForDestName("env1")
 	assert.IsType(t, &config.DynamicSamplerConfig{}, d)
 	assert.Equal(t, "DynamicSampler", name)
 
-	d, name, err = c.GetSamplerConfigForDestName("env4")
-	assert.NoError(t, err)
+	d, name = c.GetSamplerConfigForDestName("env4")
 	switch r := d.(type) {
 	case *config.RulesBasedSamplerConfig:
 		assert.Len(t, r.Rules, 6)
@@ -403,7 +399,7 @@ func TestPeerManagementType(t *testing.T) {
 	c, err := getConfig([]string{"--no-validate", "--config", config, "--rules_config", rules})
 	assert.NoError(t, err)
 
-	if d, _ := c.GetPeerManagementType(); d != "redis" {
+	if d := c.GetPeerManagementType(); d != "redis" {
 		t.Error("received", d, "expected", "redis")
 	}
 
@@ -425,7 +421,7 @@ func TestDebugServiceAddr(t *testing.T) {
 	c, err := getConfig([]string{"--no-validate", "--config", config, "--rules_config", rules})
 	assert.NoError(t, err)
 
-	if d, _ := c.GetDebugServiceAddr(); d != "localhost:8085" {
+	if d := c.GetDebugServiceAddr(); d != "localhost:8085" {
 		t.Error("received", d, "expected", "localhost:8085")
 	}
 }
@@ -468,8 +464,7 @@ func TestMaxAlloc(t *testing.T) {
 	assert.NoError(t, err)
 
 	expected := config.MemorySize(16 * 1024 * 1024 * 1024)
-	inMemConfig, err := c.GetCollectionConfig()
-	assert.NoError(t, err)
+	inMemConfig := c.GetCollectionConfig()
 	assert.Equal(t, expected, inMemConfig.MaxAlloc)
 }
 
@@ -514,8 +509,7 @@ func TestPeerAndIncomingQueueSize(t *testing.T) {
 		c, err := getConfig([]string{"--no-validate", "--config", config, "--rules_config", rules})
 		assert.NoError(t, err)
 
-		inMemConfig, err := c.GetCollectionConfig()
-		assert.NoError(t, err)
+		inMemConfig := c.GetCollectionConfig()
 		assert.Equal(t, tc.expectedForPeer, inMemConfig.GetPeerQueueSize())
 		assert.Equal(t, tc.expectedForIncoming, inMemConfig.GetIncomingQueueSize())
 	}
@@ -531,7 +525,7 @@ func TestAvailableMemoryCmdLine(t *testing.T) {
 	assert.NoError(t, err)
 
 	expected := config.MemorySize(2*1024*1024*1024 + 512*1024*1024)
-	inMemConfig, err := c.GetCollectionConfig()
+	inMemConfig := c.GetCollectionConfig()
 	assert.NoError(t, err)
 	assert.Equal(t, expected, inMemConfig.AvailableMemory)
 }
@@ -563,27 +557,27 @@ func TestGetSamplerTypes(t *testing.T) {
 	c, err := getConfig([]string{"--no-validate", "--config", cfg, "--rules_config", rules})
 	assert.NoError(t, err)
 
-	if d, name, err := c.GetSamplerConfigForDestName("dataset-doesnt-exist"); assert.Equal(t, nil, err) {
+	if d, name := c.GetSamplerConfigForDestName("dataset-doesnt-exist"); assert.Equal(t, nil, err) {
 		assert.IsType(t, &config.DeterministicSamplerConfig{}, d)
 		assert.Equal(t, "DeterministicSampler", name)
 	}
 
-	if d, name, err := c.GetSamplerConfigForDestName("dataset 1"); assert.Equal(t, nil, err) {
+	if d, name := c.GetSamplerConfigForDestName("dataset 1"); assert.Equal(t, nil, err) {
 		assert.IsType(t, &config.DynamicSamplerConfig{}, d)
 		assert.Equal(t, "DynamicSampler", name)
 	}
 
-	if d, name, err := c.GetSamplerConfigForDestName("dataset2"); assert.Equal(t, nil, err) {
+	if d, name := c.GetSamplerConfigForDestName("dataset2"); assert.Equal(t, nil, err) {
 		assert.IsType(t, &config.DeterministicSamplerConfig{}, d)
 		assert.Equal(t, "DeterministicSampler", name)
 	}
 
-	if d, name, err := c.GetSamplerConfigForDestName("dataset3"); assert.Equal(t, nil, err) {
+	if d, name := c.GetSamplerConfigForDestName("dataset3"); assert.Equal(t, nil, err) {
 		assert.IsType(t, &config.EMADynamicSamplerConfig{}, d)
 		assert.Equal(t, "EMADynamicSampler", name)
 	}
 
-	if d, name, err := c.GetSamplerConfigForDestName("dataset4"); assert.Equal(t, nil, err) {
+	if d, name := c.GetSamplerConfigForDestName("dataset4"); assert.Equal(t, nil, err) {
 		assert.IsType(t, &config.TotalThroughputSamplerConfig{}, d)
 		assert.Equal(t, "TotalThroughputSampler", name)
 	}
@@ -600,11 +594,9 @@ func TestDefaultSampler(t *testing.T) {
 
 	assert.NoError(t, err)
 
-	s, name, err := c.GetSamplerConfigForDestName("nonexistent")
+	s, name := c.GetSamplerConfigForDestName("nonexistent")
 
-	assert.NoError(t, err)
 	assert.Equal(t, "DeterministicSampler", name)
-
 	assert.IsType(t, &config.DeterministicSamplerConfig{}, s)
 }
 
@@ -625,9 +617,7 @@ func TestHoneycombLoggerConfig(t *testing.T) {
 	c, err := getConfig([]string{"--no-validate", "--config", config, "--rules_config", rules})
 	assert.NoError(t, err)
 
-	loggerConfig, err := c.GetHoneycombLoggerConfig()
-
-	assert.NoError(t, err)
+	loggerConfig := c.GetHoneycombLoggerConfig()
 
 	assert.Equal(t, "http://honeycomb.io", loggerConfig.APIHost)
 	assert.Equal(t, "1234", loggerConfig.APIKey)
@@ -651,9 +641,7 @@ func TestHoneycombLoggerConfigDefaults(t *testing.T) {
 	c, err := getConfig([]string{"--no-validate", "--config", config, "--rules_config", rules})
 	assert.NoError(t, err)
 
-	loggerConfig, err := c.GetHoneycombLoggerConfig()
-
-	assert.NoError(t, err)
+	loggerConfig := c.GetHoneycombLoggerConfig()
 
 	assert.Equal(t, true, loggerConfig.GetSamplerEnabled())
 	assert.Equal(t, 10, loggerConfig.SamplerThroughput)
@@ -674,8 +662,7 @@ func TestHoneycombGRPCConfigDefaults(t *testing.T) {
 
 	assert.Equal(t, true, c.GetGRPCEnabled())
 
-	a, err := c.GetGRPCListenAddr()
-	assert.NoError(t, err)
+	a := c.GetGRPCListenAddr()
 	assert.Equal(t, "localhost:4343", a)
 
 	grpcConfig := c.GetGRPCConfig()
@@ -706,9 +693,7 @@ func TestStdoutLoggerConfig(t *testing.T) {
 	c, err := getConfig([]string{"--no-validate", "--config", config, "--rules_config", rules})
 	assert.NoError(t, err)
 
-	loggerConfig, err := c.GetStdoutLoggerConfig()
-
-	assert.NoError(t, err)
+	loggerConfig := c.GetStdoutLoggerConfig()
 
 	assert.True(t, loggerConfig.Structured)
 	assert.True(t, loggerConfig.SamplerEnabled)
@@ -726,9 +711,7 @@ func TestStdoutLoggerConfigDefaults(t *testing.T) {
 	c, err := getConfig([]string{"--no-validate", "--config", config, "--rules_config", rules})
 	assert.NoError(t, err)
 
-	loggerConfig, err := c.GetStdoutLoggerConfig()
-
-	assert.NoError(t, err)
+	loggerConfig := c.GetStdoutLoggerConfig()
 
 	assert.False(t, loggerConfig.Structured)
 	assert.False(t, loggerConfig.SamplerEnabled)
@@ -790,8 +773,7 @@ func TestGRPCServerParameters(t *testing.T) {
 	assert.Equal(t, 4*time.Minute, time.Duration(gc.KeepAlive))
 	assert.Equal(t, 5*time.Minute, time.Duration(gc.KeepAliveTimeout))
 	assert.Equal(t, true, c.GetGRPCEnabled())
-	addr, err := c.GetGRPCListenAddr()
-	assert.NoError(t, err)
+	addr := c.GetGRPCListenAddr()
 	assert.Equal(t, "localhost:4317", addr)
 }
 
@@ -925,8 +907,7 @@ func TestOverrideConfigDefaults(t *testing.T) {
 
 	assert.Equal(t, false, c.GetAddSpanCountToRoot())
 	assert.Equal(t, false, c.GetAddHostMetadataToTrace())
-	loggerConfig, err := c.GetHoneycombLoggerConfig()
-	assert.NoError(t, err)
+	loggerConfig := c.GetHoneycombLoggerConfig()
 	assert.Equal(t, false, loggerConfig.GetSamplerEnabled())
 	assert.Equal(t, false, c.GetCompressPeerCommunication())
 	assert.Equal(t, false, c.GetGRPCEnabled())

--- a/config/config_test_reload_error_test.go
+++ b/config/config_test_reload_error_test.go
@@ -48,7 +48,7 @@ func TestErrorReloading(t *testing.T) {
 	watcher.Start()
 	defer watcher.Stop()
 
-	d, name, _ := c.GetSamplerConfigForDestName("dataset5")
+	d, name := c.GetSamplerConfigForDestName("dataset5")
 	if _, ok := d.(config.DeterministicSamplerConfig); ok {
 		t.Error("type received", d, "expected", "DeterministicSampler")
 	}
@@ -81,7 +81,7 @@ func TestErrorReloading(t *testing.T) {
 	wg.Wait()
 
 	// config should error and not update sampler to invalid type
-	d, _, _ = c.GetSamplerConfigForDestName("dataset5")
+	d, _ = c.GetSamplerConfigForDestName("dataset5")
 	if _, ok := d.(config.DeterministicSamplerConfig); ok {
 		t.Error("received", d, "expected", "DeterministicSampler")
 	}

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -42,6 +41,9 @@ type fileConfig struct {
 	mux           sync.RWMutex
 	lastLoadTime  time.Time
 }
+
+// ensure that fileConfig implements Config
+var _ Config = (*fileConfig)(nil)
 
 type configContents struct {
 	General              GeneralConfig             `yaml:"General"`
@@ -466,26 +468,26 @@ func (f *fileConfig) RegisterReloadCallback(cb ConfigReloadCallback) {
 	f.callbacks = append(f.callbacks, cb)
 }
 
-func (f *fileConfig) GetListenAddr() (string, error) {
+func (f *fileConfig) GetListenAddr() string {
 	f.mux.RLock()
 	defer f.mux.RUnlock()
 
 	_, _, err := net.SplitHostPort(f.mainConfig.Network.ListenAddr)
 	if err != nil {
-		return "", err
+		return ""
 	}
-	return f.mainConfig.Network.ListenAddr, nil
+	return f.mainConfig.Network.ListenAddr
 }
 
-func (f *fileConfig) GetPeerListenAddr() (string, error) {
+func (f *fileConfig) GetPeerListenAddr() string {
 	f.mux.RLock()
 	defer f.mux.RUnlock()
 
 	_, _, err := net.SplitHostPort(f.mainConfig.Network.PeerListenAddr)
 	if err != nil {
-		return "", err
+		return ""
 	}
-	return f.mainConfig.Network.PeerListenAddr, nil
+	return f.mainConfig.Network.PeerListenAddr
 }
 
 func (f *fileConfig) GetHTTPIdleTimeout() time.Duration {
@@ -509,7 +511,7 @@ func (f *fileConfig) GetGRPCEnabled() bool {
 	return f.mainConfig.GRPCServerParameters.Enabled.Get()
 }
 
-func (f *fileConfig) GetGRPCListenAddr() (string, error) {
+func (f *fileConfig) GetGRPCListenAddr() string {
 	f.mux.RLock()
 	defer f.mux.RUnlock()
 
@@ -517,10 +519,10 @@ func (f *fileConfig) GetGRPCListenAddr() (string, error) {
 	if f.mainConfig.GRPCServerParameters.ListenAddr != "" {
 		_, _, err := net.SplitHostPort(f.mainConfig.GRPCServerParameters.ListenAddr)
 		if err != nil {
-			return "", err
+			return ""
 		}
 	}
-	return f.mainConfig.GRPCServerParameters.ListenAddr, nil
+	return f.mainConfig.GRPCServerParameters.ListenAddr
 }
 
 func (f *fileConfig) GetGRPCConfig() GRPCServerParameters {
@@ -546,32 +548,32 @@ func (f *fileConfig) IsAPIKeyValid(key string) bool {
 	return f.mainConfig.AccessKeys.keymap.Contains(key)
 }
 
-func (f *fileConfig) GetPeerManagementType() (string, error) {
+func (f *fileConfig) GetPeerManagementType() string {
 	f.mux.RLock()
 	defer f.mux.RUnlock()
 
-	return f.mainConfig.PeerManagement.Type, nil
+	return f.mainConfig.PeerManagement.Type
 }
 
-func (f *fileConfig) GetPeers() ([]string, error) {
+func (f *fileConfig) GetPeers() []string {
 	f.mux.RLock()
 	defer f.mux.RUnlock()
 
-	return f.mainConfig.PeerManagement.Peers, nil
+	return f.mainConfig.PeerManagement.Peers
 }
 
-func (f *fileConfig) GetRedisHost() (string, error) {
+func (f *fileConfig) GetRedisHost() string {
 	f.mux.RLock()
 	defer f.mux.RUnlock()
 
-	return f.mainConfig.RedisPeerManagement.Host, nil
+	return f.mainConfig.RedisPeerManagement.Host
 }
 
-func (f *fileConfig) GetRedisUsername() (string, error) {
+func (f *fileConfig) GetRedisUsername() string {
 	f.mux.RLock()
 	defer f.mux.RUnlock()
 
-	return f.mainConfig.RedisPeerManagement.Username, nil
+	return f.mainConfig.RedisPeerManagement.Username
 }
 
 func (f *fileConfig) GetRedisPrefix() string {
@@ -581,18 +583,18 @@ func (f *fileConfig) GetRedisPrefix() string {
 	return f.mainConfig.RedisPeerManagement.Prefix
 }
 
-func (f *fileConfig) GetRedisPassword() (string, error) {
+func (f *fileConfig) GetRedisPassword() string {
 	f.mux.RLock()
 	defer f.mux.RUnlock()
 
-	return f.mainConfig.RedisPeerManagement.Password, nil
+	return f.mainConfig.RedisPeerManagement.Password
 }
 
-func (f *fileConfig) GetRedisAuthCode() (string, error) {
+func (f *fileConfig) GetRedisAuthCode() string {
 	f.mux.RLock()
 	defer f.mux.RUnlock()
 
-	return f.mainConfig.RedisPeerManagement.AuthCode, nil
+	return f.mainConfig.RedisPeerManagement.AuthCode
 }
 
 func (f *fileConfig) GetRedisDatabase() int {
@@ -602,46 +604,46 @@ func (f *fileConfig) GetRedisDatabase() int {
 	return f.mainConfig.RedisPeerManagement.Database
 }
 
-func (f *fileConfig) GetUseTLS() (bool, error) {
+func (f *fileConfig) GetUseTLS() bool {
 	f.mux.RLock()
 	defer f.mux.RUnlock()
 
-	return f.mainConfig.RedisPeerManagement.UseTLS, nil
+	return f.mainConfig.RedisPeerManagement.UseTLS
 }
 
-func (f *fileConfig) GetUseTLSInsecure() (bool, error) {
+func (f *fileConfig) GetUseTLSInsecure() bool {
 	f.mux.RLock()
 	defer f.mux.RUnlock()
 
-	return f.mainConfig.RedisPeerManagement.UseTLSInsecure, nil
+	return f.mainConfig.RedisPeerManagement.UseTLSInsecure
 }
 
-func (f *fileConfig) GetIdentifierInterfaceName() (string, error) {
+func (f *fileConfig) GetIdentifierInterfaceName() string {
 	f.mux.RLock()
 	defer f.mux.RUnlock()
 
-	return f.mainConfig.PeerManagement.IdentifierInterfaceName, nil
+	return f.mainConfig.PeerManagement.IdentifierInterfaceName
 }
 
-func (f *fileConfig) GetUseIPV6Identifier() (bool, error) {
+func (f *fileConfig) GetUseIPV6Identifier() bool {
 	f.mux.RLock()
 	defer f.mux.RUnlock()
 
-	return f.mainConfig.PeerManagement.UseIPV6Identifier, nil
+	return f.mainConfig.PeerManagement.UseIPV6Identifier
 }
 
-func (f *fileConfig) GetRedisIdentifier() (string, error) {
+func (f *fileConfig) GetRedisIdentifier() string {
 	f.mux.RLock()
 	defer f.mux.RUnlock()
 
-	return f.mainConfig.PeerManagement.Identifier, nil
+	return f.mainConfig.PeerManagement.Identifier
 }
 
-func (f *fileConfig) GetHoneycombAPI() (string, error) {
+func (f *fileConfig) GetHoneycombAPI() string {
 	f.mux.RLock()
 	defer f.mux.RUnlock()
 
-	return f.mainConfig.Network.HoneycombAPI, nil
+	return f.mainConfig.Network.HoneycombAPI
 }
 
 func (f *fileConfig) GetLoggerLevel() Level {
@@ -651,40 +653,40 @@ func (f *fileConfig) GetLoggerLevel() Level {
 	return f.mainConfig.Logger.Level
 }
 
-func (f *fileConfig) GetLoggerType() (string, error) {
+func (f *fileConfig) GetLoggerType() string {
 	f.mux.RLock()
 	defer f.mux.RUnlock()
 
-	return f.mainConfig.Logger.Type, nil
+	return f.mainConfig.Logger.Type
 }
 
-func (f *fileConfig) GetHoneycombLoggerConfig() (HoneycombLoggerConfig, error) {
+func (f *fileConfig) GetHoneycombLoggerConfig() HoneycombLoggerConfig {
 	f.mux.RLock()
 	defer f.mux.RUnlock()
 
-	return f.mainConfig.HoneycombLogger, nil
+	return f.mainConfig.HoneycombLogger
 }
 
-func (f *fileConfig) GetStdoutLoggerConfig() (StdoutLoggerConfig, error) {
+func (f *fileConfig) GetStdoutLoggerConfig() StdoutLoggerConfig {
 	f.mux.RLock()
 	defer f.mux.RUnlock()
 
-	return f.mainConfig.StdoutLogger, nil
+	return f.mainConfig.StdoutLogger
 }
 
-func (f *fileConfig) GetAllSamplerRules() (*V2SamplerConfig, error) {
+func (f *fileConfig) GetAllSamplerRules() *V2SamplerConfig {
 	f.mux.RLock()
 	defer f.mux.RUnlock()
 
 	// This is probably good enough for debug; if not we can extend it.
-	return f.rulesConfig, nil
+	return f.rulesConfig
 }
 
 // GetSamplerConfigForDestName returns the sampler config for the given
 // destination (environment, or dataset in classic mode), as well as the name of
 // the sampler type. If the specific destination is not found, it returns the
 // default sampler config.
-func (f *fileConfig) GetSamplerConfigForDestName(destname string) (any, string, error) {
+func (f *fileConfig) GetSamplerConfigForDestName(destname string) (any, string) {
 	f.mux.RLock()
 	defer f.mux.RUnlock()
 
@@ -693,23 +695,19 @@ func (f *fileConfig) GetSamplerConfigForDestName(destname string) (any, string, 
 		nameToUse = destname
 	}
 
-	err := errors.New("no sampler found and no default configured")
 	name := "not found"
 	var cfg any
 	if sampler, ok := f.rulesConfig.Samplers[nameToUse]; ok {
 		cfg, name = sampler.Sampler()
-		if cfg != nil {
-			err = nil
-		}
 	}
-	return cfg, name, err
+	return cfg, name
 }
 
-func (f *fileConfig) GetCollectionConfig() (CollectionConfig, error) {
+func (f *fileConfig) GetCollectionConfig() CollectionConfig {
 	f.mux.RLock()
 	defer f.mux.RUnlock()
 
-	return f.mainConfig.Collection, nil
+	return f.mainConfig.Collection
 }
 
 func (f *fileConfig) GetLegacyMetricsConfig() LegacyMetricsConfig {
@@ -733,11 +731,11 @@ func (f *fileConfig) GetOTelMetricsConfig() OTelMetricsConfig {
 	return f.mainConfig.OTelMetrics
 }
 
-func (f *fileConfig) GetSendDelay() (time.Duration, error) {
+func (f *fileConfig) GetSendDelay() time.Duration {
 	f.mux.RLock()
 	defer f.mux.RUnlock()
 
-	return time.Duration(f.mainConfig.Traces.SendDelay), nil
+	return time.Duration(f.mainConfig.Traces.SendDelay)
 }
 
 func (f *fileConfig) GetBatchTimeout() time.Duration {
@@ -747,11 +745,11 @@ func (f *fileConfig) GetBatchTimeout() time.Duration {
 	return time.Duration(f.mainConfig.Traces.BatchTimeout)
 }
 
-func (f *fileConfig) GetTraceTimeout() (time.Duration, error) {
+func (f *fileConfig) GetTraceTimeout() time.Duration {
 	f.mux.RLock()
 	defer f.mux.RUnlock()
 
-	return time.Duration(f.mainConfig.Traces.TraceTimeout), nil
+	return time.Duration(f.mainConfig.Traces.TraceTimeout)
 }
 
 func (f *fileConfig) GetMaxBatchSize() uint {
@@ -782,15 +780,15 @@ func (f *fileConfig) GetSendTickerValue() time.Duration {
 	return time.Duration(f.mainConfig.Traces.SendTicker)
 }
 
-func (f *fileConfig) GetDebugServiceAddr() (string, error) {
+func (f *fileConfig) GetDebugServiceAddr() string {
 	f.mux.RLock()
 	defer f.mux.RUnlock()
 
 	_, _, err := net.SplitHostPort(f.mainConfig.Debugging.DebugServiceAddr)
 	if err != nil {
-		return "", err
+		return ""
 	}
-	return f.mainConfig.Debugging.DebugServiceAddr, nil
+	return f.mainConfig.Debugging.DebugServiceAddr
 }
 
 func (f *fileConfig) GetIsDryRun() bool {

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -264,14 +264,16 @@ groups:
         type: duration
         valuetype: nondefault
         default: 2s
+        validations:
+          - type: minimum
+            arg: 100ms
         reload: true
         summary: is the duration to wait before sending a trace.
         description: >
           This setting is a short timer that is triggered when a trace is
           complete. Refinery waits for this duration before sending the trace.
-          The reason for this setting is to allow for small network delays or
-          clock jitters to elapse and any final spans to arrive before sending
-          the trace. Set to "0" for immediate sending.
+          The reason for this setting is to allow for asynchronous spans and
+          small network delays to elapse before sending the trace.
 
       - name: BatchTimeout
         type: duration
@@ -286,6 +288,9 @@ groups:
         type: duration
         valuetype: nondefault
         default: 60s
+        validations:
+          - type: minimum
+            arg: 1s
         reload: true
         summary: is the duration to wait before making the trace decision on an incomplete trace.
         description: >

--- a/config/mock.go
+++ b/config/mock.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"fmt"
 	"sync"
 	"time"
 )
@@ -11,59 +10,39 @@ import (
 type MockConfig struct {
 	Callbacks                        []ConfigReloadCallback
 	IsAPIKeyValidFunc                func(string) bool
-	GetCollectorTypeErr              error
 	GetCollectorTypeVal              string
-	GetCollectionConfigErr           error
 	GetCollectionConfigVal           CollectionConfig
-	GetHoneycombAPIErr               error
 	GetHoneycombAPIVal               string
-	GetListenAddrErr                 error
 	GetListenAddrVal                 string
-	GetPeerListenAddrErr             error
 	GetPeerListenAddrVal             string
 	GetHTTPIdleTimeoutVal            time.Duration
 	GetCompressPeerCommunicationsVal bool
 	GetGRPCEnabledVal                bool
-	GetGRPCListenAddrErr             error
 	GetGRPCListenAddrVal             string
 	GetGRPCServerParameters          GRPCServerParameters
-	GetLoggerTypeErr                 error
 	GetLoggerTypeVal                 string
-	GetHoneycombLoggerConfigErr      error
 	GetHoneycombLoggerConfigVal      HoneycombLoggerConfig
-	GetStdoutLoggerConfigErr         error
 	GetStdoutLoggerConfigVal         StdoutLoggerConfig
 	GetLoggerLevelVal                Level
-	GetPeersErr                      error
 	GetPeersVal                      []string
-	GetRedisHostErr                  error
 	GetRedisHostVal                  string
-	GetRedisUsernameErr              error
 	GetRedisUsernameVal              string
-	GetRedisPasswordErr              error
 	GetRedisPasswordVal              string
-	GetRedisAuthCodeErr              error
 	GetRedisAuthCodeVal              string
 	GetRedisDatabaseVal              int
 	GetRedisPrefixVal                string
-	GetUseTLSErr                     error
 	GetUseTLSVal                     bool
-	GetUseTLSInsecureErr             error
 	GetUseTLSInsecureVal             bool
-	GetSamplerTypeErr                error
 	GetSamplerTypeName               string
 	GetSamplerTypeVal                interface{}
-	GetMetricsTypeErr                error
 	GetMetricsTypeVal                string
 	GetGeneralConfigVal              GeneralConfig
 	GetLegacyMetricsConfigVal        LegacyMetricsConfig
 	GetPrometheusMetricsConfigVal    PrometheusMetricsConfig
 	GetOTelMetricsConfigVal          OTelMetricsConfig
 	GetOTelTracingConfigVal          OTelTracingConfig
-	GetSendDelayErr                  error
 	GetSendDelayVal                  time.Duration
 	GetBatchTimeoutVal               time.Duration
-	GetTraceTimeoutErr               error
 	GetTraceTimeoutVal               time.Duration
 	GetMaxBatchSizeVal               uint
 	GetUpstreamBufferSizeVal         int
@@ -97,6 +76,9 @@ type MockConfig struct {
 
 	Mux sync.RWMutex
 }
+
+// assert that MockConfig implements Config
+var _ Config = (*MockConfig)(nil)
 
 func (m *MockConfig) Reload() {
 	m.Mux.RLock()
@@ -132,39 +114,39 @@ func (m *MockConfig) IsAPIKeyValid(key string) bool {
 	return m.IsAPIKeyValidFunc(key)
 }
 
-func (m *MockConfig) GetCollectorType() (string, error) {
+func (m *MockConfig) GetCollectorType() string {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
-	return m.GetCollectorTypeVal, m.GetCollectorTypeErr
+	return m.GetCollectorTypeVal
 }
 
-func (m *MockConfig) GetCollectionConfig() (CollectionConfig, error) {
+func (m *MockConfig) GetCollectionConfig() CollectionConfig {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
-	return m.GetCollectionConfigVal, m.GetCollectionConfigErr
+	return m.GetCollectionConfigVal
 }
 
-func (m *MockConfig) GetHoneycombAPI() (string, error) {
+func (m *MockConfig) GetHoneycombAPI() string {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
-	return m.GetHoneycombAPIVal, m.GetHoneycombAPIErr
+	return m.GetHoneycombAPIVal
 }
 
-func (m *MockConfig) GetListenAddr() (string, error) {
+func (m *MockConfig) GetListenAddr() string {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
-	return m.GetListenAddrVal, m.GetListenAddrErr
+	return m.GetListenAddrVal
 }
 
-func (m *MockConfig) GetPeerListenAddr() (string, error) {
+func (m *MockConfig) GetPeerListenAddr() string {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
-	return m.GetPeerListenAddrVal, m.GetPeerListenAddrErr
+	return m.GetPeerListenAddrVal
 }
 
 func (m *MockConfig) GetHTTPIdleTimeout() time.Duration {
@@ -187,32 +169,32 @@ func (m *MockConfig) GetGRPCEnabled() bool {
 	return m.GetGRPCEnabledVal
 }
 
-func (m *MockConfig) GetGRPCListenAddr() (string, error) {
+func (m *MockConfig) GetGRPCListenAddr() string {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
-	return m.GetGRPCListenAddrVal, m.GetGRPCListenAddrErr
+	return m.GetGRPCListenAddrVal
 }
 
-func (m *MockConfig) GetLoggerType() (string, error) {
+func (m *MockConfig) GetLoggerType() string {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
-	return m.GetLoggerTypeVal, m.GetLoggerTypeErr
+	return m.GetLoggerTypeVal
 }
 
-func (m *MockConfig) GetHoneycombLoggerConfig() (HoneycombLoggerConfig, error) {
+func (m *MockConfig) GetHoneycombLoggerConfig() HoneycombLoggerConfig {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
-	return m.GetHoneycombLoggerConfigVal, m.GetHoneycombLoggerConfigErr
+	return m.GetHoneycombLoggerConfigVal
 }
 
-func (m *MockConfig) GetStdoutLoggerConfig() (StdoutLoggerConfig, error) {
+func (m *MockConfig) GetStdoutLoggerConfig() StdoutLoggerConfig {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
-	return m.GetStdoutLoggerConfigVal, m.GetStdoutLoggerConfigErr
+	return m.GetStdoutLoggerConfigVal
 }
 
 func (m *MockConfig) GetLoggerLevel() Level {
@@ -222,39 +204,39 @@ func (m *MockConfig) GetLoggerLevel() Level {
 	return m.GetLoggerLevelVal
 }
 
-func (m *MockConfig) GetPeers() ([]string, error) {
+func (m *MockConfig) GetPeers() []string {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
-	return m.GetPeersVal, m.GetPeersErr
+	return m.GetPeersVal
 }
 
-func (m *MockConfig) GetRedisHost() (string, error) {
+func (m *MockConfig) GetRedisHost() string {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
-	return m.GetRedisHostVal, m.GetRedisHostErr
+	return m.GetRedisHostVal
 }
 
-func (m *MockConfig) GetRedisUsername() (string, error) {
+func (m *MockConfig) GetRedisUsername() string {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
-	return m.GetRedisUsernameVal, m.GetRedisUsernameErr
+	return m.GetRedisUsernameVal
 }
 
-func (m *MockConfig) GetRedisPassword() (string, error) {
+func (m *MockConfig) GetRedisPassword() string {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
-	return m.GetRedisPasswordVal, m.GetRedisPasswordErr
+	return m.GetRedisPasswordVal
 }
 
-func (m *MockConfig) GetRedisAuthCode() (string, error) {
+func (m *MockConfig) GetRedisAuthCode() string {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
-	return m.GetRedisAuthCodeVal, m.GetRedisAuthCodeErr
+	return m.GetRedisAuthCodeVal
 }
 
 func (m *MockConfig) GetRedisPrefix() string {
@@ -271,18 +253,18 @@ func (m *MockConfig) GetRedisDatabase() int {
 	return m.GetRedisDatabaseVal
 }
 
-func (m *MockConfig) GetUseTLS() (bool, error) {
+func (m *MockConfig) GetUseTLS() bool {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
-	return m.GetUseTLSVal, m.GetUseTLSErr
+	return m.GetUseTLSVal
 }
 
-func (m *MockConfig) GetUseTLSInsecure() (bool, error) {
+func (m *MockConfig) GetUseTLSInsecure() bool {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
-	return m.GetUseTLSInsecureVal, m.GetUseTLSInsecureErr
+	return m.GetUseTLSInsecureVal
 }
 
 func (m *MockConfig) GetGeneralConfig() GeneralConfig {
@@ -320,11 +302,11 @@ func (m *MockConfig) GetOTelTracingConfig() OTelTracingConfig {
 	return m.GetOTelTracingConfigVal
 }
 
-func (m *MockConfig) GetSendDelay() (time.Duration, error) {
+func (m *MockConfig) GetSendDelay() time.Duration {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
-	return m.GetSendDelayVal, m.GetSendDelayErr
+	return m.GetSendDelayVal
 }
 
 func (m *MockConfig) GetBatchTimeout() time.Duration {
@@ -334,11 +316,11 @@ func (m *MockConfig) GetBatchTimeout() time.Duration {
 	return m.GetBatchTimeoutVal
 }
 
-func (m *MockConfig) GetTraceTimeout() (time.Duration, error) {
+func (m *MockConfig) GetTraceTimeout() time.Duration {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
-	return m.GetTraceTimeoutVal, m.GetTraceTimeoutErr
+	return m.GetTraceTimeoutVal
 }
 
 func (m *MockConfig) GetMaxBatchSize() uint {
@@ -349,16 +331,16 @@ func (m *MockConfig) GetMaxBatchSize() uint {
 }
 
 // TODO: allow per-dataset mock values
-func (m *MockConfig) GetSamplerConfigForDestName(dataset string) (interface{}, string, error) {
+func (m *MockConfig) GetSamplerConfigForDestName(dataset string) (interface{}, string) {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
-	return m.GetSamplerTypeVal, m.GetSamplerTypeName, m.GetSamplerTypeErr
+	return m.GetSamplerTypeVal, m.GetSamplerTypeName
 }
 
 // GetAllSamplerRules normally returns all dataset rules, including the default
 // In this mock, it returns only the rules for "dataset1" according to the type of the value field
-func (m *MockConfig) GetAllSamplerRules() (*V2SamplerConfig, error) {
+func (m *MockConfig) GetAllSamplerRules() *V2SamplerConfig {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
@@ -375,14 +357,14 @@ func (m *MockConfig) GetAllSamplerRules() (*V2SamplerConfig, error) {
 	case *TotalThroughputSamplerConfig:
 		choice.TotalThroughputSampler = sampler
 	default:
-		return nil, fmt.Errorf("unable to determine data format")
+		return nil
 	}
 
 	v := &V2SamplerConfig{
 		Samplers: map[string]*V2SamplerChoice{"dataset1": choice},
 	}
 
-	return v, m.GetSamplerTypeErr
+	return v
 }
 
 func (m *MockConfig) GetUpstreamBufferSize() int {
@@ -399,25 +381,25 @@ func (m *MockConfig) GetPeerBufferSize() int {
 	return m.GetPeerBufferSizeVal
 }
 
-func (m *MockConfig) GetIdentifierInterfaceName() (string, error) {
+func (m *MockConfig) GetIdentifierInterfaceName() string {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
-	return m.IdentifierInterfaceName, nil
+	return m.IdentifierInterfaceName
 }
 
-func (m *MockConfig) GetUseIPV6Identifier() (bool, error) {
+func (m *MockConfig) GetUseIPV6Identifier() bool {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
-	return m.UseIPV6Identifier, nil
+	return m.UseIPV6Identifier
 }
 
-func (m *MockConfig) GetRedisIdentifier() (string, error) {
+func (m *MockConfig) GetRedisIdentifier() string {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
-	return m.RedisIdentifier, nil
+	return m.RedisIdentifier
 }
 
 func (m *MockConfig) GetSendTickerValue() time.Duration {
@@ -427,18 +409,18 @@ func (m *MockConfig) GetSendTickerValue() time.Duration {
 	return m.SendTickerVal
 }
 
-func (m *MockConfig) GetPeerManagementType() (string, error) {
+func (m *MockConfig) GetPeerManagementType() string {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
-	return m.PeerManagementType, nil
+	return m.PeerManagementType
 }
 
-func (m *MockConfig) GetDebugServiceAddr() (string, error) {
+func (m *MockConfig) GetDebugServiceAddr() string {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()
 
-	return m.DebugServiceAddr, nil
+	return m.DebugServiceAddr
 }
 
 func (m *MockConfig) GetIsDryRun() bool {

--- a/internal/peer/file.go
+++ b/internal/peer/file.go
@@ -21,7 +21,7 @@ func (p *FilePeers) GetPeers() ([]string, error) {
 	// we never want to return an empty list of peers, so if the config
 	// returns an empty list, return a single peer. This keeps the sharding
 	// logic happy.
-	peers, err := p.Cfg.GetPeers()
+	peers := p.Cfg.GetPeers()
 	if len(peers) == 0 {
 		addr, err := p.publicAddr()
 		if err != nil {
@@ -31,7 +31,7 @@ func (p *FilePeers) GetPeers() ([]string, error) {
 		peers = []string{addr}
 	}
 	p.Metrics.Gauge("num_file_peers", float64(len(peers)))
-	return peers, err
+	return peers, nil
 }
 
 func (p *FilePeers) GetInstanceID() (string, error) {
@@ -60,10 +60,7 @@ func (p *FilePeers) Stop() error {
 }
 
 func (p *FilePeers) publicAddr() (string, error) {
-	addr, err := p.Cfg.GetPeerListenAddr()
-	if err != nil {
-		return "", err
-	}
+	addr := p.Cfg.GetPeerListenAddr()
 	host, port, err := net.SplitHostPort(addr)
 	if err != nil {
 		return "", err

--- a/internal/peer/peers_test.go
+++ b/internal/peer/peers_test.go
@@ -24,10 +24,7 @@ import (
 func newPeers(c config.Config) (Peers, error) {
 	var peers Peers
 	var pubsubber pubsub.PubSub
-	ptype, err := c.GetPeerManagementType()
-	if err != nil {
-		return nil, err
-	}
+	ptype := c.GetPeerManagementType()
 	switch ptype {
 	case "file":
 		peers = &FilePeers{
@@ -67,7 +64,7 @@ func newPeers(c config.Config) (Peers, error) {
 		{Value: &logger.NullLogger{}},
 		{Value: clockwork.NewFakeClock()},
 	}
-	err = g.Provide(objects...)
+	err := g.Provide(objects...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to provide injection graph. error: %+v\n", err)
 	}

--- a/internal/peer/pubsub_redis.go
+++ b/internal/peer/pubsub_redis.go
@@ -206,7 +206,7 @@ func (p *RedisPubsubPeers) RegisterUpdatedPeersCallback(callback func()) {
 
 func (p *RedisPubsubPeers) publicAddr() (string, error) {
 	// compute the public version of my peer listen address
-	listenAddr, _ := p.Config.GetPeerListenAddr()
+	listenAddr := p.Config.GetPeerListenAddr()
 	// first, extract the port
 	_, port, err := net.SplitHostPort(listenAddr)
 
@@ -217,7 +217,7 @@ func (p *RedisPubsubPeers) publicAddr() (string, error) {
 	var myIdentifier string
 
 	// If RedisIdentifier is set, use as identifier.
-	if redisIdentifier, _ := p.Config.GetRedisIdentifier(); redisIdentifier != "" {
+	if redisIdentifier := p.Config.GetRedisIdentifier(); redisIdentifier != "" {
 		myIdentifier = redisIdentifier
 		p.Logger.Info().WithField("identifier", myIdentifier).Logf("using specified RedisIdentifier from config")
 	} else {
@@ -239,7 +239,7 @@ func (p *RedisPubsubPeers) publicAddr() (string, error) {
 // Otherwise, it will use the hostname.
 func (p *RedisPubsubPeers) getIdentifierFromInterface() (string, error) {
 	myIdentifier, _ := os.Hostname()
-	identifierInterfaceName, _ := p.Config.GetIdentifierInterfaceName()
+	identifierInterfaceName := p.Config.GetIdentifierInterfaceName()
 
 	if identifierInterfaceName != "" {
 		ifc, err := net.InterfaceByName(identifierInterfaceName)
@@ -258,7 +258,7 @@ func (p *RedisPubsubPeers) getIdentifierFromInterface() (string, error) {
 		for _, addr := range addrs {
 			// ParseIP doesn't know what to do with the suffix
 			ip := net.ParseIP(strings.Split(addr.String(), "/")[0])
-			ipv6, _ := p.Config.GetUseIPV6Identifier()
+			ipv6 := p.Config.GetUseIPV6Identifier()
 			if ipv6 && ip.To16() != nil {
 				ipStr = fmt.Sprintf("[%s]", ip.String())
 				break

--- a/logger/honeycomb.go
+++ b/logger/honeycomb.go
@@ -40,10 +40,7 @@ func (h *HoneycombLogger) Start() error {
 	// preserve it.
 	// TODO: make LogLevel part of the HoneycombLogger/LogrusLogger sections?
 	h.level = h.Config.GetLoggerLevel()
-	loggerConfig, err := h.Config.GetHoneycombLoggerConfig()
-	if err != nil {
-		return err
-	}
+	loggerConfig := h.Config.GetHoneycombLoggerConfig()
 	h.loggerConfig = loggerConfig
 	var loggerTx transmission.Sender
 	if h.loggerConfig.APIKey == "" {
@@ -126,14 +123,7 @@ func (h *HoneycombLogger) reloadBuilder(cfgHash, ruleHash string) {
 	h.Debug().Logf("reloading config for Honeycomb logger")
 	// preserve log level
 	h.level = h.Config.GetLoggerLevel()
-	loggerConfig, err := h.Config.GetHoneycombLoggerConfig()
-	if err != nil {
-		// complain about this both to STDOUT and to the previously configured
-		// honeycomb logger
-		fmt.Printf("failed to reload configs for Honeycomb logger: %+v\n", err)
-		h.Error().Logf("failed to reload configs for Honeycomb logger: %+v", err)
-		return
-	}
+	loggerConfig := h.Config.GetHoneycombLoggerConfig()
 	h.loggerConfig = loggerConfig
 	h.builder.APIHost = h.loggerConfig.APIHost
 	h.builder.WriteKey = h.loggerConfig.APIKey

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -29,11 +29,7 @@ type Entry interface {
 
 func GetLoggerImplementation(c config.Config) Logger {
 	var logger Logger
-	loggerType, err := c.GetLoggerType()
-	if err != nil {
-		fmt.Printf("unable to get logger type from config: %v\n", err)
-		os.Exit(1)
-	}
+	loggerType := c.GetLoggerType()
 	switch loggerType {
 	case "honeycomb":
 		logger = &HoneycombLogger{}

--- a/logger/logrus.go
+++ b/logger/logrus.go
@@ -25,18 +25,15 @@ type StdoutLogger struct {
 var _ = Logger((*StdoutLogger)(nil))
 
 type LogrusEntry struct {
-	entry *logrus.Entry
-	level logrus.Level
+	entry   *logrus.Entry
+	level   logrus.Level
 	sampler dynsampler.Sampler
 }
 
 func (l *StdoutLogger) Start() error {
 	l.logger = logrus.New()
 	l.logger.SetLevel(l.level)
-	cfg, err := l.Config.GetStdoutLoggerConfig()
-	if err != nil {
-		return err
-	}
+	cfg := l.Config.GetStdoutLoggerConfig()
 
 	if cfg.Structured {
 		l.logger.SetFormatter(&logrus.JSONFormatter{})
@@ -44,11 +41,11 @@ func (l *StdoutLogger) Start() error {
 
 	if cfg.SamplerEnabled {
 		l.sampler = &dynsampler.PerKeyThroughput{
-			ClearFrequencyDuration: 10*time.Second,
+			ClearFrequencyDuration: 10 * time.Second,
 			PerKeyThroughputPerSec: cfg.SamplerThroughput,
-			MaxKeys: 1000,
+			MaxKeys:                1000,
 		}
-		err = l.sampler.Start()
+		err := l.sampler.Start()
 		if err != nil {
 			return err
 		}
@@ -63,8 +60,8 @@ func (l *StdoutLogger) Debug() Entry {
 	}
 
 	return &LogrusEntry{
-		entry: logrus.NewEntry(l.logger),
-		level: logrus.DebugLevel,
+		entry:   logrus.NewEntry(l.logger),
+		level:   logrus.DebugLevel,
 		sampler: l.sampler,
 	}
 }
@@ -75,8 +72,8 @@ func (l *StdoutLogger) Info() Entry {
 	}
 
 	return &LogrusEntry{
-		entry: logrus.NewEntry(l.logger),
-		level: logrus.InfoLevel,
+		entry:   logrus.NewEntry(l.logger),
+		level:   logrus.InfoLevel,
 		sampler: l.sampler,
 	}
 }
@@ -87,8 +84,8 @@ func (l *StdoutLogger) Warn() Entry {
 	}
 
 	return &LogrusEntry{
-		entry: logrus.NewEntry(l.logger),
-		level: logrus.WarnLevel,
+		entry:   logrus.NewEntry(l.logger),
+		level:   logrus.WarnLevel,
 		sampler: l.sampler,
 	}
 }
@@ -99,8 +96,8 @@ func (l *StdoutLogger) Error() Entry {
 	}
 
 	return &LogrusEntry{
-		entry: logrus.NewEntry(l.logger),
-		level: logrus.ErrorLevel,
+		entry:   logrus.NewEntry(l.logger),
+		level:   logrus.ErrorLevel,
 		sampler: l.sampler,
 	}
 }
@@ -120,24 +117,24 @@ func (l *StdoutLogger) SetLevel(level string) error {
 
 func (l *LogrusEntry) WithField(key string, value interface{}) Entry {
 	return &LogrusEntry{
-		entry: l.entry.WithField(key, value),
-		level: l.level,
+		entry:   l.entry.WithField(key, value),
+		level:   l.level,
 		sampler: l.sampler,
 	}
 }
 
 func (l *LogrusEntry) WithString(key string, value string) Entry {
 	return &LogrusEntry{
-		entry: l.entry.WithField(key, value),
-		level: l.level,
+		entry:   l.entry.WithField(key, value),
+		level:   l.level,
 		sampler: l.sampler,
 	}
 }
 
 func (l *LogrusEntry) WithFields(fields map[string]interface{}) Entry {
 	return &LogrusEntry{
-		entry: l.entry.WithFields(fields),
-		level: l.level,
+		entry:   l.entry.WithFields(fields),
+		level:   l.level,
 		sampler: l.sampler,
 	}
 }
@@ -148,8 +145,8 @@ func (l *LogrusEntry) Logf(f string, args ...interface{}) {
 		// this will give us a different sample rate for each level and format string
 		// and avoid high cardinality args making the throughput sampler less effective
 		rate := l.sampler.GetSampleRate(fmt.Sprintf("%s:%s", l.level, f))
-		if shouldDrop(uint(rate)){
-			return 
+		if shouldDrop(uint(rate)) {
+			return
 		}
 		l.entry.WithField("SampleRate", rate)
 	}

--- a/pubsub/pubsub_goredis.go
+++ b/pubsub/pubsub_goredis.go
@@ -56,23 +56,10 @@ func (ps *GoRedisPubSub) Start() error {
 	ps.Metrics.Register("redis_pubsub_received", "counter")
 
 	if ps.Config != nil {
-		host, err := ps.Config.GetRedisHost()
-		if err != nil {
-			return err
-		}
-		username, err := ps.Config.GetRedisUsername()
-		if err != nil {
-			return err
-		}
-		pw, err := ps.Config.GetRedisPassword()
-		if err != nil {
-			return err
-		}
-
-		authcode, err = ps.Config.GetRedisAuthCode()
-		if err != nil {
-			return err
-		}
+		host := ps.Config.GetRedisHost()
+		username := ps.Config.GetRedisUsername()
+		pw := ps.Config.GetRedisPassword()
+		authcode = ps.Config.GetRedisAuthCode()
 
 		// we may have multiple hosts, separated by commas, so split them up and
 		// use them as the addrs for the client (if there are multiples, it will

--- a/route/otlp_trace_test.go
+++ b/route/otlp_trace_test.go
@@ -59,7 +59,7 @@ func TestOTLPHandler(t *testing.T) {
 	}
 
 	conf := &config.MockConfig{
-		GetSendDelayVal:    0,
+		GetSendDelayVal:    1 * time.Millisecond,
 		GetTraceTimeoutVal: 60 * time.Second,
 		GetSamplerTypeVal:  &config.DeterministicSamplerConfig{SampleRate: 1},
 		SendTickerVal:      2 * time.Millisecond,

--- a/route/proxy.go
+++ b/route/proxy.go
@@ -13,13 +13,7 @@ import (
 func (r *Router) proxy(w http.ResponseWriter, req *http.Request) {
 	r.Metrics.Increment(r.incomingOrPeer + "_router_proxied")
 	r.Logger.Debug().Logf("proxying request for %s", req.URL.Path)
-	upstreamTarget, err := r.Config.GetHoneycombAPI()
-	if err != nil {
-		w.WriteHeader(http.StatusServiceUnavailable)
-		io.WriteString(w, `{"error":"upstream target unavailable"}`)
-		r.Logger.Error().Logf("error getting honeycomb API config: %s", err)
-		return
-	}
+	upstreamTarget := r.Config.GetHoneycombAPI()
 	forwarded := req.Header.Get("X-Forwarded-For")
 	// let's copy the request over to a new one and
 	// dispatch it upstream

--- a/sample/sample.go
+++ b/sample/sample.go
@@ -65,10 +65,7 @@ func (s *SamplerFactory) GetSamplerImplementationForKey(samplerKey string, isLeg
 		}
 	}
 
-	c, _, err := s.Config.GetSamplerConfigForDestName(samplerKey)
-	if err != nil {
-		return nil
-	}
+	c, _ := s.Config.GetSamplerConfigForDestName(samplerKey)
 
 	var sampler Sampler
 
@@ -92,7 +89,7 @@ func (s *SamplerFactory) GetSamplerImplementationForKey(samplerKey string, isLeg
 		os.Exit(1)
 	}
 
-	err = sampler.Start()
+	err := sampler.Start()
 	if err != nil {
 		s.Logger.Debug().WithField("dataset", samplerKey).Logf("failed to start sampler")
 		return nil

--- a/service/debug/debug_service.go
+++ b/service/debug/debug_service.go
@@ -61,7 +61,7 @@ func (s *DebugService) Start() error {
 	s.Publish("memstats", Func(memstats))
 
 	go func() {
-		configAddr, _ := s.Config.GetDebugServiceAddr()
+		configAddr := s.Config.GetDebugServiceAddr()
 		if configAddr != "" {
 			host, portStr, _ := net.SplitHostPort(configAddr)
 			addr := net.JoinHostPort(host, portStr)

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -13,13 +13,11 @@ Logger:
 LegacyMetrics:
   Enabled: true
   Dataset: refinery_metrics
-  APIKey: $REFINERY_HONEYCOMB_API_KEY
   APIHost: https://api-dogfood.honeycomb.io
 
 OTelMetrics:
   Enabled: true
   Dataset: refinery_metrics_otel
-  APIKey: $REFINERY_HONEYCOMB_API_KEY
   APIHost: https://api-dogfood.honeycomb.io
 
 RefineryTelemetry:

--- a/transmit/transmit.go
+++ b/transmit/transmit.go
@@ -56,10 +56,7 @@ func (d *DefaultTransmission) Start() error {
 
 	// upstreamAPI doesn't get set when the client is initialized, because
 	// it can be reloaded from the config file while live
-	upstreamAPI, err := d.Config.GetHoneycombAPI()
-	if err != nil {
-		return err
-	}
+	upstreamAPI := d.Config.GetHoneycombAPI()
 
 	d.builder = d.LibhClient.NewBuilder()
 	d.builder.APIHost = upstreamAPI
@@ -85,11 +82,7 @@ func (d *DefaultTransmission) Start() error {
 
 func (d *DefaultTransmission) reloadTransmissionBuilder(cfgHash, ruleHash string) {
 	d.Logger.Debug().Logf("reloading transmission config")
-	upstreamAPI, err := d.Config.GetHoneycombAPI()
-	if err != nil {
-		// log and skip reload
-		d.Logger.Error().Logf("Failed to reload Honeycomb API when reloading configs:", err)
-	}
+	upstreamAPI := d.Config.GetHoneycombAPI()
 	builder := d.LibhClient.NewBuilder()
 	builder.APIHost = upstreamAPI
 }


### PR DESCRIPTION
## Which problem is this PR solving?

- Since the introduction of validation of config, the config functions can't fail, and the error returns are useless. 

## Short description of the changes

- Remove error returns from all the config getters
- Fix all the places we used (or didn't use them)
- Fix a couple of tests that assumed things that are no longer true

