### PR TITLE
fix: don't assume attribute type in oteltracing

### DIFF
--- a/cmd/refinery/main.go
+++ b/cmd/refinery/main.go
@@ -249,6 +249,12 @@ func main() {
 				span.SetAttributes(attribute.String(key, v))
 			case bool:
 				span.SetAttributes(attribute.Bool(key, v))
+			case int:
+				span.SetAttributes(attribute.Int(key, v))
+			case float64:
+				span.SetAttributes(attribute.Float64(key, v))
+			default:
+				span.SetAttributes(attribute.String(key, fmt.Sprintf("%v", v)))
 			}
 		}
 	}

--- a/cmd/refinery/main.go
+++ b/cmd/refinery/main.go
@@ -244,7 +244,12 @@ func main() {
 		// add telemetry callback so husky can enrich spans with attributes
 		husky.AddTelemetryAttributeFunc = func(ctx context.Context, key string, value any) {
 			span := trace.SpanFromContext(ctx)
-			span.SetAttributes(attribute.String(key, value.(string)))
+			switch v := value.(type) {
+			case string:
+				span.SetAttributes(attribute.String(key, v))
+			case bool:
+				span.SetAttributes(attribute.Bool(key, v))
+			}
 		}
 	}
 	defer shutdown()


### PR DESCRIPTION
## Which problem is this PR solving?

When a non-string type value is passed in to the `AddTelemetryAttributeFunc` when `OTELTracing` is enabled, Refinery currently panics

## Short description of the changes

- don't assume the attribute type

