### PR TITLE
feat(DO NOT MERGE): remove collector from health check

### DIFF
--- a/collect/collect.go
+++ b/collect/collect.go
@@ -850,7 +850,7 @@ func (i *InMemCollector) Stop() error {
 	close(i.done)
 	// signal the health system to not be ready
 	// so that no new traces are accepted
-	i.Health.Ready(CollectorHealthKey, false)
+	//i.Health.Ready(CollectorHealthKey, false)
 
 	i.mutex.Lock()
 

--- a/collect/collect.go
+++ b/collect/collect.go
@@ -104,7 +104,7 @@ func (i *InMemCollector) Start() error {
 	// listen for config reloads
 	i.Config.RegisterReloadCallback(i.sendReloadSignal)
 
-	i.Health.Register(CollectorHealthKey, time.Duration(imcConfig.HealthCheckTimeout))
+	//i.Health.Register(CollectorHealthKey, time.Duration(imcConfig.HealthCheckTimeout))
 
 	i.Metrics.Register("trace_duration_ms", "histogram")
 	i.Metrics.Register("trace_span_count", "histogram")
@@ -332,7 +332,7 @@ func (i *InMemCollector) collect() {
 	for {
 		startTime := time.Now()
 
-		i.Health.Ready(CollectorHealthKey, true)
+		// i.Health.Ready(CollectorHealthKey, true)
 		// record channel lengths as histogram but also as gauges
 		i.Metrics.Histogram("collector_incoming_queue", float64(len(i.incoming)))
 		i.Metrics.Histogram("collector_peer_queue", float64(len(i.fromPeer)))


### PR DESCRIPTION

## Which problem is this PR solving?

- I would like to gather the `collector_collect_loop_duration_ms` metric without the health check in our internal refinery

## Short description of the changes

-

