### PR TITLE
Use HTTP/2 for all upstream and peer-to-peer connections

### DIFF
--- a/cmd/refinery/main.go
+++ b/cmd/refinery/main.go
@@ -147,6 +147,7 @@ func main() {
 			Timeout: 10 * time.Second,
 		}).Dial,
 		TLSHandshakeTimeout: 15 * time.Second,
+		ForceAttemptHTTP2:   true,
 	}
 
 	// peerTransport is the http transport used to send things to a local peer
@@ -156,6 +157,7 @@ func main() {
 			Timeout: 3 * time.Second,
 		}).Dial,
 		TLSHandshakeTimeout: 1200 * time.Millisecond,
+		ForceAttemptHTTP2:   true,
 	}
 
 	genericMetricsRecorder := metrics.NewMetricsPrefixer("")


### PR DESCRIPTION
## Which problem is this PR solving?

- Refinery currently uses HTTP/1 for all outbound connections, both to upstream and peers.  In Classic settings this is fine, but in E&S settings with very high service counts this can result in thousands of new connections made per minute, and a heavy toll on any intermediary proxies. 
- According to Go's [http.Transport documentation](https://cs.opensource.google/go/go/+/refs/tags/go1.22.6:src/net/http/transport.go;l=287-293),  it `conservatively disables HTTP/2` because we're passing in `Dial`.

## Short description of the changes

- This PR sets the flag to tell Go's http.Transport that it's okay to go ahead and attempt HTTP/2 if available. 
- I've put the upstream aspect of this through heavy testing so far, but not the peer-to-peer aspect.   I imagine it may provide benefit to customers with service meshes, and marginal benefit to Linux kernels in general to track fewer connections.

