### PR TITLE
fix: set up tls for redis when it's enabled

### DIFF
--- a/internal/peer/pubsub_redis.go
+++ b/internal/peer/pubsub_redis.go
@@ -197,6 +197,7 @@ func (p *RedisPubsubPeers) stop() {
 		p.Logger.Error().Logf("failed to get public address")
 		return
 	}
+
 	err = p.PubSub.Publish(context.Background(), "peers", newPeerCommand(Unregister, myaddr).marshal())
 	if err != nil {
 		p.Logger.Error().WithFields(map[string]interface{}{
@@ -204,7 +205,6 @@ func (p *RedisPubsubPeers) stop() {
 			"hostaddress": myaddr,
 		}).Logf("failed to publish peer address")
 	}
-
 }
 
 func (p *RedisPubsubPeers) GetPeers() ([]string, error) {

--- a/internal/peer/pubsub_redis.go
+++ b/internal/peer/pubsub_redis.go
@@ -166,7 +166,13 @@ func (p *RedisPubsubPeers) Start() error {
 			case <-ticker.Chan():
 				// publish our presence periodically
 				ctx, cancel := context.WithTimeout(context.Background(), p.Config.GetPeerTimeout())
-				p.PubSub.Publish(ctx, "peers", newPeerCommand(Register, myaddr).marshal())
+				err := p.PubSub.Publish(ctx, "peers", newPeerCommand(Register, myaddr).marshal())
+				if err != nil {
+					p.Logger.Error().WithFields(map[string]interface{}{
+						"error":       err,
+						"hostaddress": myaddr,
+					}).Logf("failed to publish peer address")
+				}
 				cancel()
 			case <-logTicker.Chan():
 				p.Logger.Debug().WithFields(map[string]any{
@@ -191,7 +197,14 @@ func (p *RedisPubsubPeers) stop() {
 		p.Logger.Error().Logf("failed to get public address")
 		return
 	}
-	p.PubSub.Publish(context.Background(), "peers", newPeerCommand(Unregister, myaddr).marshal())
+	err = p.PubSub.Publish(context.Background(), "peers", newPeerCommand(Unregister, myaddr).marshal())
+	if err != nil {
+		p.Logger.Error().WithFields(map[string]interface{}{
+			"error":       err,
+			"hostaddress": myaddr,
+		}).Logf("failed to publish peer address")
+	}
+
 }
 
 func (p *RedisPubsubPeers) GetPeers() ([]string, error) {

--- a/pubsub/pubsub_goredis.go
+++ b/pubsub/pubsub_goredis.go
@@ -2,6 +2,7 @@ package pubsub
 
 import (
 	"context"
+	"crypto/tls"
 	"strings"
 	"sync"
 
@@ -69,6 +70,20 @@ func (ps *GoRedisPubSub) Start() error {
 		options.Username = username
 		options.Password = pw
 		options.DB = ps.Config.GetRedisDatabase()
+		useTLS := ps.Config.GetUseTLS()
+		tlsInsecure := ps.Config.GetUseTLSInsecure()
+		if useTLS {
+			tlsConfig := &tls.Config{
+				MinVersion: tls.VersionTLS12,
+			}
+
+			if tlsInsecure {
+				tlsConfig.InsecureSkipVerify = true
+			}
+
+			options.TLSConfig = tlsConfig
+		}
+
 	}
 	client := redis.NewUniversalClient(options)
 

--- a/pubsub/pubsub_goredis.go
+++ b/pubsub/pubsub_goredis.go
@@ -70,21 +70,15 @@ func (ps *GoRedisPubSub) Start() error {
 		options.Username = username
 		options.Password = pw
 		options.DB = ps.Config.GetRedisDatabase()
-		useTLS := ps.Config.GetUseTLS()
-		tlsInsecure := ps.Config.GetUseTLSInsecure()
-		if useTLS {
-			tlsConfig := &tls.Config{
-				MinVersion: tls.VersionTLS12,
-			}
 
-			if tlsInsecure {
-				tlsConfig.InsecureSkipVerify = true
+		if ps.Config.GetUseTLS() {
+			options.TLSConfig = &tls.Config{
+				MinVersion:         tls.VersionTLS12,
+				InsecureSkipVerify: ps.Config.GetUseTLSInsecure(),
 			}
-
-			options.TLSConfig = tlsConfig
 		}
-
 	}
+
 	client := redis.NewUniversalClient(options)
 
 	// if an authcode was provided, use it to authenticate the connection


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

Currently, we are not setting the tls config for go-redis even through we do have `UseTLS` configuration option.

## Short description of the changes

- config tls with go-redis when it's enabled

