### PR TITLE
feat: only send one datapoint per signal in usage report

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -218,9 +218,8 @@ func (agent *Agent) healthCheck() {
 				agent.logger.Errorf(context.Background(), "unexpected missing log usage metric")
 			}
 
-			now := agent.clock.Now()
-			agent.usageTracker.Add(newTraceCumulativeUsage(traceUsage, now))
-			agent.usageTracker.Add(newLogCumulativeUsage(logUsage, now))
+			agent.usageTracker.Add(signal_traces, traceUsage)
+			agent.usageTracker.Add(signal_logs, logUsage)
 		}
 	}
 }
@@ -248,7 +247,7 @@ func (agent *Agent) reportUsagePeriodically() {
 }
 
 func (agent *Agent) sendUsageReport() error {
-	usageReport, err := agent.usageTracker.NewReport(agent.agentType, agent.agentVersion, agent.hostname)
+	usageReport, err := agent.usageTracker.NewReport(agent.agentType, agent.agentVersion, agent.hostname, agent.clock.Now())
 	if err != nil {
 		return err
 	}

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/honeycombio/refinery/internal/health"
 	"github.com/honeycombio/refinery/logger"
 	"github.com/honeycombio/refinery/metrics"
+	"github.com/jonboulle/clockwork"
 	"github.com/open-telemetry/opamp-go/client"
 	"github.com/open-telemetry/opamp-go/client/types"
 	"github.com/open-telemetry/opamp-go/protobufs"
@@ -147,6 +148,7 @@ func TestAgentUsageReport(t *testing.T) {
 		metrics:         &metrics.NullMetrics{},
 		health:          &health.MockHealthReporter{},
 		usageTracker:    newUsageTracker(),
+		clock:           clockwork.NewRealClock(),
 	}
 	agent.createAgentIdentity()
 	agent.hostname = "my-hostname"
@@ -157,18 +159,18 @@ func TestAgentUsageReport(t *testing.T) {
 	mockClient.On("SendCustomMessage", mock.Anything).Return(isSent, nil)
 
 	now := time.Now()
-	agent.usageTracker.Add(newTraceCumulativeUsage(1, now))
-	agent.usageTracker.Add(newLogCumulativeUsage(2, now))
-	agent.usageTracker.Add(newTraceCumulativeUsage(3, now))
-	agent.usageTracker.Add(newLogCumulativeUsage(4, now))
+	agent.usageTracker.Add(signal_traces, 1)
+	agent.usageTracker.Add(signal_logs, 2)
+	agent.usageTracker.Add(signal_traces, 3)
+	agent.usageTracker.Add(signal_logs, 4)
 
 	err := agent.sendUsageReport()
 	require.NoError(t, err)
 
 	// Format the timestamp to match the expected format in the payload
 	timeUnixNano := now.UnixNano()
-	expectedPayload := fmt.Sprintf(`{"resourceMetrics":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"refinery"}},{"key":"service.version","value":{"stringValue":"1.0.0"}},{"key":"host.name","value":{"stringValue":"my-hostname"}}]},"scopeMetrics":[{"scope":{},"metrics":[{"name":"bytes_received","sum":{"dataPoints":[{"attributes":[{"key":"signal","value":{"stringValue":"traces"}}],"timeUnixNano":"%d","asInt":"1"},{"attributes":[{"key":"signal","value":{"stringValue":"logs"}}],"timeUnixNano":"%d","asInt":"2"},{"attributes":[{"key":"signal","value":{"stringValue":"traces"}}],"timeUnixNano":"%d","asInt":"2"},{"attributes":[{"key":"signal","value":{"stringValue":"logs"}}],"timeUnixNano":"%d","asInt":"2"}],"aggregationTemporality":1}}]}]}]}`,
-		timeUnixNano, timeUnixNano, timeUnixNano, timeUnixNano)
+	expectedPayload := fmt.Sprintf(`{"resourceMetrics":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"refinery"}},{"key":"service.version","value":{"stringValue":"1.0.0"}},{"key":"host.name","value":{"stringValue":"my-hostname"}}]},"scopeMetrics":[{"scope":{},"metrics":[{"name":"bytes_received","sum":{"dataPoints":[{"attributes":[{"key":"signal","value":{"stringValue":"traces"}}],"timeUnixNano":"%d","asInt":"3"},{"attributes":[{"key":"signal","value":{"stringValue":"logs"}}],"timeUnixNano":"%d","asInt":"4"}],"aggregationTemporality":1}}]}]}]}`,
+		timeUnixNano, timeUnixNano)
 
 	// Assert that the mock client was called with the expected custom message
 	mockClient.AssertCalled(t, "SendCustomMessage", &protobufs.CustomMessage{


### PR DESCRIPTION
## Which problem is this PR solving?

To reduce the payload size for usage reporting, this PR changes the usage reporting calculation to only report one datapoint per signal during one reporting interval

## Short description of the changes
- storing only one cumulative datapoint per signal type
- modify tests

