### PR TITLE
feat: Log response bodies when sending events to Honeycomb

### DIFF
--- a/transmit/transmit.go
+++ b/transmit/transmit.go
@@ -187,6 +187,9 @@ func (d *DefaultTransmission) processResponses(
 					"environment":    environment,
 					"roundtrip_usec": dequeuedAt - enqueuedAt,
 				})
+				if len(r.Body) > 0 {
+					log = log.WithField("response_body", string(r.Body))
+				}
 				for _, k := range d.Config.GetAdditionalErrorFields() {
 					if v, ok := r.Metadata.(map[string]any)[k]; ok {
 						log = log.WithField(k, v)


### PR DESCRIPTION
## Which problem is this PR solving?

Updates the response handler to log the response body when sending events to Honeycomb. This can be a useful tool to identify when there there is a problem sending events.

- Closes #1048

## Short description of the changes
- If the response has a body, add it to the logged fields

