### PR TITLE
feat: increase KeptDecisionSendInterval default value to 1s

### DIFF
--- a/config/file_config.go
+++ b/config/file_config.go
@@ -323,7 +323,7 @@ type CollectionConfig struct {
 	MaxDropDecisionBatchSize int      `yaml:"MaxDropDecisionBatchSize" default:"1000"`
 	DropDecisionSendInterval Duration `yaml:"DropDecisionSendInterval" default:"1s"`
 	MaxKeptDecisionBatchSize int      `yaml:"MaxKeptDecisionBatchSize" default:"1000"`
-	KeptDecisionSendInterval Duration `yaml:"KeptDecisionSendInterval" default:"100ms"`
+	KeptDecisionSendInterval Duration `yaml:"KeptDecisionSendInterval" default:"1s"`
 }
 
 // GetMaxAlloc returns the maximum amount of memory to use for the cache.

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -1396,7 +1396,7 @@ groups:
         type: duration
         valuetype: nondefault
         firstversion: v2.9
-        default: 100ms
+        default: 1s
         reload: true
         summary: Interval for sending kept decisions in batches.
         description: >


### PR DESCRIPTION
## Which problem is this PR solving?

Allow more efficient batching for publishing kept decisions

## Short description of the changes

- increase default config value to 1s

