### PR TITLE
Yingrong/refinery opamp health

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -67,7 +67,7 @@ func (a *App) Start() error {
 
 	// only enable the opamp agent if it's configured
 	if a.Config.GetOpAMPConfig().Enabled {
-		a.opampAgent = agent.NewAgent(agent.Logger{Logger: a.Logger}, a.Version, a.Config)
+		a.opampAgent = agent.NewAgent(agent.Logger{Logger: a.Logger}, a.Version, a.Config, a.Metrics, a.IncomingRouter.Health)
 	}
 
 	return nil

--- a/internal/health/mock.go
+++ b/internal/health/mock.go
@@ -1,0 +1,33 @@
+package health
+
+import "sync"
+
+type MockHealthReporter struct {
+	isAlive bool
+	isReady bool
+	mutex   sync.Mutex
+}
+
+func (m *MockHealthReporter) SetAlive(isAlive bool) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.isAlive = isAlive
+}
+
+func (m *MockHealthReporter) IsAlive() bool {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	return m.isAlive
+}
+
+func (m *MockHealthReporter) SetReady(isReady bool) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.isReady = isReady
+}
+
+func (m *MockHealthReporter) IsReady() bool {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	return m.isReady
+}


### PR DESCRIPTION
## Which problem is this PR solving?

Report Refinery health status through opamp

## Short description of the changes

- run health check on a ticker in refinery opamp agent
- add tests
- I also started working on adding metrics and custom message capability. I probably should split those changes out into a separate PR

