### PR TITLE
feat: Add a cache to the cache

### DIFF
--- a/collect/cache/cuckoo_test.go
+++ b/collect/cache/cuckoo_test.go
@@ -11,14 +11,15 @@ import (
 )
 
 // genID returns a random hex string of length numChars
+var seed = 3565269841805
+var rng = wyhash.Rng(seed)
+
+const charset = "abcdef0123456789"
+
 func genID(numChars int) string {
-	seed := 3565269841805
-
-	const charset = "abcdef0123456789"
-
 	id := make([]byte, numChars)
 	for i := 0; i < numChars; i++ {
-		id[i] = charset[int(wyhash.Rng(seed))%len(charset)]
+		id[i] = charset[int(rng.Next()%uint64(len(charset)))]
 	}
 	return string(id)
 }

--- a/generics/setttl.go
+++ b/generics/setttl.go
@@ -58,7 +58,7 @@ func (s *SetWithTTL[T]) Contains(e T) bool {
 	if !ok {
 		return false
 	}
-	return item.After(time.Now())
+	return item.After(s.Clock.Now())
 }
 
 func (s *SetWithTTL[T]) cleanup() int {

--- a/generics/setttl_test.go
+++ b/generics/setttl_test.go
@@ -4,9 +4,24 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dgryski/go-wyhash"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
 )
+
+var seed = 3565269841805
+var rng = wyhash.Rng(seed)
+
+const charset = "abcdef0123456789"
+
+func genID(numChars int) string {
+
+	id := make([]byte, numChars)
+	for i := 0; i < numChars; i++ {
+		id[i] = charset[int(rng.Next()%uint64(len(charset)))]
+	}
+	return string(id)
+}
 
 func TestSetTTLBasics(t *testing.T) {
 	s := NewSetWithTTL(100*time.Millisecond, "a", "b", "b")
@@ -23,4 +38,53 @@ func TestSetTTLBasics(t *testing.T) {
 	fakeclock.Advance(100 * time.Millisecond)
 	assert.Equal(t, 0, s.Length())
 	assert.Equal(t, s.Members(), []string{})
+}
+
+func BenchmarkSetWithTTLContains(b *testing.B) {
+	s := NewSetWithTTL[string](10 * time.Second)
+	fc := clockwork.NewFakeClock()
+	s.Clock = fc
+
+	n := 10000
+	traceIDs := make([]string, n)
+	for i := 0; i < n; i++ {
+		traceIDs[i] = genID(32)
+		if i%2 == 0 {
+			s.Add(traceIDs[i])
+		}
+		fc.Advance(1 * time.Microsecond)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		s.Contains(traceIDs[i%n])
+	}
+}
+
+func BenchmarkSetWithTTLExpire(b *testing.B) {
+	s := NewSetWithTTL[string](1 * time.Second)
+	fc := clockwork.NewFakeClock()
+	s.Clock = fc
+
+	// 1K ids created at 1ms intervals
+	// we'll check them over the course of 1 second as well, so they should all expire by the end
+	n := 1000
+	traceIDs := make([]string, n)
+	for i := 0; i < n; i++ {
+		traceIDs[i] = genID(32)
+		s.Add(traceIDs[i])
+		fc.Advance(1 * time.Millisecond)
+	}
+	// make sure we have 1000 ids now
+	assert.Equal(b, n, s.Length())
+	b.ResetTimer()
+	advanceTime := 100 * time.Second / time.Duration(b.N)
+	for i := 0; i < b.N; i++ {
+		s.Contains(traceIDs[i%n])
+		if i%100 == 0 {
+			fc.Advance(advanceTime)
+		}
+	}
+	b.StopTimer()
+	// make sure all ids have expired by now (there might be 1 or 2 that haven't)
+	assert.GreaterOrEqual(b, 2, s.Length())
 }


### PR DESCRIPTION
## Which problem is this PR solving?

We have a customer who has so much traffic sometimes, that the cuckoo drop cache can't record the dropped IDs as fast as they're dropping them, so it's overrunning its input queue.

This is a frustrating single point of failure because there is a single goroutine responsible for filling this cache which means adding CPUs won't help, and because of trace locality, adding more nodes won't help when a burst of spans comes from a single giant trace. Making the queue larger just means that it will take a little longer to fill up.

The contention is that we write to the cache when we drop a trace, but we read from it for every span that arrives. So if you have a single huge trace, you might fairly quickly decide to drop it, but still have to query the cache tens of thousands of times for new spans. The cuckoo cache is pretty fast but we can make it faster.

## Short description of the changes

- Add a cache in front of the cache (a Set with a TTL of 3 seconds) that buffers only the most recently dropped trace IDs; we check that before we check the cuckoo cache. This set responds quite a bit faster (at least 4x) than the cuckoo cache, and importantly it also prevents lock contention for the cuckoo cache, speeding it up for the cache writes.
- Tweak the logic for draining the write queue; it benchmarks faster this way.
- Move the metrics timer inside the lock so we're not measuring the waiting time
- The function `genID` used by another benchmark, that I also wanted to use here, was broken so I fixed it.
- Added a couple of benchmarks I used to prove to myself that the Set was fast enough.

![YO DAWG meme](https://github.com/user-attachments/assets/9d83102a-8b26-4694-882a-943f67953ae0)

