### PR TITLE
docs: Sync Refinery docs content for 2.8

### DIFF
--- a/config.md
+++ b/config.md
@@ -1,7 +1,7 @@
 # Honeycomb Refinery Configuration Documentation
 
 This is the documentation for the configuration file for Honeycomb's Refinery.
-It was automatically generated on 2024-09-03 at 19:48:55 UTC.
+It was automatically generated on 2024-09-05 at 17:40:33 UTC.
 
 ## The Config file
 
@@ -171,7 +171,7 @@ AcceptOnlyListedKeys is a boolean flag that causes events arriving with API keys
 If `true`, then only traffic using the keys listed in `ReceiveKeys` is accepted.
 Events arriving with API keys not in the `ReceiveKeys` list will be rejected with an HTTP `401` error.
 If `false`, then all traffic is accepted and `ReceiveKeys` is ignored.
-This setting is applied *before* the `SendKey` and `SendKeyMode` settings.
+This setting is applied **before** the `SendKey` and `SendKeyMode` settings.
 
 - Eligible for live reload.
 - Type: `bool`
@@ -216,8 +216,8 @@ AddRuleReasonToTrace controls whether to decorate traces with Refinery rule eval
 When enabled, this setting causes traces that are sent to Honeycomb to include the field `meta.refinery.reason`.
 This field contains text indicating which rule was evaluated that caused the trace to be included.
 This setting also includes the field `meta.refinery.send_reason`, which contains the reason that the trace was sent.
-Possible values of this field are `trace_send_got_root`, which means that the root span arrived; `trace_send_expired`, which means that TraceTimeout was reached; `trace_send_ejected_full`, which means that the trace cache was full; and `trace_send_ejected_memsize`, which means that refinery was out of memory.
-These names are also the names of metrics that refinery tracks.
+Possible values of this field are `trace_send_got_root`, which means that the root span arrived; `trace_send_expired`, which means that `TraceTimeout` was reached; `trace_send_ejected_full`, which means that the trace cache was full; and `trace_send_ejected_memsize`, which means that Refinery was out of memory.
+These names are also the names of metrics that Refinery tracks.
 We recommend enabling this setting whenever a rules-based sampler is in use, as it is useful for debugging and understanding the behavior of your Refinery installation.
 
 - Eligible for live reload.
@@ -269,7 +269,7 @@ SendDelay is the duration to wait after the root span arrives before sending a t
 This setting is a short timer that is triggered when a trace is marked complete by the arrival of the root span.
 Refinery waits for this duration before sending the trace.
 This setting exists to allow for asynchronous spans and small network delays to elapse before sending the trace.
-`SendDelay` is not applied if the TraceTimeout expires or the `SpanLimit` is reached.
+`SendDelay` is not applied if the `TraceTimeout` expires or the `SpanLimit` is reached.
 
 - Eligible for live reload.
 - Type: `duration`
@@ -308,8 +308,8 @@ Note that this increase will also increase the memory requirements for Refinery.
 SpanLimit is the number of spans after which a trace becomes eligible for a trace decision.
 
 This setting helps to keep memory usage under control.
-If a trace has more than this number of spans, then it becomes eligible for a trace decision.
-It's most helpful in a situation where a sudden burst of many spans in a large trace hits refinery all at once, causing memory usage to spike and possibly crashing refinery.
+If a trace has more than this set number of spans, then it becomes eligible for a trace decision.
+It's most helpful in a situation where a sudden burst of many spans in a large trace hits Refinery all at once, causing memory usage to spike and possibly crashing Refinery.
 
 - Eligible for live reload.
 - Type: `int`
@@ -354,7 +354,7 @@ If this value is not specified, then the debug service runs on the first open po
 
 ### `QueryAuthToken`
 
-QueryAuthToken is the token that must be specified to access the `/query` endpoint. Setting this value via a command line flag may expose credentials - it is recommended to use the env var or a configuration file.
+QueryAuthToken is the token that must be specified to access the `/query` endpoint. Setting this value via a command line flag may expose credentials - it is recommended to use the environment variable or a configuration file.
 
 This token must be specified with the header "X-Honeycomb-Refinery-Query" in order for a `/query` request to succeed.
 These `/query` requests are intended for debugging Refinery during setup and are not typically needed in normal operation.
@@ -437,7 +437,7 @@ Refinery's internal logs will be sent to this host using the standard Honeycomb 
 
 ### `APIKey`
 
-APIKey is the API key used to send Refinery's logs to Honeycomb. Setting this value via a command line flag may expose credentials - it is recommended to use the env var or a configuration file.
+APIKey is the API key used to send Refinery's logs to Honeycomb. Setting this value via a command line flag may expose credentials - it is recommended to use the environment variable or a configuration file.
 
 It is recommended that you create a separate team and key for Refinery logs.
 
@@ -566,7 +566,7 @@ Refinery's internal metrics will be sent to this host using the standard Honeyco
 
 ### `APIKey`
 
-APIKey is the API key used by Refinery to send its metrics to Honeycomb. Setting this value via a command line flag may expose credentials - it is recommended to use the env var or a configuration file.
+APIKey is the API key used by Refinery to send its metrics to Honeycomb. Setting this value via a command line flag may expose credentials - it is recommended to use the environment variable or a configuration file.
 
 It is recommended that you create a separate team and key for Refinery metrics.
 
@@ -623,7 +623,7 @@ Refinery's internal metrics will be sent to the `/v1/metrics` endpoint on this h
 
 ### `APIKey`
 
-APIKey is the API key used to send Honeycomb metrics via OpenTelemetry. Setting this value via a command line flag may expose credentials - it is recommended to use the env var or a configuration file.
+APIKey is the API key used to send Honeycomb metrics via OpenTelemetry. Setting this value via a command line flag may expose credentials - it is recommended to use the environment variable or a configuration file.
 
 It is recommended that you create a separate team and key for Refinery metrics.
 If this is blank, then Refinery will not set the Honeycomb-specific headers for OpenTelemetry, and your `APIHost` must be set to a valid OpenTelemetry endpoint.
@@ -689,7 +689,7 @@ Refinery's internal traces will be sent to the `/v1/traces` endpoint on this hos
 
 ### `APIKey`
 
-APIKey is the API key used to send Refinery's traces to Honeycomb. Setting this value via a command line flag may expose credentials - it is recommended to use the env var or a configuration file.
+APIKey is the API key used to send Refinery's traces to Honeycomb. Setting this value via a command line flag may expose credentials - it is recommended to use the environment variable or a configuration file.
 
 It is recommended that you create a separate team and key for Refinery telemetry.
 If this value is blank, then Refinery will not set the Honeycomb-specific headers for OpenTelemetry, and your `APIHost` must be set to a valid OpenTelemetry endpoint.
@@ -802,7 +802,7 @@ Must be in the form `host:port`.
 
 ### `ClusterHosts`
 
-ClusterHosts is a list of host and port pairs for the instances in a Redis Cluster, used for managing peer cluster membership.
+ClusterHosts is a list of host and port pairs for the instances in a Redis Cluster, and used for managing peer cluster membership.
 
 This configuration enables Refinery to connect to a Redis deployment setup in Cluster Mode.
 Each entry in the list should follow the format `host:port`.
@@ -814,7 +814,7 @@ If `ClusterHosts` is specified, the `Host` setting will be ignored.
 
 ### `Username`
 
-Username is the username used to connect to Redis for peer cluster membership management. Setting this value via a command line flag may expose credentials - it is recommended to use the env var or a configuration file.
+Username is the username used to connect to Redis for peer cluster membership management. Setting this value via a command line flag may expose credentials - it is recommended to use the environment variable or a configuration file.
 
 Many Redis installations do not use this field.
 
@@ -824,7 +824,7 @@ Many Redis installations do not use this field.
 
 ### `Password`
 
-Password is the password used to connect to Redis for peer cluster membership management. Setting this value via a command line flag may expose credentials - it is recommended to use the env var or a configuration file.
+Password is the password used to connect to Redis for peer cluster membership management. Setting this value via a command line flag may expose credentials - it is recommended to use the environment variable or a configuration file.
 
 Many Redis installations do not use this field.
 
@@ -834,7 +834,7 @@ Many Redis installations do not use this field.
 
 ### `AuthCode`
 
-AuthCode is the string used to connect to Redis for peer cluster membership management using an explicit AUTH command. Setting this value via a command line flag may expose credentials - it is recommended to use the env var or a configuration file.
+AuthCode is the string used to connect to Redis for peer cluster membership management using an explicit AUTH command. Setting this value via a command line flag may expose credentials - it is recommended to use the environment variable or a configuration file.
 
 Many Redis installations do not use this field.
 
@@ -882,7 +882,7 @@ CacheCapacity is the number of traces to keep in the cache's circular buffer.
 
 The collection cache is used to collect all active spans into traces.
 It is organized as a circular buffer.
-When the buffer wraps around Refinery will try a few times to find an empty slot; if it fails, it starts ejecting traces from the cache earlier than would otherwise be necessary.
+When the buffer wraps around, Refinery will try a few times to find an empty slot; if it fails, it starts ejecting traces from the cache earlier than would otherwise be necessary.
 Ideally, the size of the cache should be many multiples (100x to 1000x) of the total number of concurrently active traces (average trace throughput * average trace duration).
 
 - Eligible for live reload.
@@ -964,7 +964,7 @@ If set, `Collections.AvailableMemory` must not be defined.
 DisableRedistribution controls whether to transmit traces in cache to remaining peers during cluster scaling event.
 
 If `true`, Refinery will NOT forward live traces in its cache to the rest of the peers when peers join or leave the cluster.
-By diabling this behavior, it can help to prevent distuptive burst of network traffic when large traces with long TraceTimeout are redistributed.
+By disabling this behavior, it can help to prevent disruptive bursts of network traffic when large traces with long `TraceTimeout` are redistributed.
 
 - Eligible for live reload.
 - Type: `bool`

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -359,9 +359,13 @@ groups:
         reload: true
         summary: is the number of spans after which a trace becomes eligible for a trace decision.
         description: >
-          This setting helps to keep memory usage under control. If a trace has more than this set number of spans, then it becomes eligible for a trace decision.
+          This setting helps to keep memory usage under control. If a trace has
+          more than this set number of spans, then it becomes eligible for a
+          trace decision.
 
-          It's most helpful in a situation where a sudden burst of many spans in a large trace hits Refinery all at once, causing memory usage to spike and possibly crashing Refinery.
+          It's most helpful in a situation where a sudden burst of many spans in
+          a large trace hits Refinery all at once, causing memory usage to spike
+          and possibly crashing Refinery.
 
       - name: MaxBatchSize
         type: int

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -181,7 +181,7 @@ groups:
 
           If `false`, then all traffic is accepted and `ReceiveKeys` is ignored.
 
-          This setting is applied *before* the `SendKey` and `SendKeyMode` settings.
+          This setting is applied **before** the `SendKey` and `SendKeyMode` settings.
 
       - name: SendKey
         type: string
@@ -239,11 +239,11 @@ groups:
           This setting also includes the field `meta.refinery.send_reason`,
           which contains the reason that the trace was sent. Possible values of
           this field are `trace_send_got_root`, which means that the root span
-          arrived; `trace_send_expired`, which means that TraceTimeout was reached;
+          arrived; `trace_send_expired`, which means that `TraceTimeout` was reached;
           `trace_send_ejected_full`, which means that the trace cache was full; and
-          `trace_send_ejected_memsize`, which means that refinery was out of memory.
+          `trace_send_ejected_memsize`, which means that Refinery was out of memory.
 
-          These names are also the names of metrics that refinery tracks.
+          These names are also the names of metrics that Refinery tracks.
 
           We recommend enabling this setting whenever a rules-based
           sampler is in use, as it is useful for debugging and understanding
@@ -312,7 +312,7 @@ groups:
           complete by the arrival of the root span. Refinery waits for this
           duration before sending the trace. This setting exists to allow for
           asynchronous spans and small network delays to elapse before sending
-          the trace. `SendDelay` is not applied if the TraceTimeout expires or
+          the trace. `SendDelay` is not applied if the `TraceTimeout` expires or
           the `SpanLimit` is reached.
 
       - name: BatchTimeout
@@ -359,11 +359,9 @@ groups:
         reload: true
         summary: is the number of spans after which a trace becomes eligible for a trace decision.
         description: >
-          This setting helps to keep memory usage under control. If a trace has more than this
-          number of spans, then it becomes eligible for a trace decision.
+          This setting helps to keep memory usage under control. If a trace has more than this set number of spans, then it becomes eligible for a trace decision.
 
-          It's most helpful in a situation where a sudden burst of many spans in a large trace hits
-          refinery all at once, causing memory usage to spike and possibly crashing refinery.
+          It's most helpful in a situation where a sudden burst of many spans in a large trace hits Refinery all at once, causing memory usage to spike and possibly crashing Refinery.
 
       - name: MaxBatchSize
         type: int
@@ -419,7 +417,7 @@ groups:
         reload: false
         envvar: REFINERY_QUERY_AUTH_TOKEN
         commandline: query-auth-token
-        summary: is the token that must be specified to access the `/query` endpoint. Setting this value via a command line flag may expose credentials - it is recommended to use the env var or a configuration file.
+        summary: is the token that must be specified to access the `/query` endpoint. Setting this value via a command line flag may expose credentials - it is recommended to use the environment variable or a configuration file.
         description: >
           This token must be specified with the header
           "X-Honeycomb-Refinery-Query" in order for a `/query` request to
@@ -530,7 +528,7 @@ groups:
         validations:
           - type: format
             arg: apikey
-        summary: is the API key used to send Refinery's logs to Honeycomb. Setting this value via a command line flag may expose credentials - it is recommended to use the env var or a configuration file.
+        summary: is the API key used to send Refinery's logs to Honeycomb. Setting this value via a command line flag may expose credentials - it is recommended to use the environment variable or a configuration file.
         description: >
           It is recommended that you create a separate team and key for
           Refinery logs.
@@ -686,7 +684,7 @@ groups:
             arg: apikey
         envvar: REFINERY_HONEYCOMB_METRICS_API_KEY, HONEYCOMB_API_KEY
         commandline: legacy-metrics-api-key
-        summary: is the API key used by Refinery to send its metrics to Honeycomb. Setting this value via a command line flag may expose credentials - it is recommended to use the env var or a configuration file.
+        summary: is the API key used by Refinery to send its metrics to Honeycomb. Setting this value via a command line flag may expose credentials - it is recommended to use the environment variable or a configuration file.
         description: >
           It is recommended that you create a separate team and key for
           Refinery metrics.
@@ -757,7 +755,7 @@ groups:
         envvar: REFINERY_OTEL_METRICS_API_KEY, HONEYCOMB_API_KEY
         commandline: otel-metrics-api-key
         firstversion: v2.0
-        summary: is the API key used to send Honeycomb metrics via OpenTelemetry. Setting this value via a command line flag may expose credentials - it is recommended to use the env var or a configuration file.
+        summary: is the API key used to send Honeycomb metrics via OpenTelemetry. Setting this value via a command line flag may expose credentials - it is recommended to use the environment variable or a configuration file.
         description: >
           It is recommended that you create a separate team and key for
           Refinery metrics.
@@ -839,7 +837,7 @@ groups:
         validations:
           - type: format
             arg: apikey
-        summary: is the API key used to send Refinery's traces to Honeycomb. Setting this value via a command line flag may expose credentials - it is recommended to use the env var or a configuration file.
+        summary: is the API key used to send Refinery's traces to Honeycomb. Setting this value via a command line flag may expose credentials - it is recommended to use the environment variable or a configuration file.
         description: >
           It is recommended that you create a separate team and key for
           Refinery telemetry.
@@ -996,7 +994,7 @@ groups:
           - type: elementType
             arg: hostport
         reload: false
-        summary: is a list of host and port pairs for the instances in a Redis Cluster, used for managing peer cluster membership.
+        summary: is a list of host and port pairs for the instances in a Redis Cluster, and used for managing peer cluster membership.
         description: >
           This configuration enables Refinery to connect to a Redis deployment setup in Cluster Mode.
           Each entry in the list should follow the format `host:port`.
@@ -1011,7 +1009,7 @@ groups:
         reload: false
         envvar: REFINERY_REDIS_USERNAME
         commandline: redis-username
-        summary: is the username used to connect to Redis for peer cluster membership management. Setting this value via a command line flag may expose credentials - it is recommended to use the env var or a configuration file.
+        summary: is the username used to connect to Redis for peer cluster membership management. Setting this value via a command line flag may expose credentials - it is recommended to use the environment variable or a configuration file.
         description: >
           Many Redis installations do not use this field.
 
@@ -1024,7 +1022,7 @@ groups:
         reload: false
         envvar: REFINERY_REDIS_PASSWORD
         commandline: redis-password
-        summary: is the password used to connect to Redis for peer cluster membership management. Setting this value via a command line flag may expose credentials - it is recommended to use the env var or a configuration file.
+        summary: is the password used to connect to Redis for peer cluster membership management. Setting this value via a command line flag may expose credentials - it is recommended to use the environment variable or a configuration file.
         description: >
           Many Redis installations do not use this field.
 
@@ -1038,7 +1036,7 @@ groups:
         firstversion: v2.2
         envvar: REFINERY_REDIS_AUTH_CODE
         commandline: redis-auth-code
-        summary: is the string used to connect to Redis for peer cluster membership management using an explicit AUTH command. Setting this value via a command line flag may expose credentials - it is recommended to use the env var or a configuration file.
+        summary: is the string used to connect to Redis for peer cluster membership management using an explicit AUTH command. Setting this value via a command line flag may expose credentials - it is recommended to use the environment variable or a configuration file.
         description: >
           Many Redis installations do not use this field.
 
@@ -1163,7 +1161,7 @@ groups:
         summary: is the number of traces to keep in the cache's circular buffer.
         description: >
           The collection cache is used to collect all active spans into traces.
-          It is organized as a circular buffer. When the buffer wraps around
+          It is organized as a circular buffer. When the buffer wraps around,
           Refinery will try a few times to find an empty slot; if it fails, it
           starts ejecting traces from the cache earlier than would otherwise be
           necessary. Ideally, the size of the cache should be many
@@ -1262,7 +1260,7 @@ groups:
         summary: controls whether to transmit traces in cache to remaining peers during cluster scaling event.
         description: >
           If `true`, Refinery will NOT forward live traces in its cache to the rest of the peers when peers join or leave the cluster.
-          By diabling this behavior, it can help to prevent distuptive burst of network traffic when large traces with long TraceTimeout
+          By disabling this behavior, it can help to prevent disruptive bursts of network traffic when large traces with long `TraceTimeout`
           are redistributed.
 
       - name: ShutdownDelay

--- a/config_complete.yaml
+++ b/config_complete.yaml
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created on 2024-09-03 at 19:48:54 UTC from ../../config.yaml using a template generated on 2024-09-03 at 19:48:51 UTC
+# created on 2024-09-05 at 17:40:32 UTC from ../../config.yaml using a template generated on 2024-09-05 at 17:40:29 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of
@@ -155,7 +155,7 @@ AccessKeys:
     ## accepted. Events arriving with API keys not in the `ReceiveKeys` list
     ## will be rejected with an HTTP `401` error.
     ## If `false`, then all traffic is accepted and `ReceiveKeys` is ignored.
-    ## This setting is applied *before* the `SendKey` and `SendKeyMode`
+    ## This setting is applied **before** the `SendKey` and `SendKeyMode`
     ## settings.
     ##
     ## Eligible for live reload.
@@ -209,11 +209,11 @@ RefineryTelemetry:
     ## This setting also includes the field `meta.refinery.send_reason`,
     ## which contains the reason that the trace was sent. Possible values of
     ## this field are `trace_send_got_root`, which means that the root span
-    ## arrived; `trace_send_expired`, which means that TraceTimeout was
+    ## arrived; `trace_send_expired`, which means that `TraceTimeout` was
     ## reached; `trace_send_ejected_full`, which means that the trace cache
-    ## was full; and `trace_send_ejected_memsize`, which means that refinery
+    ## was full; and `trace_send_ejected_memsize`, which means that Refinery
     ## was out of memory.
-    ## These names are also the names of metrics that refinery tracks.
+    ## These names are also the names of metrics that Refinery tracks.
     ## We recommend enabling this setting whenever a rules-based sampler is
     ## in use, as it is useful for debugging and understanding the behavior
     ## of your Refinery installation.
@@ -274,7 +274,7 @@ Traces:
     ## complete by the arrival of the root span. Refinery waits for this
     ## duration before sending the trace. This setting exists to allow for
     ## asynchronous spans and small network delays to elapse before sending
-    ## the trace. `SendDelay` is not applied if the TraceTimeout expires or
+    ## the trace. `SendDelay` is not applied if the `TraceTimeout` expires or
     ## the `SpanLimit` is reached.
     ##
     ## Accepts a duration string with units, like "2s".
@@ -318,11 +318,11 @@ Traces:
     ## for a trace decision.
     ##
     ## This setting helps to keep memory usage under control. If a trace has
-    ## more than this number of spans, then it becomes eligible for a trace
-    ## decision.
+    ## more than this set number of spans, then it becomes eligible for a
+    ## trace decision.
     ## It's most helpful in a situation where a sudden burst of many spans in
-    ## a large trace hits refinery all at once, causing memory usage to spike
-    ## and possibly crashing refinery.
+    ## a large trace hits Refinery all at once, causing memory usage to spike
+    ## and possibly crashing Refinery.
     ##
     ## Eligible for live reload.
     # SpanLimit: 0
@@ -373,8 +373,8 @@ Debugging:
 
     ## QueryAuthToken is the token that must be specified to access the
     ## `/query` endpoint. Setting this value via a command line flag may
-    ## expose credentials - it is recommended to use the env var or a
-    ## configuration file.
+    ## expose credentials - it is recommended to use the environment variable
+    ## or a configuration file.
     ##
     ## This token must be specified with the header
     ## "X-Honeycomb-Refinery-Query" in order for a `/query` request to
@@ -462,7 +462,8 @@ HoneycombLogger:
 
     ## APIKey is the API key used to send Refinery's logs to Honeycomb.
     ## Setting this value via a command line flag may expose credentials - it
-    ## is recommended to use the env var or a configuration file.
+    ## is recommended to use the environment variable or a configuration
+    ## file.
     ##
     ## It is recommended that you create a separate team and key for Refinery
     ## logs.
@@ -594,8 +595,8 @@ LegacyMetrics:
 
     ## APIKey is the API key used by Refinery to send its metrics to
     ## Honeycomb. Setting this value via a command line flag may expose
-    ## credentials - it is recommended to use the env var or a configuration
-    ## file.
+    ## credentials - it is recommended to use the environment variable or a
+    ## configuration file.
     ##
     ## It is recommended that you create a separate team and key for Refinery
     ## metrics.
@@ -650,8 +651,8 @@ OTelMetrics:
 
     ## APIKey is the API key used to send Honeycomb metrics via
     ## OpenTelemetry. Setting this value via a command line flag may expose
-    ## credentials - it is recommended to use the env var or a configuration
-    ## file.
+    ## credentials - it is recommended to use the environment variable or a
+    ## configuration file.
     ##
     ## It is recommended that you create a separate team and key for Refinery
     ## metrics.
@@ -718,7 +719,8 @@ OTelTracing:
 
     ## APIKey is the API key used to send Refinery's traces to Honeycomb.
     ## Setting this value via a command line flag may expose credentials - it
-    ## is recommended to use the env var or a configuration file.
+    ## is recommended to use the environment variable or a configuration
+    ## file.
     ##
     ## It is recommended that you create a separate team and key for Refinery
     ## telemetry.
@@ -842,7 +844,7 @@ RedisPeerManagement:
     # Host: "localhost:6379"
 
     ## ClusterHosts is a list of host and port pairs for the instances in a
-    ## Redis Cluster, used for managing peer cluster membership.
+    ## Redis Cluster, and used for managing peer cluster membership.
     ##
     ## This configuration enables Refinery to connect to a Redis deployment
     ## setup in Cluster Mode. Each entry in the list should follow the format
@@ -855,8 +857,8 @@ RedisPeerManagement:
 
     ## Username is the username used to connect to Redis for peer cluster
     ## membership management. Setting this value via a command line flag may
-    ## expose credentials - it is recommended to use the env var or a
-    ## configuration file.
+    ## expose credentials - it is recommended to use the environment variable
+    ## or a configuration file.
     ##
     ## Many Redis installations do not use this field.
     ##
@@ -865,8 +867,8 @@ RedisPeerManagement:
 
     ## Password is the password used to connect to Redis for peer cluster
     ## membership management. Setting this value via a command line flag may
-    ## expose credentials - it is recommended to use the env var or a
-    ## configuration file.
+    ## expose credentials - it is recommended to use the environment variable
+    ## or a configuration file.
     ##
     ## Many Redis installations do not use this field.
     ##
@@ -876,7 +878,7 @@ RedisPeerManagement:
     ## AuthCode is the string used to connect to Redis for peer cluster
     ## membership management using an explicit AUTH command. Setting this
     ## value via a command line flag may expose credentials - it is
-    ## recommended to use the env var or a configuration file.
+    ## recommended to use the environment variable or a configuration file.
     ##
     ## Many Redis installations do not use this field.
     ##
@@ -925,7 +927,7 @@ Collection:
     ## buffer.
     ##
     ## The collection cache is used to collect all active spans into traces.
-    ## It is organized as a circular buffer. When the buffer wraps around
+    ## It is organized as a circular buffer. When the buffer wraps around,
     ## Refinery will try a few times to find an empty slot; if it fails, it
     ## starts ejecting traces from the cache earlier than would otherwise be
     ## necessary. Ideally, the size of the cache should be many multiples
@@ -1009,9 +1011,9 @@ Collection:
     ## remaining peers during cluster scaling event.
     ##
     ## If `true`, Refinery will NOT forward live traces in its cache to the
-    ## rest of the peers when peers join or leave the cluster. By diabling
-    ## this behavior, it can help to prevent distuptive burst of network
-    ## traffic when large traces with long TraceTimeout are redistributed.
+    ## rest of the peers when peers join or leave the cluster. By disabling
+    ## this behavior, it can help to prevent disruptive bursts of network
+    ## traffic when large traces with long `TraceTimeout` are redistributed.
     ##
     ## Eligible for live reload.
     # DisableRedistribution: false

--- a/refinery_config.md
+++ b/refinery_config.md
@@ -147,7 +147,7 @@ This list only applies to span traffic - other Honeycomb API actions will be pro
 If `true`, then only traffic using the keys listed in `ReceiveKeys` is accepted.
 Events arriving with API keys not in the `ReceiveKeys` list will be rejected with an HTTP `401` error.
 If `false`, then all traffic is accepted and `ReceiveKeys` is ignored.
-This setting is applied *before* the `SendKey` and `SendKeyMode` settings.
+This setting is applied **before** the `SendKey` and `SendKeyMode` settings.
 
 - Eligible for live reload.
 - Type: `bool`
@@ -193,8 +193,8 @@ All other events use their original keys.
 When enabled, this setting causes traces that are sent to Honeycomb to include the field `meta.refinery.reason`.
 This field contains text indicating which rule was evaluated that caused the trace to be included.
 This setting also includes the field `meta.refinery.send_reason`, which contains the reason that the trace was sent.
-Possible values of this field are `trace_send_got_root`, which means that the root span arrived; `trace_send_expired`, which means that TraceTimeout was reached; `trace_send_ejected_full`, which means that the trace cache was full; and `trace_send_ejected_memsize`, which means that refinery was out of memory.
-These names are also the names of metrics that refinery tracks.
+Possible values of this field are `trace_send_got_root`, which means that the root span arrived; `trace_send_expired`, which means that `TraceTimeout` was reached; `trace_send_ejected_full`, which means that the trace cache was full; and `trace_send_ejected_memsize`, which means that Refinery was out of memory.
+These names are also the names of metrics that Refinery tracks.
 We recommend enabling this setting whenever a rules-based sampler is in use, as it is useful for debugging and understanding the behavior of your Refinery installation.
 
 - Eligible for live reload.
@@ -247,7 +247,7 @@ If `true`, then Refinery will add the following tag to all traces: - `meta.refin
 This setting is a short timer that is triggered when a trace is marked complete by the arrival of the root span.
 Refinery waits for this duration before sending the trace.
 This setting exists to allow for asynchronous spans and small network delays to elapse before sending the trace.
-`SendDelay` is not applied if the TraceTimeout expires or the `SpanLimit` is reached.
+`SendDelay` is not applied if the `TraceTimeout` expires or the `SpanLimit` is reached.
 
 - Eligible for live reload.
 - Type: `duration`
@@ -286,8 +286,8 @@ Note that this increase will also increase the memory requirements for Refinery.
 `SpanLimit` is the number of spans after which a trace becomes eligible for a trace decision.
 
 This setting helps to keep memory usage under control.
-If a trace has more than this number of spans, then it becomes eligible for a trace decision.
-It's most helpful in a situation where a sudden burst of many spans in a large trace hits refinery all at once, causing memory usage to spike and possibly crashing refinery.
+If a trace has more than this set number of spans, then it becomes eligible for a trace decision.
+It's most helpful in a situation where a sudden burst of many spans in a large trace hits Refinery all at once, causing memory usage to spike and possibly crashing Refinery.
 
 - Eligible for live reload.
 - Type: `int`
@@ -333,7 +333,7 @@ If this value is not specified, then the debug service runs on the first open po
 
 ### `QueryAuthToken`
 
-`QueryAuthToken` is the token that must be specified to access the `/query` endpoint. Setting this value via a command line flag may expose credentials - it is recommended to use the env var or a configuration file.
+`QueryAuthToken` is the token that must be specified to access the `/query` endpoint. Setting this value via a command line flag may expose credentials - it is recommended to use the environment variable or a configuration file.
 
 This token must be specified with the header "X-Honeycomb-Refinery-Query" in order for a `/query` request to succeed.
 These `/query` requests are intended for debugging Refinery during setup and are not typically needed in normal operation.
@@ -418,7 +418,7 @@ Refinery's internal logs will be sent to this host using the standard Honeycomb 
 
 ### `APIKey`
 
-`APIKey` is the API key used to send Refinery's logs to Honeycomb. Setting this value via a command line flag may expose credentials - it is recommended to use the env var or a configuration file.
+`APIKey` is the API key used to send Refinery's logs to Honeycomb. Setting this value via a command line flag may expose credentials - it is recommended to use the environment variable or a configuration file.
 
 It is recommended that you create a separate team and key for Refinery logs.
 
@@ -549,7 +549,7 @@ Refinery's internal metrics will be sent to this host using the standard Honeyco
 
 ### `APIKey`
 
-`APIKey` is the API key used by Refinery to send its metrics to Honeycomb. Setting this value via a command line flag may expose credentials - it is recommended to use the env var or a configuration file.
+`APIKey` is the API key used by Refinery to send its metrics to Honeycomb. Setting this value via a command line flag may expose credentials - it is recommended to use the environment variable or a configuration file.
 
 It is recommended that you create a separate team and key for Refinery metrics.
 
@@ -606,7 +606,7 @@ Refinery's internal metrics will be sent to the `/v1/metrics` endpoint on this h
 
 ### `APIKey`
 
-`APIKey` is the API key used to send Honeycomb metrics via OpenTelemetry. Setting this value via a command line flag may expose credentials - it is recommended to use the env var or a configuration file.
+`APIKey` is the API key used to send Honeycomb metrics via OpenTelemetry. Setting this value via a command line flag may expose credentials - it is recommended to use the environment variable or a configuration file.
 
 It is recommended that you create a separate team and key for Refinery metrics.
 If this is blank, then Refinery will not set the Honeycomb-specific headers for OpenTelemetry, and your `APIHost` must be set to a valid OpenTelemetry endpoint.
@@ -673,7 +673,7 @@ Refinery's internal traces will be sent to the `/v1/traces` endpoint on this hos
 
 ### `APIKey`
 
-`APIKey` is the API key used to send Refinery's traces to Honeycomb. Setting this value via a command line flag may expose credentials - it is recommended to use the env var or a configuration file.
+`APIKey` is the API key used to send Refinery's traces to Honeycomb. Setting this value via a command line flag may expose credentials - it is recommended to use the environment variable or a configuration file.
 
 It is recommended that you create a separate team and key for Refinery telemetry.
 If this value is blank, then Refinery will not set the Honeycomb-specific headers for OpenTelemetry, and your `APIHost` must be set to a valid OpenTelemetry endpoint.
@@ -787,7 +787,7 @@ Must be in the form `host:port`.
 
 ### `ClusterHosts`
 
-`ClusterHosts` is a list of host and port pairs for the instances in a Redis Cluster, used for managing peer cluster membership.
+`ClusterHosts` is a list of host and port pairs for the instances in a Redis Cluster, and used for managing peer cluster membership.
 
 This configuration enables Refinery to connect to a Redis deployment setup in Cluster Mode.
 Each entry in the list should follow the format `host:port`.
@@ -799,7 +799,7 @@ If `ClusterHosts` is specified, the `Host` setting will be ignored.
 
 ### `Username`
 
-`Username` is the username used to connect to Redis for peer cluster membership management. Setting this value via a command line flag may expose credentials - it is recommended to use the env var or a configuration file.
+`Username` is the username used to connect to Redis for peer cluster membership management. Setting this value via a command line flag may expose credentials - it is recommended to use the environment variable or a configuration file.
 
 Many Redis installations do not use this field.
 
@@ -809,7 +809,7 @@ Many Redis installations do not use this field.
 
 ### `Password`
 
-`Password` is the password used to connect to Redis for peer cluster membership management. Setting this value via a command line flag may expose credentials - it is recommended to use the env var or a configuration file.
+`Password` is the password used to connect to Redis for peer cluster membership management. Setting this value via a command line flag may expose credentials - it is recommended to use the environment variable or a configuration file.
 
 Many Redis installations do not use this field.
 
@@ -819,7 +819,7 @@ Many Redis installations do not use this field.
 
 ### `AuthCode`
 
-`AuthCode` is the string used to connect to Redis for peer cluster membership management using an explicit AUTH command. Setting this value via a command line flag may expose credentials - it is recommended to use the env var or a configuration file.
+`AuthCode` is the string used to connect to Redis for peer cluster membership management using an explicit AUTH command. Setting this value via a command line flag may expose credentials - it is recommended to use the environment variable or a configuration file.
 
 Many Redis installations do not use this field.
 
@@ -867,7 +867,7 @@ This is not recommended for production use since a burst of traffic could cause 
 
 The collection cache is used to collect all active spans into traces.
 It is organized as a circular buffer.
-When the buffer wraps around Refinery will try a few times to find an empty slot; if it fails, it starts ejecting traces from the cache earlier than would otherwise be necessary.
+When the buffer wraps around, Refinery will try a few times to find an empty slot; if it fails, it starts ejecting traces from the cache earlier than would otherwise be necessary.
 Ideally, the size of the cache should be many multiples (100x to 1000x) of the total number of concurrently active traces (average trace throughput * average trace duration).
 
 - Eligible for live reload.
@@ -949,7 +949,7 @@ If set, `Collections.AvailableMemory` must not be defined.
 `DisableRedistribution` controls whether to transmit traces in cache to remaining peers during cluster scaling event.
 
 If `true`, Refinery will NOT forward live traces in its cache to the rest of the peers when peers join or leave the cluster.
-By diabling this behavior, it can help to prevent distuptive burst of network traffic when large traces with long TraceTimeout are redistributed.
+By disabling this behavior, it can help to prevent disruptive bursts of network traffic when large traces with long `TraceTimeout` are redistributed.
 
 - Eligible for live reload.
 - Type: `bool`

--- a/tools/convert/templates/configV2.tmpl
+++ b/tools/convert/templates/configV2.tmpl
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created {{ now }} from {{ .Input }} using a template generated on 2024-09-03 at 19:48:51 UTC
+# created {{ now }} from {{ .Input }} using a template generated on 2024-09-05 at 17:40:29 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of
@@ -154,7 +154,7 @@ AccessKeys:
     ## accepted. Events arriving with API keys not in the `ReceiveKeys` list
     ## will be rejected with an HTTP `401` error.
     ## If `false`, then all traffic is accepted and `ReceiveKeys` is ignored.
-    ## This setting is applied *before* the `SendKey` and `SendKeyMode`
+    ## This setting is applied **before** the `SendKey` and `SendKeyMode`
     ## settings.
     ##
     ## Eligible for live reload.
@@ -208,11 +208,11 @@ RefineryTelemetry:
     ## This setting also includes the field `meta.refinery.send_reason`,
     ## which contains the reason that the trace was sent. Possible values of
     ## this field are `trace_send_got_root`, which means that the root span
-    ## arrived; `trace_send_expired`, which means that TraceTimeout was
+    ## arrived; `trace_send_expired`, which means that `TraceTimeout` was
     ## reached; `trace_send_ejected_full`, which means that the trace cache
-    ## was full; and `trace_send_ejected_memsize`, which means that refinery
+    ## was full; and `trace_send_ejected_memsize`, which means that Refinery
     ## was out of memory.
-    ## These names are also the names of metrics that refinery tracks.
+    ## These names are also the names of metrics that Refinery tracks.
     ## We recommend enabling this setting whenever a rules-based sampler is
     ## in use, as it is useful for debugging and understanding the behavior
     ## of your Refinery installation.
@@ -273,7 +273,7 @@ Traces:
     ## complete by the arrival of the root span. Refinery waits for this
     ## duration before sending the trace. This setting exists to allow for
     ## asynchronous spans and small network delays to elapse before sending
-    ## the trace. `SendDelay` is not applied if the TraceTimeout expires or
+    ## the trace. `SendDelay` is not applied if the `TraceTimeout` expires or
     ## the `SpanLimit` is reached.
     ##
     ## Accepts a duration string with units, like "2s".
@@ -317,11 +317,11 @@ Traces:
     ## for a trace decision.
     ##
     ## This setting helps to keep memory usage under control. If a trace has
-    ## more than this number of spans, then it becomes eligible for a trace
-    ## decision.
+    ## more than this set number of spans, then it becomes eligible for a
+    ## trace decision.
     ## It's most helpful in a situation where a sudden burst of many spans in
-    ## a large trace hits refinery all at once, causing memory usage to spike
-    ## and possibly crashing refinery.
+    ## a large trace hits Refinery all at once, causing memory usage to spike
+    ## and possibly crashing Refinery.
     ##
     ## Eligible for live reload.
     {{ nonDefaultOnly .Data "SpanLimit" "SpanLimit" 0 }}
@@ -372,8 +372,8 @@ Debugging:
 
     ## QueryAuthToken is the token that must be specified to access the
     ## `/query` endpoint. Setting this value via a command line flag may
-    ## expose credentials - it is recommended to use the env var or a
-    ## configuration file.
+    ## expose credentials - it is recommended to use the environment variable
+    ## or a configuration file.
     ##
     ## This token must be specified with the header
     ## "X-Honeycomb-Refinery-Query" in order for a `/query` request to
@@ -460,7 +460,8 @@ HoneycombLogger:
 
     ## APIKey is the API key used to send Refinery's logs to Honeycomb.
     ## Setting this value via a command line flag may expose credentials - it
-    ## is recommended to use the env var or a configuration file.
+    ## is recommended to use the environment variable or a configuration
+    ## file.
     ##
     ## It is recommended that you create a separate team and key for Refinery
     ## logs.
@@ -592,8 +593,8 @@ LegacyMetrics:
 
     ## APIKey is the API key used by Refinery to send its metrics to
     ## Honeycomb. Setting this value via a command line flag may expose
-    ## credentials - it is recommended to use the env var or a configuration
-    ## file.
+    ## credentials - it is recommended to use the environment variable or a
+    ## configuration file.
     ##
     ## It is recommended that you create a separate team and key for Refinery
     ## metrics.
@@ -648,8 +649,8 @@ OTelMetrics:
 
     ## APIKey is the API key used to send Honeycomb metrics via
     ## OpenTelemetry. Setting this value via a command line flag may expose
-    ## credentials - it is recommended to use the env var or a configuration
-    ## file.
+    ## credentials - it is recommended to use the environment variable or a
+    ## configuration file.
     ##
     ## It is recommended that you create a separate team and key for Refinery
     ## metrics.
@@ -716,7 +717,8 @@ OTelTracing:
 
     ## APIKey is the API key used to send Refinery's traces to Honeycomb.
     ## Setting this value via a command line flag may expose credentials - it
-    ## is recommended to use the env var or a configuration file.
+    ## is recommended to use the environment variable or a configuration
+    ## file.
     ##
     ## It is recommended that you create a separate team and key for Refinery
     ## telemetry.
@@ -838,7 +840,7 @@ RedisPeerManagement:
     {{ nonEmptyString .Data "Host" "PeerManagement.RedisHost" "localhost:6379" }}
 
     ## ClusterHosts is a list of host and port pairs for the instances in a
-    ## Redis Cluster, used for managing peer cluster membership.
+    ## Redis Cluster, and used for managing peer cluster membership.
     ##
     ## This configuration enables Refinery to connect to a Redis deployment
     ## setup in Cluster Mode. Each entry in the list should follow the format
@@ -850,8 +852,8 @@ RedisPeerManagement:
 
     ## Username is the username used to connect to Redis for peer cluster
     ## membership management. Setting this value via a command line flag may
-    ## expose credentials - it is recommended to use the env var or a
-    ## configuration file.
+    ## expose credentials - it is recommended to use the environment variable
+    ## or a configuration file.
     ##
     ## Many Redis installations do not use this field.
     ##
@@ -860,8 +862,8 @@ RedisPeerManagement:
 
     ## Password is the password used to connect to Redis for peer cluster
     ## membership management. Setting this value via a command line flag may
-    ## expose credentials - it is recommended to use the env var or a
-    ## configuration file.
+    ## expose credentials - it is recommended to use the environment variable
+    ## or a configuration file.
     ##
     ## Many Redis installations do not use this field.
     ##
@@ -871,7 +873,7 @@ RedisPeerManagement:
     ## AuthCode is the string used to connect to Redis for peer cluster
     ## membership management using an explicit AUTH command. Setting this
     ## value via a command line flag may expose credentials - it is
-    ## recommended to use the env var or a configuration file.
+    ## recommended to use the environment variable or a configuration file.
     ##
     ## Many Redis installations do not use this field.
     ##
@@ -920,7 +922,7 @@ Collection:
     ## buffer.
     ##
     ## The collection cache is used to collect all active spans into traces.
-    ## It is organized as a circular buffer. When the buffer wraps around
+    ## It is organized as a circular buffer. When the buffer wraps around,
     ## Refinery will try a few times to find an empty slot; if it fails, it
     ## starts ejecting traces from the cache earlier than would otherwise be
     ## necessary. Ideally, the size of the cache should be many multiples
@@ -1004,9 +1006,9 @@ Collection:
     ## remaining peers during cluster scaling event.
     ##
     ## If `true`, Refinery will NOT forward live traces in its cache to the
-    ## rest of the peers when peers join or leave the cluster. By diabling
-    ## this behavior, it can help to prevent distuptive burst of network
-    ## traffic when large traces with long TraceTimeout are redistributed.
+    ## rest of the peers when peers join or leave the cluster. By disabling
+    ## this behavior, it can help to prevent disruptive bursts of network
+    ## traffic when large traces with long `TraceTimeout` are redistributed.
     ##
     ## Eligible for live reload.
     {{ nonDefaultOnly .Data "DisableRedistribution" "DisableRedistribution" false }}


### PR DESCRIPTION
## Which problem is this PR solving?

This PR syncs the Refinery docs content between the Honeycomb docs site and the Refinery docs source file for v. 2.8.

## Short description of the changes

This PR includes minor formatting and other changes for clarity in the docs.

