### PR TITLE
maint: Update log level for making a trace decision to debug

### DIFF
--- a/collect/collect.go
+++ b/collect/collect.go
@@ -1485,7 +1485,7 @@ func (i *InMemCollector) makeDecision(ctx context.Context, trace *types.Trace, s
 		"send_reason": sendReason,
 		"hasRoot":     hasRoot,
 	})
-	i.Logger.Warn().WithField("key", key).Logf("making decision for trace")
+	i.Logger.Debug().WithField("key", key).Logf("making decision for trace")
 	td := TraceDecision{
 		TraceID:         trace.ID(),
 		Kept:            shouldSend,


### PR DESCRIPTION
## Which problem is this PR solving?

There's a log entry when making a decision that is a warn level, which is too high. Lowering to debug.

## Short description of the changes
- Upate log level for making a decision from warn to debug