### PR TITLE
fix: load peer list in sharder once manually on startup

### DIFF
--- a/sharder/deterministic.go
+++ b/sharder/deterministic.go
@@ -108,6 +108,10 @@ func (d *DeterministicSharder) Start() error {
 		}
 	})
 
+	if err := d.loadPeerList(); err != nil {
+		d.Logger.Error().Logf("failed to reload peer list: %+v", err)
+	}
+
 	// Try up to 5 times to find myself in the peer list before giving up
 	var self string
 	var err error


### PR DESCRIPTION
## Which problem is this PR solving?

Since we changed the peer to only announce itself after refinery has started up, we need to make sure sharder populates its peer list manually on startup

## Short description of the changes

- call `loadPeerList` in sharder once in `Start`

