### PR TITLE
fix: remove unnecessary assertion to any

### DIFF
--- a/sample/rules.go
+++ b/sample/rules.go
@@ -85,10 +85,7 @@ func (s *RulesBasedSampler) Start() error {
 
 func (s *RulesBasedSampler) SetClusterSize(size int) {
 	for _, sampler := range s.samplers {
-		// Sampler does not implement ClusterSizer.
-		// By asserting Sampler to an empty interface, we will have access to the underlying pointer.
-		// We can then assert that pointer to the ClusterSizer.
-		if sampler, ok := sampler.(any).(ClusterSizer); ok {
+		if sampler, ok := sampler.(ClusterSizer); ok {
 			sampler.SetClusterSize(size)
 		}
 	}

--- a/sample/sample.go
+++ b/sample/sample.go
@@ -43,11 +43,11 @@ func (s *SamplerFactory) updatePeerCounts() {
 
 	// all the samplers who want it should use the stored count
 	for _, sampler := range s.samplers {
-		// Sampler does not implement ClusterSizer.
-		// By asserting Sampler to an empty interface, we will have access to the underlying pointer.
-		// We can then assert that pointer to the ClusterSizer.
-		if clusterSizer, ok := sampler.(any).(ClusterSizer); ok {
+		if clusterSizer, ok := sampler.(ClusterSizer); ok {
+			s.Logger.Warn().Logf("set cluster size to %d", s.peerCount)
 			clusterSizer.SetClusterSize(s.peerCount)
+		} else {
+			s.Logger.Warn().Logf("sampler does not implement ClusterSizer")
 		}
 	}
 }


### PR DESCRIPTION
## Which problem is this PR solving?

- in #1329 , we introduced the assertion to `any` as the intermediate step to check whether a Sampler is a ClusterSizer. 
- It turns out that this intermediate step is unnecessary.

## Short description of the changes

- remove assertion to `any` in `SetClusterSize`

