### PR TITLE
fix: escape use input in debug route

### DIFF
--- a/route/route.go
+++ b/route/route.go
@@ -302,9 +302,9 @@ func (r *Router) version(w http.ResponseWriter, req *http.Request) {
 }
 
 func (r *Router) debugTrace(w http.ResponseWriter, req *http.Request) {
-	traceID := html.EscapeString(mux.Vars(req)["traceID"])
+	traceID := mux.Vars(req)["traceID"]
 	shard := r.Sharder.WhichShard(traceID)
-	w.Write([]byte(fmt.Sprintf(`{"traceID":"%s","node":"%s"}`, traceID, shard.GetAddress())))
+	w.Write([]byte(fmt.Sprintf(`{"traceID":"%s","node":"%s"}`, html.EscapeString(traceID), shard.GetAddress())))
 }
 
 func (r *Router) getSamplerRules(w http.ResponseWriter, req *http.Request) {

--- a/route/route.go
+++ b/route/route.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"html"
 	"io"
 	"math"
 	"net"
@@ -301,7 +302,7 @@ func (r *Router) version(w http.ResponseWriter, req *http.Request) {
 }
 
 func (r *Router) debugTrace(w http.ResponseWriter, req *http.Request) {
-	traceID := mux.Vars(req)["traceID"]
+	traceID := html.EscapeString(mux.Vars(req)["traceID"])
 	shard := r.Sharder.WhichShard(traceID)
 	w.Write([]byte(fmt.Sprintf(`{"traceID":"%s","node":"%s"}`, traceID, shard.GetAddress())))
 }


### PR DESCRIPTION
## Which problem is this PR solving?

- The debug endpoint doesn't sanitize the user input before using it in the response.

## Short description of the changes

- use `html.EscapeString` to escape the user's input string for use in refinery and the response.

