### PR TITLE
fix: revert "Use HTTP/2 for all upstream and peer-to-peer connections…

### DIFF
--- a/cmd/refinery/main.go
+++ b/cmd/refinery/main.go
@@ -147,7 +147,6 @@ func main() {
 			Timeout: 10 * time.Second,
 		}).Dial,
 		TLSHandshakeTimeout: 15 * time.Second,
-		ForceAttemptHTTP2:   true,
 	}
 
 	// peerTransport is the http transport used to send things to a local peer
@@ -157,7 +156,6 @@ func main() {
 			Timeout: 3 * time.Second,
 		}).Dial,
 		TLSHandshakeTimeout: 1200 * time.Millisecond,
-		ForceAttemptHTTP2:   true,
 	}
 
 	genericMetricsRecorder := metrics.NewMetricsPrefixer("")


### PR DESCRIPTION
… (#1269)"

This reverts commit 24436a5237bd8fe4da9c57e8551d3e1b79231fb5.

## Which problem is this PR solving?

- We see what appears to be a memory leak, and it seems like it might be in the connections, so we're going to try reverting this to see if it fixes it.
