### PR TITLE
feat: Update Honeycomb logger to use EMAThroughput sampler

### DIFF
--- a/logger/honeycomb.go
+++ b/logger/honeycomb.go
@@ -58,7 +58,7 @@ func (h *HoneycombLogger) Start() error {
 
 	if loggerConfig.GetSamplerEnabled() {
 		h.sampler = &dynsampler.EMAThroughput{
-			AdjustmentInterval:   10 * time.Second,
+			AdjustmentInterval:   30 * time.Second,
 			GoalThroughputPerSec: loggerConfig.SamplerThroughput,
 			MaxKeys:              1000,
 		}

--- a/logger/honeycomb.go
+++ b/logger/honeycomb.go
@@ -57,10 +57,10 @@ func (h *HoneycombLogger) Start() error {
 	}
 
 	if loggerConfig.GetSamplerEnabled() {
-		h.sampler = &dynsampler.PerKeyThroughput{
-			ClearFrequencyDuration: 10 * time.Second,
-			PerKeyThroughputPerSec: loggerConfig.SamplerThroughput,
-			MaxKeys:                1000,
+		h.sampler = &dynsampler.EMAThroughput{
+			AdjustmentInterval:   10 * time.Second,
+			GoalThroughputPerSec: loggerConfig.SamplerThroughput,
+			MaxKeys:              1000,
 		}
 		err := h.sampler.Start()
 		if err != nil {


### PR DESCRIPTION
## Which problem is this PR solving?

Updates the Honeycomb logger to use the [EMAThroughput](https://github.com/honeycombio/dynsampler-go/blob/main/emathroughput.go#L77) sampler. This sampler has built-in support for burst protection that the [PerKeyThroughput](https://github.com/honeycombio/dynsampler-go/blob/main/perkeythroughput.go#L17) sampler does not.

Burst protection would be useful when a cluster node does down unexpectedly because the other nodes in the cluster will fail to make peer requests until it is removed from the cluster. This can result in a very high number of "failed to send" log messages in a very small window, faster than what the PerKeyThroughput sampler can adjust the sample rate which results in all log messages being sent. The burst protection from the EMAThroughput sampler would help here as it will schedule an update to sample rates if a high number of events are received very quickly, allowing it to react quicker.

This is a like for like replacement, and such I haven't added any additional configuration options the new sampler supports. We can add more later if desired.

## Short description of the changes
- Replace the Honeycomb logger sampler with the EMAThroughput sampler.
