### PR TITLE
fix: use trace.DescendantCount for span limit

### DIFF
--- a/collect/collect.go
+++ b/collect/collect.go
@@ -456,7 +456,7 @@ func (i *InMemCollector) sendExpiredTracesInCache(now time.Time) {
 		if t.RootSpan != nil {
 			i.send(t, TraceSendGotRoot)
 		} else {
-			if spanLimit > 0 && t.SpanCount() > spanLimit {
+			if spanLimit > 0 && t.DescendantCount() > spanLimit {
 				i.send(t, TraceSendSpanLimit)
 			} else {
 				i.send(t, TraceSendExpired)
@@ -543,7 +543,7 @@ func (i *InMemCollector) processSpan(sp *types.Span) {
 	}
 
 	// if the span count has exceeded our SpanLimit, send the trace immediately
-	if tcfg.SpanLimit > 0 && uint(trace.SpanCount()) > tcfg.SpanLimit {
+	if tcfg.SpanLimit > 0 && uint(trace.DescendantCount()) > tcfg.SpanLimit {
 		markTraceForSending = true
 		timeout = 0 // don't use a timeout in this case; this is an "act fast" situation
 	}

--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -1840,7 +1840,7 @@ func TestBigTracesGoEarly(t *testing.T) {
 			SendTicker:   config.Duration(2 * time.Millisecond),
 			SendDelay:    config.Duration(10 * time.Millisecond),
 			TraceTimeout: config.Duration(500 * time.Millisecond),
-			SpanLimit:    uint(spanlimit),
+			SpanLimit:    uint(spanlimit - 1),
 			MaxBatchSize: 1500,
 		},
 		GetSamplerTypeVal:    &config.DeterministicSamplerConfig{SampleRate: 2},
@@ -1911,6 +1911,7 @@ func TestBigTracesGoEarly(t *testing.T) {
 	transmission.Mux.RLock()
 	require.Equal(t, spanlimit+1, len(transmission.Events), "adding a root span should send all spans in the trace")
 	assert.Equal(t, nil, transmission.Events[0].Data["meta.span_count"], "child span metadata should NOT be populated with span count")
+	assert.Equal(t, "trace_send_span_limit", transmission.Events[0].Data["meta.refinery.send_reason"], "child span metadata should set to trace_send_span_limit")
 	assert.EqualValues(t, spanlimit+1, transmission.Events[spanlimit].Data["meta.span_count"], "root span metadata should be populated with span count")
 	assert.EqualValues(t, spanlimit+1, transmission.Events[spanlimit].Data["meta.event_count"], "root span metadata should be populated with event count")
 	assert.Equal(t, "deterministic/chance - late arriving span", transmission.Events[spanlimit].Data["meta.refinery.reason"], "the late root span should have meta.refinery.reason set to rules + late arriving span.")


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

Refinery converts SpanEvent and SpanLink to individual events just like regular spans. We should use DescendantCount to check against the SpanLimit instead of only spans.

## Short description of the changes

- use DescendantCount to check against SpanLimit
- modify test to explicitly check for span limit trace send reason

