### PR TITLE
fix: use current node address as default peer list

### DIFF
--- a/internal/peer/pubsub_redis.go
+++ b/internal/peer/pubsub_redis.go
@@ -229,7 +229,11 @@ func (p *RedisPubsubPeers) GetPeers() ([]string, error) {
 	// This keeps the sharding logic happy.
 	peers := p.peers.Members()
 	if len(peers) == 0 {
-		peers = []string{"http://127.0.0.1:8081"}
+		myaddr, err := p.publicAddr()
+		if err != nil {
+			return nil, err
+		}
+		peers = []string{myaddr}
 	}
 	return peers, nil
 }


### PR DESCRIPTION
## Which problem is this PR solving?

- #1369 

## Short description of the changes

Since `GetPeers()` in redis peer implementation returns `127.0.0.1:8080` when no peer is present, it causes trace forwarding to fail if all peers have unregistered itself from the system.
- use current node address as the default peer list

