### PR TITLE
maint: remove trace cache metrics

### DIFF
--- a/collect/cache/cache.go
+++ b/collect/cache/cache.go
@@ -56,10 +56,6 @@ var collectCacheMetrics = []metrics.Metadata{
 	{Name: "collect_cache_buffer_overrun", Type: metrics.Counter, Unit: metrics.Dimensionless, Description: "The number of times the trace overwritten in the circular buffer has not yet been sent"},
 	{Name: "collect_cache_capacity", Type: metrics.Gauge, Unit: metrics.Dimensionless, Description: "The number of traces that can be stored in the cache"},
 	{Name: "collect_cache_entries", Type: metrics.Histogram, Unit: metrics.Dimensionless, Description: "The number of traces currently stored in the cache"},
-	{Name: "trace_cache_set_dur_ms", Type: metrics.Histogram, Unit: metrics.Dimensionless, Description: "duration to set a trace in the cache"},
-	{Name: "trace_cache_take_expired_traces_dur_ms", Type: metrics.Histogram, Unit: metrics.Dimensionless, Description: "duration to take expired traces from the cache"},
-	{Name: "trace_cache_remove_traces_dur_ms", Type: metrics.Histogram, Unit: metrics.Dimensionless, Description: "duration to remove traces from the cache"},
-	{Name: "trace_cache_get_all_dur_ms", Type: metrics.Histogram, Unit: metrics.Dimensionless, Description: "duration to get all traces from the cache"},
 }
 
 func NewInMemCache(
@@ -95,9 +91,7 @@ func (d *DefaultInMemCache) Set(trace *types.Trace) {
 	if trace == nil {
 		return
 	}
-	start := time.Now()
 
-	defer d.Metrics.Histogram("trace_cache_set_dur_ms", float64(time.Since(start).Microseconds())/1000.0)
 	// update the cache and priority queue
 	d.cache[trace.TraceID] = trace
 	d.pq.Set(trace.TraceID, trace.SendBy)
@@ -111,9 +105,6 @@ func (d *DefaultInMemCache) Get(traceID string) *types.Trace {
 // GetAll is not thread safe and should only be used when that's ok
 // Returns all non-nil trace entries.
 func (d *DefaultInMemCache) GetAll() []*types.Trace {
-	start := time.Now()
-
-	defer d.Metrics.Histogram("trace_cache_get_all_dur_ms", float64(time.Since(start).Microseconds())/1000.0)
 	return maps.Values(d.cache)
 }
 
@@ -126,9 +117,6 @@ func (d *DefaultInMemCache) GetCacheCapacity() int {
 // If a filter is provided, it will be called with each trace to determine if it should be skipped.
 func (d *DefaultInMemCache) TakeExpiredTraces(now time.Time, max int, filter func(*types.Trace) bool) []*types.Trace {
 	d.Metrics.Histogram("collect_cache_entries", float64(len(d.cache)))
-
-	start := time.Now()
-	defer d.Metrics.Histogram("trace_cache_take_expired_traces_dur_ms", float64(time.Since(start).Microseconds())/1000.0)
 
 	var expired, skipped []*types.Trace
 	for !d.pq.IsEmpty() && (max <= 0 || len(expired) < max) {
@@ -173,8 +161,6 @@ func (d *DefaultInMemCache) TakeExpiredTraces(now time.Time, max int, filter fun
 // the insertion list. This is used in the case of a cache overrun.
 func (d *DefaultInMemCache) RemoveTraces(toDelete generics.Set[string]) {
 	d.Metrics.Histogram("collect_cache_entries", float64(len(d.cache)))
-	start := time.Now()
-	defer d.Metrics.Histogram("trace_cache_remove_traces_dur_ms", float64(time.Since(start).Microseconds())/1000.0)
 
 	for _, traceID := range toDelete.Members() {
 		delete(d.cache, traceID)


### PR DESCRIPTION
## Which problem is this PR solving?

we are not using these metrics.
By removing them, we should also gain some CPU time back. Though, this is not the driver for this change.

## Short description of the changes

- removing histogram metrics from trace cache

