### PR TITLE
fix: error from logrus when sending a trace

### DIFF
--- a/collect/collect.go
+++ b/collect/collect.go
@@ -1014,7 +1014,7 @@ func (i *InMemCollector) send(ctx context.Context, trace *types.Trace, td *Trace
 	} else {
 		logFields["environment"] = td.SamplerSelector
 	}
-	logFields["reason"] = td.KeptReason
+	logFields["reason"] = td.Reason
 	if td.SamplerKey != "" {
 		logFields["sample_key"] = td.SamplerKey
 	}


### PR DESCRIPTION
## Which problem is this PR solving?

Attempts to address issue honeycombio/refinery#1477 

## Short description of the changes

In `collect.go`, it changes values passed to logger so as to avoid an error in logrus lib (see issue for repro steps). Begins passing a string value to `logFields` map where currently a function ref is being passed. From looking at [logrus source at this line](https://github.com/sirupsen/logrus/blob/master/entry.go#L135), it seems the library treats passing functions or function pointers as an error.

The code was passing `td.KeptReason` function pointer to logger, but I've made the assumption that the intended value was actually the `td.Reason` string. This assumption is based on the logFields map using key of `"reason"` (rather than it using `"keptReason"`) and also that it is `td.Reason` being subsequently passed to `sendableTrace{...}`. 

Was unclear where to add a unit test as anywhere I began writing one it just felt like I was testing logrus directly, rather than refinery, but happy to be advised on best place for a test.

