### PR TITLE
feat: ignore trace decision messages produced by the publishers

### DIFF
--- a/collect/trace_decision.go
+++ b/collect/trace_decision.go
@@ -120,6 +120,10 @@ func newKeptTraceDecision(msg string, senderID string) ([]TraceDecision, error) 
 }
 
 func isMyDecision(msg string, senderID string) bool {
+	if senderID == "" {
+		return false
+	}
+
 	return strings.HasPrefix(msg, senderID+decisionMessageSeparator)
 }
 

--- a/collect/trace_decision_test.go
+++ b/collect/trace_decision_test.go
@@ -21,12 +21,12 @@ func TestDropDecisionRoundTrip(t *testing.T) {
 	}
 
 	// Step 1: Create a dropped decision message
-	msg, err := newDroppedDecisionMessage(tds)
+	msg, err := newDroppedDecisionMessage(tds, "sender1")
 	assert.NoError(t, err, "expected no error for valid dropped decision message")
 	assert.NotEmpty(t, msg, "expected non-empty message")
 
 	// Step 2: Decompress the message back to TraceDecision using newDroppedTraceDecision
-	decompressedTds, err := newDroppedTraceDecision(msg)
+	decompressedTds, err := newDroppedTraceDecision(msg, "sender1")
 	assert.NoError(t, err, "expected no error during decompression of the dropped decision message")
 	assert.Len(t, decompressedTds, len(tds), "expected decompressed TraceDecision length to match original")
 
@@ -68,12 +68,12 @@ func TestKeptDecisionRoundTrip(t *testing.T) {
 	}
 
 	// Step 1: Create a kept decision message
-	msg, err := newKeptDecisionMessage(tds)
+	msg, err := newKeptDecisionMessage(tds, "sender1")
 	assert.NoError(t, err, "expected no error for valid kept decision message")
 	assert.NotEmpty(t, msg, "expected non-empty message")
 
 	// Step 2: Decompress the message back to TraceDecision using newKeptTraceDecision
-	decompressedTds, err := newKeptTraceDecision(msg)
+	decompressedTds, err := newKeptTraceDecision(msg, "sender1")
 	assert.NoError(t, err, "expected no error during decompression of the kept decision message")
 	assert.Len(t, decompressedTds, len(tds), "expected decompressed TraceDecision length to match original")
 
@@ -123,7 +123,7 @@ func BenchmarkDynamicCompressedEncoding(b *testing.B) {
 	// Run the benchmark
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := newKeptDecisionMessage(decisions)
+		_, err := newKeptDecisionMessage(decisions, "sender1")
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -132,14 +132,14 @@ func BenchmarkDynamicCompressedEncoding(b *testing.B) {
 
 func BenchmarkDynamicJSONDecoding(b *testing.B) {
 	decisions := generateRandomDecisions(1000)
-	jsonData, err := newKeptDecisionMessage(decisions)
+	jsonData, err := newKeptDecisionMessage(decisions, "sender1")
 	if err != nil {
 		b.Fatal(err)
 	}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := newKeptTraceDecision(jsonData)
+		_, err := newKeptTraceDecision(jsonData, "sender1")
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -148,14 +148,14 @@ func BenchmarkDynamicJSONDecoding(b *testing.B) {
 
 func BenchmarkDynamicCompressedDecoding(b *testing.B) {
 	decisions := generateRandomDecisions(1000)
-	compressedData, err := newKeptDecisionMessage(decisions)
+	compressedData, err := newKeptDecisionMessage(decisions, "sender1")
 	if err != nil {
 		b.Fatal(err)
 	}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := newKeptTraceDecision(compressedData)
+		_, err := newKeptTraceDecision(compressedData, "sender1")
 		if err != nil {
 			b.Fatal(err)
 		}


### PR DESCRIPTION
## Which problem is this PR solving?

collect loop iteration is precious to make sure Refinery is able to process incoming data as soon as possible. Trace decision pubsub messages are broadcasted to all peers including the publisher itself. There's no need for the publisher to process those messages since it already knows about those trace decisions.

## Short description of the changes

- prefix each decision messages with the peer ID. I didn't include it into the compression logic. That way we can skip the whole decompression process for a message if we know it's produced by its publisher
- ignore decision messages in the pubsub callback before we ask the collect loop to process them

