### PR TITLE
fix: explictly assign float64 type for trace cache metrics

### DIFF
--- a/collect/cache/cache.go
+++ b/collect/cache/cache.go
@@ -97,7 +97,7 @@ func (d *DefaultInMemCache) Set(trace *types.Trace) {
 	}
 	start := time.Now()
 
-	defer d.Metrics.Histogram("trace_cache_set_dur_ms", time.Since(start).Microseconds()/1000.0)
+	defer d.Metrics.Histogram("trace_cache_set_dur_ms", float64(time.Since(start).Microseconds())/1000.0)
 	// update the cache and priority queue
 	d.cache[trace.TraceID] = trace
 	d.pq.Set(trace.TraceID, trace.SendBy)
@@ -113,7 +113,7 @@ func (d *DefaultInMemCache) Get(traceID string) *types.Trace {
 func (d *DefaultInMemCache) GetAll() []*types.Trace {
 	start := time.Now()
 
-	defer d.Metrics.Histogram("trace_cache_get_all_dur_ms", time.Since(start).Microseconds()/1000.0)
+	defer d.Metrics.Histogram("trace_cache_get_all_dur_ms", float64(time.Since(start).Microseconds())/1000.0)
 	return maps.Values(d.cache)
 }
 
@@ -128,7 +128,7 @@ func (d *DefaultInMemCache) TakeExpiredTraces(now time.Time, max int, filter fun
 	d.Metrics.Histogram("collect_cache_entries", float64(len(d.cache)))
 
 	start := time.Now()
-	defer d.Metrics.Histogram("trace_cache_take_expired_traces_dur_ms", time.Since(start).Microseconds()/1000.0)
+	defer d.Metrics.Histogram("trace_cache_take_expired_traces_dur_ms", float64(time.Since(start).Microseconds())/1000.0)
 
 	var expired, skipped []*types.Trace
 	for !d.pq.IsEmpty() && (max <= 0 || len(expired) < max) {
@@ -174,7 +174,7 @@ func (d *DefaultInMemCache) TakeExpiredTraces(now time.Time, max int, filter fun
 func (d *DefaultInMemCache) RemoveTraces(toDelete generics.Set[string]) {
 	d.Metrics.Histogram("collect_cache_entries", float64(len(d.cache)))
 	start := time.Now()
-	defer d.Metrics.Histogram("trace_cache_remove_traces_dur_ms", time.Since(start).Microseconds()/1000.0)
+	defer d.Metrics.Histogram("trace_cache_remove_traces_dur_ms", float64(time.Since(start).Microseconds())/1000.0)
 
 	for _, traceID := range toDelete.Members() {
 		delete(d.cache, traceID)


### PR DESCRIPTION
## Which problem is this PR solving?

 in Go, numeric constants are untyped. We need to explicitly assign float64 to the result in order to get floating-point result

## Short description of the changes

- assign the duration metrics to float64

