### PR TITLE
feat: unregister peer asap on shutdown

### DIFF
--- a/cmd/refinery/main.go
+++ b/cmd/refinery/main.go
@@ -116,6 +116,10 @@ func main() {
 		os.Exit(1)
 	}
 
+	// when refinery receives a shutdown signal, we need to
+	// immediately let its peers know so they can stop sending
+	// data to it.
+	done := make(chan struct{})
 	// set up the peer management and pubsub implementations
 	var peers peer.Peers
 	var pubsubber pubsub.PubSub
@@ -128,11 +132,11 @@ func main() {
 		// In the case of file peers, we do not use Redis for anything, including pubsub, so
 		// we use the local pubsub implementation. Even if we have multiple peers, these
 		// peers cannot communicate using pubsub.
-		peers = &peer.FilePeers{}
+		peers = &peer.FilePeers{Done: done}
 		pubsubber = &pubsub.LocalPubSub{}
 	case "redis":
 		// if we're using redis, we need to set it up for both peers and pubsub
-		peers = &peer.RedisPubsubPeers{}
+		peers = &peer.RedisPubsubPeers{Done: done}
 		pubsubber = &pubsub.GoRedisPubSub{}
 	default:
 		// this should have been caught by validation
@@ -198,7 +202,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	done := make(chan struct{})
 	stressRelief := &collect.StressRelief{Done: done}
 	upstreamTransmission := transmit.NewDefaultTransmission(upstreamClient, upstreamMetricsRecorder, "upstream")
 	peerTransmission := transmit.NewDefaultTransmission(peerClient, peerMetricsRecorder, "peer")

--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -325,9 +325,6 @@ func TestAddSpan(t *testing.T) {
 	}
 	coll.AddSpan(rootSpan)
 	time.Sleep(conf.SendTickerVal * 5)
-	// make sure no other goroutines are trying to access traces in the cache
-	close(coll.done)
-
 	assert.Nil(t, coll.getFromCache(traceID), "after adding a leaf and root span, it should be removed from the cache")
 	transmission.Mux.RLock()
 	assert.Equal(t, 2, len(transmission.Events), "adding a root span should send all spans in the trace")

--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -325,6 +325,9 @@ func TestAddSpan(t *testing.T) {
 	}
 	coll.AddSpan(rootSpan)
 	time.Sleep(conf.SendTickerVal * 5)
+	// make sure no other goroutines are trying to access traces in the cache
+	close(coll.done)
+
 	assert.Nil(t, coll.getFromCache(traceID), "after adding a leaf and root span, it should be removed from the cache")
 	transmission.Mux.RLock()
 	assert.Equal(t, 2, len(transmission.Events), "adding a root span should send all spans in the trace")

--- a/collect/stressRelief.go
+++ b/collect/stressRelief.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/dgryski/go-wyhash"
+	"github.com/facebookgo/startstop"
 	"github.com/honeycombio/refinery/config"
 	"github.com/honeycombio/refinery/internal/health"
 	"github.com/honeycombio/refinery/internal/peer"
@@ -22,12 +23,13 @@ import (
 const stressReliefTopic = "refinery-stress-relief"
 
 type StressReliever interface {
-	Start() error
 	UpdateFromConfig(cfg config.StressReliefConfig)
 	Recalc() uint
 	Stressed() bool
 	GetSampleRate(traceID string) (rate uint, keep bool, reason string)
 	ShouldSampleDeterministically(traceID string) bool
+
+	startstop.Starter
 }
 
 var _ StressReliever = &MockStressReliever{}

--- a/collect/stress_relief_test.go
+++ b/collect/stress_relief_test.go
@@ -288,7 +288,6 @@ func newStressRelief(t *testing.T, clock clockwork.Clock, channel pubsub.PubSub)
 
 	return sr, func() {
 		require.NoError(t, healthReporter.Stop())
-		require.NoError(t, peer.Stop())
 		require.NoError(t, channel.Stop())
 	}
 }

--- a/internal/peer/file.go
+++ b/internal/peer/file.go
@@ -8,11 +8,12 @@ import (
 	"github.com/honeycombio/refinery/metrics"
 )
 
-var _ Peers = &FilePeers{}
+var _ Peers = (*FilePeers)(nil)
 
 type FilePeers struct {
 	Cfg     config.Config   `inject:""`
 	Metrics metrics.Metrics `inject:"metrics"`
+	Done    chan struct{}
 
 	id string
 }
@@ -52,10 +53,6 @@ func (p *FilePeers) Start() (err error) {
 		return err
 	}
 
-	return nil
-}
-
-func (p *FilePeers) Stop() error {
 	return nil
 }
 

--- a/internal/peer/mock.go
+++ b/internal/peer/mock.go
@@ -26,6 +26,4 @@ func (p *MockPeers) Start() error {
 	return nil
 }
 
-func (p *MockPeers) Stop() error {
-	return nil
-}
+func (p *MockPeers) stop() {}

--- a/internal/peer/peers.go
+++ b/internal/peer/peers.go
@@ -11,5 +11,4 @@ type Peers interface {
 	RegisterUpdatedPeersCallback(callback func())
 	// make it injectable
 	startstop.Starter
-	startstop.Stopper
 }

--- a/sharder/deterministic_test.go
+++ b/sharder/deterministic_test.go
@@ -34,7 +34,6 @@ func TestWhichShard(t *testing.T) {
 
 	filePeers := &peer.FilePeers{Cfg: config, Metrics: &metrics.NullMetrics{}}
 	require.NoError(t, filePeers.Start())
-	defer filePeers.Stop()
 
 	sharder := DeterministicSharder{
 		Config: config,
@@ -81,7 +80,6 @@ func TestWhichShardAtEdge(t *testing.T) {
 
 	filePeers := &peer.FilePeers{Cfg: config, Metrics: &metrics.NullMetrics{}}
 	require.NoError(t, filePeers.Start())
-	defer filePeers.Stop()
 
 	sharder := DeterministicSharder{
 		Config: config,
@@ -136,7 +134,6 @@ func BenchmarkShardBulk(b *testing.B) {
 
 	filePeers := &peer.FilePeers{Cfg: config, Metrics: &metrics.NullMetrics{}}
 	require.NoError(b, filePeers.Start())
-	defer filePeers.Stop()
 
 	sharder := DeterministicSharder{
 		Config: config,
@@ -186,7 +183,6 @@ func TestShardBulk(t *testing.T) {
 
 				filePeers := &peer.FilePeers{Cfg: config, Metrics: &metrics.NullMetrics{}}
 				require.NoError(t, filePeers.Start())
-				defer filePeers.Stop()
 
 				sharder := DeterministicSharder{
 					Config: config,
@@ -262,7 +258,6 @@ func TestShardDrop(t *testing.T) {
 
 				filePeers := &peer.FilePeers{Cfg: config, Metrics: &metrics.NullMetrics{}}
 				require.NoError(t, filePeers.Start())
-				defer filePeers.Stop()
 
 				sharder := DeterministicSharder{
 					Config: config,
@@ -349,7 +344,6 @@ func TestShardAddHash(t *testing.T) {
 
 				filePeers := &peer.FilePeers{Cfg: config, Metrics: &metrics.NullMetrics{}}
 				require.NoError(t, filePeers.Start())
-				defer filePeers.Stop()
 
 				sharder := DeterministicSharder{
 					Config: config,
@@ -435,7 +429,6 @@ func BenchmarkDeterministicShard(b *testing.B) {
 
 			filePeers := &peer.FilePeers{Cfg: config, Metrics: &metrics.NullMetrics{}}
 			require.NoError(b, filePeers.Start())
-			defer filePeers.Stop()
 
 			sharder := DeterministicSharder{
 				Config: config,


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

In order to recalculate new destination for traces during shutdown as soon as possible, we need to announce peer unregistration first thing.

## Short description of the changes

- use the `done` channel from catching the termination signal in main.go in peer management

