### PR TITLE
maint: cherry pick v2.8.4 commits into main.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Refinery Changelog
 
+## 2.8.4 2024-10-11
+
+### Fixes
+
+- fix: Switch `collector_collect_loop_duration_ms` metric to be a histogram  (#1381) | [Tyler Helmuth](https://github.com/TylerHelmuth)
+
 ## 2.8.3 2024-10-08
 
 ### Changes 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,11 @@
 
 While [CHANGELOG.md](./CHANGELOG.md) contains detailed documentation and links to all the source code changes in a given release, this document is intended to be aimed at a more comprehensible version of the contents of the release from the point of view of users of Refinery.
 
+## Version 2.8.4
+
+This is a bug fix release and includes the follow change:
+* Changes the new `collector_collect_loop_duration_ms` metric introduced in `v2.8.3` to be a histogram instead of a gauge. This ensures the minimum and maximum values from each interval is recorded. 
+
 ## Version 2.8.3
 
 This is a bug fix release and includes the follow changes+~+:

--- a/collect/collect.go
+++ b/collect/collect.go
@@ -129,7 +129,7 @@ var inMemCollectorMetrics = []metrics.Metadata{
 	{Name: "trace_kept_sample_rate", Type: metrics.Histogram, Unit: metrics.Dimensionless, Description: "sample rate of kept traces"},
 	{Name: "trace_aggregate_sample_rate", Type: metrics.Histogram, Unit: metrics.Dimensionless, Description: "aggregate sample rate of both kept and dropped traces"},
 	{Name: "collector_redistribute_traces_duration_ms", Type: metrics.Histogram, Unit: metrics.Milliseconds, Description: "duration of redistributing traces to peers"},
-	{Name: "collector_collect_loop_duration_ms", Type: metrics.Gauge, Unit: metrics.Milliseconds, Description: "duration of the collect loop, the primary event processing goroutine"},
+	{Name: "collector_collect_loop_duration_ms", Type: metrics.Histogram, Unit: metrics.Milliseconds, Description: "duration of the collect loop, the primary event processing goroutine"},
 }
 
 func (i *InMemCollector) Start() error {

--- a/collect/collect.go
+++ b/collect/collect.go
@@ -399,7 +399,7 @@ func (i *InMemCollector) collect() {
 			}
 		}
 
-		i.Metrics.Gauge("collector_collect_loop_duration_ms", float64(time.Now().Sub(startTime).Milliseconds()))
+		i.Metrics.Histogram("collector_collect_loop_duration_ms", float64(time.Now().Sub(startTime).Milliseconds()))
 	}
 }
 

--- a/config.md
+++ b/config.md
@@ -1,7 +1,7 @@
 # Honeycomb Refinery Configuration Documentation
 
 This is the documentation for the configuration file for Honeycomb's Refinery.
-It was automatically generated on 2024-10-10 at 17:01:39 UTC.
+It was automatically generated on 2024-10-11 at 15:40:59 UTC.
 
 ## The Config file
 
@@ -192,7 +192,7 @@ The exact behavior depends on the value of `SendKeyMode`.
 
 SendKeyMode controls how SendKey is used to replace or augment API keys used in incoming telemetry.
 
-controls how SendKey is used to replace or supply API keys used in incoming telemetry.
+Controls how SendKey is used to replace or supply API keys used in incoming telemetry.
 If `AcceptOnlyListedKeys` is `true`, then `SendKeys` will only be used for events with keys listed in `ReceiveKeys`.
 `none` uses the incoming key for all telemetry (default).
 `all` overwrites all keys, even missing ones, with `SendKey`.
@@ -982,18 +982,9 @@ This value should be set to a bit less than the normal timeout period for shutti
 - Type: `duration`
 - Default: `15s`
 
-### `EnableTraceLocality`
-
-EnableTraceLocality controls whether all spans that belongs to the same trace are sent to a single Refinery for processing.
-
-If `true`, Refinery's will route all spans that belongs to the same trace to a single peer.
-
-- Eligible for live reload.
-- Type: `bool`
-
 ### `HealthCheckTimeout`
 
-HealthCheckTimeout controls the maximum duration allowed for collection health checks to complete.
+HealthCheckTimeout Controls the maximum duration allowed for collection health checks to complete.
 
 The `HealthCheckTimeout` setting specifies the maximum duration allowed for the health checks of the collection subsystems to complete.
 If a subsystem does not respond within this timeout period, it will be marked as unhealthy.

--- a/config.md
+++ b/config.md
@@ -1,7 +1,7 @@
 # Honeycomb Refinery Configuration Documentation
 
 This is the documentation for the configuration file for Honeycomb's Refinery.
-It was automatically generated on 2024-10-11 at 15:40:59 UTC.
+It was automatically generated on 2024-10-11 at 16:33:01 UTC.
 
 ## The Config file
 
@@ -192,7 +192,7 @@ The exact behavior depends on the value of `SendKeyMode`.
 
 SendKeyMode controls how SendKey is used to replace or augment API keys used in incoming telemetry.
 
-Controls how SendKey is used to replace or supply API keys used in incoming telemetry.
+controls how SendKey is used to replace or supply API keys used in incoming telemetry.
 If `AcceptOnlyListedKeys` is `true`, then `SendKeys` will only be used for events with keys listed in `ReceiveKeys`.
 `none` uses the incoming key for all telemetry (default).
 `all` overwrites all keys, even missing ones, with `SendKey`.
@@ -982,9 +982,18 @@ This value should be set to a bit less than the normal timeout period for shutti
 - Type: `duration`
 - Default: `15s`
 
+### `EnableTraceLocality`
+
+EnableTraceLocality controls whether all spans that belongs to the same trace are sent to a single Refinery for processing.
+
+If `true`, Refinery's will route all spans that belongs to the same trace to a single peer.
+
+- Eligible for live reload.
+- Type: `bool`
+
 ### `HealthCheckTimeout`
 
-HealthCheckTimeout Controls the maximum duration allowed for collection health checks to complete.
+HealthCheckTimeout controls the maximum duration allowed for collection health checks to complete.
 
 The `HealthCheckTimeout` setting specifies the maximum duration allowed for the health checks of the collection subsystems to complete.
 If a subsystem does not respond within this timeout period, it will be marked as unhealthy.

--- a/config_complete.yaml
+++ b/config_complete.yaml
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created on 2024-10-11 at 15:40:58 UTC from ../../config.yaml using a template generated on 2024-10-11 at 15:40:56 UTC
+# created on 2024-10-11 at 16:33:00 UTC from ../../config.yaml using a template generated on 2024-10-11 at 16:32:50 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of
@@ -176,7 +176,7 @@ AccessKeys:
     ## SendKeyMode controls how SendKey is used to replace or augment API
     ## keys used in incoming telemetry.
     ##
-    ## Controls how SendKey is used to replace or supply API keys used in
+    ## controls how SendKey is used to replace or supply API keys used in
     ## incoming telemetry. If `AcceptOnlyListedKeys` is `true`, then
     ## `SendKeys` will only be used for events with keys listed in
     ## `ReceiveKeys`.
@@ -1036,7 +1036,16 @@ Collection:
     ## Eligible for live reload.
     # ShutdownDelay: 15s
 
-    ## HealthCheckTimeout Controls the maximum duration allowed for
+    ## EnableTraceLocality controls whether all spans that belongs to the
+    ## same trace are sent to a single Refinery for processing.
+    ##
+    ## If `true`, Refinery's will route all spans that belongs to the same
+    ## trace to a single peer.
+    ##
+    ## Eligible for live reload.
+    # EnableTraceLocality: false
+
+    ## HealthCheckTimeout controls the maximum duration allowed for
     ## collection health checks to complete.
     ##
     ## The `HealthCheckTimeout` setting specifies the maximum duration

--- a/config_complete.yaml
+++ b/config_complete.yaml
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created on 2024-10-10 at 17:01:39 UTC from ../../config.yaml using a template generated on 2024-10-10 at 17:01:33 UTC
+# created on 2024-10-11 at 15:40:58 UTC from ../../config.yaml using a template generated on 2024-10-11 at 15:40:56 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of
@@ -176,7 +176,7 @@ AccessKeys:
     ## SendKeyMode controls how SendKey is used to replace or augment API
     ## keys used in incoming telemetry.
     ##
-    ## controls how SendKey is used to replace or supply API keys used in
+    ## Controls how SendKey is used to replace or supply API keys used in
     ## incoming telemetry. If `AcceptOnlyListedKeys` is `true`, then
     ## `SendKeys` will only be used for events with keys listed in
     ## `ReceiveKeys`.
@@ -1036,16 +1036,7 @@ Collection:
     ## Eligible for live reload.
     # ShutdownDelay: 15s
 
-    ## EnableTraceLocality controls whether all spans that belongs to the
-    ## same trace are sent to a single Refinery for processing.
-    ##
-    ## If `true`, Refinery's will route all spans that belongs to the same
-    ## trace to a single peer.
-    ##
-    ## Eligible for live reload.
-    # EnableTraceLocality: false
-
-    ## HealthCheckTimeout controls the maximum duration allowed for
+    ## HealthCheckTimeout Controls the maximum duration allowed for
     ## collection health checks to complete.
     ##
     ## The `HealthCheckTimeout` setting specifies the maximum duration
@@ -1135,8 +1126,8 @@ Specialized:
     ##
     ## Eligible for live reload.
     # AdditionalAttributes:
-      #  environment: production
       #  ClusterName: MyCluster
+      #  environment: production
 
 ###############
 ## ID Fields ##

--- a/metrics.md
+++ b/metrics.md
@@ -1,7 +1,7 @@
 # Honeycomb Refinery Metrics Documentation
 
 This document contains the description of various metrics used in Refinery.
-It was automatically generated on 2024-10-10 at 17:01:38 UTC.
+It was automatically generated on 2024-10-11 at 16:33:00 UTC.
 
 Note: This document does not include metrics defined in the dynsampler-go dependency, as those metrics are generated dynamically at runtime. As a result, certain metrics may be missing or incomplete in this document, but they will still be available during execution with their full names.
 
@@ -59,7 +59,7 @@ This table includes metrics with fully defined names.
 | trace_kept_sample_rate | Histogram | Dimensionless | sample rate of kept traces |
 | trace_aggregate_sample_rate | Histogram | Dimensionless | aggregate sample rate of both kept and dropped traces |
 | collector_redistribute_traces_duration_ms | Histogram | Milliseconds | duration of redistributing traces to peers |
-| collector_collect_loop_duration_ms | Gauge | Milliseconds | duration of the collect loop, the primary event processing goroutine |
+| collector_collect_loop_duration_ms | Histogram | Milliseconds | duration of the collect loop, the primary event processing goroutine |
 | cluster_stress_level | Gauge | Dimensionless | The overall stress level of the cluster |
 | individual_stress_level | Gauge | Dimensionless | The stress level of the individual node |
 | stress_level | Gauge | Dimensionless | The stress level that's being used to determine whether to activate stress relief |

--- a/refinery_config.md
+++ b/refinery_config.md
@@ -168,7 +168,7 @@ The exact behavior depends on the value of `SendKeyMode`.
 
 `SendKeyMode` controls how SendKey is used to replace or augment API keys used in incoming telemetry.
 
-controls how SendKey is used to replace or supply API keys used in incoming telemetry.
+Controls how SendKey is used to replace or supply API keys used in incoming telemetry.
 If `AcceptOnlyListedKeys` is `true`, then `SendKeys` will only be used for events with keys listed in `ReceiveKeys`.
 `none` uses the incoming key for all telemetry (default).
 `all` overwrites all keys, even missing ones, with `SendKey`.
@@ -967,18 +967,9 @@ This value should be set to a bit less than the normal timeout period for shutti
 - Type: `duration`
 - Default: `15s`
 
-### `EnableTraceLocality`
-
-`EnableTraceLocality` controls whether all spans that belongs to the same trace are sent to a single Refinery for processing.
-
-If `true`, Refinery's will route all spans that belongs to the same trace to a single peer.
-
-- Eligible for live reload.
-- Type: `bool`
-
 ### `HealthCheckTimeout`
 
-`HealthCheckTimeout` controls the maximum duration allowed for collection health checks to complete.
+`HealthCheckTimeout` Controls the maximum duration allowed for collection health checks to complete.
 
 The `HealthCheckTimeout` setting specifies the maximum duration allowed for the health checks of the collection subsystems to complete.
 If a subsystem does not respond within this timeout period, it will be marked as unhealthy.

--- a/refinery_config.md
+++ b/refinery_config.md
@@ -168,7 +168,7 @@ The exact behavior depends on the value of `SendKeyMode`.
 
 `SendKeyMode` controls how SendKey is used to replace or augment API keys used in incoming telemetry.
 
-Controls how SendKey is used to replace or supply API keys used in incoming telemetry.
+controls how SendKey is used to replace or supply API keys used in incoming telemetry.
 If `AcceptOnlyListedKeys` is `true`, then `SendKeys` will only be used for events with keys listed in `ReceiveKeys`.
 `none` uses the incoming key for all telemetry (default).
 `all` overwrites all keys, even missing ones, with `SendKey`.
@@ -967,9 +967,18 @@ This value should be set to a bit less than the normal timeout period for shutti
 - Type: `duration`
 - Default: `15s`
 
+### `EnableTraceLocality`
+
+`EnableTraceLocality` controls whether all spans that belongs to the same trace are sent to a single Refinery for processing.
+
+If `true`, Refinery's will route all spans that belongs to the same trace to a single peer.
+
+- Eligible for live reload.
+- Type: `bool`
+
 ### `HealthCheckTimeout`
 
-`HealthCheckTimeout` Controls the maximum duration allowed for collection health checks to complete.
+`HealthCheckTimeout` controls the maximum duration allowed for collection health checks to complete.
 
 The `HealthCheckTimeout` setting specifies the maximum duration allowed for the health checks of the collection subsystems to complete.
 If a subsystem does not respond within this timeout period, it will be marked as unhealthy.

--- a/rules.md
+++ b/rules.md
@@ -1,7 +1,7 @@
 # Honeycomb Refinery Rules Documentation
 
 This is the documentation for the rules configuration for Honeycomb's Refinery.
-It was automatically generated on 2024-10-10 at 17:01:40 UTC.
+It was automatically generated on 2024-10-11 at 15:41:00 UTC.
 
 ## The Rules file
 

--- a/rules.md
+++ b/rules.md
@@ -1,7 +1,7 @@
 # Honeycomb Refinery Rules Documentation
 
 This is the documentation for the rules configuration for Honeycomb's Refinery.
-It was automatically generated on 2024-10-11 at 15:41:00 UTC.
+It was automatically generated on 2024-10-11 at 16:33:02 UTC.
 
 ## The Rules file
 

--- a/tools/convert/configDataNames.txt
+++ b/tools/convert/configDataNames.txt
@@ -1,5 +1,5 @@
 # Names of groups and fields in the new config file format.
-# Automatically generated on 2024-10-10 at 17:01:34 UTC.
+# Automatically generated on 2024-10-11 at 15:40:57 UTC.
 
 General:
   - ConfigurationVersion
@@ -187,8 +187,6 @@ Collection:
   - DisableRedistribution
 
   - ShutdownDelay
-
-  - EnableTraceLocality
 
   - HealthCheckTimeout
 

--- a/tools/convert/configDataNames.txt
+++ b/tools/convert/configDataNames.txt
@@ -1,5 +1,5 @@
 # Names of groups and fields in the new config file format.
-# Automatically generated on 2024-10-11 at 15:40:57 UTC.
+# Automatically generated on 2024-10-11 at 16:32:56 UTC.
 
 General:
   - ConfigurationVersion
@@ -187,6 +187,8 @@ Collection:
   - DisableRedistribution
 
   - ShutdownDelay
+
+  - EnableTraceLocality
 
   - HealthCheckTimeout
 

--- a/tools/convert/metricsMeta.yaml
+++ b/tools/convert/metricsMeta.yaml
@@ -196,7 +196,7 @@ complete:
       unit: Milliseconds
       description: duration of redistributing traces to peers
     - name: collector_collect_loop_duration_ms
-      type: Gauge
+      type: Histogram
       unit: Milliseconds
       description: duration of the collect loop, the primary event processing goroutine
     - name: cluster_stress_level

--- a/tools/convert/minimal_config.yaml
+++ b/tools/convert/minimal_config.yaml
@@ -1,5 +1,5 @@
 # sample uncommented config file containing all possible fields
-# automatically generated on 2024-10-10 at 17:01:35 UTC
+# automatically generated on 2024-10-11 at 15:40:58 UTC
 General:
   ConfigurationVersion: 2
   MinRefineryVersion: "v2.0"
@@ -103,7 +103,6 @@ Collection:
   MaxAlloc: 0
   DisableRedistribution: false
   ShutdownDelay: 15s
-  EnableTraceLocality: false
   HealthCheckTimeout: 3s
 BufferSizes:
   UpstreamBufferSize: 10_000

--- a/tools/convert/minimal_config.yaml
+++ b/tools/convert/minimal_config.yaml
@@ -1,5 +1,5 @@
 # sample uncommented config file containing all possible fields
-# automatically generated on 2024-10-11 at 15:40:58 UTC
+# automatically generated on 2024-10-11 at 16:32:57 UTC
 General:
   ConfigurationVersion: 2
   MinRefineryVersion: "v2.0"
@@ -103,6 +103,7 @@ Collection:
   MaxAlloc: 0
   DisableRedistribution: false
   ShutdownDelay: 15s
+  EnableTraceLocality: false
   HealthCheckTimeout: 3s
 BufferSizes:
   UpstreamBufferSize: 10_000

--- a/tools/convert/templates/configV2.tmpl
+++ b/tools/convert/templates/configV2.tmpl
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created {{ now }} from {{ .Input }} using a template generated on 2024-10-11 at 15:40:56 UTC
+# created {{ now }} from {{ .Input }} using a template generated on 2024-10-11 at 16:32:50 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of
@@ -175,7 +175,7 @@ AccessKeys:
     ## SendKeyMode controls how SendKey is used to replace or augment API
     ## keys used in incoming telemetry.
     ##
-    ## Controls how SendKey is used to replace or supply API keys used in
+    ## controls how SendKey is used to replace or supply API keys used in
     ## incoming telemetry. If `AcceptOnlyListedKeys` is `true`, then
     ## `SendKeys` will only be used for events with keys listed in
     ## `ReceiveKeys`.
@@ -1031,7 +1031,16 @@ Collection:
     ## Eligible for live reload.
     {{ nonDefaultOnly .Data "ShutdownDelay" "ShutdownDelay" "15s" }}
 
-    ## HealthCheckTimeout Controls the maximum duration allowed for
+    ## EnableTraceLocality controls whether all spans that belongs to the
+    ## same trace are sent to a single Refinery for processing.
+    ##
+    ## If `true`, Refinery's will route all spans that belongs to the same
+    ## trace to a single peer.
+    ##
+    ## Eligible for live reload.
+    {{ nonDefaultOnly .Data "EnableTraceLocality" "EnableTraceLocality" false }}
+
+    ## HealthCheckTimeout controls the maximum duration allowed for
     ## collection health checks to complete.
     ##
     ## The `HealthCheckTimeout` setting specifies the maximum duration

--- a/tools/convert/templates/configV2.tmpl
+++ b/tools/convert/templates/configV2.tmpl
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created {{ now }} from {{ .Input }} using a template generated on 2024-10-10 at 17:01:33 UTC
+# created {{ now }} from {{ .Input }} using a template generated on 2024-10-11 at 15:40:56 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of
@@ -175,7 +175,7 @@ AccessKeys:
     ## SendKeyMode controls how SendKey is used to replace or augment API
     ## keys used in incoming telemetry.
     ##
-    ## controls how SendKey is used to replace or supply API keys used in
+    ## Controls how SendKey is used to replace or supply API keys used in
     ## incoming telemetry. If `AcceptOnlyListedKeys` is `true`, then
     ## `SendKeys` will only be used for events with keys listed in
     ## `ReceiveKeys`.
@@ -1031,16 +1031,7 @@ Collection:
     ## Eligible for live reload.
     {{ nonDefaultOnly .Data "ShutdownDelay" "ShutdownDelay" "15s" }}
 
-    ## EnableTraceLocality controls whether all spans that belongs to the
-    ## same trace are sent to a single Refinery for processing.
-    ##
-    ## If `true`, Refinery's will route all spans that belongs to the same
-    ## trace to a single peer.
-    ##
-    ## Eligible for live reload.
-    {{ nonDefaultOnly .Data "EnableTraceLocality" "EnableTraceLocality" false }}
-
-    ## HealthCheckTimeout controls the maximum duration allowed for
+    ## HealthCheckTimeout Controls the maximum duration allowed for
     ## collection health checks to complete.
     ##
     ## The `HealthCheckTimeout` setting specifies the maximum duration


### PR DESCRIPTION
## Which problem is this PR solving?

- gets the changes from 2.8.4 into main

## Short description of the changes

- update `collector_collect_loop_duration_ms` type
- run `make all`
- get 2.8.4 changelog and release notes.

