### PR TITLE
feat: Allow SendKey to be set via command line and env var

### DIFF
--- a/config/cmdenv.go
+++ b/config/cmdenv.go
@@ -44,6 +44,7 @@ type CmdEnv struct {
 	OTelTracesAPIKey      string     `long:"otel-traces-api-key" env:"REFINERY_OTEL_TRACES_API_KEY" description:"API key for OTel traces if being sent to Honeycomb. Setting this value via a flag may expose credentials - it is recommended to use the env var or a configuration file."`
 	QueryAuthToken        string     `long:"query-auth-token" env:"REFINERY_QUERY_AUTH_TOKEN" description:"Token for debug/management queries. Setting this value via a flag may expose credentials - it is recommended to use the env var or a configuration file."`
 	AvailableMemory       MemorySize `long:"available-memory" env:"REFINERY_AVAILABLE_MEMORY" description:"The maximum memory available for Refinery to use (ex: 4GiB)."`
+	SendKey               string     `long:"send-key" env:"REFINERY_SEND_KEY" description:"The Honeycomb API key that Refinery can use to send data to Honeycomb."`
 	Debug                 bool       `short:"d" long:"debug" description:"Runs debug service (on the first open port between localhost:6060 and :6069 by default)"`
 	Version               bool       `short:"v" long:"version" description:"Print version number and exit"`
 	InterfaceNames        bool       `long:"interface-names" description:"Print system's network interface names and exit."`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -547,9 +547,7 @@ func TestSendKeyEnvVar(t *testing.T) {
 	rm := makeYAML("ConfigVersion", 2)
 	cfg, rules := createTempConfigs(t, cm, rm)
 
-	oldenv := os.Getenv("REFINERY_SEND_KEY")
-	os.Setenv("REFINERY_SEND_KEY", "another-send-key")
-	defer os.Setenv("REFINERY_SEND_KEY", oldenv)
+	t.Setenv("REFINERY_SEND_KEY", "another-send-key")
 
 	c, err := getConfig([]string{"--no-validate", "--config", cfg, "--rules_config", rules})
 	assert.NoError(t, err)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -531,6 +531,33 @@ func TestAvailableMemoryCmdLine(t *testing.T) {
 	assert.Equal(t, expected, inMemConfig.AvailableMemory)
 }
 
+func TestSendKeyCmdLine(t *testing.T) {
+	cm := makeYAML("General.ConfigurationVersion", 2, "AccessKeys.SendKey", "my-send-key")
+	rm := makeYAML("ConfigVersion", 2)
+	cfg, rules := createTempConfigs(t, cm, rm)
+	c, err := getConfig([]string{"--no-validate", "--config", cfg, "--rules_config", rules, "--send-key", "another-send-key"})
+	assert.NoError(t, err)
+
+	accessKeysConfig := c.GetAccessKeyConfig()
+	assert.Equal(t, "another-send-key", accessKeysConfig.SendKey)
+}
+
+func TestSendKeyEnvvart(t *testing.T) {
+	cm := makeYAML("General.ConfigurationVersion", 2, "AccessKeys.SendKey", "my-send-key")
+	rm := makeYAML("ConfigVersion", 2)
+	cfg, rules := createTempConfigs(t, cm, rm)
+
+	oldenv := os.Getenv("REFINERY_SEND_KEY")
+	os.Setenv("REFINERY_SEND_KEY", "another-send-key")
+	defer os.Setenv("REFINERY_SEND_KEY", oldenv)
+
+	c, err := getConfig([]string{"--no-validate", "--config", cfg, "--rules_config", rules})
+	assert.NoError(t, err)
+
+	accessKeysConfig := c.GetAccessKeyConfig()
+	assert.Equal(t, "another-send-key", accessKeysConfig.SendKey)
+}
+
 func TestGetSamplerTypes(t *testing.T) {
 	cm := makeYAML("General.ConfigurationVersion", 2)
 	rm := makeYAML(

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -542,7 +542,7 @@ func TestSendKeyCmdLine(t *testing.T) {
 	assert.Equal(t, "another-send-key", accessKeysConfig.SendKey)
 }
 
-func TestSendKeyEnvvart(t *testing.T) {
+func TestSendKeyEnvVar(t *testing.T) {
 	cm := makeYAML("General.ConfigurationVersion", 2, "AccessKeys.SendKey", "my-send-key")
 	rm := makeYAML("ConfigVersion", 2)
 	cfg, rules := createTempConfigs(t, cm, rm)

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -86,7 +86,7 @@ type NetworkConfig struct {
 
 type AccessKeyConfig struct {
 	ReceiveKeys          []string `yaml:"ReceiveKeys" default:"[]"`
-	SendKey              string   `yaml:"SendKey"`
+	SendKey              string   `yaml:"SendKey" cmdenv:"SendKey"`
 	SendKeyMode          string   `yaml:"SendKeyMode" default:"none"`
 	AcceptOnlyListedKeys bool     `yaml:"AcceptOnlyListedKeys"`
 }


### PR DESCRIPTION
## Which problem is this PR solving?

Adds support for setting the send key (API key) used to send data to Honeycomb via both command line and env var.

- closes #1317

## Short description of the changes
- Add support for setting AccessKeys.SendKey via command line arg `--send-key` or env  var `REFINERY_SEND_KEY`.
- Add unit tests to verify behaviour 

