### PR TITLE
feat: make InMemoryCache concurrent safe

### DIFF
--- a/collect/cache/cache.go
+++ b/collect/cache/cache.go
@@ -10,11 +10,13 @@ import (
 	"github.com/honeycombio/refinery/types"
 )
 
-// Cache is a non-threadsafe cache. It must not be used for concurrent access.
+// Cache is a multi-threadsafe cache. It is used to store traces that have
+// been received but not yet sent.
 type Cache interface {
 	// Set adds the trace to the cache. If it is kicking out a trace from the cache
 	// that has not yet been sent, it will return that trace. Otherwise returns nil.
 	Set(trace *types.Trace) *types.Trace
+	//Get returns the trace with the given traceID, or nil if it is not in the cache.
 	Get(traceID string) *types.Trace
 	// GetAll is used during shutdown to get all in-flight traces to flush them
 	GetAll() []*types.Trace
@@ -39,6 +41,7 @@ type DefaultInMemCache struct {
 
 	// traceBuffer is a circular buffer of currently stored traces
 	traceBuffer []*types.Trace
+
 	// currentIndex is the current location in the circle.
 	currentIndex int
 }

--- a/collect/cache/cache_test.go
+++ b/collect/cache/cache_test.go
@@ -1,6 +1,8 @@
 package cache
 
 import (
+	"fmt"
+	"math/rand"
 	"testing"
 	"time"
 
@@ -8,6 +10,7 @@ import (
 	"github.com/honeycombio/refinery/logger"
 	"github.com/honeycombio/refinery/metrics"
 	"github.com/honeycombio/refinery/types"
+	"github.com/sourcegraph/conc/pool"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -139,4 +142,130 @@ func TestSkipOldUnsentTraces(t *testing.T) {
 	prev := c.Set(&types.Trace{TraceID: "7", SendBy: now})
 	// make sure we kicked out #4
 	assert.Equal(t, traces[3], prev)
+}
+
+// Benchamark the cache's Set method
+func BenchmarkCache_Set(b *testing.B) {
+	s := &metrics.MockMetrics{}
+	s.Start()
+	c := NewInMemCache(100000, s, &logger.NullLogger{})
+	now := time.Now()
+	traces := make([]*types.Trace, 0, b.N)
+	for i := 0; i < b.N; i++ {
+		traces = append(traces, &types.Trace{
+			TraceID: "trace" + fmt.Sprint(i),
+			SendBy:  now.Add(time.Duration(i) * time.Second),
+		})
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c.Set(traces[i])
+	}
+}
+
+// Benchmark the cache's Get method
+func BenchmarkCache_Get(b *testing.B) {
+	s := &metrics.MockMetrics{}
+	s.Start()
+	c := NewInMemCache(100000, s, &logger.NullLogger{})
+	now := time.Now()
+	traces := make([]*types.Trace, 0, b.N)
+	for i := 0; i < b.N; i++ {
+		traces = append(traces, &types.Trace{
+			TraceID: "trace" + fmt.Sprint(i),
+			SendBy:  now.Add(time.Duration(i) * time.Second),
+		})
+		c.Set(traces[i])
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c.Get(traces[i].TraceID)
+	}
+}
+
+// Benmark concurrent access to the cache's Set method
+func BenchmarkCache_SetConcurrent(b *testing.B) {
+	s := &metrics.MockMetrics{}
+	s.Start()
+	c := NewInMemCache(1000000, s, &logger.NullLogger{})
+	now := time.Now()
+	traces := make([]*types.Trace, 0, b.N)
+	for i := 0; i < b.N; i++ {
+		traces = append(traces, &types.Trace{
+			TraceID: "trace" + fmt.Sprint(i),
+			SendBy:  now.Add(time.Duration(i) * time.Second),
+		})
+	}
+
+	const numGoroutines = 70
+
+	p := pool.New().WithMaxGoroutines(numGoroutines + 1)
+	stop := make(chan struct{})
+	p.Go(func() {
+		select {
+		case <-stop:
+			return
+		default:
+			rand.Intn(100)
+		}
+	})
+
+	ch := make(chan int, numGoroutines)
+	for i := 0; i < numGoroutines; i++ {
+		p.Go(func() {
+			for n := range ch {
+				if i%1000 == 0 {
+					c.TakeExpiredTraces(time.Now())
+				}
+
+				c.Set(traces[n])
+			}
+		})
+	}
+}
+
+// Benchmark the cache's TakeExpiredTraces method
+func BenchmarkCache_TakeExpiredTraces(b *testing.B) {
+	s := &metrics.MockMetrics{}
+	s.Start()
+	c := NewInMemCache(100000, s, &logger.NullLogger{})
+	now := time.Now()
+	traces := make([]*types.Trace, 0, b.N)
+	for i := 0; i < b.N; i++ {
+		traces = append(traces, &types.Trace{
+			TraceID: "trace" + fmt.Sprint(i),
+			SendBy:  now.Add(time.Duration(i) * time.Second),
+		})
+		c.Set(traces[i])
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c.TakeExpiredTraces(now.Add(time.Duration(i) * time.Second))
+	}
+}
+
+// Benchmark the cache's RemoveTraces method
+func BenchmarkCache_RemoveTraces(b *testing.B) {
+	s := &metrics.MockMetrics{}
+	s.Start()
+	c := NewInMemCache(100000, s, &logger.NullLogger{})
+	now := time.Now()
+	traces := make([]*types.Trace, 0, b.N)
+	for i := 0; i < b.N; i++ {
+		traces = append(traces, &types.Trace{
+			TraceID: "trace" + fmt.Sprint(i),
+			SendBy:  now.Add(time.Duration(i) * time.Second),
+		})
+		c.Set(traces[i])
+	}
+
+	deletes := generics.NewSetWithCapacity[string](b.N / 2)
+	for i := 0; i < b.N/2; i++ {
+		deletes.Add("trace" + fmt.Sprint(i))
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c.RemoveTraces(deletes)
+	}
 }

--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -512,9 +512,6 @@ func TestCacheSizeReload(t *testing.T) {
 	conf.Reload()
 
 	assert.Eventually(t, func() bool {
-		coll.mutex.RLock()
-		defer coll.mutex.RUnlock()
-
 		return coll.cache.(*cache.DefaultInMemCache).GetCacheSize() == 2
 	}, 60*wait, wait, "cache size to change")
 
@@ -568,20 +565,19 @@ func TestSampleConfigReload(t *testing.T) {
 	coll.AddSpan(span)
 
 	assert.Eventually(t, func() bool {
-		coll.mutex.Lock()
-		defer coll.mutex.Unlock()
-
+		coll.mut.RLock()
 		_, ok := coll.datasetSamplers[dataset]
+		coll.mut.RUnlock()
+
 		return ok
 	}, conf.GetTraceTimeoutVal*2, conf.SendTickerVal)
 
 	conf.Reload()
 
 	assert.Eventually(t, func() bool {
-		coll.mutex.Lock()
-		defer coll.mutex.Unlock()
-
+		coll.mut.RLock()
 		_, ok := coll.datasetSamplers[dataset]
+		coll.mut.RUnlock()
 		return !ok
 	}, conf.GetTraceTimeoutVal*2, conf.SendTickerVal)
 
@@ -596,10 +592,9 @@ func TestSampleConfigReload(t *testing.T) {
 	coll.AddSpan(span)
 
 	assert.Eventually(t, func() bool {
-		coll.mutex.Lock()
-		defer coll.mutex.Unlock()
-
+		coll.mut.RLock()
 		_, ok := coll.datasetSamplers[dataset]
+		coll.mut.RUnlock()
 		return ok
 	}, conf.GetTraceTimeoutVal*2, conf.SendTickerVal)
 }
@@ -656,7 +651,6 @@ func TestStableMaxAlloc(t *testing.T) {
 	}
 
 	// Now there should be 500 traces in the cache.
-	coll.mutex.Lock()
 	assert.Equal(t, 500, len(coll.cache.GetAll()))
 
 	// We want to induce an eviction event, so set MaxAlloc a bit below
@@ -665,19 +659,17 @@ func TestStableMaxAlloc(t *testing.T) {
 	var mem runtime.MemStats
 	runtime.ReadMemStats(&mem)
 	// Set MaxAlloc, which should cause cache evictions.
-	conf.GetCollectionConfigVal.MaxAlloc = config.MemorySize(mem.Alloc * 99 / 100)
-
-	coll.mutex.Unlock()
+	cfg := conf.GetCollectionConfig()
+	cfg.MaxAlloc = config.MemorySize(mem.Alloc * 99 / 100)
+	conf.SetCollectionConfig(cfg)
 
 	// wait for the cache to take some action
 	var traces []*types.Trace
 	for {
-		coll.mutex.Lock()
 		traces = coll.cache.GetAll()
 		if len(traces) < 500 {
 			break
 		}
-		coll.mutex.Unlock()
 
 		time.Sleep(conf.SendTickerVal)
 	}
@@ -687,7 +679,6 @@ func TestStableMaxAlloc(t *testing.T) {
 	tracesLeft := len(traces)
 	assert.Less(t, tracesLeft, 480, "should have sent some traces")
 	assert.Greater(t, tracesLeft, 100, "should have NOT sent some traces")
-	coll.mutex.Unlock()
 
 	// We discarded the most costly spans, and sent them.
 	transmission.Mux.Lock()

--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -52,6 +52,7 @@ func newTestCollector(conf config.Config, transmission transmit.Transmission) *I
 			Metrics: s,
 			Logger:  &logger.NullLogger{},
 		},
+		done:  make(chan struct{}),
 	}
 }
 

--- a/config/mock.go
+++ b/config/mock.go
@@ -80,6 +80,13 @@ type MockConfig struct {
 // assert that MockConfig implements Config
 var _ Config = (*MockConfig)(nil)
 
+func (m *MockConfig) SetCollectionConfig(c CollectionConfig) {
+	m.Mux.Lock()
+	defer m.Mux.Unlock()
+
+	m.GetCollectionConfigVal = c
+}
+
 func (m *MockConfig) Reload() {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

To be able to process incoming traces while redistributing traces when a peer membership change happens, the trace cache needs to be able to support concurrent operations.

## Short description of the changes

- Add mutex to each cache access operations
- Add benchmark for cache operations

