### PR TITLE
fix: Allow insecure otlp traces

### DIFF
--- a/config/file_config.go
+++ b/config/file_config.go
@@ -273,6 +273,7 @@ type OTelTracingConfig struct {
 	APIKey     string `yaml:"APIKey" cmdenv:"OTelTracesAPIKey,HoneycombAPIKey"`
 	Dataset    string `yaml:"Dataset" default:"Refinery Traces"`
 	SampleRate uint64 `yaml:"SampleRate" default:"100"`
+	Insecure   bool   `yaml:"Insecure" default:"false"`
 }
 
 type PeerManagementConfig struct {

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -878,6 +878,17 @@ groups:
           incoming span generates multiple outgoing spans, a minimum sample rate of `100` is
           strongly advised.
 
+      - name: Insecure
+        type: bool
+        valuetype: nondefault
+        default: false
+        reload: false
+        firstversion: v2.8.5
+        summary: controls whether to send Refinery's own OpenTelemetry traces via http instead of https.
+        description: >
+          When true Refinery will export its internal traces over http instead of https. Useful if you
+          plan on sending your traces to a different refinery instance for tail sampling.
+
   - name: PeerManagement
     title: "Peer Management"
     description: controls how the Refinery cluster communicates between peers.

--- a/internal/otelutil/otel_tracing.go
+++ b/internal/otelutil/otel_tracing.go
@@ -89,7 +89,7 @@ func SetupTracing(cfg config.OTelTracingConfig, resourceLibrary string, resource
 	}
 
 	cfg.APIHost = strings.TrimSuffix(cfg.APIHost, "/")
-	apihost, err := url.Parse(fmt.Sprintf("%s", cfg.APIHost))
+	apihost, err := url.Parse(cfg.APIHost)
 	if err != nil {
 		log.Fatalf("failed to parse otel API host: %v", err)
 	}


### PR DESCRIPTION
## Which problem is this PR solving?

- Closes https://github.com/honeycombio/refinery/issues/1392

## Short description of the changes

- Adds new `OTelTracing.Insecure` config option to allow exporting internal traces via http.
- Update otelutil's `SetupTracing` to switch between insecure and tls based on `OTelTracing.Insecure`.
- Remove the hard-coded `:443` when parsing the configured `OTelTracing.APIHost`

