### PR TITLE
feat: Try out FIFO queue of trace IDs for Trace Cache

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.21.8
+golang 1.23.1

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.23.1
+golang 1.21.8

--- a/collect/cache/cache.go
+++ b/collect/cache/cache.go
@@ -171,10 +171,12 @@ func (d *DefaultInMemCache) TakeExpiredTraces(now time.Time, max int) []*types.T
 			// trace has expired
 			expired = append(expired, trace)
 
-			// remove the trace from the cache and queue
+			// remove the trace from the cache
 			delete(d.cache, traceID)
-			d.queue = d.queue[1:]
 		}
+
+		// remove the trace ID from the queue
+		d.queue = d.queue[1:]
 	}
 	return expired
 }

--- a/collect/cache/cache.go
+++ b/collect/cache/cache.go
@@ -71,8 +71,8 @@ func NewInMemCache(
 		Metrics:  met,
 		Logger:   logger,
 		capacity: capacity,
-		cache:    make(map[string]*types.Trace),
-		queue:    make([]string, 0, 0),
+		cache:    make(map[string]*types.Trace, capacity),
+		queue:    make([]string, 0, capacity),
 	}
 }
 

--- a/collect/cache/cache_test.go
+++ b/collect/cache/cache_test.go
@@ -165,9 +165,12 @@ func BenchmarkCache_Set(b *testing.B) {
 	_, traces := generateTraces(b.N)
 
 	c := NewInMemCache(b.N, metrics, &logger.NullLogger{})
-	b.Run("InMemCache", func(b *testing.B) {
-		populateCache(c, traces)
-	})
+
+	// setup is expensive, so reset timer and report allocations
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	populateCache(c, traces)
 }
 
 // Benchmark the cache's Get method
@@ -178,11 +181,14 @@ func BenchmarkCache_Get(b *testing.B) {
 
 	c := NewInMemCache(b.N, metrics, &logger.NullLogger{})
 	populateCache(c, traces)
-	b.Run("InMemCache", func(b *testing.B) {
-		for traceID, _ := range traces {
-			c.Get(traceID)
-		}
-	})
+
+	// setup is expensive, so reset timer and report allocations
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for traceID, _ := range traces {
+		c.Get(traceID)
+	}
 }
 
 // Benchmark the cache's TakeExpiredTraces method
@@ -193,11 +199,14 @@ func BenchmarkCache_TakeExpiredTraces(b *testing.B) {
 
 	c := NewInMemCache(b.N, metrics, &logger.NullLogger{})
 	populateCache(c, traces)
-	b.Run("InMemCache", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
-			c.TakeExpiredTraces(now.Add(time.Duration(i)*time.Second), 0)
-		}
-	})
+
+	// setup is expensive, so reset timer and report allocations
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		c.TakeExpiredTraces(now.Add(time.Duration(i)*time.Second), 0)
+	}
 }
 
 // Benchmark the cache's RemoveTraces method
@@ -213,9 +222,12 @@ func BenchmarkCache_RemoveTraces(b *testing.B) {
 
 	c := NewInMemCache(b.N, metrics, &logger.NullLogger{})
 	populateCache(c, traces)
-	b.Run("InMemCache", func(b *testing.B) {
-		c.RemoveTraces(deletes)
-	})
+
+	// setup is expensive, so reset timer and report allocations
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	c.RemoveTraces(deletes)
 }
 
 func generateTraces(n int) (time.Time, map[string]*types.Trace) {

--- a/collect/cache/cache_test.go
+++ b/collect/cache/cache_test.go
@@ -64,15 +64,15 @@ func TestTakeExpiredTraces(t *testing.T) {
 
 	expired := c.TakeExpiredTraces(now, 0)
 	assert.Equal(t, 2, len(expired))
-	assert.Equal(t, traces[0], expired[0])
-	assert.Equal(t, traces[1], expired[1])
+	assert.Contains(t, expired, traces[0])
+	assert.Contains(t, expired, traces[1])
 
 	assert.Equal(t, 2, c.GetCacheEntryCount())
 
 	all := c.GetAll()
 	assert.Equal(t, 2, len(all))
-	assert.Equal(t, traces[2], all[0])
-	assert.Equal(t, traces[3], all[1])
+	assert.Contains(t, all, traces[2])
+	assert.Contains(t, all, traces[3])
 }
 
 func TestRemoveSentTraces(t *testing.T) {

--- a/collect/cache/cache_test.go
+++ b/collect/cache/cache_test.go
@@ -140,6 +140,24 @@ func TestSkipOldUnsentTraces(t *testing.T) {
 	assert.Equal(t, traces[2], prev)
 }
 
+func TestSettingTheSameTraceDoesNotReaddItsIDToTheQueue(t *testing.T) {
+	s := &metrics.MockMetrics{}
+	s.Start()
+	c := NewInMemCache(4, s, &logger.NullLogger{})
+	now := time.Now()
+
+	trace := &types.Trace{
+		TraceID: "1",
+		SendBy:  now.Add(-time.Minute),
+	}
+
+	for i := 0; i < 10; i++ {
+		c.Set(trace)
+		assert.Len(t, c.GetAll(), 1)
+		assert.Len(t, c.queue, 1)
+	}
+}
+
 // Benchamark the cache's Set method
 func BenchmarkCache_Set(b *testing.B) {
 	metrics := &metrics.MockMetrics{}


### PR DESCRIPTION
## Which problem is this PR solving?

After further testing with higher load, we found the LRU cache maintained an unexpected number of items in the cache. This is because while the SentBy time is static and set only once when the first span is received, the LRU would update it's last used timestamp for each interaction such as receiving new spans.

The cache needs to be ordered by the SentBy time otherwise traces are not considered to have expired when intended and so stay in memory for longer than expected.

This PR updates the cache to use a FIFO queue of trace IDs that is ordered on first insertion into the map. The order of the queue aids in ordering traces so we can effectively traverse older traces first.

Note: by design, it's expected that items can be removed from the map of traces (eg redistribute or max alloc event) but the trace ID may still exist in the queue. When iterating the queue, we must check the trace still exists in the cache and ignore it if it's not present in the map.

## Short description of the changes
- replace LRU with map and `[]sting` array that's used as a FIFO of trace IDs
- update cache implementation to maintain both map and queue
- add unit test to verify that if the same trace is set multiple times, it does not get re-added to the queue


Benchmarks after changes:
```
BenchmarkCache_Set-10                  	 6006460	       229.7 ns/op	       2 B/op	       0 allocs/op
BenchmarkCache_Get-10                  	11458786	       130.9 ns/op	       0 B/op	       0 allocs/op
BenchmarkCache_TakeExpiredTraces-10    	 3227960	       429.2 ns/op	     108 B/op	       2 allocs/op
BenchmarkCache_RemoveTraces-10         	17387629	        97.48 ns/op	       8 B/op	       0 allocs/op
```