### PR TITLE
maint: remove unused collect_cache metrics

### DIFF
--- a/collect/cache/cache.go
+++ b/collect/cache/cache.go
@@ -53,8 +53,6 @@ type DefaultInMemCache struct {
 const DefaultInMemCacheCapacity = 10000
 
 var collectCacheMetrics = []metrics.Metadata{
-	{Name: "collect_cache_buffer_overrun", Type: metrics.Counter, Unit: metrics.Dimensionless, Description: "The number of times the trace overwritten in the circular buffer has not yet been sent"},
-	{Name: "collect_cache_capacity", Type: metrics.Gauge, Unit: metrics.Dimensionless, Description: "The number of traces that can be stored in the cache"},
 	{Name: "collect_cache_entries", Type: metrics.Histogram, Unit: metrics.Dimensionless, Description: "The number of traces currently stored in the cache"},
 }
 

--- a/collect/collect.go
+++ b/collect/collect.go
@@ -294,8 +294,8 @@ func (i *InMemCollector) checkAlloc(ctx context.Context) {
 	// successive traces until we've crossed the totalToRemove threshold
 	// or just run out of traces to delete.
 
-	cap := i.cache.GetCacheCapacity()
-	i.Metrics.Gauge("collector_cache_size", cap)
+	cacheSize := len(allTraces)
+	i.Metrics.Gauge("collector_cache_size", cacheSize)
 
 	totalDataSizeSent := 0
 	tracesSent := generics.NewSet[string]()
@@ -325,7 +325,7 @@ func (i *InMemCollector) checkAlloc(ctx context.Context) {
 
 	// Treat any MaxAlloc overage as an error so we know it's happening
 	i.Logger.Warn().
-		WithField("cache_size", cap).
+		WithField("cache_size", cacheSize).
 		WithField("alloc", mem.Alloc).
 		WithField("num_traces_sent", len(tracesSent)).
 		WithField("datasize_sent", totalDataSizeSent).

--- a/metrics.md
+++ b/metrics.md
@@ -1,7 +1,7 @@
 # Honeycomb Refinery Metrics Documentation
 
 This document contains the description of various metrics used in Refinery.
-It was automatically generated on 2024-11-25 at 17:24:16 UTC.
+It was automatically generated on 2024-12-02 at 18:38:37 UTC.
 
 Note: This document does not include metrics defined in the dynsampler-go dependency, as those metrics are generated dynamically at runtime. As a result, certain metrics may be missing or incomplete in this document, but they will still be available during execution with their full names.
 
@@ -10,8 +10,6 @@ This table includes metrics with fully defined names.
 
 | Name | Type | Unit | Description |
 |------|------|------|-------------|
-| collect_cache_buffer_overrun | Counter | Dimensionless | The number of times the trace overwritten in the circular buffer has not yet been sent |
-| collect_cache_capacity | Gauge | Dimensionless | The number of traces that can be stored in the cache |
 | collect_cache_entries | Histogram | Dimensionless | The number of traces currently stored in the cache |
 | cuckoo_current_capacity | Gauge | Dimensionless | current capacity of the cuckoo filter |
 | cuckoo_future_load_factor | Gauge | Percent | the fraction of slots occupied in the future cuckoo filter |

--- a/tools/convert/metrics.go
+++ b/tools/convert/metrics.go
@@ -95,7 +95,6 @@ func GenerateMetricsMetadata() error {
 											continue
 										}
 										if slices.Contains(packagesContainsPrefix, pkg.Name) {
-											fmt.Println("name", pkg.Name)
 											usages.HasPrefix = append(usages.HasPrefix, usage)
 										} else {
 											usages.Complete = append(usages.Complete, usage)

--- a/tools/convert/metricsMeta.yaml
+++ b/tools/convert/metricsMeta.yaml
@@ -1,12 +1,4 @@
 complete:
-    - name: collect_cache_buffer_overrun
-      type: Counter
-      unit: Dimensionless
-      description: The number of times the trace overwritten in the circular buffer has not yet been sent
-    - name: collect_cache_capacity
-      type: Gauge
-      unit: Dimensionless
-      description: The number of traces that can be stored in the cache
     - name: collect_cache_entries
       type: Histogram
       unit: Dimensionless


### PR DESCRIPTION
## Which problem is this PR solving?

- With the new priority queue based trace cache implementation, we no longer need to monitor cache capacity and buffer overrun 

## Short description of the changes

- remove `collect_cache_capacity` ad `collect_cache_buffer_overrun`

