### PR TITLE
feat: record bytes_received metrics for traces and logs signal

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -214,7 +214,7 @@ func TestReload(t *testing.T) {
 	watcher := &configwatcher.ConfigWatcher{
 		Config: c,
 		PubSub: pubsub,
-		Logger: &logger.StdoutLogger{},
+		Logger: &logger.NullLogger{},
 	}
 	watcher.Start()
 	defer watcher.Stop()

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/honeycombio/refinery/config"
 	"github.com/honeycombio/refinery/internal/configwatcher"
+	"github.com/honeycombio/refinery/logger"
 	"github.com/honeycombio/refinery/pubsub"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -213,6 +214,7 @@ func TestReload(t *testing.T) {
 	watcher := &configwatcher.ConfigWatcher{
 		Config: c,
 		PubSub: pubsub,
+		Logger: &logger.StdoutLogger{},
 	}
 	watcher.Start()
 	defer watcher.Stop()

--- a/metrics/multi_metrics.go
+++ b/metrics/multi_metrics.go
@@ -76,6 +76,9 @@ func (m *MultiMetrics) Increment(name string) { // for counters
 	for _, ch := range m.children {
 		ch.Increment(name)
 	}
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	m.values[name]++
 }
 
 func (m *MultiMetrics) Gauge(name string, val interface{}) { // for gauges
@@ -91,6 +94,9 @@ func (m *MultiMetrics) Count(name string, n interface{}) { // for counters
 	for _, ch := range m.children {
 		ch.Count(name, n)
 	}
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	m.values[name] += ConvertNumeric(n)
 }
 
 func (m *MultiMetrics) Histogram(name string, obs interface{}) { // for histogram

--- a/metrics/multi_metrics.go
+++ b/metrics/multi_metrics.go
@@ -12,9 +12,9 @@ var _ Metrics = (*MultiMetrics)(nil)
 // underlying metrics provider (StoreMetrics). It can be configured to send
 // metrics to multiple providers at once.
 //
-// It also stores the values saved with Store(), gauges, and updown counters,
-// which can then be retrieved with Get(). This is for use with StressRelief. It
-// does not track histograms or counters, which are reset after each scrape.
+// It also stores the values saved with Store(), counters, gauges, and updown counters,
+// which can then be retrieved with Get(). This is for use with StressRelief and OpAMP agent. It
+// does not track histograms, which are reset after each scrape.
 type MultiMetrics struct {
 	Config        config.Config `inject:""`
 	LegacyMetrics Metrics       `inject:"legacyMetrics"`

--- a/metrics/multi_metrics_test.go
+++ b/metrics/multi_metrics_test.go
@@ -91,10 +91,10 @@ func TestMultiMetrics_Register(t *testing.T) {
 	mm.Down("updown")
 	mm.Gauge("gauge", 42)
 
-	// counter should be 0 because it's not tracked by StoreMetrics
+	// counter should be 1 because it's tracked by StoreMetrics
 	val, ok := mm.Get("counter")
 	assert.True(t, ok)
-	assert.Equal(t, 0, int(val))
+	assert.Equal(t, 1, int(val))
 
 	// updown should be 2 because it's tracked by StoreMetrics
 	val, ok = mm.Get("updown")

--- a/route/route.go
+++ b/route/route.go
@@ -134,6 +134,8 @@ var routerMetrics = []metrics.Metadata{
 	{Name: "_router_peer", Type: metrics.Counter, Unit: metrics.Dimensionless, Description: "the number of spans proxied to a peer"},
 	{Name: "_router_batch", Type: metrics.Counter, Unit: metrics.Dimensionless, Description: "the number of batches of events received"},
 	{Name: "_router_otlp", Type: metrics.Counter, Unit: metrics.Dimensionless, Description: "the number of batches of otlp requests received"},
+	{Name: "bytes_received_traces", Type: metrics.Counter, Unit: metrics.Bytes, Description: "the number of bytes received in trace events"},
+	{Name: "bytes_received_logs", Type: metrics.Counter, Unit: metrics.Bytes, Description: "the number of bytes received in log events"},
 }
 
 // LnS spins up the Listen and Serve portion of the router. A router is
@@ -161,7 +163,9 @@ func (r *Router) LnS(incomingOrPeer string) {
 	}
 
 	for _, metric := range routerMetrics {
-		metric.Name = r.incomingOrPeer + metric.Name
+		if strings.HasPrefix(metric.Name, "_") {
+			metric.Name = r.incomingOrPeer + metric.Name
+		}
 		r.Metrics.Register(metric)
 	}
 
@@ -600,6 +604,14 @@ func (r *Router) processEvent(ev *types.Event, reqID interface{}) error {
 		Event:   *ev,
 		TraceID: traceID,
 		IsRoot:  isRootSpan(ev, r.Config),
+	}
+
+	if r.incomingOrPeer == "incoming" {
+		if span.Data["meta.signal_type"] == "log" {
+			r.Metrics.Count("bytes_received_logs", span.GetDataSize())
+		} else {
+			r.Metrics.Count("bytes_received_traces", span.GetDataSize())
+		}
 	}
 
 	// we know we're a span, but we need to check if we're in Stress Relief mode;

--- a/route/route.go
+++ b/route/route.go
@@ -606,7 +606,8 @@ func (r *Router) processEvent(ev *types.Event, reqID interface{}) error {
 		IsRoot:  isRootSpan(ev, r.Config),
 	}
 
-	if r.incomingOrPeer == "incoming" {
+	// only record bytes received for incoming traffic when opamp is enabled
+	if r.incomingOrPeer == "incoming" && r.Config.GetOpAMPConfig().Enabled {
 		if span.Data["meta.signal_type"] == "log" {
 			r.Metrics.Count("bytes_received_logs", span.GetDataSize())
 		} else {


### PR DESCRIPTION
## Which problem is this PR solving?

- Add a new `bytes_received_*` metric for both trace and log signal so that we can retrieve it later in our opamp agent

## Short description of the changes

- Record `bytes_received` only for `incoming` data before the logic to route peer traffic. This is to prevent double counting peer traffic.
- Store counter values in `multi_metrics` so that metrics value can be retrieved later

