### PR TITLE
fix: dropped_from_stress description

### DIFF
--- a/collect/collect.go
+++ b/collect/collect.go
@@ -149,7 +149,7 @@ var inMemCollectorMetrics = []metrics.Metadata{
 	{Name: TraceSendEjectedMemsize, Type: metrics.Counter, Unit: metrics.Dimensionless, Description: "number of traces that are ready for decision due to memory overrun"},
 	{Name: TraceSendLateSpan, Type: metrics.Counter, Unit: metrics.Dimensionless, Description: "number of spans that are sent due to late span arrival"},
 
-	{Name: "dropped_from_stress", Type: metrics.Counter, Unit: metrics.Dimensionless, Description: "number of traces dropped due to stress relief"},
+	{Name: "dropped_from_stress", Type: metrics.Counter, Unit: metrics.Dimensionless, Description: "number of spans dropped due to stress relief"},
 	{Name: "trace_kept_sample_rate", Type: metrics.Histogram, Unit: metrics.Dimensionless, Description: "sample rate of kept traces"},
 	{Name: "trace_aggregate_sample_rate", Type: metrics.Histogram, Unit: metrics.Dimensionless, Description: "aggregate sample rate of both kept and dropped traces"},
 	{Name: "collector_redistribute_traces_duration_ms", Type: metrics.Histogram, Unit: metrics.Milliseconds, Description: "duration of redistributing traces to peers"},

--- a/metrics.md
+++ b/metrics.md
@@ -55,7 +55,7 @@ This table includes metrics with fully defined names.
 | trace_send_ejected_full | Counter | Dimensionless | number of traces that are ready for decision due to cache capacity overrun |
 | trace_send_ejected_memsize | Counter | Dimensionless | number of traces that are ready for decision due to memory overrun |
 | trace_send_late_span | Counter | Dimensionless | number of spans that are sent due to late span arrival |
-| dropped_from_stress | Counter | Dimensionless | number of traces dropped due to stress relief |
+| dropped_from_stress | Counter | Dimensionless | number of spans dropped due to stress relief |
 | trace_kept_sample_rate | Histogram | Dimensionless | sample rate of kept traces |
 | trace_aggregate_sample_rate | Histogram | Dimensionless | aggregate sample rate of both kept and dropped traces |
 | collector_redistribute_traces_duration_ms | Histogram | Milliseconds | duration of redistributing traces to peers |

--- a/tools/convert/metricsMeta.yaml
+++ b/tools/convert/metricsMeta.yaml
@@ -182,7 +182,7 @@ complete:
     - name: dropped_from_stress
       type: Counter
       unit: Dimensionless
-      description: number of traces dropped due to stress relief
+      description: number of spans dropped due to stress relief
     - name: trace_kept_sample_rate
       type: Histogram
       unit: Dimensionless


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- The "dropped_from_stress" metric says it's counting traces but counts spans.

## Short description of the changes

- Fix the description

