### PR TITLE
fix: set a better version for dev builds

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -15,12 +15,12 @@ if [[ "${CIRCLE_BRANCH}" == "main" ]]; then
     TAGS+=",latest"
 fi
 
-# Local builds just get "dev" for version
-VERSION="dev"
+# Determine a version number based on most recent version tag in git.
+VERSION=$(git describe --tags --match='v[0-9]*' --always)
 
-# If we are doing a dev build on circle, we will version it as the circleci buildnumber
-if [[ -n "${CIRCLE_BUILD_NUM}" ]]; then
-    VERSION="${CIRCLE_BUILD_NUM}"
+# If we are doing a dev build on circle, append the build number (job id) to the version
+if [[ -n "${CIRCLE_BUILD_NUM:-}" ]]; then
+  VERSION="${VERSION}-ci${CIRCLE_BUILD_NUM}"
 fi
 
 # if we're running off a git tag, it is a release which we tag with the versions as well as latest


### PR DESCRIPTION
## Which problem is this PR solving?

Prior to these changes, dev builds in CI have only an integer set for their version (main.BuildID). That left humans to:

1. Humans have to remember that [this integer is a CircleCI job ID](https://github.com/honeycombio/refinery/blob/de51cafdd4c25a2644f5e92536e952fb134ab75f/build-docker.sh#L21-L24).
2. Humans have to remember how to get to a CircleCI job ID directly on the right workflow.
```
https://app.circleci.com/pipelines/github/honeycombio/refinery/4470/workflows/21612810-63c4-4780-8b30-a9f98575931f/jobs/<JOB_ID_HERE>
```
3. Humans then have to open that job and read the banner at the top to determine which branch and commit that job was run on.

## Short description of the changes

What if we encode most of that in the version number?

* Use git to consistently generate a version number for any dev build.
    * `git describe` - Return the most recent _annotated_ tag that is reachable from a commit.
    * `--tags` - OK, _any_ tag, not just the annotated ones. We don't always remember to annotate a version tag.
    * `--match='v[0-9]*'` - But of all those tags, only the version ones (starts with a v and a digit).
    * `--always` - … and if a tag can't be found, fallback to the commit ID.
* Append the CircleCI job ID to the version number if the build is running there.

Example of a version computed in CI for any build that isn't a tagging event: 

```
v2.8.2-45-ge527ea1-ci8675309
```

That is has _more_ than `v2.8.2` indicates:
* It's a dev build.
* It's from `g`it commit `e527ea1`.
* That commit is `45` commits ahead of the commit tagged with `v2.8.2`.
* It was built in CI in job number `8675309`.