### PR TITLE
feat(doc): separate table for metrics contains prefix

### DIFF
--- a/collect/collect.go
+++ b/collect/collect.go
@@ -126,6 +126,8 @@ var inMemCollectorMetrics = []metrics.Metadata{
 	{Name: TraceSendLateSpan, Type: metrics.Counter, Unit: metrics.Dimensionless, Description: "number of spans that are sent due to late span arrival"},
 
 	{Name: "dropped_from_stress", Type: metrics.Counter, Unit: metrics.Dimensionless, Description: "number of traces dropped due to stress relief"},
+	{Name: "trace_kept_sample_rate", Type: metrics.Histogram, Unit: metrics.Dimensionless, Description: "sample rate of kept traces"},
+	{Name: "trace_aggregate_sample_rate", Type: metrics.Histogram, Unit: metrics.Dimensionless, Description: "aggregate sample rate of both kept and dropped traces"},
 }
 
 func (i *InMemCollector) Start() error {

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -357,6 +357,7 @@ groups:
       - name: SpanLimit
         type: int
         valuetype: nondefault
+        firstversion: v2.8
         default: 0
         reload: true
         summary: is the number of spans after which a trace becomes eligible for a trace decision.

--- a/metrics.md
+++ b/metrics.md
@@ -1,7 +1,12 @@
-# Metrics Documentation
-# Automatically generated on 2024-09-26 at 18:58:58 UTC
+# Honeycomb Refinery Metrics Documentation
 
-This document contains the description of various metrics used in the system.
+This document contains the description of various metrics used in Refinery.
+It was automatically generated on 2024-09-27 at 16:19:55 UTC.
+
+Note: This document does not include metrics defined in the dynsampler-go dependency, as those metrics are generated dynamically at runtime. As a result, certain metrics may be missing or incomplete in this document, but they will still be available during execution with their full names.
+
+## Complete Metrics
+This table includes metrics with fully defined names.
 
 | Name | Type | Unit | Description |
 |------|------|------|-------------|
@@ -23,15 +28,6 @@ This document contains the description of various metrics used in the system.
 | num_peers | Gauge | Dimensionless | the active number of peers in the cluster |
 | peer_hash | Gauge | Dimensionless | the hash of the current list of peers |
 | peer_messages | Counter | Dimensionless | the number of messages received by the peers service |
-| _num_dropped_by_drop_rule | Counter | Dimensionless | Number of traces dropped by the drop rule |
-| _num_dropped | Counter | Dimensionless | Number of traces dropped by configured sampler |
-| _num_kept | Counter | Dimensionless | Number of traces kept by configured sampler |
-| _sample_rate | Histogram | Dimensionless | Sample rate for traces |
-| enqueue_errors | Counter | Dimensionless | The number of errors encountered when enqueueing events |
-| response_20x | Counter | Dimensionless | The number of successful responses from Honeycomb |
-| response_errors | Counter | Dimensionless | The number of errors encountered when sending events to Honeycomb |
-| queued_items | UpDown | Dimensionless | The number of events queued for transmission to Honeycomb |
-| queue_time | Histogram | Microseconds | The time spent in the queue before being sent to Honeycomb |
 | trace_duration_ms | Histogram | Milliseconds | time taken to process a trace from arrival to send |
 | trace_span_count | Histogram | Dimensionless | number of spans in a trace |
 | collector_incoming_queue | Histogram | Dimensionless | number of spans currently in the incoming queue |
@@ -60,14 +56,33 @@ This document contains the description of various metrics used in the system.
 | trace_send_ejected_memsize | Counter | Dimensionless | number of traces that are ready for decision due to memory overrun |
 | trace_send_late_span | Counter | Dimensionless | number of spans that are sent due to late span arrival |
 | dropped_from_stress | Counter | Dimensionless | number of traces dropped due to stress relief |
+| trace_kept_sample_rate | Histogram | Dimensionless | sample rate of kept traces |
+| trace_aggregate_sample_rate | Histogram | Dimensionless | aggregate sample rate of both kept and dropped traces |
 | cluster_stress_level | Gauge | Dimensionless | The overall stress level of the cluster |
 | individual_stress_level | Gauge | Dimensionless | The stress level of the individual node |
 | stress_level | Gauge | Dimensionless | The stress level that's being used to determine whether to activate stress relief |
 | stress_relief_activated | Gauge | Dimensionless | Whether stress relief is currently activated |
-| _router_proxied | Counter | Dimensionless | the number of events proxied to another refinery |
-| _router_event | Counter | Dimensionless | the number of events received |
 | config_hash | Gauge | Dimensionless | The hash of the current configuration |
 | rule_config_hash | Gauge | Dimensionless | The hash of the current rules configuration |
+
+
+## Metrics with Prefix
+This table includes metrics with partially defined names.
+Metrics in this table don't contain their expected prefixes. This is because the auto-generator is unable to resolve dynamically created metric names during the generation process.
+
+| Name | Type | Unit | Description |
+|------|------|------|-------------|
+| _num_dropped_by_drop_rule | Counter | Dimensionless | Number of traces dropped by the drop rule |
+| _num_dropped | Counter | Dimensionless | Number of traces dropped by configured sampler |
+| _num_kept | Counter | Dimensionless | Number of traces kept by configured sampler |
+| _sample_rate | Histogram | Dimensionless | Sample rate for traces |
+| enqueue_errors | Counter | Dimensionless | The number of errors encountered when enqueueing events |
+| response_20x | Counter | Dimensionless | The number of successful responses from Honeycomb |
+| response_errors | Counter | Dimensionless | The number of errors encountered when sending events to Honeycomb |
+| queued_items | UpDown | Dimensionless | The number of events queued for transmission to Honeycomb |
+| queue_time | Histogram | Microseconds | The time spent in the queue before being sent to Honeycomb |
+| _router_proxied | Counter | Dimensionless | the number of events proxied to another refinery |
+| _router_event | Counter | Dimensionless | the number of events received |
 | queue_length | Gauge | Dimensionless | number of events waiting to be sent to destination |
 | queue_overflow | Counter | Dimensionless | number of events dropped due to queue overflow |
 | send_errors | Counter | Dimensionless | number of errors encountered while sending events to destination |

--- a/tools/convert/main.go
+++ b/tools/convert/main.go
@@ -395,7 +395,7 @@ func GenerateMetricsDoc(w io.Writer) error {
 		return err
 	}
 
-	var metricsUsages []MetricsUsage
+	var metricsUsages MetricsOutput
 	err = yaml.Unmarshal(data, &metricsUsages)
 	if err != nil {
 		return err

--- a/tools/convert/metricsMeta.yaml
+++ b/tools/convert/metricsMeta.yaml
@@ -1,280 +1,290 @@
-- name: collect_cache_buffer_overrun
-  type: Counter
-  unit: Dimensionless
-  description: The number of times the trace overwritten in the circular buffer has not yet been sent
-- name: collect_cache_capacity
-  type: Gauge
-  unit: Dimensionless
-  description: The number of traces that can be stored in the cache
-- name: collect_cache_entries
-  type: Histogram
-  unit: Dimensionless
-  description: The number of traces currently stored in the cache
-- name: cuckoo_current_capacity
-  type: Gauge
-  unit: Dimensionless
-  description: current capacity of the cuckoo filter
-- name: cuckoo_future_load_factor
-  type: Gauge
-  unit: Percent
-  description: the fraction of slots occupied in the future cuckoo filter
-- name: cuckoo_current_load_factor
-  type: Gauge
-  unit: Percent
-  description: the fraction of slots occupied in the current cuckoo filter
-- name: cache_recent_dropped_traces
-  type: Gauge
-  unit: Dimensionless
-  description: the current size of the most recent dropped trace cache
-- name: collect_sent_reasons_cache_entries
-  type: Histogram
-  unit: Dimensionless
-  description: Number of entries in the sent reasons cache
-- name: is_ready
-  type: Gauge
-  unit: Dimensionless
-  description: Whether the system is ready to receive traffic
-- name: is_alive
-  type: Gauge
-  unit: Dimensionless
-  description: Whether the system is alive and reporting in
-- name: redis_pubsub_published
-  type: Counter
-  unit: Dimensionless
-  description: Number of messages published to Redis PubSub
-- name: redis_pubsub_received
-  type: Counter
-  unit: Dimensionless
-  description: Number of messages received from Redis PubSub
-- name: local_pubsub_published
-  type: Counter
-  unit: Dimensionless
-  description: The total number of messages sent via the local pubsub implementation
-- name: local_pubsub_received
-  type: Counter
-  unit: Dimensionless
-  description: The total number of messages received via the local pubsub implementation
-- name: num_file_peers
-  type: Gauge
-  unit: Dimensionless
-  description: Number of peers in the file peer list
-- name: num_peers
-  type: Gauge
-  unit: Dimensionless
-  description: the active number of peers in the cluster
-- name: peer_hash
-  type: Gauge
-  unit: Dimensionless
-  description: the hash of the current list of peers
-- name: peer_messages
-  type: Counter
-  unit: Dimensionless
-  description: the number of messages received by the peers service
-- name: _num_dropped_by_drop_rule
-  type: Counter
-  unit: Dimensionless
-  description: Number of traces dropped by the drop rule
-- name: _num_dropped
-  type: Counter
-  unit: Dimensionless
-  description: Number of traces dropped by configured sampler
-- name: _num_kept
-  type: Counter
-  unit: Dimensionless
-  description: Number of traces kept by configured sampler
-- name: _sample_rate
-  type: Histogram
-  unit: Dimensionless
-  description: Sample rate for traces
-- name: enqueue_errors
-  type: Counter
-  unit: Dimensionless
-  description: The number of errors encountered when enqueueing events
-- name: response_20x
-  type: Counter
-  unit: Dimensionless
-  description: The number of successful responses from Honeycomb
-- name: response_errors
-  type: Counter
-  unit: Dimensionless
-  description: The number of errors encountered when sending events to Honeycomb
-- name: queued_items
-  type: UpDown
-  unit: Dimensionless
-  description: The number of events queued for transmission to Honeycomb
-- name: queue_time
-  type: Histogram
-  unit: Microseconds
-  description: The time spent in the queue before being sent to Honeycomb
-- name: trace_duration_ms
-  type: Histogram
-  unit: Milliseconds
-  description: time taken to process a trace from arrival to send
-- name: trace_span_count
-  type: Histogram
-  unit: Dimensionless
-  description: number of spans in a trace
-- name: collector_incoming_queue
-  type: Histogram
-  unit: Dimensionless
-  description: number of spans currently in the incoming queue
-- name: collector_peer_queue_length
-  type: Gauge
-  unit: Dimensionless
-  description: number of spans in the peer queue
-- name: collector_incoming_queue_length
-  type: Gauge
-  unit: Dimensionless
-  description: number of spans in the incoming queue
-- name: collector_peer_queue
-  type: Histogram
-  unit: Dimensionless
-  description: number of spans currently in the peer queue
-- name: collector_cache_size
-  type: Gauge
-  unit: Dimensionless
-  description: number of traces currently stored in the trace cache
-- name: memory_heap_allocation
-  type: Gauge
-  unit: Bytes
-  description: current heap allocation
-- name: span_received
-  type: Counter
-  unit: Dimensionless
-  description: number of spans received by the collector
-- name: span_processed
-  type: Counter
-  unit: Dimensionless
-  description: number of spans processed by the collector
-- name: spans_waiting
-  type: UpDown
-  unit: Dimensionless
-  description: number of spans waiting to be processed by the collector
-- name: trace_sent_cache_hit
-  type: Counter
-  unit: Dimensionless
-  description: number of late spans received for traces that have already been sent
-- name: trace_accepted
-  type: Counter
-  unit: Dimensionless
-  description: number of new traces received by the collector
-- name: trace_send_kept
-  type: Counter
-  unit: Dimensionless
-  description: number of traces that has been kept
-- name: trace_send_dropped
-  type: Counter
-  unit: Dimensionless
-  description: number of traces that has been dropped
-- name: trace_send_has_root
-  type: Counter
-  unit: Dimensionless
-  description: number of kept traces that have a root span
-- name: trace_send_no_root
-  type: Counter
-  unit: Dimensionless
-  description: number of kept traces that do not have a root span
-- name: trace_forwarded_on_peer_change
-  type: Gauge
-  unit: Dimensionless
-  description: number of traces forwarded due to peer membership change
-- name: trace_redistribution_count
-  type: Gauge
-  unit: Dimensionless
-  description: number of traces redistributed due to peer membership change
-- name: trace_send_on_shutdown
-  type: Counter
-  unit: Dimensionless
-  description: number of traces sent during shutdown
-- name: trace_forwarded_on_shutdown
-  type: Counter
-  unit: Dimensionless
-  description: number of traces forwarded during shutdown
-- name: trace_send_got_root
-  type: Counter
-  unit: Dimensionless
-  description: number of traces that are ready for decision due to root span arrival
-- name: trace_send_expired
-  type: Counter
-  unit: Dimensionless
-  description: number of traces that are ready for decision due to TraceTimeout or SendDelay
-- name: trace_send_span_limit
-  type: Counter
-  unit: Dimensionless
-  description: number of traces that are ready for decision due to span limit
-- name: trace_send_ejected_full
-  type: Counter
-  unit: Dimensionless
-  description: number of traces that are ready for decision due to cache capacity overrun
-- name: trace_send_ejected_memsize
-  type: Counter
-  unit: Dimensionless
-  description: number of traces that are ready for decision due to memory overrun
-- name: trace_send_late_span
-  type: Counter
-  unit: Dimensionless
-  description: number of spans that are sent due to late span arrival
-- name: dropped_from_stress
-  type: Counter
-  unit: Dimensionless
-  description: number of traces dropped due to stress relief
-- name: cluster_stress_level
-  type: Gauge
-  unit: Dimensionless
-  description: The overall stress level of the cluster
-- name: individual_stress_level
-  type: Gauge
-  unit: Dimensionless
-  description: The stress level of the individual node
-- name: stress_level
-  type: Gauge
-  unit: Dimensionless
-  description: The stress level that's being used to determine whether to activate stress relief
-- name: stress_relief_activated
-  type: Gauge
-  unit: Dimensionless
-  description: Whether stress relief is currently activated
-- name: _router_proxied
-  type: Counter
-  unit: Dimensionless
-  description: the number of events proxied to another refinery
-- name: _router_event
-  type: Counter
-  unit: Dimensionless
-  description: the number of events received
-- name: config_hash
-  type: Gauge
-  unit: Dimensionless
-  description: The hash of the current configuration
-- name: rule_config_hash
-  type: Gauge
-  unit: Dimensionless
-  description: The hash of the current rules configuration
-- name: queue_length
-  type: Gauge
-  unit: Dimensionless
-  description: number of events waiting to be sent to destination
-- name: queue_overflow
-  type: Counter
-  unit: Dimensionless
-  description: number of events dropped due to queue overflow
-- name: send_errors
-  type: Counter
-  unit: Dimensionless
-  description: number of errors encountered while sending events to destination
-- name: send_retries
-  type: Counter
-  unit: Dimensionless
-  description: number of times a batch of events was retried
-- name: batches_sent
-  type: Counter
-  unit: Dimensionless
-  description: number of batches of events sent to destination
-- name: messages_sent
-  type: Counter
-  unit: Dimensionless
-  description: number of messages sent to destination
-- name: response_decode_errors
-  type: Counter
-  unit: Dimensionless
-  description: number of errors encountered while decoding responses from destination
+complete:
+    - name: collect_cache_buffer_overrun
+      type: Counter
+      unit: Dimensionless
+      description: The number of times the trace overwritten in the circular buffer has not yet been sent
+    - name: collect_cache_capacity
+      type: Gauge
+      unit: Dimensionless
+      description: The number of traces that can be stored in the cache
+    - name: collect_cache_entries
+      type: Histogram
+      unit: Dimensionless
+      description: The number of traces currently stored in the cache
+    - name: cuckoo_current_capacity
+      type: Gauge
+      unit: Dimensionless
+      description: current capacity of the cuckoo filter
+    - name: cuckoo_future_load_factor
+      type: Gauge
+      unit: Percent
+      description: the fraction of slots occupied in the future cuckoo filter
+    - name: cuckoo_current_load_factor
+      type: Gauge
+      unit: Percent
+      description: the fraction of slots occupied in the current cuckoo filter
+    - name: cache_recent_dropped_traces
+      type: Gauge
+      unit: Dimensionless
+      description: the current size of the most recent dropped trace cache
+    - name: collect_sent_reasons_cache_entries
+      type: Histogram
+      unit: Dimensionless
+      description: Number of entries in the sent reasons cache
+    - name: is_ready
+      type: Gauge
+      unit: Dimensionless
+      description: Whether the system is ready to receive traffic
+    - name: is_alive
+      type: Gauge
+      unit: Dimensionless
+      description: Whether the system is alive and reporting in
+    - name: redis_pubsub_published
+      type: Counter
+      unit: Dimensionless
+      description: Number of messages published to Redis PubSub
+    - name: redis_pubsub_received
+      type: Counter
+      unit: Dimensionless
+      description: Number of messages received from Redis PubSub
+    - name: local_pubsub_published
+      type: Counter
+      unit: Dimensionless
+      description: The total number of messages sent via the local pubsub implementation
+    - name: local_pubsub_received
+      type: Counter
+      unit: Dimensionless
+      description: The total number of messages received via the local pubsub implementation
+    - name: num_file_peers
+      type: Gauge
+      unit: Dimensionless
+      description: Number of peers in the file peer list
+    - name: num_peers
+      type: Gauge
+      unit: Dimensionless
+      description: the active number of peers in the cluster
+    - name: peer_hash
+      type: Gauge
+      unit: Dimensionless
+      description: the hash of the current list of peers
+    - name: peer_messages
+      type: Counter
+      unit: Dimensionless
+      description: the number of messages received by the peers service
+    - name: trace_duration_ms
+      type: Histogram
+      unit: Milliseconds
+      description: time taken to process a trace from arrival to send
+    - name: trace_span_count
+      type: Histogram
+      unit: Dimensionless
+      description: number of spans in a trace
+    - name: collector_incoming_queue
+      type: Histogram
+      unit: Dimensionless
+      description: number of spans currently in the incoming queue
+    - name: collector_peer_queue_length
+      type: Gauge
+      unit: Dimensionless
+      description: number of spans in the peer queue
+    - name: collector_incoming_queue_length
+      type: Gauge
+      unit: Dimensionless
+      description: number of spans in the incoming queue
+    - name: collector_peer_queue
+      type: Histogram
+      unit: Dimensionless
+      description: number of spans currently in the peer queue
+    - name: collector_cache_size
+      type: Gauge
+      unit: Dimensionless
+      description: number of traces currently stored in the trace cache
+    - name: memory_heap_allocation
+      type: Gauge
+      unit: Bytes
+      description: current heap allocation
+    - name: span_received
+      type: Counter
+      unit: Dimensionless
+      description: number of spans received by the collector
+    - name: span_processed
+      type: Counter
+      unit: Dimensionless
+      description: number of spans processed by the collector
+    - name: spans_waiting
+      type: UpDown
+      unit: Dimensionless
+      description: number of spans waiting to be processed by the collector
+    - name: trace_sent_cache_hit
+      type: Counter
+      unit: Dimensionless
+      description: number of late spans received for traces that have already been sent
+    - name: trace_accepted
+      type: Counter
+      unit: Dimensionless
+      description: number of new traces received by the collector
+    - name: trace_send_kept
+      type: Counter
+      unit: Dimensionless
+      description: number of traces that has been kept
+    - name: trace_send_dropped
+      type: Counter
+      unit: Dimensionless
+      description: number of traces that has been dropped
+    - name: trace_send_has_root
+      type: Counter
+      unit: Dimensionless
+      description: number of kept traces that have a root span
+    - name: trace_send_no_root
+      type: Counter
+      unit: Dimensionless
+      description: number of kept traces that do not have a root span
+    - name: trace_forwarded_on_peer_change
+      type: Gauge
+      unit: Dimensionless
+      description: number of traces forwarded due to peer membership change
+    - name: trace_redistribution_count
+      type: Gauge
+      unit: Dimensionless
+      description: number of traces redistributed due to peer membership change
+    - name: trace_send_on_shutdown
+      type: Counter
+      unit: Dimensionless
+      description: number of traces sent during shutdown
+    - name: trace_forwarded_on_shutdown
+      type: Counter
+      unit: Dimensionless
+      description: number of traces forwarded during shutdown
+    - name: trace_send_got_root
+      type: Counter
+      unit: Dimensionless
+      description: number of traces that are ready for decision due to root span arrival
+    - name: trace_send_expired
+      type: Counter
+      unit: Dimensionless
+      description: number of traces that are ready for decision due to TraceTimeout or SendDelay
+    - name: trace_send_span_limit
+      type: Counter
+      unit: Dimensionless
+      description: number of traces that are ready for decision due to span limit
+    - name: trace_send_ejected_full
+      type: Counter
+      unit: Dimensionless
+      description: number of traces that are ready for decision due to cache capacity overrun
+    - name: trace_send_ejected_memsize
+      type: Counter
+      unit: Dimensionless
+      description: number of traces that are ready for decision due to memory overrun
+    - name: trace_send_late_span
+      type: Counter
+      unit: Dimensionless
+      description: number of spans that are sent due to late span arrival
+    - name: dropped_from_stress
+      type: Counter
+      unit: Dimensionless
+      description: number of traces dropped due to stress relief
+    - name: trace_kept_sample_rate
+      type: Histogram
+      unit: Dimensionless
+      description: sample rate of kept traces
+    - name: trace_aggregate_sample_rate
+      type: Histogram
+      unit: Dimensionless
+      description: aggregate sample rate of both kept and dropped traces
+    - name: cluster_stress_level
+      type: Gauge
+      unit: Dimensionless
+      description: The overall stress level of the cluster
+    - name: individual_stress_level
+      type: Gauge
+      unit: Dimensionless
+      description: The stress level of the individual node
+    - name: stress_level
+      type: Gauge
+      unit: Dimensionless
+      description: The stress level that's being used to determine whether to activate stress relief
+    - name: stress_relief_activated
+      type: Gauge
+      unit: Dimensionless
+      description: Whether stress relief is currently activated
+    - name: config_hash
+      type: Gauge
+      unit: Dimensionless
+      description: The hash of the current configuration
+    - name: rule_config_hash
+      type: Gauge
+      unit: Dimensionless
+      description: The hash of the current rules configuration
+hasprefix:
+    - name: _num_dropped_by_drop_rule
+      type: Counter
+      unit: Dimensionless
+      description: Number of traces dropped by the drop rule
+    - name: _num_dropped
+      type: Counter
+      unit: Dimensionless
+      description: Number of traces dropped by configured sampler
+    - name: _num_kept
+      type: Counter
+      unit: Dimensionless
+      description: Number of traces kept by configured sampler
+    - name: _sample_rate
+      type: Histogram
+      unit: Dimensionless
+      description: Sample rate for traces
+    - name: enqueue_errors
+      type: Counter
+      unit: Dimensionless
+      description: The number of errors encountered when enqueueing events
+    - name: response_20x
+      type: Counter
+      unit: Dimensionless
+      description: The number of successful responses from Honeycomb
+    - name: response_errors
+      type: Counter
+      unit: Dimensionless
+      description: The number of errors encountered when sending events to Honeycomb
+    - name: queued_items
+      type: UpDown
+      unit: Dimensionless
+      description: The number of events queued for transmission to Honeycomb
+    - name: queue_time
+      type: Histogram
+      unit: Microseconds
+      description: The time spent in the queue before being sent to Honeycomb
+    - name: _router_proxied
+      type: Counter
+      unit: Dimensionless
+      description: the number of events proxied to another refinery
+    - name: _router_event
+      type: Counter
+      unit: Dimensionless
+      description: the number of events received
+    - name: queue_length
+      type: Gauge
+      unit: Dimensionless
+      description: number of events waiting to be sent to destination
+    - name: queue_overflow
+      type: Counter
+      unit: Dimensionless
+      description: number of events dropped due to queue overflow
+    - name: send_errors
+      type: Counter
+      unit: Dimensionless
+      description: number of errors encountered while sending events to destination
+    - name: send_retries
+      type: Counter
+      unit: Dimensionless
+      description: number of times a batch of events was retried
+    - name: batches_sent
+      type: Counter
+      unit: Dimensionless
+      description: number of batches of events sent to destination
+    - name: messages_sent
+      type: Counter
+      unit: Dimensionless
+      description: number of messages sent to destination
+    - name: response_decode_errors
+      type: Counter
+      unit: Dimensionless
+      description: number of errors encountered while decoding responses from destination

--- a/tools/convert/templates/metrics.tmpl
+++ b/tools/convert/templates/metrics.tmpl
@@ -1,10 +1,26 @@
-# Metrics Documentation
-# Automatically generated {{ now }}
+# Honeycomb Refinery Metrics Documentation
 
-This document contains the description of various metrics used in the system.
+This document contains the description of various metrics used in Refinery.
+It was automatically generated {{ now }}.
+
+Note: This document does not include metrics defined in the dynsampler-go dependency, as those metrics are generated dynamically at runtime. As a result, certain metrics may be missing or incomplete in this document, but they will still be available during execution with their full names.
+
+## Complete Metrics
+This table includes metrics with fully defined names.
 
 | Name | Type | Unit | Description |
 |------|------|------|-------------|
-{{- range . }}
+{{- range .Complete }}
+| {{ .Name }} | {{ .Type }} | {{ .Unit }} | {{ .Description }} |
+{{- end }}
+
+
+## Metrics with Prefix
+This table includes metrics with partially defined names.
+Metrics in this table don't contain their expected prefixes. This is because the auto-generator is unable to resolve dynamically created metric names during the generation process.
+
+| Name | Type | Unit | Description |
+|------|------|------|-------------|
+{{- range .HasPrefix }}
 | {{ .Name }} | {{ .Type }} | {{ .Unit }} | {{ .Description }} |
 {{- end }}


### PR DESCRIPTION
## Which problem is this PR solving?

The current metrics metadata generator does not resolve dynamically assigned prefixes during metrics registration. As a result, metrics with dynamic prefixes are not displayed with their full names. To improve clarity, these metrics should be shown in a separate table.

## Short description of the changes

- Identified that certain packages in Refinery—specifically those used for peer and incoming nodes, as well as the sampling package—assign dynamic prefixes to their metrics.
- Added logic to the generator to detect metrics from these packages and categorize them separately.
- Updated the metrics.tmpl template to display metrics with dynamic prefixes in a distinct table, ensuring clear differentiation between metrics with and without full names.