### PR TITLE
fix: set 0 for otel metrics during registration

### DIFF
--- a/cmd/refinery/main.go
+++ b/cmd/refinery/main.go
@@ -316,10 +316,15 @@ func main() {
 		"messages_sent":          "counter",
 		"response_decode_errors": "counter",
 	}
+
 	for name, typ := range libhoneyMetricsName {
 		upstreamMetricsRecorder.Register(name, typ)
 		peerMetricsRecorder.Register(name, typ)
 	}
+
+	// Register metrics after the metrics object has been created
+	peerTransmission.RegisterMetrics()
+	upstreamTransmission.RegisterMetrics()
 
 	metricsSingleton.Store("UPSTREAM_BUFFER_SIZE", float64(c.GetUpstreamBufferSize()))
 	metricsSingleton.Store("PEER_BUFFER_SIZE", float64(c.GetPeerBufferSize()))

--- a/transmit/mock.go
+++ b/transmit/mock.go
@@ -31,3 +31,5 @@ func (m *MockTransmission) Flush() {
 	defer m.Mux.Unlock()
 	m.Events = m.Events[:0]
 }
+
+func (m *MockTransmission) RegisterMetrics() {}

--- a/transmit/transmit.go
+++ b/transmit/transmit.go
@@ -20,6 +20,8 @@ type Transmission interface {
 	EnqueueSpan(ev *types.Span)
 	// Flush flushes the in-flight queue of all events and spans
 	Flush()
+
+	RegisterMetrics()
 }
 
 const (
@@ -64,12 +66,6 @@ func (d *DefaultTransmission) Start() error {
 	once.Do(func() {
 		libhoney.UserAgentAddition = "refinery/" + d.Version
 	})
-
-	d.Metrics.Register(counterEnqueueErrors, "counter")
-	d.Metrics.Register(counterResponse20x, "counter")
-	d.Metrics.Register(counterResponseErrors, "counter")
-	d.Metrics.Register(updownQueuedItems, "updown")
-	d.Metrics.Register(histogramQueueTime, "histogram")
 
 	processCtx, canceler := context.WithCancel(context.Background())
 	d.responseCanceler = canceler
@@ -139,6 +135,16 @@ func (d *DefaultTransmission) EnqueueSpan(sp *types.Span) {
 
 func (d *DefaultTransmission) Flush() {
 	d.LibhClient.Flush()
+}
+
+// RegisterMetrics registers the metrics used by the DefaultTransmission.
+// it should be called after the metrics object has been created.
+func (d *DefaultTransmission) RegisterMetrics() {
+	d.Metrics.Register(counterEnqueueErrors, "counter")
+	d.Metrics.Register(counterResponse20x, "counter")
+	d.Metrics.Register(counterResponseErrors, "counter")
+	d.Metrics.Register(updownQueuedItems, "updown")
+	d.Metrics.Register(histogramQueueTime, "histogram")
 }
 
 func (d *DefaultTransmission) Stop() error {


### PR DESCRIPTION
## Which problem is this PR solving?
Honeycomb’s board template requires that columns be created before any queries can be added. However, in OpenTelemetry (OTel), metrics are not sent until they have a value, which caused an issue where customers missed queries on their Refinery boards during the initial setup of their instances.

This PR addresses the issue by setting a default value of 0 for all OTel metrics during the Register call. This ensures that OTel sends these metrics to Honeycomb immediately upon Refinery startup, preventing gaps in the board’s initial queries.

## Short description of the changes

- Set 0 for each OTel metrics during registration

