### PR TITLE
fix: assertion for ClusterSizer

### DIFF
--- a/sample/rules.go
+++ b/sample/rules.go
@@ -12,6 +12,8 @@ import (
 	"github.com/tidwall/gjson"
 )
 
+var _ ClusterSizer = (*RulesBasedSampler)(nil)
+
 type RulesBasedSampler struct {
 	Config   *config.RulesBasedSamplerConfig
 	Logger   logger.Logger
@@ -77,6 +79,17 @@ func (s *RulesBasedSampler) Start() error {
 		}
 	}
 	return nil
+}
+
+func (s *RulesBasedSampler) SetClusterSize(size int) {
+	for _, sampler := range s.samplers {
+		// Sampler does not implement ClusterSizer.
+		// By asserting Sampler to an empty interface, we will have access to the underlying pointer.
+		// We can then assert that pointer to the ClusterSizer.
+		if sampler, ok := sampler.(any).(ClusterSizer); ok {
+			sampler.SetClusterSize(size)
+		}
+	}
 }
 
 func (s *RulesBasedSampler) GetSampleRate(trace *types.Trace) (rate uint, keep bool, reason string, key string) {

--- a/sample/sample.go
+++ b/sample/sample.go
@@ -42,7 +42,10 @@ func (s *SamplerFactory) updatePeerCounts() {
 
 	// all the samplers who want it should use the stored count
 	for _, sampler := range s.samplers {
-		if clusterSizer, ok := sampler.(ClusterSizer); ok {
+		// Sampler does not implement ClusterSizer.
+		// By asserting Sampler to an empty interface, we will have access to the underlying pointer.
+		// We can then assert that pointer to the ClusterSizer.
+		if clusterSizer, ok := sampler.(any).(ClusterSizer); ok {
 			clusterSizer.SetClusterSize(s.peerCount)
 		}
 	}


### PR DESCRIPTION
## Which problem is this PR solving?

- ClusterSize was not properly set for samplers that supports `UseClusterSize`

## Short description of the changes

- implement `ClusterSizer` for rules sampler
- convert a `Sampler` to `ClusterSizer` by going through `any`

