### PR TITLE
feat: add a limit to queue draining logic

### DIFF
--- a/collect/collect.go
+++ b/collect/collect.go
@@ -1576,6 +1576,7 @@ func (i *InMemCollector) publishTraceDecision(ctx context.Context, td TraceDecis
 
 	if td.Kept {
 		select {
+		case <-i.done:
 		case i.keptDecisionBuffer <- td:
 		default:
 			i.Metrics.Increment("collector_kept_decisions_queue_full")
@@ -1584,6 +1585,7 @@ func (i *InMemCollector) publishTraceDecision(ctx context.Context, td TraceDecis
 		return
 	} else {
 		select {
+		case <-i.done:
 		case i.dropDecisionBuffer <- td:
 		default:
 			i.Metrics.Increment("collector_drop_decisions_queue_full")


### PR DESCRIPTION
## Which problem is this PR solving?

The timer may never fire due to Go scheduler starving the timer goroutine.
To prevent the timer being starved, this PR adds a limit to the number of spans being processed during one iteration of the collect loop

## Short description of the changes

- add a limit to the draining logic

