### PR TITLE
feat: Add SpanLimit (includes some config changes)

### DIFF
--- a/cmd/refinery/main.go
+++ b/cmd/refinery/main.go
@@ -165,8 +165,8 @@ func main() {
 	userAgentAddition := "refinery/" + version
 	upstreamClient, err := libhoney.NewClient(libhoney.ClientConfig{
 		Transmission: &transmission.Honeycomb{
-			MaxBatchSize:          c.GetMaxBatchSize(),
-			BatchTimeout:          c.GetBatchTimeout(),
+			MaxBatchSize:          c.GetTracesConfig().GetMaxBatchSize(),
+			BatchTimeout:          time.Duration(c.GetTracesConfig().GetBatchTimeout()),
 			MaxConcurrentBatches:  libhoney.DefaultMaxConcurrentBatches,
 			PendingWorkCapacity:   uint(c.GetUpstreamBufferSize()),
 			UserAgentAddition:     userAgentAddition,
@@ -183,8 +183,8 @@ func main() {
 
 	peerClient, err := libhoney.NewClient(libhoney.ClientConfig{
 		Transmission: &transmission.Honeycomb{
-			MaxBatchSize:          c.GetMaxBatchSize(),
-			BatchTimeout:          c.GetBatchTimeout(),
+			MaxBatchSize:          c.GetTracesConfig().GetMaxBatchSize(),
+			BatchTimeout:          time.Duration(c.GetTracesConfig().GetBatchTimeout()),
 			MaxConcurrentBatches:  libhoney.DefaultMaxConcurrentBatches,
 			PendingWorkCapacity:   uint(c.GetPeerBufferSize()),
 			UserAgentAddition:     userAgentAddition,

--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -1718,7 +1718,7 @@ func TestBigTracesGoEarly(t *testing.T) {
 		transmission.Mux.RLock()
 		assert.Equal(collect, spanlimit, len(transmission.Events), "hitting the spanlimit should send the trace")
 		transmission.Mux.RUnlock()
-	}, 2*time.Second, 100*time.Millisecond)
+	}, 5*time.Second, 100*time.Millisecond)
 
 	// now we add the root span and verify that it got sent and that the root span had the span count
 	rootSpan := &types.Span{
@@ -1735,7 +1735,7 @@ func TestBigTracesGoEarly(t *testing.T) {
 		transmission.Mux.RLock()
 		assert.Equal(collect, spanlimit, len(transmission.Events), "hitting the spanlimit should send the trace")
 		transmission.Mux.RUnlock()
-	}, 2*time.Second, 100*time.Millisecond)
+	}, 5*time.Second, 100*time.Millisecond)
 
 	transmission.Mux.RLock()
 	require.Equal(t, spanlimit+1, len(transmission.Events), "adding a root span should send all spans in the trace")

--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -1733,7 +1733,7 @@ func TestBigTracesGoEarly(t *testing.T) {
 
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
 		transmission.Mux.RLock()
-		assert.Equal(collect, spanlimit, len(transmission.Events), "hitting the spanlimit should send the trace")
+		assert.Equal(collect, spanlimit+1, len(transmission.Events), "hitting the spanlimit should send the trace")
 		transmission.Mux.RUnlock()
 	}, 5*time.Second, 100*time.Millisecond)
 

--- a/config/config.go
+++ b/config/config.go
@@ -96,20 +96,7 @@ type Config interface {
 	// the upstream Honeycomb API server
 	GetHoneycombAPI() string
 
-	// GetSendDelay returns the number of seconds to pause after a trace is
-	// complete before sending it, to allow stragglers to arrive
-	GetSendDelay() time.Duration
-
-	// GetBatchTimeout returns how often to send off batches in seconds
-	GetBatchTimeout() time.Duration
-
-	// GetTraceTimeout is how long to wait before sending a trace even if it's
-	// not complete. This should be longer than the longest expected trace
-	// duration.
-	GetTraceTimeout() time.Duration
-
-	// GetMaxBatchSize is the number of events to be included in the batch for sending
-	GetMaxBatchSize() uint
+	GetTracesConfig() TracesConfig
 
 	// GetLoggerType returns the type of the logger to use. Valid types are in
 	// the logger package
@@ -160,9 +147,6 @@ type Config interface {
 	GetUseIPV6Identifier() bool
 
 	GetRedisIdentifier() string
-
-	// GetSendTickerValue returns the duration to use to check for traces to send
-	GetSendTickerValue() time.Duration
 
 	// GetDebugServiceAddr sets the IP and port the debug service will run on (you must provide the
 	// command line flag -d to start the debug service)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -303,15 +303,15 @@ func TestReadDefaults(t *testing.T) {
 	c, err := getConfig([]string{"--no-validate", "--config", "../config.yaml", "--rules_config", "../rules.yaml"})
 	assert.NoError(t, err)
 
-	if d := c.GetSendDelay(); d != 2*time.Second {
+	if d := c.GetTracesConfig().GetSendDelay(); d != 2*time.Second {
 		t.Error("received", d, "expected", 2*time.Second)
 	}
 
-	if d := c.GetTraceTimeout(); d != 60*time.Second {
+	if d := c.GetTracesConfig().GetTraceTimeout(); d != 60*time.Second {
 		t.Error("received", d, "expected", 60*time.Second)
 	}
 
-	if d := c.GetSendTickerValue(); d != 100*time.Millisecond {
+	if d := c.GetTracesConfig().GetSendTickerValue(); d != 100*time.Millisecond {
 		t.Error("received", d, "expected", 100*time.Millisecond)
 	}
 

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -190,6 +190,27 @@ type TracesConfig struct {
 	TraceTimeout Duration `yaml:"TraceTimeout" default:"60s"`
 	MaxBatchSize uint     `yaml:"MaxBatchSize" default:"500"`
 	SendTicker   Duration `yaml:"SendTicker" default:"100ms"`
+	SpanLimit    uint     `yaml:"SpanLimit"`
+}
+
+func (t TracesConfig) GetSendDelay() time.Duration {
+	return time.Duration(t.SendDelay)
+}
+
+func (t TracesConfig) GetBatchTimeout() time.Duration {
+	return time.Duration(t.BatchTimeout)
+}
+
+func (t TracesConfig) GetTraceTimeout() time.Duration {
+	return time.Duration(t.TraceTimeout)
+}
+
+func (t TracesConfig) GetMaxBatchSize() uint {
+	return t.MaxBatchSize
+}
+
+func (t TracesConfig) GetSendTickerValue() time.Duration {
+	return time.Duration(t.SendTicker)
 }
 
 type DebuggingConfig struct {
@@ -595,6 +616,13 @@ func (f *fileConfig) GetGRPCConfig() GRPCServerParameters {
 	return f.mainConfig.GRPCServerParameters
 }
 
+func (f *fileConfig) GetTracesConfig() TracesConfig {
+	f.mux.RLock()
+	defer f.mux.RUnlock()
+
+	return f.mainConfig.Traces
+}
+
 func (f *fileConfig) GetAccessKeyConfig() AccessKeyConfig {
 	f.mux.RLock()
 	defer f.mux.RUnlock()
@@ -785,34 +813,6 @@ func (f *fileConfig) GetOTelMetricsConfig() OTelMetricsConfig {
 	return f.mainConfig.OTelMetrics
 }
 
-func (f *fileConfig) GetSendDelay() time.Duration {
-	f.mux.RLock()
-	defer f.mux.RUnlock()
-
-	return time.Duration(f.mainConfig.Traces.SendDelay)
-}
-
-func (f *fileConfig) GetBatchTimeout() time.Duration {
-	f.mux.RLock()
-	defer f.mux.RUnlock()
-
-	return time.Duration(f.mainConfig.Traces.BatchTimeout)
-}
-
-func (f *fileConfig) GetTraceTimeout() time.Duration {
-	f.mux.RLock()
-	defer f.mux.RUnlock()
-
-	return time.Duration(f.mainConfig.Traces.TraceTimeout)
-}
-
-func (f *fileConfig) GetMaxBatchSize() uint {
-	f.mux.RLock()
-	defer f.mux.RUnlock()
-
-	return f.mainConfig.Traces.MaxBatchSize
-}
-
 func (f *fileConfig) GetUpstreamBufferSize() int {
 	f.mux.RLock()
 	defer f.mux.RUnlock()
@@ -825,13 +825,6 @@ func (f *fileConfig) GetPeerBufferSize() int {
 	defer f.mux.RUnlock()
 
 	return f.mainConfig.BufferSizes.PeerBufferSize
-}
-
-func (f *fileConfig) GetSendTickerValue() time.Duration {
-	f.mux.RLock()
-	defer f.mux.RUnlock()
-
-	return time.Duration(f.mainConfig.Traces.SendTicker)
 }
 
 func (f *fileConfig) GetDebugServiceAddr() string {

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -350,6 +350,20 @@ groups:
           should increase this timer. Note that this increase will also
           increase the memory requirements for Refinery.
 
+      - name: SpanLimit
+        type: int
+        valuetype: nondefault
+        default: 0
+        reload: true
+        summary: is the number of spans after which a trace becomes eligible for a trace decision.
+        description: >
+          This setting helps to keep memory usage under control. If a trace has more than this
+          number of spans, then it becomes eligible for a trace decision.
+
+          It's most helpful in a situation where a sudden burst of many spans in a large trace hits
+          refinery all at once, causing memory usage to spike and possibly crashing refinery.
+          TODO: Write more
+
       - name: MaxBatchSize
         type: int
         valuetype: nondefault

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -362,7 +362,6 @@ groups:
 
           It's most helpful in a situation where a sudden burst of many spans in a large trace hits
           refinery all at once, causing memory usage to spike and possibly crashing refinery.
-          TODO: Write more
 
       - name: MaxBatchSize
         type: int

--- a/config/mock.go
+++ b/config/mock.go
@@ -12,6 +12,7 @@ type MockConfig struct {
 	GetAccessKeyConfigVal            AccessKeyConfig
 	GetCollectorTypeVal              string
 	GetCollectionConfigVal           CollectionConfig
+	GetTracesConfigVal               TracesConfig
 	GetHoneycombAPIVal               string
 	GetListenAddrVal                 string
 	GetPeerListenAddrVal             string
@@ -41,13 +42,8 @@ type MockConfig struct {
 	GetPrometheusMetricsConfigVal    PrometheusMetricsConfig
 	GetOTelMetricsConfigVal          OTelMetricsConfig
 	GetOTelTracingConfigVal          OTelTracingConfig
-	GetSendDelayVal                  time.Duration
-	GetBatchTimeoutVal               time.Duration
-	GetTraceTimeoutVal               time.Duration
-	GetMaxBatchSizeVal               uint
 	GetUpstreamBufferSizeVal         int
 	GetPeerBufferSizeVal             int
-	SendTickerVal                    time.Duration
 	IdentifierInterfaceName          string
 	UseIPV6Identifier                bool
 	RedisIdentifier                  string
@@ -121,6 +117,13 @@ func (m *MockConfig) GetCollectionConfig() CollectionConfig {
 	defer m.Mux.RUnlock()
 
 	return m.GetCollectionConfigVal
+}
+
+func (m *MockConfig) GetTracesConfig() TracesConfig {
+	m.Mux.RLock()
+	defer m.Mux.RUnlock()
+
+	return m.GetTracesConfigVal
 }
 
 func (m *MockConfig) GetHoneycombAPI() string {
@@ -297,34 +300,6 @@ func (m *MockConfig) GetOTelTracingConfig() OTelTracingConfig {
 	return m.GetOTelTracingConfigVal
 }
 
-func (m *MockConfig) GetSendDelay() time.Duration {
-	m.Mux.RLock()
-	defer m.Mux.RUnlock()
-
-	return m.GetSendDelayVal
-}
-
-func (m *MockConfig) GetBatchTimeout() time.Duration {
-	m.Mux.RLock()
-	defer m.Mux.RUnlock()
-
-	return m.GetBatchTimeoutVal
-}
-
-func (m *MockConfig) GetTraceTimeout() time.Duration {
-	m.Mux.RLock()
-	defer m.Mux.RUnlock()
-
-	return m.GetTraceTimeoutVal
-}
-
-func (m *MockConfig) GetMaxBatchSize() uint {
-	m.Mux.RLock()
-	defer m.Mux.RUnlock()
-
-	return m.GetMaxBatchSizeVal
-}
-
 // TODO: allow per-dataset mock values
 func (m *MockConfig) GetSamplerConfigForDestName(dataset string) (interface{}, string) {
 	m.Mux.RLock()
@@ -395,13 +370,6 @@ func (m *MockConfig) GetRedisIdentifier() string {
 	defer m.Mux.RUnlock()
 
 	return m.RedisIdentifier
-}
-
-func (m *MockConfig) GetSendTickerValue() time.Duration {
-	m.Mux.RLock()
-	defer m.Mux.RUnlock()
-
-	return m.SendTickerVal
 }
 
 func (m *MockConfig) GetPeerManagementType() string {


### PR DESCRIPTION
## Which problem is this PR solving?

#1257 -- helps to keep Refinery from exploding when a giant trace arrives.

## Short description of the changes

- Adds a SpanLimit that kicks off trace evaluation as soon as the number of spans in a trace exceeds that value
- Moves some config stuff around (reducing the size of Config) and fixes the tests that touch it
- Fixes #1257 


