### PR TITLE
maint: change default for MaxSendMsgSize and MaxRcvMsgSize.

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -677,8 +677,8 @@ func TestHoneycombGRPCConfigDefaults(t *testing.T) {
 	assert.Equal(t, 1*time.Minute, time.Duration(grpcConfig.MaxConnectionAgeGrace))
 	assert.Equal(t, 1*time.Minute, time.Duration(grpcConfig.KeepAlive))
 	assert.Equal(t, 20*time.Second, time.Duration(grpcConfig.KeepAliveTimeout))
-	assert.Equal(t, config.MemorySize(5*1_000_000), grpcConfig.MaxSendMsgSize)
-	assert.Equal(t, config.MemorySize(5*1_000_000), grpcConfig.MaxRecvMsgSize)
+	assert.Equal(t, config.MemorySize(15*1_000_000), grpcConfig.MaxSendMsgSize)
+	assert.Equal(t, config.MemorySize(15*1_000_000), grpcConfig.MaxRecvMsgSize)
 }
 
 func TestStdoutLoggerConfig(t *testing.T) {

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -363,8 +363,8 @@ type GRPCServerParameters struct {
 	MaxConnectionAgeGrace Duration     `yaml:"MaxConnectionAgeGrace" default:"1m"`
 	KeepAlive             Duration     `yaml:"KeepAlive" default:"1m"`
 	KeepAliveTimeout      Duration     `yaml:"KeepAliveTimeout" default:"20s"`
-	MaxSendMsgSize        MemorySize   `yaml:"MaxSendMsgSize" default:"5MB"`
-	MaxRecvMsgSize        MemorySize   `yaml:"MaxRecvMsgSize" default:"5MB"`
+	MaxSendMsgSize        MemorySize   `yaml:"MaxSendMsgSize" default:"15MB"`
+	MaxRecvMsgSize        MemorySize   `yaml:"MaxRecvMsgSize" default:"15MB"`
 }
 
 type SampleCacheConfig struct {

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -1535,7 +1535,7 @@ groups:
       - name: MaxSendMsgSize
         type: memorysize
         valuetype: memorysize
-        default: 5MB
+        default: 15MB
         reload: false
         firstversion: v2.2
         validations:
@@ -1552,7 +1552,7 @@ groups:
       - name: MaxRecvMsgSize
         type: memorysize
         valuetype: memorysize
-        default: 5MB
+        default: 15MB
         reload: false
         firstversion: v2.2
         validations:


### PR DESCRIPTION
## Which problem is this PR solving?

- Fixes #1131 
- The default receive message size is smaller than Honeycomb accepts, which can be confusing. Change it, and the default send size, for better efficiency.

## Short description of the changes

- Change the defaults from 5MB to 15MB
- This is *technically* a breaking change but only by the most pedantic definition -- there's no realistic situation in which this actually matters, so we're not going to stress over it.
