### PR TITLE
fix: Only set incoming user agent if not already present

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -28,7 +27,6 @@ import (
 
 	"github.com/honeycombio/libhoney-go"
 	"github.com/honeycombio/libhoney-go/transmission"
-	"github.com/honeycombio/libhoney-go/version"
 	"github.com/honeycombio/refinery/collect"
 	"github.com/honeycombio/refinery/config"
 	"github.com/honeycombio/refinery/internal/health"
@@ -223,6 +221,7 @@ func newStartedApp(
 }
 
 func post(t testing.TB, req *http.Request) {
+	req.Header.Set("User-Agent", "Test-Client")
 	resp, err := httpClient.Do(req)
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -405,7 +404,7 @@ func TestPeerRouting(t *testing.T) {
 			"field10":                            float64(10),
 			"long":                               "this is a test of the emergency broadcast system",
 			"meta.refinery.original_sample_rate": uint(2),
-			"meta.refinery.incoming_user_agent":  getLibhoneyUserAgent(),
+			"meta.refinery.incoming_user_agent":  "Test-Client",
 			"foo":                                "bar",
 		},
 		Metadata: map[string]any{
@@ -538,7 +537,7 @@ func TestEventsEndpoint(t *testing.T) {
 				"trace.trace_id":                     "1",
 				"foo":                                "bar",
 				"meta.refinery.original_sample_rate": uint(10),
-				"meta.refinery.incoming_user_agent":  getLibhoneyUserAgent(),
+				"meta.refinery.incoming_user_agent":  "Test-Client",
 			},
 			Metadata: map[string]any{
 				"api_host":    "http://api.honeycomb.io",
@@ -586,7 +585,7 @@ func TestEventsEndpoint(t *testing.T) {
 				"trace.trace_id":                     "1",
 				"foo":                                "bar",
 				"meta.refinery.original_sample_rate": uint(10),
-				"meta.refinery.incoming_user_agent":  getLibhoneyUserAgent(),
+				"meta.refinery.incoming_user_agent":  "Test-Client",
 			},
 			Metadata: map[string]any{
 				"api_host":    "http://api.honeycomb.io",
@@ -661,7 +660,7 @@ func TestEventsEndpointWithNonLegacyKey(t *testing.T) {
 				"trace.trace_id":                     traceID,
 				"foo":                                "bar",
 				"meta.refinery.original_sample_rate": uint(10),
-				"meta.refinery.incoming_user_agent":  getLibhoneyUserAgent(),
+				"meta.refinery.incoming_user_agent":  "Test-Client",
 			},
 			Metadata: map[string]any{
 				"api_host":    "http://api.honeycomb.io",
@@ -710,7 +709,7 @@ func TestEventsEndpointWithNonLegacyKey(t *testing.T) {
 				"trace.trace_id":                     traceID,
 				"foo":                                "bar",
 				"meta.refinery.original_sample_rate": uint(10),
-				"meta.refinery.incoming_user_agent":  getLibhoneyUserAgent(),
+				"meta.refinery.incoming_user_agent":  "Test-Client",
 			},
 			Metadata: map[string]any{
 				"api_host":    "http://api.honeycomb.io",
@@ -780,7 +779,7 @@ func TestPeerRouting_TraceLocalityDisabled(t *testing.T) {
 			"meta.refinery.min_span":       true,
 			"meta.annotation_type":         types.SpanAnnotationTypeUnknown,
 			"meta.refinery.root":           false,
-			"meta.refinery.span_data_size": 175,
+			"meta.refinery.span_data_size": 168,
 		},
 		Metadata: map[string]any{
 			"api_host":    "http://localhost:17001",
@@ -1001,12 +1000,4 @@ func BenchmarkDistributedTraces(b *testing.B) {
 		}
 		sender.waitForCount(b, b.N)
 	})
-}
-
-// ideally we should get this from libhoney, but we don't have a way to get it yet
-// this can be removed if libhoney does provide it
-func getLibhoneyUserAgent() string {
-	baseUserAgent := fmt.Sprintf("libhoney-go/%s", version.Version)
-	runtimeInfo := fmt.Sprintf("%s (%s/%s)", strings.Replace(runtime.Version(), "go", "go/", 1), runtime.GOOS, runtime.GOARCH)
-	return fmt.Sprintf("%s %s", baseUserAgent, runtimeInfo)
 }

--- a/route/route.go
+++ b/route/route.go
@@ -1063,7 +1063,7 @@ func getUserAgentFromRequest(req *http.Request) string {
 }
 
 func addIncomingUserAgent(ev *types.Event, userAgent string) {
-	if userAgent != "" {
+	if userAgent != "" && ev.Data["meta.refinery.incoming_user_agent"] == nil {
 		ev.Data["meta.refinery.incoming_user_agent"] = userAgent
 	}
 }

--- a/route/route_test.go
+++ b/route/route_test.go
@@ -774,3 +774,25 @@ func TestIsRootSpan(t *testing.T) {
 		})
 	}
 }
+
+func TestAddIncomingUserAgent(t *testing.T) {
+	t.Run("no incoming user agent", func(t *testing.T) {
+		event := &types.Event{
+			Data: map[string]interface{}{},
+		}
+
+		addIncomingUserAgent(event, "test-agent")
+		require.Equal(t, "test-agent", event.Data["meta.refinery.incoming_user_agent"])
+	})
+
+	t.Run("existing incoming user agent", func(t *testing.T) {
+		event := &types.Event{
+			Data: map[string]interface{}{
+				"meta.refinery.incoming_user_agent": "test-agent",
+			},
+		}
+
+		addIncomingUserAgent(event, "another-test-agent")
+		require.Equal(t, "test-agent", event.Data["meta.refinery.incoming_user_agent"])
+	})
+}


### PR DESCRIPTION
## Which problem is this PR solving?

Following up to the following PR, we should only set the incoming user agent if the key does not already exist. This is useful in certain scenarios when two Refinery's are connected together.

- #1358

## Short description of the changes
- Only set incoming user agent meta field if the event doesn't already have a value for it
- Add unit test to verify behaviour
- Update existing tests to set custom user-agent and verify it's set correctly