### PR TITLE
fix: Use peer transmission during redistribute and shutdown events

### DIFF
--- a/collect/collect.go
+++ b/collect/collect.go
@@ -67,11 +67,12 @@ type InMemCollector struct {
 	Health  health.Recorder `inject:""`
 	Sharder sharder.Sharder `inject:""`
 
-	Transmission   transmit.Transmission  `inject:"upstreamTransmission"`
-	Metrics        metrics.Metrics        `inject:"genericMetrics"`
-	SamplerFactory *sample.SamplerFactory `inject:""`
-	StressRelief   StressReliever         `inject:"stressRelief"`
-	Peers          peer.Peers             `inject:""`
+	Transmission     transmit.Transmission  `inject:"upstreamTransmission"`
+	PeerTransmission transmit.Transmission  `inject:"peerTransmission"`
+	Metrics          metrics.Metrics        `inject:"genericMetrics"`
+	SamplerFactory   *sample.SamplerFactory `inject:""`
+	StressRelief     StressReliever         `inject:"stressRelief"`
+	Peers            peer.Peers             `inject:""`
 
 	// For test use only
 	BlockOnAddSpan bool
@@ -431,7 +432,7 @@ func (i *InMemCollector) redistributeTraces() {
 				sp.Data["meta.refinery.forwarded"] = i.hostname
 			}
 
-			i.Transmission.EnqueueSpan(sp)
+			i.PeerTransmission.EnqueueSpan(sp)
 		}
 
 		forwardedTraces.Add(trace.TraceID)
@@ -1031,7 +1032,7 @@ func (i *InMemCollector) sendSpansOnShutdown(ctx context.Context, sentSpanChan <
 				sp.Data["meta.refinery.forwarded"] = i.hostname
 			}
 
-			i.Transmission.EnqueueSpan(sp)
+			i.PeerTransmission.EnqueueSpan(sp)
 			_, exist := forwardedTraces[sp.TraceID]
 			if !exist {
 				forwardedTraces[sp.TraceID] = struct{}{}


### PR DESCRIPTION
## Which problem is this PR solving?

Updates the collector use the configured peer transmission to send spans to peers during redistribute and shutdown events. This ensures metrics for sending to Honeycomb and peers are accurate.

The peer transmission is already configured and used by the router when receiving spans that should be sent to a peer. This is used the same transmission object after a span was originally accepted but then should be forwarded to a peer.

- Closes #1324

## Short description of the changes
- Inject the already configured peer transmission during collector init
- Update redistribute and shutdown logic to use the peer transmission
- Update tests throughout to verify the peer transmission is used correctly and also verify it can be injected correctly
  - note: there were existing tests to verify redistribute and shutdown behaviour and have been updated
