### PR TITLE
fix: support TLS connections to Redis

### DIFF
--- a/pubsub/pubsub_goredis.go
+++ b/pubsub/pubsub_goredis.go
@@ -2,6 +2,7 @@ package pubsub
 
 import (
 	"context"
+	"crypto/tls"
 	"strings"
 	"sync"
 
@@ -82,6 +83,21 @@ func (ps *GoRedisPubSub) Start() error {
 		options.Username = username
 		options.Password = pw
 		options.DB = ps.Config.GetRedisDatabase()
+
+		useTLS, err := ps.Config.GetUseTLS()
+		if err != nil {
+			return err
+		}
+		if useTLS {
+			tlsInsecure, err := ps.Config.GetUseTLSInsecure()
+			if err != nil {
+				return err
+			}
+			options.TLSConfig = &tls.Config{
+				MinVersion:         tls.VersionTLS12,
+				InsecureSkipVerify: tlsInsecure,
+			}
+		}
 	}
 	client := redis.NewUniversalClient(options)
 


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

Currently, we are not setting the tls config for go-redis even through we do have `UseTLS` configuration option.


## Short description of the changes

- log the pubsub publish error
- configure redis client tls

