### PR TITLE
feat: Try sync.pool to manage events

### DIFF
--- a/transmit/transmit.go
+++ b/transmit/transmit.go
@@ -134,6 +134,7 @@ func (d *DefaultTransmission) EnqueueEvent(ev *types.Event) {
 			Logf("failed to enqueue event")
 	}
 	d.Metrics.Up(updownQueuedItems)
+	types.DisposeEvent(ev)
 }
 
 func (d *DefaultTransmission) EnqueueSpan(sp *types.Span) {


### PR DESCRIPTION
## Which problem is this PR solving?

Tries out using a `sync.pool` to manage Event structs, which is the most commonly allocated and deallocated struct.

I chose to pool Event as that's where the variable size `map[string]any` lives and can also then be used for non-span data that gets passed through Refinery (eg regular events and logs with no Trace ID).

Could try pooling span instead if we wanted to make the interfaces a little cleaner.

## Short description of the changes

-

