### PR TITLE
fix: upgrade husky to 0.32.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/grafana/pyroscope-go/godeltaprof v0.1.8
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/honeycombio/dynsampler-go v0.6.0
-	github.com/honeycombio/husky v0.31.0
+	github.com/honeycombio/husky v0.32.0
 	github.com/honeycombio/libhoney-go v1.23.1
 	github.com/jessevdk/go-flags v1.6.1
 	github.com/jonboulle/clockwork v0.4.0
@@ -63,7 +63,7 @@ require (
 	github.com/facebookgo/structtag v0.0.0-20150214074306-217e25fb9691 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
-	github.com/google/uuid v1.6.0 // indirect
+	github.com/google/uuid v1.6.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.22.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/honeycombio/dynsampler-go v0.6.0 h1:fs4mrfeFGU5V+ClwpblFzbWqn4Apb+lKlE7Ja5zL22I=
 github.com/honeycombio/dynsampler-go v0.6.0/go.mod h1:pJqWFeoMN3syX74PEvlusieyGBbtIBjmTVjLc3thmK4=
-github.com/honeycombio/husky v0.31.0 h1:zcwHeX4ISDP6FwLrj+XPvuSbOKWmWaw6tMHX/nnYTts=
-github.com/honeycombio/husky v0.31.0/go.mod h1:H6pnmxn/TrPL7Rvrz6T7UEyM4/gsvSUJ0BxHSdVDdHs=
+github.com/honeycombio/husky v0.32.0 h1:WehQykmu/Hp4clN9KsGFYRQ74z0PsNfUV8Ua6oxDI+M=
+github.com/honeycombio/husky v0.32.0/go.mod h1:GrgP4xYSUPtUPTOo4pFvsek3/tETLp+kwvySKkMzHtc=
 github.com/honeycombio/libhoney-go v1.23.1 h1:dsZrY7wfnKyBnpQJeW9B+eawDYCZBGtmP06QEcE+YDM=
 github.com/honeycombio/libhoney-go v1.23.1/go.mod h1:mbaBmUkuGwrVa9NdsskMaOzvkYMRbknsfIvavWq+5kA=
 github.com/honeycombio/opentelemetry-proto-go/otlp v1.3.1-compat h1:i9CAIguM5tMQC9xSRihqdFBoh40OBOhuhfR8OrXsZ9o=


### PR DESCRIPTION
## Which problem is this PR solving?

- [This release fixes a bug introduced in v0.31.0 that caused OTel attributes named SampleRate to stop working.](https://github.com/honeycombio/husky/releases/tag/v0.32.0)



## Short description of the changes

- upgrade husky to 0.32.0

