### PR TITLE
feat: batch kept decisions

### DIFF
--- a/collect/collect.go
+++ b/collect/collect.go
@@ -1422,10 +1422,7 @@ func (i *InMemCollector) processTraceDecisions(msg string, decisionType decision
 
 		i.sampleTraceCache.Record(trace, decision.Kept, decision.KeptReason)
 
-		// Send the processed trace (only in Kept case)
-		if decisionType == keptDecision {
-			i.send(context.Background(), trace, &decision)
-		}
+		i.send(context.Background(), trace, &decision)
 	}
 
 	i.cache.RemoveTraces(toDelete)

--- a/collect/collect.go
+++ b/collect/collect.go
@@ -1529,24 +1529,6 @@ func (i *InMemCollector) publishTraceDecision(ctx context.Context, td TraceDecis
 	}
 }
 
-type decisionType int
-
-func (d decisionType) String() string {
-	switch d {
-	case keptDecision:
-		return "kept"
-	case dropDecision:
-		return "drop"
-	default:
-		return "unknown"
-	}
-}
-
-var (
-	keptDecision decisionType = 1
-	dropDecision decisionType = 2
-)
-
 func (i *InMemCollector) sendKeptDecisions() {
 	if i.Config.GetCollectionConfig().EnableTraceLocality {
 		return

--- a/collect/trace_decision.go
+++ b/collect/trace_decision.go
@@ -6,6 +6,24 @@ import (
 	"strings"
 )
 
+type decisionType int
+
+func (d decisionType) String() string {
+	switch d {
+	case keptDecision:
+		return "kept"
+	case dropDecision:
+		return "drop"
+	default:
+		return "unknown"
+	}
+}
+
+var (
+	keptDecision decisionType = 1
+	dropDecision decisionType = 2
+)
+
 type newDecisionMessage func([]TraceDecision) (string, error)
 
 func newDroppedDecisionMessage(tds []TraceDecision) (string, error) {

--- a/collect/trace_decision.go
+++ b/collect/trace_decision.go
@@ -6,18 +6,32 @@ import (
 	"strings"
 )
 
-func newDroppedDecisionMessage(traceIDs ...string) (string, error) {
+type newDecisionMessage func([]TraceDecision) (string, error)
+
+func newDroppedDecisionMessage(tds []TraceDecision) (string, error) {
+	if len(tds) == 0 {
+		return "", fmt.Errorf("no dropped trace decisions provided")
+	}
+
+	traceIDs := make([]string, 0, len(tds))
+	for _, td := range tds {
+		if td.TraceID != "" {
+			traceIDs = append(traceIDs, td.TraceID)
+		}
+	}
+
 	if len(traceIDs) == 0 {
-		return "", fmt.Errorf("no traceIDs provided")
+		return "", fmt.Errorf("no valid trace IDs provided")
 	}
-	data := strings.Join(traceIDs, ",")
-	return string(data), nil
+
+	return strings.Join(traceIDs, ","), nil
 }
-func newKeptDecisionMessage(td TraceDecision) (string, error) {
-	if td.TraceID == "" {
-		return "", fmt.Errorf("no traceID provided")
+func newKeptDecisionMessage(tds []TraceDecision) (string, error) {
+	if len(tds) == 0 {
+		return "", fmt.Errorf("no kept trace decisions provided")
 	}
-	data, err := json.Marshal(td)
+
+	data, err := json.Marshal(tds)
 	if err != nil {
 		return "", err
 	}
@@ -25,23 +39,28 @@ func newKeptDecisionMessage(td TraceDecision) (string, error) {
 	return string(data), nil
 }
 
-func newDroppedTraceDecision(msg string) []string {
-	var traceIDs []string
+func newDroppedTraceDecision(msg string) ([]TraceDecision, error) {
+	if msg == "" {
+		return nil, fmt.Errorf("empty drop message")
+	}
+	var decisions []TraceDecision
 	for _, traceID := range strings.Split(msg, ",") {
-		traceIDs = append(traceIDs, traceID)
+		decisions = append(decisions, TraceDecision{
+			TraceID: traceID,
+		})
 	}
 
-	return traceIDs
+	return decisions, nil
 }
 
-func newKeptTraceDecision(msg string) (*TraceDecision, error) {
-	keptDecision := &TraceDecision{}
-	err := json.Unmarshal([]byte(msg), keptDecision)
+func newKeptTraceDecision(msg string) ([]TraceDecision, error) {
+	keptDecisions := make([]TraceDecision, 0)
+	err := json.Unmarshal([]byte(msg), &keptDecisions)
 	if err != nil {
 		return nil, err
 	}
 
-	return keptDecision, nil
+	return keptDecisions, nil
 }
 
 type TraceDecision struct {

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -320,6 +320,8 @@ type CollectionConfig struct {
 
 	MaxDropDecisionBatchSize int      `yaml:"MaxDropDecisionBatchSize" default:"1000"`
 	DropDecisionSendInterval Duration `yaml:"DropDecisionSendInterval" default:"1s"`
+	MaxKeptDecisionBatchSize int      `yaml:"MaxKeptDecisionBatchSize" default:"1000"`
+	KeptDecisionSendInterval Duration `yaml:"KeptDecisionSendInterval" default:"100ms"`
 }
 
 // GetMaxAlloc returns the maximum amount of memory to use for the cache.

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -1314,7 +1314,7 @@ groups:
         reload: false
         summary: controls the amount of time Refinery waits after each cluster scaling event before redistributing in-memory traces.
         description: >
-          This value should be longer than the amount of time between individual pod changes in a bulk scaling operation 
+          This value should be longer than the amount of time between individual pod changes in a bulk scaling operation
           (changing the cluster size by more than one pod).
           Each redistribution generates additional traffic between peers.
           If this value is too short, multiple consecutive redistributions will occur and the resulting traffic
@@ -1375,6 +1375,26 @@ groups:
         summary: Interval for sending drop decisions in batches.
         description: >
           Sets the time interval for sending accumulated drop decisions in batches. This ensures that drop decisions are processed at regular intervals, improving efficiency by reducing the frequency of network transmissions. If the maximum batch size (MaxDropDecisionBatchSize) is reached before this interval elapses, the batch will be sent immediately.
+
+      - name: MaxKeptDecisionBatchSize
+        type: int
+        valuetype: nondefault
+        firstversion: v2.9
+        default: 1000
+        reload: false
+        summary: Maximum size for batching kept decisions.
+        description: >
+          Specifies the maximum number of kept decisions that can be batched before triggering processing. This ensures that kept decisions do not accumulate indefinitely, allowing timely and efficient management of spans by processing them in bulk. If the number of kept decisions reaches this limit, the batch will be processed immediately, even if the timeout has not been reached.
+
+      - name: KeptDecisionSendInterval
+        type: duration
+        valuetype: nondefault
+        firstversion: v2.9
+        default: 100ms
+        reload: false
+        summary: Interval for sending kept decisions in batches.
+        description: >
+          Sets the time interval for sending accumulated kept decisions in batches. This ensures that kept decisions are processed at regular intervals, improving efficiency by reducing the frequency of network transmissions. If the maximum batch size (MaxKeptDecisionBatchSize) is reached before this interval elapses, the batch will be sent immediately.
 
   - name: BufferSizes
     title: "Buffer Sizes"


### PR DESCRIPTION
## Which problem is this PR solving?

The throughput of Redis pub/sub is impacted by the number of messages sent per time unit. To improve performance and ensure a higher throughput of kept messages, we need to reduce the number of kept messages sent. 
This PR implements a batching strategy similar to the one used for dropped messages, reducing the frequency of sending individual kept messages.

## Short description of the changes

- Introduced a batching strategy for kept messages, similar to the existing strategy for dropped messages.
- Refactor kept and dropped decision processing to reduce duplicated code

