### PR TITLE
maint: clean up sampler log entry

### DIFF
--- a/sample/sample.go
+++ b/sample/sample.go
@@ -45,10 +45,9 @@ func (s *SamplerFactory) updatePeerCounts() {
 	// all the samplers who want it should use the stored count
 	for _, sampler := range s.samplers {
 		if clusterSizer, ok := sampler.(ClusterSizer); ok {
-			s.Logger.Warn().Logf("set cluster size to %d", s.peerCount)
 			clusterSizer.SetClusterSize(s.peerCount)
 		} else {
-			s.Logger.Warn().Logf("sampler does not implement ClusterSizer")
+			s.Logger.Debug().Logf("sampler does not implement ClusterSizer")
 		}
 	}
 }


### PR DESCRIPTION
## Which problem is this PR solving?

- We already have a signal for cluster size change. We don't need to log this in sampler as well.

## Short description of the changes

- remove the log for cluster size change
- change the interface assertion log to debug

