### PR TITLE
fix: missing read lock in MapWithTTL

### DIFF
--- a/generics/mapttl.go
+++ b/generics/mapttl.go
@@ -113,6 +113,9 @@ func (m *MapWithTTL[K, V]) Values() []V {
 // SortedValues returns the values of the map, sorted by key
 func (m *MapWithTTL[K, V]) SortedValues() []V {
 	keys := m.SortedKeys()
+
+	m.mut.RLock()
+	defer m.mut.RUnlock()
 	values := make([]V, 0, len(keys))
 	for _, k := range keys {
 		values = append(values, m.Items[k].Value)


### PR DESCRIPTION
## Which problem is this PR solving?

```
fatal error: concurrent map read and map write

goroutine 193 [running]:
github.com/honeycombio/refinery/generics.(*MapWithTTL[...]).SortedValues(0xdd8a60)
	github.com/honeycombio/refinery/generics/mapttl.go:118 +0xcc
github.com/honeycombio/refinery/internal/peer.(*RedisPubsubPeers).Ready.func1()
	github.com/honeycombio/refinery/internal/peer/pubsub_redis.go:212 +0x454
created by github.com/honeycombio/refinery/internal/peer.(*RedisPubsubPeers).Ready in goroutine 1
	github.com/honeycombio/refinery/internal/peer/pubsub_redis.go:180 +0x84

```

## Short description of the changes

- add `RLock` for `SortedValues`

