### PR TITLE
fix: cherry pick Allow insecure otlp traces (#1395) from v2.8.x to main

### DIFF
--- a/config/file_config.go
+++ b/config/file_config.go
@@ -278,6 +278,7 @@ type OTelTracingConfig struct {
 	APIKey     string `yaml:"APIKey" cmdenv:"OTelTracesAPIKey,HoneycombAPIKey"`
 	Dataset    string `yaml:"Dataset" default:"Refinery Traces"`
 	SampleRate uint64 `yaml:"SampleRate" default:"100"`
+	Insecure   bool   `yaml:"Insecure" default:"false"`
 }
 
 type PeerManagementConfig struct {

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -901,6 +901,17 @@ groups:
           incoming span generates multiple outgoing spans, a minimum sample rate of `100` is
           strongly advised.
 
+      - name: Insecure
+        type: bool
+        valuetype: nondefault
+        default: false
+        reload: false
+        firstversion: v2.8.5
+        summary: controls whether to send Refinery's own OpenTelemetry traces via http instead of https.
+        description: >
+          When true Refinery will export its internal traces over http instead of https. Useful if you
+          plan on sending your traces to a different refinery instance for tail sampling.
+
   - name: PeerManagement
     title: "Peer Management"
     description: controls how the Refinery cluster communicates between peers.

--- a/internal/otelutil/otel_tracing.go
+++ b/internal/otelutil/otel_tracing.go
@@ -89,7 +89,7 @@ func SetupTracing(cfg config.OTelTracingConfig, resourceLibrary string, resource
 	}
 
 	cfg.APIHost = strings.TrimSuffix(cfg.APIHost, "/")
-	apihost, err := url.Parse(fmt.Sprintf("%s:443", cfg.APIHost))
+	apihost, err := url.Parse(cfg.APIHost)
 	if err != nil {
 		log.Fatalf("failed to parse otel API host: %v", err)
 	}
@@ -113,15 +113,20 @@ func SetupTracing(cfg config.OTelTracingConfig, resourceLibrary string, resource
 		}
 	}
 
-	tlsconfig := &tls.Config{}
-	secureOption := otlptracehttp.WithTLSClientConfig(tlsconfig)
+	options := []otlptracehttp.Option{
+		otlptracehttp.WithEndpoint(apihost.Host),
+		otlptracehttp.WithHeaders(headers),
+		otlptracehttp.WithCompression(otlptracehttp.GzipCompression),
+	}
+	if cfg.Insecure {
+		options = append(options, otlptracehttp.WithInsecure())
+	} else {
+		options = append(options, otlptracehttp.WithTLSClientConfig(&tls.Config{}))
+	}
 	exporter, err := otlptrace.New(
 		context.Background(),
 		otlptracehttp.NewClient(
-			secureOption,
-			otlptracehttp.WithEndpoint(apihost.Host),
-			otlptracehttp.WithHeaders(headers),
-			otlptracehttp.WithCompression(otlptracehttp.GzipCompression),
+			options...,
 		),
 	)
 	if err != nil {


### PR DESCRIPTION
## Which problem is this PR solving?

- Closes https://github.com/honeycombio/refinery/issues/1392

## Short description of the changes

- Adds new `OTelTracing.Insecure` config option to allow exporting internal traces via http.
- Update otelutil's `SetupTracing` to switch between insecure and tls based on `OTelTracing.Insecure`.
- Remove the hard-coded `:443` when parsing the configured `OTelTracing.APIHost`

