### PR TITLE
feat: publish refinery instance ID during pubsub peer comms

### DIFF
--- a/cmd/refinery/main.go
+++ b/cmd/refinery/main.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/facebookgo/inject"
 	"github.com/facebookgo/startstop"
+	"github.com/google/uuid"
 	libhoney "github.com/honeycombio/libhoney-go"
 	"github.com/honeycombio/libhoney-go/transmission"
 	"github.com/jonboulle/clockwork"
@@ -41,6 +42,9 @@ import (
 // set by travis.
 var BuildID string
 var version string
+
+// instanceID is a unique identifier for this instance of refinery.
+var instanceID = uuid.NewString()
 
 type graphLogger struct {
 }
@@ -265,6 +269,7 @@ func main() {
 		{Value: refineryHealth},
 		{Value: &configwatcher.ConfigWatcher{}},
 		{Value: &a},
+		{Value: instanceID, Name: "instanceID"},
 	}
 	err = g.Provide(objects...)
 	if err != nil {

--- a/internal/peer/peers_test.go
+++ b/internal/peer/peers_test.go
@@ -63,6 +63,7 @@ func newPeers(c config.Config) (Peers, error) {
 		{Value: &metrics.NullMetrics{}, Name: "metrics"},
 		{Value: &logger.NullLogger{}},
 		{Value: clockwork.NewFakeClock()},
+		{Value: "testID", Name: "instanceID"},
 	}
 	err := g.Provide(objects...)
 	if err != nil {

--- a/internal/peer/pubsub_test.go
+++ b/internal/peer/pubsub_test.go
@@ -41,15 +41,17 @@ func Test_publicAddr(t *testing.T) {
 }
 
 func TestPeerActions(t *testing.T) {
-	cmd := newPeerCommand(Register, "foo")
-	assert.Equal(t, "Rfoo", cmd.marshal())
-	assert.Equal(t, "foo", cmd.peer)
+	cmd := newPeerCommand(Register, "foo", "id1")
+	assert.Equal(t, "Rfoo,id1", cmd.marshal())
+	assert.Equal(t, "foo", cmd.address)
 	assert.Equal(t, Register, cmd.action)
+	assert.Equal(t, "id1", cmd.id)
 	cmd2 := peerCommand{}
-	b := cmd2.unmarshal("Ubar")
+	b := cmd2.unmarshal("Ubar,id2")
 	assert.True(t, b)
-	assert.Equal(t, "bar", cmd2.peer)
+	assert.Equal(t, "bar", cmd2.address)
 	assert.Equal(t, Unregister, cmd2.action)
+	assert.Equal(t, "id2", cmd2.id)
 
 	b = cmd2.unmarshal("invalid")
 	assert.False(t, b)


### PR DESCRIPTION
## Which problem is this PR solving?

When publishing peers via redis pubsub, we need a way to identify whether a node can receive keep and drop decision messages. This is important when performing migrations that update an older deployment that does not support keep/drop decisions to one that does.

Also, it would also be nice to not have to rely purely on a peer address as a means of testing whether the instance if the same for determining whether we need to re-send trace decisions. For example, it's possible the same IP address is used even though the refinery instance has restarted.

This PR updates refinery to generate a new instance ID on start up and then publish the refinery's instance ID as part of it's peer register/unregister commands. As the message format is changing, any messages that does not conform to the new format will not be added as valid peers.

## Short description of the changes
- Generate and inject an instance ID during process start up in main.go
- Update redis pubsub to take the instance ID via injection
- Update redis pubsub peer commands to also specify the instance ID
- Update marshal and unmarshall funcs to handle and require instance ID
- Update pubsub tests