### PR TITLE
feat: Rename EnableTraceLocality to DisableTraceLocality

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -118,10 +118,9 @@ func defaultConfig(basePort int, redisDB int) *config.MockConfig {
 		GetPeerListenAddrVal:     "127.0.0.1:" + strconv.Itoa(basePort+1),
 		GetHoneycombAPIVal:       "http://api.honeycomb.io",
 		GetCollectionConfigVal: config.CollectionConfig{
-			CacheCapacity:       10000,
-			ShutdownDelay:       config.Duration(1 * time.Second),
-			HealthCheckTimeout:  config.Duration(3 * time.Second),
-			EnableTraceLocality: true,
+			CacheCapacity:      10000,
+			ShutdownDelay:      config.Duration(1 * time.Second),
+			HealthCheckTimeout: config.Duration(3 * time.Second),
 		},
 		TraceIdFieldNames:  []string{"trace.trace_id"},
 		ParentIdFieldNames: []string{"trace.parent_id"},
@@ -767,7 +766,7 @@ func TestPeerRouting_TraceLocalityDisabled(t *testing.T) {
 		redisDB := 12 + i
 		cfg := defaultConfig(basePort, redisDB)
 		collectionCfg := cfg.GetCollectionConfig()
-		collectionCfg.EnableTraceLocality = false
+		collectionCfg.DisableTraceLocality = true
 		cfg.GetCollectionConfigVal = collectionCfg
 
 		apps[i], graph = newStartedApp(t, senders[i], nil, peers, cfg)

--- a/collect/stressRelief.go
+++ b/collect/stressRelief.go
@@ -424,12 +424,12 @@ func (s *StressRelief) Recalc() uint {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	overallStressLevel := clusterStressLevel
+	// The overall stress level is the max of the individual and cluster stress levels
+	// If a single node is under significant stress, it can activate stress relief mode
+	overallStressLevel := uint(math.Max(float64(clusterStressLevel), float64(localLevel)))
 
-	if s.Config.GetCollectionConfig().EnableTraceLocality {
-		// The overall stress level is the max of the individual and cluster stress levels
-		// If a single node is under significant stress, it can activate stress relief mode
-		overallStressLevel = uint(math.Max(float64(clusterStressLevel), float64(localLevel)))
+	if s.Config.GetCollectionConfig().DisableTraceLocality {
+		overallStressLevel = clusterStressLevel
 	}
 	s.overallStressLevel = overallStressLevel
 	s.RefineryMetrics.Gauge("stress_level", s.overallStressLevel)

--- a/collect/stress_relief_test.go
+++ b/collect/stress_relief_test.go
@@ -135,7 +135,7 @@ func TestStressRelief_Peer(t *testing.T) {
 	}, 2*time.Second, 100*time.Millisecond, "stress relief should be false")
 }
 
-func TestStressRelief_OverallStressLevel(t *testing.T) {
+func TestStressRelief_OverallStressLevel_DisableTraceLocality(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 	sr, stop := newStressRelief(t, clock, nil)
 	defer stop()
@@ -156,6 +156,9 @@ func TestStressRelief_OverallStressLevel(t *testing.T) {
 			ActivationLevel:           80,
 			DeactivationLevel:         65,
 			MinimumActivationDuration: config.Duration(5 * time.Second),
+		},
+		GetCollectionConfigVal: config.CollectionConfig{
+			DisableTraceLocality: true,
 		},
 	}
 	// On startup, the stress relief should not be active
@@ -238,9 +241,6 @@ func TestStressRelief_OverallStressLevel_EnableTraceLocality(t *testing.T) {
 			ActivationLevel:           80,
 			DeactivationLevel:         65,
 			MinimumActivationDuration: config.Duration(5 * time.Second),
-		},
-		GetCollectionConfigVal: config.CollectionConfig{
-			EnableTraceLocality: true,
 		},
 	}
 	// On startup, the stress relief should not be active

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -317,8 +317,8 @@ type CollectionConfig struct {
 	DisableRedistribution bool     `yaml:"DisableRedistribution"`
 	RedistributionDelay   Duration `yaml:"RedistributionDelay" default:"30s"`
 
-	ShutdownDelay       Duration `yaml:"ShutdownDelay" default:"15s"`
-	EnableTraceLocality bool     `yaml:"EnableTraceLocality"`
+	ShutdownDelay        Duration `yaml:"ShutdownDelay" default:"15s"`
+	DisableTraceLocality bool     `yaml:"DisableTraceLocality"`
 
 	MaxDropDecisionBatchSize int      `yaml:"MaxDropDecisionBatchSize" default:"1000"`
 	DropDecisionSendInterval Duration `yaml:"DropDecisionSendInterval" default:"1s"`

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -489,9 +489,9 @@ groups:
           `meta.refinery.dryrun.sample_rate` will be set to the sample rate
           that would have been used.
 
-          NOTE: This settng is not compatible with `EnableTraceLocality` set to
-          false because drop trace decisions shared among peers does not contain
-          all relevant information to send traces to Honeycomb.
+          NOTE: This setting is not compatible with `DisableTraceLocality=true`,
+          because drop trace decisions shared among peers do not contain all
+          the relevant information needed to send traces to Honeycomb.
 
   - name: Logger
     title: "Refinery Logger"
@@ -1348,9 +1348,18 @@ groups:
         reload: false
         summary: controls whether all spans that belongs to the same trace are sent to a single Refinery for processing.
         description: >
-          If `true`, Refinery's will route all spans that belongs to the same trace to a single peer.
+          When `false`, Refinery will route all spans that belong to the same trace to a single peer. This is the
+          default behavior ("Trace Locality") and the way Refinery has worked in the past. When `true`, Refinery
+          will instead keep spans on the node where they were received, and forward proxy spans that contain only
+          the key information needed to make a trace decision. This can reduce the amount of traffic between peers
+          in most cases, and can help avoid a situation where a single large trace can cause a memory overrun on
+          a single node.
 
-          NOTE: This setting is not compatible with `DryRun` when set to false. See `DryRun` for more information.
+          If `true`, the amount of traffic between peers will be reduced, but the amount of traffic between Refinery
+          and Redis will significantly increase, because Refinery uses Redis to distribute the trace decisions to all
+          nodes in the cluster. It is important to adjust the size of the Redis cluster in this case.
+
+          NOTE: This setting is not compatible with `DryRun` when set to true. See `DryRun` for more information.
 
       - name: HealthCheckTimeout
         type: duration

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -1340,7 +1340,7 @@ groups:
           This value should be set to a bit less than the normal timeout period
           for shutting down without forcibly terminating the process.
 
-      - name: EnableTraceLocality
+      - name: DisableTraceLocality
         type: bool
         valuetype: nondefault
         firstversion: v2.9

--- a/route/route.go
+++ b/route/route.go
@@ -614,7 +614,7 @@ func (r *Router) processEvent(ev *types.Event, reqID interface{}) error {
 		}
 	}
 
-	if r.Config.GetCollectionConfig().EnableTraceLocality {
+	if !r.Config.GetCollectionConfig().DisableTraceLocality {
 		// Figure out if we should handle this span locally or pass on to a peer
 		targetShard := r.Sharder.WhichShard(traceID)
 		if !targetShard.Equals(r.Sharder.MyShard()) {


### PR DESCRIPTION
## Which problem is this PR solving?

To allow users to opt-in safely for disabling trace locality, we're renaming the option to disable trace locality.

## Short description of the changes
- Rename `EnableTraceLocality` to `DisableTraceLocality`