### PR TITLE
fix: only set send reason to span limit if it's configured

### DIFF
--- a/collect/collect.go
+++ b/collect/collect.go
@@ -456,7 +456,7 @@ func (i *InMemCollector) sendExpiredTracesInCache(now time.Time) {
 		if t.RootSpan != nil {
 			i.send(t, TraceSendGotRoot)
 		} else {
-			if t.SpanCount() > spanLimit {
+			if spanLimit > 0 && t.SpanCount() > spanLimit {
 				i.send(t, TraceSendSpanLimit)
 			} else {
 				i.send(t, TraceSendExpired)

--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -1773,7 +1773,6 @@ func TestDrainTracesOnShutdown(t *testing.T) {
 
 	sentTraceChan := make(chan sentRecord, 1)
 	forwardTraceChan := make(chan *types.Span, 1)
-	expiredTraceChan := make(chan *types.Span, 1)
 
 	// test 1
 	// the trace in cache already has decision made
@@ -1793,7 +1792,6 @@ func TestDrainTracesOnShutdown(t *testing.T) {
 	coll.distributeSpansOnShutdown(sentTraceChan, forwardTraceChan, span1)
 	require.Len(t, sentTraceChan, 1)
 	require.Len(t, forwardTraceChan, 0)
-	require.Len(t, expiredTraceChan, 0)
 
 	ctx1, cancel1 := context.WithCancel(context.Background())
 	go coll.sendSpansOnShutdown(ctx1, sentTraceChan, forwardTraceChan)
@@ -1822,7 +1820,6 @@ func TestDrainTracesOnShutdown(t *testing.T) {
 	coll.distributeSpansOnShutdown(sentTraceChan, forwardTraceChan, span2)
 	require.Len(t, sentTraceChan, 0)
 	require.Len(t, forwardTraceChan, 1)
-	require.Len(t, expiredTraceChan, 0)
 
 	ctx2, cancel2 := context.WithCancel(context.Background())
 	go coll.sendSpansOnShutdown(ctx2, sentTraceChan, forwardTraceChan)


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

We should not set send reason to span limit if users didn't specify the span limit config

## Short description of the changes

- only set send reason to span limit if span limit config is non-zero

