### PR TITLE
fix: Switch `collector_collect_loop_duration_ms` metric to be a histogram 

### DIFF
--- a/collect/collect.go
+++ b/collect/collect.go
@@ -389,7 +389,7 @@ func (i *InMemCollector) collect() {
 			}
 		}
 
-		i.Metrics.Gauge("collector_collect_loop_duration_ms", float64(time.Now().Sub(startTime).Milliseconds()))
+		i.Metrics.Histogram("collector_collect_loop_duration_ms", float64(time.Now().Sub(startTime).Milliseconds()))
 	}
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?

- Recording the value as a guage meant that a lot of values were missed as the older values got overwritten by newer values. This meant the largest value in the interval may not get exported.

## Short description of the changes

- Switch `collector_collect_loop_duration_ms` from gauge to histogram to make sure max values are captured.

