### PR TITLE
fix: Update flaky test

### DIFF
--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -214,7 +214,7 @@ func TestAddRootSpan(t *testing.T) {
 	// * remove the trace from the cache
 	assert.Eventually(t, func() bool {
 		return coll.getFromCache(decisionSpanTraceID) == nil
-	}, conf.GetTracesConfig().GetSendTickerValue()*8, conf.GetTracesConfig().GetSendTickerValue()*2, "after sending the span, it should be removed from the cache")
+	}, time.Second*1, time.Millisecond*100, "after sending the span, it should be removed from the cache")
 
 	events = transmission.GetBlock(0)
 	assert.Equal(t, 0, len(events), "adding a root decision span should send the trace but not the decision span itself")


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes a flaky test we see intermittently in CI.

- Closes #1432 

## Short description of the changes
- Update `TestAddRootSpan`'s flaky test by extending wait for duration and check internval

