### PR TITLE
fix: don't read more than max bytes from a request

### DIFF
--- a/route/route.go
+++ b/route/route.go
@@ -54,7 +54,8 @@ const (
 	numZstdDecoders        = 4
 	traceIDShortLength     = 8
 	traceIDLongLength      = 16
-	GRPCMessageSizeMax int = 5000000 // 5MB
+	GRPCMessageSizeMax int = 5_000_000 // 5MB
+	HTTPMessageSizeMax     = 5_000_000 // 5MB
 	defaultSampleRate      = 1
 )
 
@@ -687,7 +688,7 @@ func (r *Router) getMaybeCompressedBody(req *http.Request) (io.Reader, error) {
 		defer gzipReader.Close()
 
 		buf := &bytes.Buffer{}
-		if _, err := io.Copy(buf, gzipReader); err != nil {
+		if _, err := io.Copy(buf, io.LimitReader(gzipReader, HTTPMessageSizeMax)); err != nil {
 			return nil, err
 		}
 		reader = buf
@@ -703,7 +704,7 @@ func (r *Router) getMaybeCompressedBody(req *http.Request) (io.Reader, error) {
 			return nil, err
 		}
 		buf := &bytes.Buffer{}
-		if _, err := io.Copy(buf, zReader); err != nil {
+		if _, err := io.Copy(buf, io.LimitReader(zReader, HTTPMessageSizeMax)); err != nil {
 			return nil, err
 		}
 

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -13,13 +13,11 @@ Logger:
 LegacyMetrics:
   Enabled: true
   Dataset: refinery_metrics
-  APIKey: $REFINERY_HONEYCOMB_API_KEY
   APIHost: https://api-dogfood.honeycomb.io
 
 OTelMetrics:
   Enabled: true
   Dataset: refinery_metrics_otel
-  APIKey: $REFINERY_HONEYCOMB_API_KEY
   APIHost: https://api-dogfood.honeycomb.io
 
 RefineryTelemetry:


### PR DESCRIPTION
## Which problem is this PR solving?

- If the compressed input to an HTTP request is too big, it can cause Refinery to have difficulties. 

## Short description of the changes

- Set a request max for the HTTP inputs /1/batch and /1/events
- Remove bogus syntax from test config

I don't have a good way to test this in CI, but it was extensively tested locally.

