### PR TITLE
feat: Allow proxying of OTLP/gRPC metrics requests

### DIFF
--- a/route/otlp_metrics.go
+++ b/route/otlp_metrics.go
@@ -1,0 +1,34 @@
+package route
+
+import (
+	"context"
+
+	collectormetric "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
+	"google.golang.org/grpc/metadata"
+)
+
+type MetricServer struct {
+	router *Router
+	client collectormetric.MetricsServiceClient
+
+	collectormetric.UnimplementedMetricsServiceServer
+}
+
+func NewMetricServer(router *Router) *MetricServer {
+	return &MetricServer{
+		router: router,
+		client: collectormetric.NewMetricsServiceClient(router.grpcProxyClientConn),
+	}
+}
+
+func (t *MetricServer) Export(ctx context.Context, req *collectormetric.ExportMetricsServiceRequest) (*collectormetric.ExportMetricsServiceResponse, error) {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if ok {
+		ctx = metadata.NewOutgoingContext(ctx, md)
+	}
+	response, err := t.client.Export(ctx, req)
+	if err != nil {
+		t.router.Logger.Error().Logf("failed to proxy metrics: %s", err)
+	}
+	return response, nil
+}


### PR DESCRIPTION
## Which problem is this PR solving?

Enables proxying of OTLP metric requests over gRPC. This is useful when users want to control egress.

*Note*: OTLP metrics requests over HTTP are already proxied using a generic handler.

This is an updated version of the following PR:
- #609

## Short description of the changes
- add simple OTLP metrics server implementation
- register server during app start up and create proxy connection
- dispose of connection during app shutdown