### PR TITLE
fix: remove InMemoryCollector from liveness check on shutdown

### DIFF
--- a/collect/collect.go
+++ b/collect/collect.go
@@ -848,9 +848,10 @@ func (i *InMemCollector) send(trace *types.Trace, sendReason string) {
 func (i *InMemCollector) Stop() error {
 	i.redistributeTimer.Stop()
 	close(i.done)
-	// signal the health system to not be ready
+	// signal the health system to not be ready and
+	// stop liveness check
 	// so that no new traces are accepted
-	i.Health.Ready(CollectorHealthKey, false)
+	i.Health.Unregister(CollectorHealthKey)
 
 	i.mutex.Lock()
 


### PR DESCRIPTION
## Which problem is this PR solving?

related to #1348 

Currently, the collector's timeout for healthcheck is set to 3 seconds. During a shutdown, there could be a large number of traces or spans that need to be forwarded to peers. If this is taking longer than 3 seconds, it will definitely timeout the liveness check. 

Since we are shutting down anyway, just let the ShutdownDelay to do the work and not worry about the liveness.
## Short description of the changes

- Unregister `collector` from Refinery's liveness check

