### PR TITLE
feat: only redistribute traces when its ownership has changed

### DIFF
--- a/collect/collect.go
+++ b/collect/collect.go
@@ -510,10 +510,6 @@ func (i *InMemCollector) redistributeTraces(ctx context.Context) {
 		span2.SetAttributes(attribute.String("shard", newTarget.GetAddress()))
 
 		if newTarget.Equals(i.Sharder.MyShard()) {
-			if !i.Config.GetCollectionConfig().EnableTraceLocality {
-				// Drop all proxy spans since peers will resend them
-				trace.RemoveDecisionSpans()
-			}
 			span2.SetAttributes(attribute.Bool("self", true))
 			span2.End()
 			continue
@@ -521,10 +517,16 @@ func (i *InMemCollector) redistributeTraces(ctx context.Context) {
 
 		span2.SetAttributes(attribute.String("shard", newTarget.GetAddress()))
 
+		if newTarget.GetAddress() == trace.DeciderShardAddr {
+			span2.End()
+			continue
+		}
+
+		trace.DeciderShardAddr = newTarget.GetAddress()
+		// Remove decision spans from the trace that no longer belongs to the current node
+		trace.RemoveDecisionSpans()
+
 		for _, sp := range trace.GetSpans() {
-			if sp.IsDecisionSpan() {
-				continue
-			}
 
 			if !i.Config.GetCollectionConfig().EnableTraceLocality {
 				dc := i.createDecisionSpan(sp, trace, newTarget)
@@ -663,7 +665,8 @@ func (i *InMemCollector) processSpan(ctx context.Context, sp *types.Span) {
 	}
 
 	// if trace locality is enabled, we should forward all spans to its correct peer
-	if i.Config.GetCollectionConfig().EnableTraceLocality && !isMyTrace {
+	if i.Config.GetCollectionConfig().EnableTraceLocality && !targetShard.Equals(i.Sharder.MyShard()) {
+		sp.APIHost = targetShard.GetAddress()
 		i.PeerTransmission.EnqueueSpan(sp)
 		return
 	}
@@ -694,12 +697,13 @@ func (i *InMemCollector) processSpan(ctx context.Context, sp *types.Span) {
 
 		now := i.Clock.Now()
 		trace = &types.Trace{
-			APIHost:     sp.APIHost,
-			APIKey:      sp.APIKey,
-			Dataset:     sp.Dataset,
-			TraceID:     sp.TraceID,
-			ArrivalTime: now,
-			SendBy:      now.Add(timeout),
+			APIHost:          sp.APIHost,
+			APIKey:           sp.APIKey,
+			Dataset:          sp.Dataset,
+			TraceID:          sp.TraceID,
+			ArrivalTime:      now,
+			SendBy:           now.Add(timeout),
+			DeciderShardAddr: targetShard.GetAddress(),
 		}
 		trace.SetSampleRate(sp.SampleRate) // if it had a sample rate, we want to keep it
 		// push this into the cache and if we eject an unsent trace, send it ASAP

--- a/collect/collect.go
+++ b/collect/collect.go
@@ -190,7 +190,7 @@ func (i *InMemCollector) Start() error {
 	i.done = make(chan struct{})
 	i.datasetSamplers = make(map[string]sample.Sampler)
 	i.done = make(chan struct{})
-	i.redistributeTimer = newRedistributeNotifier(i.Logger, i.Metrics, i.Clock)
+	i.redistributeTimer = newRedistributeNotifier(i.Logger, i.Metrics, i.Clock, i.Config.GetCollectionConfig().RedistributionDelay)
 
 	if i.Config.GetAddHostMetadataToTrace() {
 		if hostname, err := os.Hostname(); err == nil && hostname != "" {

--- a/collect/collect.go
+++ b/collect/collect.go
@@ -509,6 +509,10 @@ func (i *InMemCollector) redistributeTraces(ctx context.Context) {
 
 		span2.SetAttributes(attribute.String("shard", newTarget.GetAddress()))
 
+		/*
+
+		 */
+
 		if newTarget.Equals(i.Sharder.MyShard()) {
 			span2.SetAttributes(attribute.Bool("self", true))
 			span2.End()

--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -1793,6 +1793,9 @@ func TestRedistributeTraces(t *testing.T) {
 			Data:    make(map[string]interface{}),
 		},
 	}
+	// TODO:
+	// test traces only be redistributed when its destination has changed
+
 	// decision span should not be forwarded
 	decisionSpan := &types.Span{
 		TraceID: "11",

--- a/collect/trace_redistributer.go
+++ b/collect/trace_redistributer.go
@@ -11,11 +11,10 @@ import (
 )
 
 type redistributeNotifier struct {
-	clock        clockwork.Clock
-	logger       logger.Logger
-	initialDelay time.Duration
-	maxDelay     float64
-	metrics      metrics.Metrics
+	clock   clockwork.Clock
+	logger  logger.Logger
+	delay   time.Duration
+	metrics metrics.Metrics
 
 	reset     chan struct{}
 	done      chan struct{}
@@ -23,17 +22,15 @@ type redistributeNotifier struct {
 	once      sync.Once
 }
 
-func newRedistributeNotifier(logger logger.Logger, met metrics.Metrics, clock clockwork.Clock) *redistributeNotifier {
+func newRedistributeNotifier(logger logger.Logger, met metrics.Metrics, clock clockwork.Clock, delay time.Duration) *redistributeNotifier {
 	r := &redistributeNotifier{
-		// TODO: make the delay configurable
-		initialDelay: 3 * time.Second,
-		maxDelay:     float64(30 * time.Second),
-		done:         make(chan struct{}),
-		clock:        clock,
-		logger:       logger,
-		metrics:      met,
-		triggered:    make(chan struct{}),
-		reset:        make(chan struct{}),
+		delay:     delay,
+		done:      make(chan struct{}),
+		clock:     clock,
+		logger:    logger,
+		metrics:   met,
+		triggered: make(chan struct{}),
+		reset:     make(chan struct{}),
 	}
 
 	return r
@@ -73,7 +70,7 @@ func (r *redistributeNotifier) Stop() {
 // because peer membership changes often happen in bunches, so we wait a while
 // before triggering the redistribution.
 func (r *redistributeNotifier) run() {
-	currentDelay := r.calculateDelay(r.initialDelay)
+	currentDelay := r.calculateDelay(r.delay)
 
 	// start a back off timer with the initial delay
 	timer := r.clock.NewTimer(currentDelay)
@@ -84,7 +81,7 @@ func (r *redistributeNotifier) run() {
 			return
 		case <-r.reset:
 			// reset the delay timer when we receive a reset signal.
-			currentDelay = r.calculateDelay(r.initialDelay)
+			currentDelay = r.calculateDelay(r.delay)
 			if !timer.Stop() {
 				// drain the timer channel
 				select {

--- a/collect/trace_redistributer.go
+++ b/collect/trace_redistributer.go
@@ -25,6 +25,7 @@ type redistributeNotifier struct {
 
 func newRedistributeNotifier(logger logger.Logger, met metrics.Metrics, clock clockwork.Clock) *redistributeNotifier {
 	r := &redistributeNotifier{
+		// TODO: make the delay configurable
 		initialDelay: 3 * time.Second,
 		maxDelay:     float64(30 * time.Second),
 		done:         make(chan struct{}),

--- a/collect/trace_redistributer_test.go
+++ b/collect/trace_redistributer_test.go
@@ -15,12 +15,12 @@ func TestRedistributeNotifier(t *testing.T) {
 
 	clock := clockwork.NewFakeClock()
 	r := &redistributeNotifier{
-		clock:        clock,
-		initialDelay: 50 * time.Millisecond, // Set the initial delay
-		metrics:      &metrics.NullMetrics{},
-		reset:        make(chan struct{}),
-		done:         make(chan struct{}),
-		triggered:    make(chan struct{}, 4), // Buffered to allow easier testing
+		clock:     clock,
+		delay:     50 * time.Millisecond, // Set the initial delay
+		metrics:   &metrics.NullMetrics{},
+		reset:     make(chan struct{}),
+		done:      make(chan struct{}),
+		triggered: make(chan struct{}, 4), // Buffered to allow easier testing
 	}
 
 	defer r.Stop()
@@ -34,7 +34,7 @@ func TestRedistributeNotifier(t *testing.T) {
 	assert.Len(t, r.triggered, 0)
 
 	// Test that the notifier is triggered after the initial delay
-	currentBackOff := r.initialDelay
+	currentBackOff := r.delay
 	clock.BlockUntil(1)
 	currentBackOff = r.calculateDelay(currentBackOff)
 	clock.Advance(currentBackOff + 100*time.Millisecond) // Advance the clock by the backoff time plus a little extra

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -304,16 +304,19 @@ type RedisPeerManagementConfig struct {
 
 type CollectionConfig struct {
 	// CacheCapacity must be less than math.MaxInt32
-	CacheCapacity         int        `yaml:"CacheCapacity" default:"10_000"`
-	PeerQueueSize         int        `yaml:"PeerQueueSize"`
-	IncomingQueueSize     int        `yaml:"IncomingQueueSize"`
-	AvailableMemory       MemorySize `yaml:"AvailableMemory" cmdenv:"AvailableMemory"`
-	HealthCheckTimeout    Duration   `yaml:"HealthCheckTimeout" default:"3s"`
-	MaxMemoryPercentage   int        `yaml:"MaxMemoryPercentage" default:"75"`
-	MaxAlloc              MemorySize `yaml:"MaxAlloc"`
-	DisableRedistribution bool       `yaml:"DisableRedistribution"`
-	ShutdownDelay         Duration   `yaml:"ShutdownDelay" default:"15s"`
-	EnableTraceLocality   bool       `yaml:"EnableTraceLocality"`
+	CacheCapacity       int        `yaml:"CacheCapacity" default:"10_000"`
+	PeerQueueSize       int        `yaml:"PeerQueueSize"`
+	IncomingQueueSize   int        `yaml:"IncomingQueueSize"`
+	AvailableMemory     MemorySize `yaml:"AvailableMemory" cmdenv:"AvailableMemory"`
+	HealthCheckTimeout  Duration   `yaml:"HealthCheckTimeout" default:"3s"`
+	MaxMemoryPercentage int        `yaml:"MaxMemoryPercentage" default:"75"`
+	MaxAlloc            MemorySize `yaml:"MaxAlloc"`
+
+	DisableRedistribution bool     `yaml:"DisableRedistribution"`
+	RedistributionDelay   Duration `yaml:"RedistributionDelay" default:"30s"`
+
+	ShutdownDelay       Duration `yaml:"ShutdownDelay" default:"15s"`
+	EnableTraceLocality bool     `yaml:"EnableTraceLocality"`
 
 	MaxDropDecisionBatchSize int      `yaml:"MaxDropDecisionBatchSize" default:"1000"`
 	DropDecisionSendInterval Duration `yaml:"DropDecisionSendInterval" default:"1s"`

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -1306,6 +1306,19 @@ groups:
           By disabling this behavior, it can help to prevent disruptive bursts of network traffic when large traces with long `TraceTimeout`
           are redistributed.
 
+      - name: RedistributionDelay
+        type: duration
+        valuetype: nondefault
+        firstversion: v2.9
+        default: 30s
+        reload: false
+        summary: controls the amount of time Refinery waits after each cluster scaling event before redistributing in-memory traces.
+        description: >
+          This value should be longer than the amount of time between each scaling operations, such as adding or removing a pod in a
+          kubernetes deployment.
+          Each redistrution generates additional traffic between peers. If this value is too short, multiple consecutive redistribution
+          event will occur and may overwhelm the cluster.
+
       - name: ShutdownDelay
         type: duration
         valuetype: nondefault

--- a/types/event.go
+++ b/types/event.go
@@ -47,8 +47,9 @@ type Trace struct {
 	// KeepSample should only be changed if the changer holds the SendSampleLock
 	KeepSample bool
 	// Sent should only be changed if the changer holds the SendSampleLock
-	Sent       bool
-	keptReason uint
+	Sent             bool
+	keptReason       uint
+	DeciderShardAddr string
 
 	SendBy time.Time
 


### PR DESCRIPTION
## Which problem is this PR solving?

To reduce the amount of traffic produced during a redistribution event, this PR changes the logic to only redistribute traces that has its ownership changed

## Short description of the changes

- update `redistributeTraces` to only forward data when a trace's ownership has changed
- make redistribution delay configurable
- add tests

