### PR TITLE
fix: join peer list only after refinery is ready to accept traffic

### DIFF
--- a/cmd/refinery/main.go
+++ b/cmd/refinery/main.go
@@ -298,6 +298,14 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Now that all components are started, we can notify our peers that we are ready
+	// to receive data.
+	err = peers.Ready()
+	if err != nil {
+		fmt.Printf("failed to start peer management: %v\n", err)
+		os.Exit(1)
+	}
+
 	// these have to be done after the injection (of metrics)
 	// these are the metrics that libhoney will emit; we preregister them so that they always appear
 	libhoneyMetricsName := map[string]string{

--- a/internal/peer/file.go
+++ b/internal/peer/file.go
@@ -56,6 +56,10 @@ func (p *FilePeers) Start() (err error) {
 	return nil
 }
 
+func (p *FilePeers) Ready() error {
+	return nil
+}
+
 func (p *FilePeers) publicAddr() (string, error) {
 	addr := p.Cfg.GetPeerListenAddr()
 	host, port, err := net.SplitHostPort(addr)

--- a/internal/peer/mock.go
+++ b/internal/peer/mock.go
@@ -26,4 +26,8 @@ func (p *MockPeers) Start() error {
 	return nil
 }
 
+func (p *MockPeers) Ready() error {
+	return nil
+}
+
 func (p *MockPeers) stop() {}

--- a/internal/peer/peers.go
+++ b/internal/peer/peers.go
@@ -9,6 +9,7 @@ type Peers interface {
 	GetPeers() ([]string, error)
 	GetInstanceID() (string, error)
 	RegisterUpdatedPeersCallback(callback func())
+	Ready() error
 	// make it injectable
 	startstop.Starter
 }


### PR DESCRIPTION
## Which problem is this PR solving?

Currently, Refinery announces its presence to peers immediately upon startup. This causes the sharding algorithm to direct other peers to forward traces to the newly added Refinery instance, even though it might not be ready to process them. As a result, any spans forwarded before the Refinery is fully operational are lost. This fix ensures that Refinery only announces itself to peers once it is fully ready to accept and process traffic, preventing any loss of spans during startup.​

Alternatives:
I have tried to use the `health` module as a signal to indicate when the `router` is ready for the `peers` module. However, due to the way the `injection` library works, the `router` starts after the `peers` module. As a result, when `peers` checks in with the health system, the `router` may not have registered itself yet. This can cause `IsReady` to return true prematurely, before the `router` is included in the health checks.

## Short description of the changes

- Add a `Ready` method on `Peers`
- call `Peers.Ready()` once all components have started
