### PR TITLE
Experiment: Add summary spans depending on the rule

### DIFF
--- a/collect/collect.go
+++ b/collect/collect.go
@@ -114,8 +114,8 @@ type InMemCollector struct {
 	dropDecisionMessages chan string
 	keptDecisionMessages chan string
 
-	dropDecisionBuffer chan TraceDecision
-	keptDecisionBuffer chan TraceDecision
+	dropDecisionBuffer chan types.TraceDecision
+	keptDecisionBuffer chan types.TraceDecision
 	hostname           string
 }
 
@@ -218,8 +218,8 @@ func (i *InMemCollector) Start() error {
 		i.PubSub.Subscribe(context.Background(), keptTraceDecisionTopic, i.signalKeptTraceDecisions)
 		i.PubSub.Subscribe(context.Background(), dropTraceDecisionTopic, i.signalDroppedTraceDecisions)
 
-		i.dropDecisionBuffer = make(chan TraceDecision, i.Config.GetCollectionConfig().MaxDropDecisionBatchSize*5)
-		i.keptDecisionBuffer = make(chan TraceDecision, i.Config.GetCollectionConfig().MaxKeptDecisionBatchSize*5)
+		i.dropDecisionBuffer = make(chan types.TraceDecision, i.Config.GetCollectionConfig().MaxDropDecisionBatchSize*5)
+		i.keptDecisionBuffer = make(chan types.TraceDecision, i.Config.GetCollectionConfig().MaxKeptDecisionBatchSize*5)
 	}
 
 	// spin up one collector because this is a single threaded collector
@@ -872,7 +872,7 @@ func (i *InMemCollector) dealWithSentTrace(ctx context.Context, tr cache.TraceSe
 	// we should just broadcast the decision again
 	if sp.IsDecisionSpan() {
 		//  late span in this case won't get HasRoot
-		td := TraceDecision{
+		td := types.TraceDecision{
 			TraceID:    sp.TraceID,
 			Kept:       tr.Kept(),
 			Reason:     keptReason,
@@ -969,7 +969,7 @@ func mergeTraceAndSpanSampleRates(sp *types.Span, traceSampleRate uint, dryRunMo
 }
 
 // this is only called when a trace decision is received
-func (i *InMemCollector) send(ctx context.Context, trace *types.Trace, td *TraceDecision) {
+func (i *InMemCollector) send(ctx context.Context, trace *types.Trace, td *types.TraceDecision) {
 	if trace.Sent {
 		// someone else already sent this so we shouldn't also send it.
 		i.Logger.Debug().
@@ -997,7 +997,7 @@ func (i *InMemCollector) send(ctx context.Context, trace *types.Trace, td *Trace
 
 	// If summarization is requested, summarize the trace before sending
 	if td.Summarize {
-		trace.SummarizeTrace(1000*time.Millisecond, nil)
+		trace.SummarizeTrace(1000*time.Millisecond, *td)
 		i.Metrics.Increment("trace_send_summarized")
 		logFields["summarized"] = true
 	}
@@ -1415,7 +1415,7 @@ func (i *InMemCollector) processTraceDecisions(msg string, decisionType decision
 	}
 
 	// Deserialize the message into trace decisions
-	decisions := make([]TraceDecision, 0)
+	decisions := make([]types.TraceDecision, 0)
 	switch decisionType {
 	case keptDecision:
 		decisions, err = newKeptTraceDecision(msg, peerID)
@@ -1464,7 +1464,7 @@ func (i *InMemCollector) processTraceDecisions(msg string, decisionType decision
 
 	i.cache.RemoveTraces(toDelete)
 }
-func (i *InMemCollector) makeDecision(ctx context.Context, trace *types.Trace, sendReason string) (*TraceDecision, error) {
+func (i *InMemCollector) makeDecision(ctx context.Context, trace *types.Trace, sendReason string) (*types.TraceDecision, error) {
 	if trace.Sent {
 		return nil, errors.New("trace already sent")
 	}
@@ -1522,7 +1522,7 @@ func (i *InMemCollector) makeDecision(ctx context.Context, trace *types.Trace, s
 		"hasRoot":     hasRoot,
 	})
 	i.Logger.Debug().WithField("key", key).Logf("making decision for trace")
-	td := TraceDecision{
+	td := types.TraceDecision{
 		TraceID:         trace.ID(),
 		Kept:            shouldSend,
 		Summarize:       summarize,
@@ -1557,7 +1557,7 @@ func (i *InMemCollector) IsMyTrace(traceID string) (sharder.Shard, bool) {
 
 }
 
-func (i *InMemCollector) publishTraceDecision(ctx context.Context, td TraceDecision) {
+func (i *InMemCollector) publishTraceDecision(ctx context.Context, td types.TraceDecision) {
 	start := time.Now()
 	defer func() {
 		i.Metrics.Histogram("collector_publish_trace_decision_dur_ms", time.Since(start).Milliseconds())
@@ -1610,10 +1610,10 @@ func (i *InMemCollector) sendDropDecisions() {
 }
 
 // Unified sendDecisions function for batching and processing TraceDecisions
-func (i *InMemCollector) sendDecisions(decisionChan <-chan TraceDecision, interval time.Duration, maxBatchSize int, decisionType decisionType) {
+func (i *InMemCollector) sendDecisions(decisionChan <-chan types.TraceDecision, interval time.Duration, maxBatchSize int, decisionType decisionType) {
 	timer := i.Clock.NewTimer(interval)
 	defer timer.Stop()
-	decisions := make([]TraceDecision, 0, maxBatchSize)
+	decisions := make([]types.TraceDecision, 0, maxBatchSize)
 	send := false
 	eg := &errgroup.Group{}
 	ctx := context.Background()
@@ -1662,7 +1662,7 @@ func (i *InMemCollector) sendDecisions(decisionChan <-chan TraceDecision, interv
 			i.Metrics.Histogram(metricName, len(decisions))
 
 			// Copy current batch to process
-			decisionsToProcess := make([]TraceDecision, len(decisions))
+			decisionsToProcess := make([]types.TraceDecision, len(decisions))
 			copy(decisionsToProcess, decisions)
 			decisions = decisions[:0] // Reset the batch
 

--- a/collect/collect.go
+++ b/collect/collect.go
@@ -997,9 +997,22 @@ func (i *InMemCollector) send(ctx context.Context, trace *types.Trace, td *types
 
 	// If summarization is requested, summarize the trace before sending
 	if td.Summarize {
-		trace.SummarizeTrace(1000*time.Millisecond, *td)
-		i.Metrics.Increment("trace_send_summarized")
-		logFields["summarized"] = true
+		summary, err := trace.SummarizeTrace(1000*time.Millisecond, *td)
+		if err != nil {
+			i.Logger.Error().WithFields(logFields).Logf("Error summarizing trace: %s", err.Error())
+		} else {
+			i.Metrics.Increment("trace_send_summarized")
+			logFields["summarized"] = true
+		}
+
+		summary.Data["meta.span_event_count"] = int64(td.EventCount)
+		summary.Data["meta.span_link_count"] = int64(td.LinkCount)
+		summary.Data["meta.span_count"] = int64(td.Count)
+		summary.Data["meta.event_count"] = int64(td.DescendantCount())
+
+		summary.Dataset = i.Config.GetSummarySpanDataset()
+		summary.APIKey = trace.APIKey
+		i.Transmission.EnqueueSpan(summary)
 	}
 
 	if td.HasRoot {

--- a/collect/collect.go
+++ b/collect/collect.go
@@ -995,6 +995,13 @@ func (i *InMemCollector) send(ctx context.Context, trace *types.Trace, td *Trace
 		return
 	}
 
+	// If summarization is requested, summarize the trace before sending
+	if td.Summarize {
+		trace.SummarizeTrace(1000*time.Millisecond, nil)
+		i.Metrics.Increment("trace_send_summarized")
+		logFields["summarized"] = true
+	}
+
 	if td.HasRoot {
 		rs := trace.RootSpan
 		if rs != nil {
@@ -1030,7 +1037,6 @@ func (i *InMemCollector) send(ctx context.Context, trace *types.Trace, td *Trace
 	} else {
 		i.Logger.Info().WithFields(logFields).Logf("Sending trace")
 	}
-	i.Logger.Info().WithFields(logFields).Logf("Sending trace")
 	i.outgoingTraces <- sendableTrace{
 		Trace:      trace,
 		reason:     td.Reason,
@@ -1487,7 +1493,7 @@ func (i *InMemCollector) makeDecision(ctx context.Context, trace *types.Trace, s
 
 	startGetSampleRate := i.Clock.Now()
 	// make sampling decision and update the trace
-	rate, shouldSend, reason, key := sampler.GetSampleRate(trace)
+	rate, shouldSend, summarize, reason, key := sampler.GetSampleRate(trace)
 	i.Metrics.Histogram("get_sample_rate_duration_ms", float64(time.Since(startGetSampleRate).Milliseconds()))
 
 	trace.SetSampleRate(rate)
@@ -1507,6 +1513,7 @@ func (i *InMemCollector) makeDecision(ctx context.Context, trace *types.Trace, s
 
 	otelutil.AddSpanFields(span, map[string]interface{}{
 		"kept":        shouldSend,
+		"summarize":   summarize,
 		"reason":      reason,
 		"sampler":     key,
 		"selector":    samplerSelector,
@@ -1518,6 +1525,7 @@ func (i *InMemCollector) makeDecision(ctx context.Context, trace *types.Trace, s
 	td := TraceDecision{
 		TraceID:         trace.ID(),
 		Kept:            shouldSend,
+		Summarize:       summarize,
 		Reason:          reason,
 		SamplerKey:      key,
 		SamplerSelector: samplerSelector,

--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -565,14 +565,14 @@ func TestDryRunMode(t *testing.T) {
 	var traceID2 = "def456"
 	var traceID3 = "ghi789"
 	// sampling decisions based on trace ID
-	sampleRate1, keepTraceID1, _, _ := sampler.GetSampleRate(&types.Trace{TraceID: traceID1})
+	sampleRate1, keepTraceID1, _, _, _ := sampler.GetSampleRate(&types.Trace{TraceID: traceID1})
 	// would be dropped if dry run mode was not enabled
 	assert.False(t, keepTraceID1)
 	assert.Equal(t, uint(10), sampleRate1)
-	sampleRate2, keepTraceID2, _, _ := sampler.GetSampleRate(&types.Trace{TraceID: traceID2})
+	sampleRate2, keepTraceID2, _, _, _ := sampler.GetSampleRate(&types.Trace{TraceID: traceID2})
 	assert.True(t, keepTraceID2)
 	assert.Equal(t, uint(10), sampleRate2)
-	sampleRate3, keepTraceID3, _, _ := sampler.GetSampleRate(&types.Trace{TraceID: traceID3})
+	sampleRate3, keepTraceID3, _, _, _ := sampler.GetSampleRate(&types.Trace{TraceID: traceID3})
 	// would be dropped if dry run mode was not enabled
 	assert.False(t, keepTraceID3)
 	assert.Equal(t, uint(10), sampleRate3)

--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -81,7 +81,7 @@ func newTestCollector(conf config.Config, transmission transmit.Transmission, pe
 		done:                 make(chan struct{}),
 		keptDecisionMessages: make(chan string, 50),
 		dropDecisionMessages: make(chan string, 50),
-		dropDecisionBuffer:   make(chan TraceDecision, 5),
+		dropDecisionBuffer:   make(chan types.TraceDecision, 5),
 		Peers: &peer.MockPeers{
 			Peers: []string{"api1", "api2"},
 			ID:    "api1",
@@ -142,7 +142,7 @@ func TestAddRootSpan(t *testing.T) {
 	coll.incoming = make(chan *types.Span, 5)
 	coll.fromPeer = make(chan *types.Span, 5)
 	coll.outgoingTraces = make(chan sendableTrace, 5)
-	coll.keptDecisionBuffer = make(chan TraceDecision, 5)
+	coll.keptDecisionBuffer = make(chan types.TraceDecision, 5)
 	coll.datasetSamplers = make(map[string]sample.Sampler)
 	go coll.collect()
 	go coll.sendTraces()
@@ -282,8 +282,8 @@ func TestOriginalSampleRateIsNotedInMetaField(t *testing.T) {
 
 	coll.incoming = make(chan *types.Span, 5)
 	coll.fromPeer = make(chan *types.Span, 5)
-	coll.dropDecisionBuffer = make(chan TraceDecision, 5)
-	coll.keptDecisionBuffer = make(chan TraceDecision, 5)
+	coll.dropDecisionBuffer = make(chan types.TraceDecision, 5)
+	coll.keptDecisionBuffer = make(chan types.TraceDecision, 5)
 
 	coll.outgoingTraces = make(chan sendableTrace, 5)
 	coll.datasetSamplers = make(map[string]sample.Sampler)
@@ -386,10 +386,10 @@ func TestTransmittedSpansShouldHaveASampleRateOfAtLeastOne(t *testing.T) {
 
 	coll.incoming = make(chan *types.Span, 5)
 	coll.fromPeer = make(chan *types.Span, 5)
-	coll.keptDecisionBuffer = make(chan TraceDecision, 5)
+	coll.keptDecisionBuffer = make(chan types.TraceDecision, 5)
 
 	coll.outgoingTraces = make(chan sendableTrace, 5)
-	coll.keptDecisionBuffer = make(chan TraceDecision, 5)
+	coll.keptDecisionBuffer = make(chan types.TraceDecision, 5)
 	coll.datasetSamplers = make(map[string]sample.Sampler)
 	go coll.collect()
 	go coll.sendTraces()
@@ -447,7 +447,7 @@ func TestAddSpan(t *testing.T) {
 	coll.incoming = make(chan *types.Span, 5)
 	coll.fromPeer = make(chan *types.Span, 5)
 	coll.outgoingTraces = make(chan sendableTrace, 5)
-	coll.keptDecisionBuffer = make(chan TraceDecision, 5)
+	coll.keptDecisionBuffer = make(chan types.TraceDecision, 5)
 	coll.datasetSamplers = make(map[string]sample.Sampler)
 	go coll.collect()
 	go coll.sendTraces()
@@ -554,7 +554,7 @@ func TestDryRunMode(t *testing.T) {
 	coll.incoming = make(chan *types.Span, 5)
 	coll.fromPeer = make(chan *types.Span, 5)
 	coll.outgoingTraces = make(chan sendableTrace, 5)
-	coll.keptDecisionBuffer = make(chan TraceDecision, 5)
+	coll.keptDecisionBuffer = make(chan types.TraceDecision, 5)
 	coll.datasetSamplers = make(map[string]sample.Sampler)
 	go coll.collect()
 	go coll.sendTraces()
@@ -781,7 +781,7 @@ func TestStableMaxAlloc(t *testing.T) {
 	coll.incoming = make(chan *types.Span, 1000)
 	coll.fromPeer = make(chan *types.Span, 5)
 	coll.outgoingTraces = make(chan sendableTrace, 500)
-	coll.keptDecisionBuffer = make(chan TraceDecision, 500)
+	coll.keptDecisionBuffer = make(chan types.TraceDecision, 500)
 	coll.datasetSamplers = make(map[string]sample.Sampler)
 	go coll.collect()
 	go coll.sendTraces()
@@ -987,7 +987,7 @@ func TestAddCountsToRoot(t *testing.T) {
 	coll.incoming = make(chan *types.Span, 5)
 	coll.fromPeer = make(chan *types.Span, 5)
 	coll.outgoingTraces = make(chan sendableTrace, 5)
-	coll.keptDecisionBuffer = make(chan TraceDecision, 5)
+	coll.keptDecisionBuffer = make(chan types.TraceDecision, 5)
 	coll.datasetSamplers = make(map[string]sample.Sampler)
 	go coll.collect()
 	go coll.sendTraces()
@@ -1081,7 +1081,7 @@ func TestLateRootGetsCounts(t *testing.T) {
 	coll.incoming = make(chan *types.Span, 5)
 	coll.fromPeer = make(chan *types.Span, 5)
 	coll.outgoingTraces = make(chan sendableTrace, 5)
-	coll.keptDecisionBuffer = make(chan TraceDecision, 5)
+	coll.keptDecisionBuffer = make(chan types.TraceDecision, 5)
 	coll.datasetSamplers = make(map[string]sample.Sampler)
 	go coll.collect()
 	go coll.sendTraces()
@@ -1176,7 +1176,7 @@ func TestAddSpanCount(t *testing.T) {
 	coll.incoming = make(chan *types.Span, 5)
 	coll.fromPeer = make(chan *types.Span, 5)
 	coll.outgoingTraces = make(chan sendableTrace, 5)
-	coll.keptDecisionBuffer = make(chan TraceDecision, 5)
+	coll.keptDecisionBuffer = make(chan types.TraceDecision, 5)
 	coll.datasetSamplers = make(map[string]sample.Sampler)
 
 	go coll.collect()
@@ -1269,7 +1269,7 @@ func TestLateRootGetsSpanCount(t *testing.T) {
 	coll.incoming = make(chan *types.Span, 5)
 	coll.fromPeer = make(chan *types.Span, 5)
 	coll.outgoingTraces = make(chan sendableTrace, 5)
-	coll.keptDecisionBuffer = make(chan TraceDecision, 5)
+	coll.keptDecisionBuffer = make(chan types.TraceDecision, 5)
 	coll.datasetSamplers = make(map[string]sample.Sampler)
 	go coll.collect()
 	go coll.sendTraces()
@@ -1348,7 +1348,7 @@ func TestLateSpanNotDecorated(t *testing.T) {
 	coll.incoming = make(chan *types.Span, 5)
 	coll.fromPeer = make(chan *types.Span, 5)
 	coll.outgoingTraces = make(chan sendableTrace, 5)
-	coll.keptDecisionBuffer = make(chan TraceDecision, 5)
+	coll.keptDecisionBuffer = make(chan types.TraceDecision, 5)
 	coll.datasetSamplers = make(map[string]sample.Sampler)
 	go coll.collect()
 	go coll.sendTraces()
@@ -1421,7 +1421,7 @@ func TestAddAdditionalAttributes(t *testing.T) {
 	coll.incoming = make(chan *types.Span, 5)
 	coll.fromPeer = make(chan *types.Span, 5)
 	coll.outgoingTraces = make(chan sendableTrace, 5)
-	coll.keptDecisionBuffer = make(chan TraceDecision, 5)
+	coll.keptDecisionBuffer = make(chan types.TraceDecision, 5)
 	coll.datasetSamplers = make(map[string]sample.Sampler)
 	go coll.collect()
 	go coll.sendTraces()
@@ -1583,7 +1583,7 @@ func TestStressReliefDecorateHostname(t *testing.T) {
 	coll.incoming = make(chan *types.Span, 5)
 	coll.fromPeer = make(chan *types.Span, 5)
 	coll.outgoingTraces = make(chan sendableTrace, 5)
-	coll.keptDecisionBuffer = make(chan TraceDecision, 5)
+	coll.keptDecisionBuffer = make(chan types.TraceDecision, 5)
 	coll.datasetSamplers = make(map[string]sample.Sampler)
 	go coll.collect()
 	go coll.sendTraces()
@@ -1691,7 +1691,7 @@ func TestSpanWithRuleReasons(t *testing.T) {
 	coll.incoming = make(chan *types.Span, 5)
 	coll.fromPeer = make(chan *types.Span, 5)
 	coll.outgoingTraces = make(chan sendableTrace, 5)
-	coll.keptDecisionBuffer = make(chan TraceDecision, 5)
+	coll.keptDecisionBuffer = make(chan types.TraceDecision, 5)
 	coll.datasetSamplers = make(map[string]sample.Sampler)
 	go coll.collect()
 	go coll.sendTraces()
@@ -1802,7 +1802,7 @@ func TestRedistributeTraces(t *testing.T) {
 	coll.incoming = make(chan *types.Span, 5)
 	coll.fromPeer = make(chan *types.Span, 5)
 	coll.outgoingTraces = make(chan sendableTrace, 5)
-	coll.keptDecisionBuffer = make(chan TraceDecision, 5)
+	coll.keptDecisionBuffer = make(chan types.TraceDecision, 5)
 	coll.datasetSamplers = make(map[string]sample.Sampler)
 
 	c := cache.NewInMemCache(3, &metrics.NullMetrics{}, &logger.NullLogger{})
@@ -1958,7 +1958,7 @@ func TestDrainTracesOnShutdown(t *testing.T) {
 	coll.fromPeer = make(chan *types.Span, 5)
 
 	coll.outgoingTraces = make(chan sendableTrace, 5)
-	coll.keptDecisionBuffer = make(chan TraceDecision, 5)
+	coll.keptDecisionBuffer = make(chan types.TraceDecision, 5)
 	coll.datasetSamplers = make(map[string]sample.Sampler)
 
 	sentTraceChan := make(chan sentRecord, 1)
@@ -2089,7 +2089,7 @@ func TestBigTracesGoEarly(t *testing.T) {
 	coll.incoming = make(chan *types.Span, 500)
 	coll.fromPeer = make(chan *types.Span, 500)
 	coll.outgoingTraces = make(chan sendableTrace, 500)
-	coll.keptDecisionBuffer = make(chan TraceDecision, 5)
+	coll.keptDecisionBuffer = make(chan types.TraceDecision, 5)
 	coll.datasetSamplers = make(map[string]sample.Sampler)
 	go coll.collect()
 	go coll.sendTraces()
@@ -2244,7 +2244,7 @@ func TestSendDropDecisions(t *testing.T) {
 	peerTransmission.Start()
 	defer peerTransmission.Stop()
 	coll := newTestCollector(conf, transmission, peerTransmission)
-	coll.dropDecisionBuffer = make(chan TraceDecision, 5)
+	coll.dropDecisionBuffer = make(chan types.TraceDecision, 5)
 
 	messages := make(chan string, 5)
 	coll.PubSub.Subscribe(context.Background(), dropTraceDecisionTopic, func(ctx context.Context, msg string) {
@@ -2262,7 +2262,7 @@ func TestSendDropDecisions(t *testing.T) {
 		close(closed)
 	}()
 
-	coll.dropDecisionBuffer <- TraceDecision{TraceID: "trace1"}
+	coll.dropDecisionBuffer <- types.TraceDecision{TraceID: "trace1"}
 	close(coll.dropDecisionBuffer)
 	droppedMessage := <-messages
 
@@ -2282,7 +2282,7 @@ func TestSendDropDecisions(t *testing.T) {
 	collectionCfg.DropDecisionSendInterval = config.Duration(60 * time.Second)
 	collectionCfg.MaxDropDecisionBatchSize = 5
 	conf.GetCollectionConfigVal = collectionCfg
-	coll.dropDecisionBuffer = make(chan TraceDecision, 5)
+	coll.dropDecisionBuffer = make(chan types.TraceDecision, 5)
 
 	closed = make(chan struct{})
 	go func() {
@@ -2291,7 +2291,7 @@ func TestSendDropDecisions(t *testing.T) {
 	}()
 
 	for i := 0; i < 5; i++ {
-		coll.dropDecisionBuffer <- TraceDecision{
+		coll.dropDecisionBuffer <- types.TraceDecision{
 			TraceID: fmt.Sprintf("trace%d", i),
 		}
 	}
@@ -2344,7 +2344,7 @@ func TestExpiredTracesCleanup(t *testing.T) {
 	coll.incoming = make(chan *types.Span, 5)
 	coll.fromPeer = make(chan *types.Span, 5)
 	coll.outgoingTraces = make(chan sendableTrace, 5)
-	coll.keptDecisionBuffer = make(chan TraceDecision, 5)
+	coll.keptDecisionBuffer = make(chan types.TraceDecision, 5)
 	coll.datasetSamplers = make(map[string]sample.Sampler)
 
 	for _, traceID := range peerTraceIDs {

--- a/collect/trace_decision.go
+++ b/collect/trace_decision.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/golang/snappy"
 	"github.com/honeycombio/refinery/collect/cache"
+	"github.com/honeycombio/refinery/types"
 )
 
 type decisionType int
@@ -35,9 +36,9 @@ var (
 	dropDecision decisionType = 2
 )
 
-type newDecisionMessage func(tds []TraceDecision, senderID string) (string, error)
+type newDecisionMessage func(tds []types.TraceDecision, senderID string) (string, error)
 
-func newDroppedDecisionMessage(tds []TraceDecision, senderID string) (string, error) {
+func newDroppedDecisionMessage(tds []types.TraceDecision, senderID string) (string, error) {
 	if len(tds) == 0 {
 		return "", fmt.Errorf("no dropped trace decisions provided")
 	}
@@ -59,7 +60,7 @@ func newDroppedDecisionMessage(tds []TraceDecision, senderID string) (string, er
 	return senderID + decisionMessageSeparator + string(compressed), nil
 }
 
-func newDroppedTraceDecision(msg string, senderID string) ([]TraceDecision, error) {
+func newDroppedTraceDecision(msg string, senderID string) ([]types.TraceDecision, error) {
 	// Use IndexRune here since it's faster than SplitN and requires less allocation
 	separatorIdx := strings.IndexRune(msg, rune(decisionMessageSeparator[0]))
 	if separatorIdx == -1 {
@@ -77,16 +78,16 @@ func newDroppedTraceDecision(msg string, senderID string) ([]TraceDecision, erro
 	}
 
 	traceIDs := strings.Split(ids, ",")
-	decisions := make([]TraceDecision, 0, len(traceIDs))
+	decisions := make([]types.TraceDecision, 0, len(traceIDs))
 	for _, traceID := range traceIDs {
-		decisions = append(decisions, TraceDecision{
+		decisions = append(decisions, types.TraceDecision{
 			TraceID: traceID,
 		})
 	}
 	return decisions, nil
 }
 
-func newKeptDecisionMessage(tds []TraceDecision, senderID string) (string, error) {
+func newKeptDecisionMessage(tds []types.TraceDecision, senderID string) (string, error) {
 	if len(tds) == 0 {
 		return "", fmt.Errorf("no kept trace decisions provided")
 	}
@@ -102,7 +103,7 @@ func newKeptDecisionMessage(tds []TraceDecision, senderID string) (string, error
 	return senderID + decisionMessageSeparator + string(compressed), nil
 }
 
-func newKeptTraceDecision(msg string, senderID string) ([]TraceDecision, error) {
+func newKeptTraceDecision(msg string, senderID string) ([]types.TraceDecision, error) {
 	// Use IndexRune here since it's faster than SplitN and requires less allocation
 	separatorIdx := strings.IndexRune(msg, rune(decisionMessageSeparator[0]))
 	if separatorIdx == -1 {
@@ -129,59 +130,7 @@ func isMyDecision(msg string, senderID string) bool {
 	return strings.HasPrefix(msg, senderID+decisionMessageSeparator)
 }
 
-var _ cache.KeptTrace = &TraceDecision{}
-
-type TraceDecision struct {
-	TraceID string
-	// if we don'g need to immediately eject traces from the trace cache,
-	// we could remove this field. The TraceDecision type could be renamed to
-	// keptDecision
-	Kept            bool
-	Summarize       bool // If true, summarize the trace into the summary dataset, whether sent or not
-	Rate            uint
-	SamplerKey      string
-	SamplerSelector string
-	SendReason      string
-	HasRoot         bool
-	Reason          string
-	Count           uint32
-	EventCount      uint32
-	LinkCount       uint32
-
-	keptReasonIdx uint
-}
-
-func (td *TraceDecision) DescendantCount() uint32 {
-	return td.Count + td.EventCount + td.LinkCount
-}
-
-func (td *TraceDecision) SpanCount() uint32 {
-	return td.Count
-}
-
-func (td *TraceDecision) SpanEventCount() uint32 {
-	return td.EventCount
-}
-
-func (td *TraceDecision) SpanLinkCount() uint32 {
-	return td.LinkCount
-}
-
-func (td *TraceDecision) SampleRate() uint {
-	return td.Rate
-}
-
-func (td *TraceDecision) ID() string {
-	return td.TraceID
-}
-
-func (td *TraceDecision) KeptReason() uint {
-	return td.keptReasonIdx
-}
-
-func (td *TraceDecision) SetKeptReason(reasonIdx uint) {
-	td.keptReasonIdx = reasonIdx
-}
+var _ cache.KeptTrace = &types.TraceDecision{}
 
 var bufferPool = sync.Pool{
 	New: func() any { return new(bytes.Buffer) },
@@ -216,7 +165,7 @@ func compress(data any) ([]byte, error) {
 	return bytes.Clone(buf.Bytes()), nil
 }
 
-func decompressKeptDecisions(data []byte) ([]TraceDecision, error) {
+func decompressKeptDecisions(data []byte) ([]types.TraceDecision, error) {
 	// Get a buffer from the pool and set it up with data
 	buf := bufferPool.Get().(*bytes.Buffer)
 	defer bufferPool.Put(buf)
@@ -227,7 +176,7 @@ func decompressKeptDecisions(data []byte) ([]TraceDecision, error) {
 	reader := snappy.NewReader(buf)
 	dec := gob.NewDecoder(reader)
 
-	var tds []TraceDecision
+	var tds []types.TraceDecision
 	if err := dec.Decode(&tds); err != nil {
 		return nil, err
 	}

--- a/collect/trace_decision.go
+++ b/collect/trace_decision.go
@@ -137,6 +137,7 @@ type TraceDecision struct {
 	// we could remove this field. The TraceDecision type could be renamed to
 	// keptDecision
 	Kept            bool
+	Summarize       bool // If true, summarize the trace into the summary dataset, whether sent or not
 	Rate            uint
 	SamplerKey      string
 	SamplerSelector string
@@ -211,7 +212,7 @@ func compress(data any) ([]byte, error) {
 		return nil, err
 	}
 
-	// Copy the buffer’s bytes to avoid reuse issues when returning
+	// Copy the buffer's bytes to avoid reuse issues when returning
 	return bytes.Clone(buf.Bytes()), nil
 }
 

--- a/collect/trace_decision_test.go
+++ b/collect/trace_decision_test.go
@@ -6,12 +6,13 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/honeycombio/refinery/types"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestDropDecisionRoundTrip(t *testing.T) {
 	// Test data for dropped decisions covering all fields
-	tds := []TraceDecision{
+	tds := []types.TraceDecision{
 		{
 			TraceID: "trace1",
 		},
@@ -47,7 +48,7 @@ func TestDropDecisionRoundTrip(t *testing.T) {
 
 func TestKeptDecisionRoundTrip(t *testing.T) {
 	// Test data for kept decisions covering all fields
-	tds := []TraceDecision{
+	tds := []types.TraceDecision{
 		{
 			TraceID:         "trace1",
 			Kept:            true,
@@ -114,7 +115,7 @@ func TestKeptDecisionRoundTrip(t *testing.T) {
 }
 
 // used in test only
-func newKeptDecisionMessageJSON(tds []TraceDecision) (string, error) {
+func newKeptDecisionMessageJSON(tds []types.TraceDecision) (string, error) {
 	if len(tds) == 0 {
 		return "", fmt.Errorf("no kept trace decisions provided")
 	}
@@ -216,7 +217,7 @@ func BenchmarkCompressionSizes(b *testing.B) {
 	})
 }
 
-func generateRandomTraceDecision() TraceDecision {
+func generateRandomTraceDecision() types.TraceDecision {
 	traceID := fmt.Sprintf("trace-%d", rand.Int63())
 
 	rate := uint(rand.Intn(100))
@@ -228,7 +229,7 @@ func generateRandomTraceDecision() TraceDecision {
 	sendReason := sendReasons[rand.Intn(len(sendReasons))]
 	reason := reasons[rand.Intn(len(reasons))]
 
-	return TraceDecision{
+	return types.TraceDecision{
 		TraceID:         traceID,
 		Kept:            true,
 		Rate:            rate,
@@ -244,8 +245,8 @@ func generateRandomTraceDecision() TraceDecision {
 }
 
 // GenerateRandomDecisions generates multiple TraceDecision
-func generateRandomDecisions(num int) []TraceDecision {
-	decisions := make([]TraceDecision, num)
+func generateRandomDecisions(num int) []types.TraceDecision {
+	decisions := make([]types.TraceDecision, num)
 	for i := 0; i < num; i++ {
 		decisions[i] = generateRandomTraceDecision()
 	}
@@ -253,7 +254,7 @@ func generateRandomDecisions(num int) []TraceDecision {
 }
 
 // calculate the size of the original JSON encoding
-func jsonEncodeSize(tds []TraceDecision) (int, error) {
+func jsonEncodeSize(tds []types.TraceDecision) (int, error) {
 	data, err := json.Marshal(tds)
 	if err != nil {
 		return 0, err
@@ -262,7 +263,7 @@ func jsonEncodeSize(tds []TraceDecision) (int, error) {
 }
 
 // calculate the size of the Snappy compressed and gob encoding
-func snappyCompressSize(tds []TraceDecision) (int, error) {
+func snappyCompressSize(tds []types.TraceDecision) (int, error) {
 	compressed, err := compress(tds)
 	if err != nil {
 		return 0, err

--- a/config.md
+++ b/config.md
@@ -1,7 +1,7 @@
 # Honeycomb Refinery Configuration Documentation
 
 This is the documentation for the configuration file for Honeycomb's Refinery.
-It was automatically generated on 2025-02-13 at 16:52:13 UTC.
+It was automatically generated on 2025-03-14 at 00:54:51 UTC.
 
 ## The Config file
 
@@ -352,6 +352,17 @@ This will mean Refinery makes fewer sampling decision calculations each `SendTic
 - Eligible for live reload.
 - Type: `int`
 - Default: `5000`
+
+### `SummarySpanDataset`
+
+SummarySpanDataset is the dataset name for summary spans.
+
+When traces are summarized, the service.name of the spans isn't applicable since traces tend to cross service boundaries.
+The summary spans will be sent to the same environemnt as the trace was going to, since it uses the same API key.
+
+- Eligible for live reload.
+- Type: `string`
+- Default: `Summary Spans`
 
 ## Debugging
 

--- a/config/config.go
+++ b/config/config.go
@@ -5,7 +5,8 @@ import (
 )
 
 const (
-	DryRunFieldName = "meta.refinery.dryrun.kept"
+	DryRunFieldName    = "meta.refinery.dryrun.kept"
+	SummarySpanDataset = "Summary Spans"
 )
 
 // Config defines the interface the rest of the code uses to get items from the
@@ -156,6 +157,8 @@ type Config interface {
 	GetTraceIdFieldNames() []string
 
 	GetParentIdFieldNames() []string
+
+	GetSummarySpanDataset() string
 }
 
 type ConfigReloadCallback func(configHash, ruleCfgHash string)

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -187,13 +187,14 @@ type RefineryTelemetryConfig struct {
 }
 
 type TracesConfig struct {
-	SendDelay        Duration `yaml:"SendDelay" default:"2s"`
-	BatchTimeout     Duration `yaml:"BatchTimeout" default:"100ms"`
-	TraceTimeout     Duration `yaml:"TraceTimeout" default:"60s"`
-	MaxBatchSize     uint     `yaml:"MaxBatchSize" default:"500"`
-	SendTicker       Duration `yaml:"SendTicker" default:"100ms"`
-	SpanLimit        uint     `yaml:"SpanLimit"`
-	MaxExpiredTraces uint     `yaml:"MaxExpiredTraces" default:"5000"`
+	SendDelay          Duration `yaml:"SendDelay" default:"2s"`
+	BatchTimeout       Duration `yaml:"BatchTimeout" default:"100ms"`
+	TraceTimeout       Duration `yaml:"TraceTimeout" default:"60s"`
+	MaxBatchSize       uint     `yaml:"MaxBatchSize" default:"500"`
+	SendTicker         Duration `yaml:"SendTicker" default:"100ms"`
+	SpanLimit          uint     `yaml:"SpanLimit"`
+	MaxExpiredTraces   uint     `yaml:"MaxExpiredTraces" default:"5000"`
+	SummarySpanDataset string   `yaml:"SummarySpanDataset"`
 }
 
 func (t TracesConfig) GetSendDelay() time.Duration {
@@ -1031,4 +1032,14 @@ func (f *fileConfig) GetAdditionalAttributes() map[string]string {
 	defer f.mux.RUnlock()
 
 	return f.mainConfig.Specialized.AdditionalAttributes
+}
+
+func (f *fileConfig) GetSummarySpanDataset() string {
+	f.mux.RLock()
+	defer f.mux.RUnlock()
+
+	if f.mainConfig.Traces.SummarySpanDataset == "" {
+		return SummarySpanDataset
+	}
+	return f.mainConfig.Traces.SummarySpanDataset
 }

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -404,8 +404,8 @@ groups:
         type: int
         valuetype: nondefault
         default: 5000
-        reload: true
         firstVersion: 2.9
+        reload: true
         validations:
           - type: minimum
             arg: 1000
@@ -421,6 +421,18 @@ groups:
           recommended to reduce this value and the `SendTicker` duration. This
           will mean Refinery makes fewer sampling decision calculations each
           `SendTicker` tick, but gets the chance to make decisions more often.
+
+      - name: SummarySpanDataset
+        type: string
+        valuetype: nondefault
+        default: "Summary Spans"
+        reload: true
+        summary: is the dataset name for summary spans.
+        description: >
+          When traces are summarized, the service.name of the spans isn't applicable
+          since traces tend to cross service boundaries. The summary spans will be
+          sent to the same environemnt as the trace was going to, since it uses the
+          same API key.
 
   - name: Debugging
     title: "Debugging"
@@ -1921,3 +1933,4 @@ groups:
           If this duration is `0`, then Refinery will not start in stressed
           mode, which will provide faster startup at the possible cost of
           startup instability.
+

--- a/config/metadata/rulesMeta.yaml
+++ b/config/metadata/rulesMeta.yaml
@@ -43,6 +43,20 @@ groups:
           A `SampleRate` of `1` or less will keep all traces.
 
           Specifying this value is required.
+      - name: SummarizeMode
+        type: string
+        valuetype: choice
+        choices: ["none", "all", "dropped", "kept"]
+        default: "none"
+        reload: true
+        summary: Creates a summary span with some metadata and sends it to the summary span dataset in the same environment.
+        description: >
+          Creates a summary span with some metadata and sends it to the summary span dataset in the same environment.
+          "none" means no summarization occurs.
+          "all" means all traces are summarized.
+          "dropped" means only dropped traces are summarized.
+          "kept" means only kept traces are summarized.
+
   - name: DynamicSampler
     title: Dynamic Sampler
     sortorder: 20
@@ -64,6 +78,19 @@ groups:
           - type: requiredInGroup
         summary: is the sample rate to use.
         description: $DeterministicSampler.SampleRate
+      - name: SummarizeMode
+        type: string
+        valuetype: choice
+        choices: ["none", "all", "dropped", "kept"]
+        default: "none"
+        reload: true
+        summary: Creates a summary span with some metadata and sends it to the summary span dataset in the same environment.
+        description: >
+          Creates a summary span with some metadata and sends it to the summary span dataset in the same environment.
+          "none" means no summarization occurs.
+          "all" means all traces are summarized.
+          "dropped" means only dropped traces are summarized.
+          "kept" means only kept traces are summarized.
       - name: ClearFrequency
         type: duration
         summary: is the duration over which the sampler will calculate the sample rate.
@@ -175,6 +202,19 @@ groups:
           - type: requiredInGroup
         summary: is the sample rate to use.
         description: $DeterministicSampler.SampleRate
+      - name: SummarizeMode
+        type: string
+        valuetype: choice
+        choices: ["none", "all", "dropped", "kept"]
+        default: "none"
+        reload: true
+        summary: Creates a summary span with some metadata and sends it to the summary span dataset in the same environment.
+        description: >
+          Creates a summary span with some metadata and sends it to the summary span dataset in the same environment.
+          "none" means no summarization occurs.
+          "all" means all traces are summarized.
+          "dropped" means only dropped traces are summarized.
+          "kept" means only kept traces are summarized.
       - name: AdjustmentInterval
         type: duration
         summary: is how often the sampler will recalculate the sample rate.
@@ -289,6 +329,19 @@ groups:
           cluster has multiple instances, then you will need to divide your
           total desired sample rate by the number of instances to get this
           value.
+      - name: SummarizeMode
+        type: string
+        valuetype: choice
+        choices: ["none", "all", "dropped", "kept"]
+        default: "none"
+        reload: true
+        summary: Creates a summary span with some metadata and sends it to the summary span dataset in the same environment.
+        description: >
+          Creates a summary span with some metadata and sends it to the summary span dataset in the same environment.
+          "none" means no summarization occurs.
+          "all" means all traces are summarized.
+          "dropped" means only dropped traces are summarized.
+          "kept" means only kept traces are summarized.
       - name: UseClusterSize
         type: bool
         summary: indicates whether to use the cluster size to calculate the goal throughput.
@@ -397,6 +450,19 @@ groups:
           cluster has multiple instances, then you will need to divide your
           total desired sample rate by the number of instances to get this
           value.
+      - name: SummarizeMode
+        type: string
+        valuetype: choice
+        choices: ["none", "all", "dropped", "kept"]
+        default: "none"
+        reload: true
+        summary: Creates a summary span with some metadata and sends it to the summary span dataset in the same environment.
+        description: >
+          Creates a summary span with some metadata and sends it to the summary span dataset in the same environment.
+          "none" means no summarization occurs.
+          "all" means all traces are summarized.
+          "dropped" means only dropped traces are summarized.
+          "kept" means only kept traces are summarized.
       - name: UseClusterSize
         type: bool
         summary: indicates whether to use the cluster size to calculate the goal throughput.
@@ -469,6 +535,19 @@ groups:
           The desired throughput per second of events sent to Honeycomb. This is
           the number of events per second you want to send. This is not the same
           as the Sample Rate.
+      - name: SummarizeMode
+        type: string
+        valuetype: choice
+        choices: ["none", "all", "dropped", "kept"]
+        default: "none"
+        reload: true
+        summary: Creates a summary span with some metadata and sends it to the summary span dataset in the same environment.
+        description: >
+          Creates a summary span with some metadata and sends it to the summary span dataset in the same environment.
+          "none" means no summarization occurs.
+          "all" means all traces are summarized.
+          "dropped" means only dropped traces are summarized.
+          "kept" means only kept traces are summarized.
       - name: UseClusterSize
         type: bool
         summary: indicates whether to use the cluster size to calculate the goal throughput.

--- a/config/mock.go
+++ b/config/mock.go
@@ -62,8 +62,8 @@ type MockConfig struct {
 	CfgMetadata                      []ConfigMetadata
 	CfgHash                          string
 	RulesHash                        string
-
-	Mux sync.RWMutex
+	SummarySpanDataset               string
+	Mux                              sync.RWMutex
 }
 
 // assert that MockConfig implements Config
@@ -446,4 +446,14 @@ func (f *MockConfig) GetAdditionalAttributes() map[string]string {
 	defer f.Mux.RUnlock()
 
 	return f.AdditionalAttributes
+}
+
+func (f *MockConfig) GetSummarySpanDataset() string {
+	f.Mux.RLock()
+	defer f.Mux.RUnlock()
+
+	if f.SummarySpanDataset == "" {
+		return SummarySpanDataset
+	}
+	return f.SummarySpanDataset
 }

--- a/config/sampler_config.go
+++ b/config/sampler_config.go
@@ -156,7 +156,8 @@ type GetSamplingFielder interface {
 var _ GetSamplingFielder = (*DeterministicSamplerConfig)(nil)
 
 type DeterministicSamplerConfig struct {
-	SampleRate int `json:"samplerate" yaml:"SampleRate,omitempty" default:"1" validate:"required,gte=1"`
+	SampleRate    int    `json:"samplerate" yaml:"SampleRate,omitempty" default:"1" validate:"required,gte=1"`
+	SummarizeMode string `json:"summarize_mode" yaml:"SummarizeMode,omitempty" validate:"oneof=none all dropped kept"`
 }
 
 func (d *DeterministicSamplerConfig) GetSamplingFields() []string {
@@ -167,6 +168,7 @@ var _ GetSamplingFielder = (*DynamicSamplerConfig)(nil)
 
 type DynamicSamplerConfig struct {
 	SampleRate     int64    `json:"samplerate" yaml:"SampleRate,omitempty" validate:"required,gte=1"`
+	SummarizeMode  string   `json:"summarize_mode" yaml:"SummarizeMode,omitempty" validate:"oneof=none all dropped kept"`
 	ClearFrequency Duration `json:"clearfrequency" yaml:"ClearFrequency,omitempty"`
 	FieldList      []string `json:"fieldlist" yaml:"FieldList,omitempty" validate:"required"`
 	MaxKeys        int      `json:"maxkeys" yaml:"MaxKeys,omitempty"`
@@ -181,6 +183,7 @@ var _ GetSamplingFielder = (*EMADynamicSamplerConfig)(nil)
 
 type EMADynamicSamplerConfig struct {
 	GoalSampleRate      int      `json:"goalsamplerate" yaml:"GoalSampleRate,omitempty" validate:"gte=1"`
+	SummarizeMode       string   `json:"summarize_mode" yaml:"SummarizeMode,omitempty" validate:"oneof=none all dropped kept"`
 	AdjustmentInterval  Duration `json:"adjustmentinterval" yaml:"AdjustmentInterval,omitempty"`
 	Weight              float64  `json:"weight" yaml:"Weight,omitempty" validate:"gt=0,lt=1"`
 	AgeOutValue         float64  `json:"ageoutvalue" yaml:"AgeOutValue,omitempty"`
@@ -199,6 +202,7 @@ var _ GetSamplingFielder = (*EMAThroughputSamplerConfig)(nil)
 
 type EMAThroughputSamplerConfig struct {
 	GoalThroughputPerSec int      `json:"goalthroughputpersec" yaml:"GoalThroughputPerSec,omitempty"`
+	SummarizeMode        string   `json:"summarize_mode" yaml:"SummarizeMode,omitempty" validate:"oneof=none all dropped kept"`
 	UseClusterSize       bool     `json:"useclustersize" yaml:"UseClusterSize,omitempty"`
 	InitialSampleRate    int      `json:"initialsamplerate" yaml:"InitialSampleRate,omitempty"`
 	AdjustmentInterval   Duration `json:"adjustmentinterval" yaml:"AdjustmentInterval,omitempty"`
@@ -221,6 +225,7 @@ type WindowedThroughputSamplerConfig struct {
 	UpdateFrequency      Duration `json:"updatefrequency" yaml:"UpdateFrequency,omitempty"`
 	LookbackFrequency    Duration `json:"lookbackfrequency" yaml:"LookbackFrequency,omitempty"`
 	GoalThroughputPerSec int      `json:"goalthroughputpersec" yaml:"GoalThroughputPerSec,omitempty"`
+	SummarizeMode        string   `json:"summarize_mode" yaml:"SummarizeMode,omitempty" validate:"oneof=none all dropped kept"`
 	UseClusterSize       bool     `json:"useclustersize" yaml:"UseClusterSize,omitempty"`
 	FieldList            []string `json:"fieldlist" yaml:"FieldList,omitempty"`
 	MaxKeys              int      `json:"maxkeys" yaml:"MaxKeys,omitempty"`
@@ -235,6 +240,7 @@ var _ GetSamplingFielder = (*TotalThroughputSamplerConfig)(nil)
 
 type TotalThroughputSamplerConfig struct {
 	GoalThroughputPerSec int      `json:"goalthroughputpersec" yaml:"GoalThroughputPerSec,omitempty" validate:"gte=1"`
+	SummarizeMode        string   `json:"summarize_mode" yaml:"SummarizeMode,omitempty" validate:"oneof=none all dropped kept"`
 	UseClusterSize       bool     `json:"useclustersize" yaml:"UseClusterSize,omitempty"`
 	ClearFrequency       Duration `json:"clearfrequency" yaml:"ClearFrequency,omitempty"`
 	FieldList            []string `json:"fieldlist" yaml:"FieldList,omitempty" validate:"required"`
@@ -329,6 +335,7 @@ type RulesBasedSamplerRule struct {
 	Name       string                        `json:"name" yaml:"Name,omitempty"`
 	SampleRate int                           `json:"samplerate" yaml:"SampleRate,omitempty"`
 	Drop       bool                          `json:"drop" yaml:"Drop,omitempty"`
+	Summarize  bool                          `json:"summarize" yaml:"Summarize,omitempty"`
 	Scope      string                        `json:"scope" yaml:"Scope,omitempty" validate:"oneof=span trace"`
 	Conditions []*RulesBasedSamplerCondition `json:"condition" yaml:"Conditions,omitempty"`
 	Sampler    *RulesBasedDownstreamSampler  `json:"sampler" yaml:"Sampler,omitempty"`

--- a/config_complete.yaml
+++ b/config_complete.yaml
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created on 2025-02-13 at 16:52:12 UTC from ../../config.yaml using a template generated on 2025-02-13 at 16:52:04 UTC
+# created on 2025-03-14 at 00:54:51 UTC from ../../config.yaml using a template generated on 2025-03-14 at 00:54:47 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of
@@ -370,6 +370,17 @@ Traces:
     ## default: 5000
     ## Eligible for live reload.
     # MaxExpiredTraces: 5_000
+
+    ## SummarySpanDataset is the dataset name for summary spans.
+    ##
+    ## When traces are summarized, the service.name of the spans isn't
+    ## applicable since traces tend to cross service boundaries. The summary
+    ## spans will be sent to the same environemnt as the trace was going to,
+    ## since it uses the same API key.
+    ##
+    ## default: Summary Spans
+    ## Eligible for live reload.
+    # SummarySpanDataset: "Summary Spans"
 
 ###############
 ## Debugging ##

--- a/config_complete.yaml
+++ b/config_complete.yaml
@@ -380,7 +380,7 @@ Traces:
     ##
     ## default: Summary Spans
     ## Eligible for live reload.
-    # SummarySpanDataset: "Summary Spans"
+    SummarySpanDataset: "Summary Spans"
 
 ###############
 ## Debugging ##

--- a/metrics.md
+++ b/metrics.md
@@ -1,7 +1,7 @@
 # Honeycomb Refinery Metrics Documentation
 
 This document contains the description of various metrics used in Refinery.
-It was automatically generated on 2025-02-13 at 16:52:11 UTC.
+It was automatically generated on 2025-03-14 at 00:54:50 UTC.
 
 Note: This document does not include metrics defined in the dynsampler-go dependency, as those metrics are generated dynamically at runtime. As a result, certain metrics may be missing or incomplete in this document, but they will still be available during execution with their full names.
 

--- a/refinery_config.md
+++ b/refinery_config.md
@@ -331,6 +331,17 @@ This will mean Refinery makes fewer sampling decision calculations each `SendTic
 - Type: `int`
 - Default: `5000`
 
+### `SummarySpanDataset`
+
+`SummarySpanDataset` is the dataset name for summary spans.
+
+When traces are summarized, the service.name of the spans isn't applicable since traces tend to cross service boundaries.
+The summary spans will be sent to the same environemnt as the trace was going to, since it uses the same API key.
+
+- Eligible for live reload.
+- Type: `string`
+- Default: `Summary Spans`
+
 ## Debugging
 
 `Debugging` contains configuration values used when setting up and debugging Refinery.

--- a/refinery_rules.md
+++ b/refinery_rules.md
@@ -57,6 +57,17 @@ Specifying this value is required.
 
 - Type: `int`
 
+### `SummarizeMode`
+
+Creates a summary span with some metadata and sends it to the summary span dataset in the same environment.
+"none" means no summarization occurs.
+"all" means all traces are summarized.
+"dropped" means only dropped traces are summarized.
+"kept" means only kept traces are summarized.
+
+- Type: `string`
+- Default: `none`- Options: `none`, `all`, `dropped`, `kept`
+
 ## Dynamic Sampler
 
 The Dynamic Sampler (`DynamicSampler`) is the basic Dynamic Sampler implementation.
@@ -77,6 +88,17 @@ A `SampleRate` of `1` or less will keep all traces.
 Specifying this value is required.
 
 - Type: `int`
+
+### `SummarizeMode`
+
+Creates a summary span with some metadata and sends it to the summary span dataset in the same environment.
+"none" means no summarization occurs.
+"all" means all traces are summarized.
+"dropped" means only dropped traces are summarized.
+"kept" means only kept traces are summarized.
+
+- Type: `string`
+- Default: `none`- Options: `none`, `all`, `dropped`, `kept`
 
 ### `ClearFrequency`
 
@@ -146,6 +168,17 @@ A `SampleRate` of `1` or less will keep all traces.
 Specifying this value is required.
 
 - Type: `int`
+
+### `SummarizeMode`
+
+Creates a summary span with some metadata and sends it to the summary span dataset in the same environment.
+"none" means no summarization occurs.
+"all" means all traces are summarized.
+"dropped" means only dropped traces are summarized.
+"kept" means only kept traces are summarized.
+
+- Type: `string`
+- Default: `none`- Options: `none`, `all`, `dropped`, `kept`
 
 ### `AdjustmentInterval`
 
@@ -247,6 +280,17 @@ The sampler will adjust sample rates to try to achieve this desired throughput.
 This value is calculated for the individual instance, not for the cluster; if your cluster has multiple instances, then you will need to divide your total desired sample rate by the number of instances to get this value.
 
 - Type: `int`
+
+### `SummarizeMode`
+
+Creates a summary span with some metadata and sends it to the summary span dataset in the same environment.
+"none" means no summarization occurs.
+"all" means all traces are summarized.
+"dropped" means only dropped traces are summarized.
+"kept" means only kept traces are summarized.
+
+- Type: `string`
+- Default: `none`- Options: `none`, `all`, `dropped`, `kept`
 
 ### `UseClusterSize`
 
@@ -371,6 +415,17 @@ The sampler will adjust sample rates to try to achieve this desired throughput.
 This value is calculated for the individual instance, not for the cluster; if your cluster has multiple instances, then you will need to divide your total desired sample rate by the number of instances to get this value.
 
 - Type: `int`
+
+### `SummarizeMode`
+
+Creates a summary span with some metadata and sends it to the summary span dataset in the same environment.
+"none" means no summarization occurs.
+"all" means all traces are summarized.
+"dropped" means only dropped traces are summarized.
+"kept" means only kept traces are summarized.
+
+- Type: `string`
+- Default: `none`- Options: `none`, `all`, `dropped`, `kept`
 
 ### `UseClusterSize`
 
@@ -592,6 +647,17 @@ This is the number of events per second you want to send.
 This is not the same as the Sample Rate.
 
 - Type: `int`
+
+### `SummarizeMode`
+
+Creates a summary span with some metadata and sends it to the summary span dataset in the same environment.
+"none" means no summarization occurs.
+"all" means all traces are summarized.
+"dropped" means only dropped traces are summarized.
+"kept" means only kept traces are summarized.
+
+- Type: `string`
+- Default: `none`- Options: `none`, `all`, `dropped`, `kept`
 
 ### `UseClusterSize`
 

--- a/rules.md
+++ b/rules.md
@@ -1,7 +1,7 @@
 # Honeycomb Refinery Rules Documentation
 
 This is the documentation for the rules configuration for Honeycomb's Refinery.
-It was automatically generated on 2025-02-13 at 16:52:14 UTC.
+It was automatically generated on 2025-03-14 at 00:54:51 UTC.
 
 ## The Rules file
 
@@ -75,6 +75,20 @@ Specifying this value is required.
 
 Type: `int`
 
+### `SummarizeMode`
+
+Creates a summary span with some metadata and sends it to the summary span dataset in the same environment.
+"none" means no summarization occurs.
+"all" means all traces are summarized.
+"dropped" means only dropped traces are summarized.
+"kept" means only kept traces are summarized.
+
+Type: `string`
+
+Default: `none`
+
+- Options: `none`, `all`, `dropped`, `kept`
+
 ---
 ## Dynamic Sampler
 
@@ -98,6 +112,20 @@ A `SampleRate` of `1` or less will keep all traces.
 Specifying this value is required.
 
 Type: `int`
+
+### `SummarizeMode`
+
+Creates a summary span with some metadata and sends it to the summary span dataset in the same environment.
+"none" means no summarization occurs.
+"all" means all traces are summarized.
+"dropped" means only dropped traces are summarized.
+"kept" means only kept traces are summarized.
+
+Type: `string`
+
+Default: `none`
+
+- Options: `none`, `all`, `dropped`, `kept`
 
 ### `ClearFrequency`
 
@@ -170,6 +198,20 @@ A `SampleRate` of `1` or less will keep all traces.
 Specifying this value is required.
 
 Type: `int`
+
+### `SummarizeMode`
+
+Creates a summary span with some metadata and sends it to the summary span dataset in the same environment.
+"none" means no summarization occurs.
+"all" means all traces are summarized.
+"dropped" means only dropped traces are summarized.
+"kept" means only kept traces are summarized.
+
+Type: `string`
+
+Default: `none`
+
+- Options: `none`, `all`, `dropped`, `kept`
 
 ### `AdjustmentInterval`
 
@@ -274,6 +316,20 @@ The sampler will adjust sample rates to try to achieve this desired throughput.
 This value is calculated for the individual instance, not for the cluster; if your cluster has multiple instances, then you will need to divide your total desired sample rate by the number of instances to get this value.
 
 Type: `int`
+
+### `SummarizeMode`
+
+Creates a summary span with some metadata and sends it to the summary span dataset in the same environment.
+"none" means no summarization occurs.
+"all" means all traces are summarized.
+"dropped" means only dropped traces are summarized.
+"kept" means only kept traces are summarized.
+
+Type: `string`
+
+Default: `none`
+
+- Options: `none`, `all`, `dropped`, `kept`
 
 ### `UseClusterSize`
 
@@ -401,6 +457,20 @@ The sampler will adjust sample rates to try to achieve this desired throughput.
 This value is calculated for the individual instance, not for the cluster; if your cluster has multiple instances, then you will need to divide your total desired sample rate by the number of instances to get this value.
 
 Type: `int`
+
+### `SummarizeMode`
+
+Creates a summary span with some metadata and sends it to the summary span dataset in the same environment.
+"none" means no summarization occurs.
+"all" means all traces are summarized.
+"dropped" means only dropped traces are summarized.
+"kept" means only kept traces are summarized.
+
+Type: `string`
+
+Default: `none`
+
+- Options: `none`, `all`, `dropped`, `kept`
 
 ### `UseClusterSize`
 
@@ -635,6 +705,20 @@ This is the number of events per second you want to send.
 This is not the same as the Sample Rate.
 
 Type: `int`
+
+### `SummarizeMode`
+
+Creates a summary span with some metadata and sends it to the summary span dataset in the same environment.
+"none" means no summarization occurs.
+"all" means all traces are summarized.
+"dropped" means only dropped traces are summarized.
+"kept" means only kept traces are summarized.
+
+Type: `string`
+
+Default: `none`
+
+- Options: `none`, `all`, `dropped`, `kept`
 
 ### `UseClusterSize`
 

--- a/rules_complete.yaml
+++ b/rules_complete.yaml
@@ -50,6 +50,7 @@ Samplers:
                 - root.http.target
                 - response.status_code
             UseTraceLength: true
+            SummarizeMode: all
     env3:
         DeterministicSampler:
             SampleRate: 10

--- a/sample/deterministic.go
+++ b/sample/deterministic.go
@@ -47,9 +47,14 @@ func (d *DeterministicSampler) Start() error {
 	return nil
 }
 
-func (d *DeterministicSampler) GetSampleRate(trace *types.Trace) (rate uint, keep bool, reason string, key string) {
+func (d *DeterministicSampler) GetSampleRate(trace *types.Trace) (rate uint, keep bool, summarize bool, reason string, key string) {
+	summarize = false
+
 	if d.sampleRate <= 1 {
-		return 1, true, "deterministic/always", ""
+		if d.Config.SummarizeMode == "all" || d.Config.SummarizeMode == "kept" {
+			summarize = true
+		}
+		return 1, true, summarize, "deterministic/always", ""
 	}
 	sum := sha1.Sum([]byte(trace.TraceID + shardingSalt))
 	v := binary.BigEndian.Uint32(sum[:4])
@@ -60,7 +65,17 @@ func (d *DeterministicSampler) GetSampleRate(trace *types.Trace) (rate uint, kee
 		d.Metrics.Increment(d.prefix + "_num_dropped")
 	}
 
-	return uint(d.sampleRate), shouldKeep, "deterministic/chance", ""
+	// Handle summarization based on configuration
+	switch d.Config.SummarizeMode {
+	case "all":
+		summarize = true
+	case "dropped":
+		summarize = !shouldKeep
+	case "kept":
+		summarize = shouldKeep
+	}
+
+	return uint(d.sampleRate), shouldKeep, summarize, "deterministic/chance", ""
 }
 
 func (d *DeterministicSampler) GetKeyFields() []string {

--- a/sample/deterministic_test.go
+++ b/sample/deterministic_test.go
@@ -50,11 +50,12 @@ func TestGetSampleRate(t *testing.T) {
 	ds.Start()
 
 	for i, tst := range tsts {
-		rate, keep, reason, key := ds.GetSampleRate(tst.trace)
+		rate, keep, summarize, reason, key := ds.GetSampleRate(tst.trace)
 		assert.Equal(t, uint(10), rate, "sample rate should be fixed")
 		assert.Equal(t, tst.sampled, keep, "%d: trace ID %s should be %v", i, tst.trace.TraceID, tst.sampled)
 		assert.Equal(t, "deterministic/chance", reason)
 		assert.Equal(t, "", key)
+		assert.Equal(t, tst.sampled, summarize, "%d: trace ID %s should be %v", i, tst.trace.TraceID, tst.sampled)
 	}
 
 }

--- a/sample/dynamic.go
+++ b/sample/dynamic.go
@@ -63,7 +63,7 @@ func (d *DynamicSampler) Start() error {
 	return nil
 }
 
-func (d *DynamicSampler) GetSampleRate(trace *types.Trace) (rate uint, keep bool, reason string, key string) {
+func (d *DynamicSampler) GetSampleRate(trace *types.Trace) (rate uint, keep bool, summarize bool, reason string, key string) {
 	key, n := d.key.build(trace)
 	if n == maxKeyLength {
 		d.Logger.Debug().Logf("trace key hit max length of %d, truncating", maxKeyLength)
@@ -82,7 +82,19 @@ func (d *DynamicSampler) GetSampleRate(trace *types.Trace) (rate uint, keep bool
 		"span_count":  count,
 	}).Logf("got sample rate and decision")
 	d.metricsRecorder.RecordMetrics(d.dynsampler, shouldKeep, rate)
-	return rate, shouldKeep, d.prefix, key
+
+	// Handle summarization based on configuration
+	summarize = false
+	switch d.Config.SummarizeMode {
+	case "all":
+		summarize = true
+	case "dropped":
+		summarize = !shouldKeep
+	case "kept":
+		summarize = shouldKeep
+	}
+
+	return rate, shouldKeep, summarize, d.prefix, key
 }
 
 func (d *DynamicSampler) GetKeyFields() []string {

--- a/sample/dynamic_ema.go
+++ b/sample/dynamic_ema.go
@@ -72,7 +72,7 @@ func (d *EMADynamicSampler) Start() error {
 	return nil
 }
 
-func (d *EMADynamicSampler) GetSampleRate(trace *types.Trace) (rate uint, keep bool, reason string, key string) {
+func (d *EMADynamicSampler) GetSampleRate(trace *types.Trace) (rate uint, keep bool, summarize bool, reason string, key string) {
 	key, n := d.key.build(trace)
 	if n == maxKeyLength {
 		d.Logger.Debug().Logf("trace key hit max length of %d, truncating", maxKeyLength)
@@ -92,7 +92,18 @@ func (d *EMADynamicSampler) GetSampleRate(trace *types.Trace) (rate uint, keep b
 	}).Logf("got sample rate and decision")
 	d.metricsRecorder.RecordMetrics(d.dynsampler, shouldKeep, rate)
 
-	return rate, shouldKeep, d.prefix, key
+	// Handle summarization based on configuration
+	summarize = false
+	switch d.Config.SummarizeMode {
+	case "all":
+		summarize = true
+	case "dropped":
+		summarize = !shouldKeep
+	case "kept":
+		summarize = shouldKeep
+	}
+
+	return rate, shouldKeep, summarize, d.prefix, key
 }
 
 func (d *EMADynamicSampler) GetKeyFields() []string {

--- a/sample/dynamic_ema_test.go
+++ b/sample/dynamic_ema_test.go
@@ -39,7 +39,7 @@ func TestDynamicEMAAddSampleRateKeyToTrace(t *testing.T) {
 		})
 	}
 	sampler.Start()
-	rate, _, reason, key := sampler.GetSampleRate(trace)
+	rate, _, summarize, reason, key := sampler.GetSampleRate(trace)
 
 	spans := trace.GetSpans()
 
@@ -47,5 +47,5 @@ func TestDynamicEMAAddSampleRateKeyToTrace(t *testing.T) {
 	assert.Equal(t, uint(10), rate, "sample rate should be 10")
 	assert.Equal(t, "emadynamic", reason)
 	assert.Equal(t, "4•,200•,true•,/{slug}/fun•,", key)
-
+	assert.False(t, summarize, "summarize should be false")
 }

--- a/sample/dynamic_test.go
+++ b/sample/dynamic_test.go
@@ -48,7 +48,7 @@ func TestDynamicAddSampleRateKeyToTrace(t *testing.T) {
 		})
 	}
 	sampler.Start()
-	rate, keep, reason, key := sampler.GetSampleRate(trace)
+	rate, keep, summarize, reason, key := sampler.GetSampleRate(trace)
 
 	spans := trace.GetSpans()
 	assert.Len(t, spans, spanCount, "should have the same number of spans as input")
@@ -56,4 +56,5 @@ func TestDynamicAddSampleRateKeyToTrace(t *testing.T) {
 	assert.True(t, keep)
 	assert.Equal(t, "dynamic", reason)
 	assert.Equal(t, "200•,test,", key)
+	assert.False(t, summarize, "summarize should be false")
 }

--- a/sample/ema_throughput.go
+++ b/sample/ema_throughput.go
@@ -88,7 +88,7 @@ func (d *EMAThroughputSampler) SetClusterSize(size int) {
 	}
 }
 
-func (d *EMAThroughputSampler) GetSampleRate(trace *types.Trace) (rate uint, keep bool, reason string, key string) {
+func (d *EMAThroughputSampler) GetSampleRate(trace *types.Trace) (rate uint, keep bool, summarize bool, reason string, key string) {
 	key, n := d.key.build(trace)
 	if n == maxKeyLength {
 		d.Logger.Debug().Logf("trace key hit max length of %d, truncating", maxKeyLength)
@@ -107,7 +107,19 @@ func (d *EMAThroughputSampler) GetSampleRate(trace *types.Trace) (rate uint, kee
 		"span_count":  count,
 	}).Logf("got sample rate and decision")
 	d.metricsRecorder.RecordMetrics(d.dynsampler, shouldKeep, rate)
-	return rate, shouldKeep, d.prefix, key
+
+	// Handle summarization based on configuration
+	summarize = false
+	switch d.Config.SummarizeMode {
+	case "all":
+		summarize = true
+	case "dropped":
+		summarize = !shouldKeep
+	case "kept":
+		summarize = shouldKeep
+	}
+
+	return rate, shouldKeep, summarize, d.prefix, key
 }
 
 func (d *EMAThroughputSampler) GetKeyFields() []string {

--- a/sample/ema_throughput_test.go
+++ b/sample/ema_throughput_test.go
@@ -39,7 +39,7 @@ func TestEMAThroughputAddSampleRateKeyToTrace(t *testing.T) {
 		})
 	}
 	sampler.Start()
-	rate, _, reason, key := sampler.GetSampleRate(trace)
+	rate, _, summarize, reason, key := sampler.GetSampleRate(trace)
 
 	spans := trace.GetSpans()
 
@@ -47,5 +47,5 @@ func TestEMAThroughputAddSampleRateKeyToTrace(t *testing.T) {
 	assert.Equal(t, uint(10), rate, "sample rate should be 10")
 	assert.Equal(t, "emathroughput", reason)
 	assert.Equal(t, "4•,200•,true•,/{slug}/fun•,", key)
-
+	assert.False(t, summarize, "summarize should be false")
 }

--- a/sample/rules_test.go
+++ b/sample/rules_test.go
@@ -22,6 +22,7 @@ type TestRulesData struct {
 	ExpectedKeep      bool
 	ExpectedName      string
 	ExpectedKeyFields []string
+	ExpectedSummarize bool
 }
 
 func TestRules(t *testing.T) {
@@ -54,6 +55,7 @@ func TestRules(t *testing.T) {
 			ExpectedKeep:      true,
 			ExpectedRate:      10,
 			ExpectedKeyFields: []string{"test"},
+			ExpectedSummarize: false,
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -83,6 +85,7 @@ func TestRules(t *testing.T) {
 			ExpectedKeep:      true,
 			ExpectedRate:      10,
 			ExpectedKeyFields: []string{"test"},
+			ExpectedSummarize: false,
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -112,6 +115,7 @@ func TestRules(t *testing.T) {
 			ExpectedKeep:      true,
 			ExpectedRate:      10,
 			ExpectedKeyFields: []string{"test"},
+			ExpectedSummarize: false,
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -141,6 +145,7 @@ func TestRules(t *testing.T) {
 			ExpectedKeep:      true,
 			ExpectedRate:      10,
 			ExpectedKeyFields: []string{"test"},
+			ExpectedSummarize: false,
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -175,6 +180,7 @@ func TestRules(t *testing.T) {
 			ExpectedRate:      10,
 			ExpectedName:      "fallback",
 			ExpectedKeyFields: []string{"test"},
+			ExpectedSummarize: false,
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -222,6 +228,7 @@ func TestRules(t *testing.T) {
 			ExpectedKeep:      true,
 			ExpectedRate:      10,
 			ExpectedKeyFields: []string{"test", "test_two"},
+			ExpectedSummarize: false,
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -251,6 +258,7 @@ func TestRules(t *testing.T) {
 			ExpectedKeep:      false,
 			ExpectedRate:      0,
 			ExpectedKeyFields: []string{"test"},
+			ExpectedSummarize: false,
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -273,6 +281,7 @@ func TestRules(t *testing.T) {
 			ExpectedKeep:      false,
 			ExpectedRate:      0,
 			ExpectedKeyFields: []string{},
+			ExpectedSummarize: false,
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -316,6 +325,7 @@ func TestRules(t *testing.T) {
 			ExpectedRate:      1,
 			ExpectedName:      "no rule matched",
 			ExpectedKeyFields: []string{"first", "second"},
+			ExpectedSummarize: false,
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -345,6 +355,7 @@ func TestRules(t *testing.T) {
 			ExpectedKeep:      true,
 			ExpectedRate:      4,
 			ExpectedKeyFields: []string{"first"},
+			ExpectedSummarize: false,
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -373,6 +384,7 @@ func TestRules(t *testing.T) {
 			ExpectedKeep:      true,
 			ExpectedRate:      4,
 			ExpectedKeyFields: []string{"first"},
+			ExpectedSummarize: false,
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -401,6 +413,7 @@ func TestRules(t *testing.T) {
 			ExpectedKeep:      true,
 			ExpectedRate:      4,
 			ExpectedKeyFields: []string{"first"},
+			ExpectedSummarize: false,
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -430,6 +443,7 @@ func TestRules(t *testing.T) {
 			ExpectedKeep:      true,
 			ExpectedRate:      4,
 			ExpectedKeyFields: []string{"first"},
+			ExpectedSummarize: false,
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -459,6 +473,7 @@ func TestRules(t *testing.T) {
 			ExpectedKeep:      true,
 			ExpectedRate:      4,
 			ExpectedKeyFields: []string{"first"},
+			ExpectedSummarize: false,
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -488,6 +503,7 @@ func TestRules(t *testing.T) {
 			ExpectedKeep:      true,
 			ExpectedRate:      4,
 			ExpectedKeyFields: []string{"first"},
+			ExpectedSummarize: false,
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -517,6 +533,7 @@ func TestRules(t *testing.T) {
 			ExpectedKeep:      true,
 			ExpectedRate:      10,
 			ExpectedKeyFields: []string{"test"},
+			ExpectedSummarize: false,
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -560,6 +577,7 @@ func TestRules(t *testing.T) {
 			ExpectedKeep:      true,
 			ExpectedRate:      1,
 			ExpectedKeyFields: []string{"meta.span_count"},
+			ExpectedSummarize: false,
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -614,6 +632,7 @@ func TestRules(t *testing.T) {
 			ExpectedKeep:      false,
 			ExpectedRate:      0,
 			ExpectedKeyFields: []string{"meta.span_count"},
+			ExpectedSummarize: false,
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -657,6 +676,7 @@ func TestRules(t *testing.T) {
 			ExpectedKeep:      false,
 			ExpectedRate:      0,
 			ExpectedKeyFields: []string{},
+			ExpectedSummarize: false,
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -709,6 +729,7 @@ func TestRules(t *testing.T) {
 			ExpectedKeep:      true,
 			ExpectedRate:      99,
 			ExpectedKeyFields: []string{},
+			ExpectedSummarize: false,
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -738,6 +759,7 @@ func TestRules(t *testing.T) {
 			ExpectedKeep:      true,
 			ExpectedRate:      10,
 			ExpectedKeyFields: []string{"test", "test2"},
+			ExpectedSummarize: false,
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -768,6 +790,7 @@ func TestRules(t *testing.T) {
 			ExpectedName:      "no rule matched",
 			ExpectedRate:      1,
 			ExpectedKeyFields: []string{"test", "test2"},
+			ExpectedSummarize: false,
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -799,6 +822,7 @@ func TestRules(t *testing.T) {
 			ExpectedName:      "no rule matched",
 			ExpectedRate:      1,
 			ExpectedKeyFields: []string{"test", "test2"},
+			ExpectedSummarize: false,
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -861,6 +885,7 @@ func TestRules(t *testing.T) {
 			ExpectedKeep:      false,
 			ExpectedRate:      1,
 			ExpectedKeyFields: []string{string(config.NUM_DESCENDANTS)},
+			ExpectedSummarize: false,
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -921,6 +946,7 @@ func TestRules(t *testing.T) {
 			ExpectedKeep:      true,
 			ExpectedRate:      1,
 			ExpectedKeyFields: []string{string(config.NUM_DESCENDANTS)},
+			ExpectedSummarize: false,
 		},
 	}
 
@@ -947,7 +973,7 @@ func TestRules(t *testing.T) {
 		}
 
 		sampler.Start()
-		rate, keep, reason, key := sampler.GetSampleRate(trace)
+		rate, keep, summarize, reason, key := sampler.GetSampleRate(trace)
 
 		assert.Equal(t, d.ExpectedRate, rate, d.Rules)
 		name := d.ExpectedName
@@ -956,7 +982,7 @@ func TestRules(t *testing.T) {
 		}
 		assert.Contains(t, reason, name)
 		assert.Equal(t, "", key)
-
+		assert.Equal(t, d.ExpectedSummarize, summarize, d.Rules)
 		keyFields := sampler.GetKeyFields()
 		slices.Sort(keyFields)
 		assert.Equal(t, d.ExpectedKeyFields, keyFields)
@@ -1001,6 +1027,7 @@ func TestRulesWithNestedFields(t *testing.T) {
 			ExpectedKeep:      true,
 			ExpectedRate:      10,
 			ExpectedKeyFields: []string{"test.test1"},
+			ExpectedSummarize: false,
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -1031,6 +1058,7 @@ func TestRulesWithNestedFields(t *testing.T) {
 			ExpectedKeep:      true,
 			ExpectedRate:      10,
 			ExpectedKeyFields: []string{"test.test1"},
+			ExpectedSummarize: false,
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -1062,6 +1090,7 @@ func TestRulesWithNestedFields(t *testing.T) {
 			ExpectedKeep:      true,
 			ExpectedRate:      4,
 			ExpectedKeyFields: []string{"test.test1"},
+			ExpectedSummarize: false,
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -1094,6 +1123,7 @@ func TestRulesWithNestedFields(t *testing.T) {
 			ExpectedRate:      1,
 			ExpectedName:      "no rule matched",
 			ExpectedKeyFields: []string{"test.test1"},
+			ExpectedSummarize: false,
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -1126,6 +1156,7 @@ func TestRulesWithNestedFields(t *testing.T) {
 			ExpectedKeep:      true,
 			ExpectedRate:      10,
 			ExpectedKeyFields: []string{"test.test1", "test.test2"},
+			ExpectedSummarize: false,
 		},
 	}
 
@@ -1150,7 +1181,7 @@ func TestRulesWithNestedFields(t *testing.T) {
 			}
 
 			sampler.Start()
-			rate, keep, reason, key := sampler.GetSampleRate(trace)
+			rate, keep, summarize, reason, key := sampler.GetSampleRate(trace)
 
 			assert.Equal(t, d.ExpectedRate, rate, d.Rules)
 			name := d.ExpectedName
@@ -1159,7 +1190,7 @@ func TestRulesWithNestedFields(t *testing.T) {
 			}
 			assert.Contains(t, reason, name)
 			assert.Equal(t, "", key)
-
+			assert.Equal(t, d.ExpectedSummarize, summarize, d.Rules)
 			keyFields := sampler.GetKeyFields()
 			slices.Sort(keyFields)
 			assert.Equal(t, d.ExpectedKeyFields, keyFields)
@@ -1215,6 +1246,7 @@ func TestRulesWithDynamicSampler(t *testing.T) {
 			ExpectedKeep:      true,
 			ExpectedRate:      10,
 			ExpectedKeyFields: []string{"http.status_code", "rule_test"},
+			ExpectedSummarize: false,
 		},
 	}
 
@@ -1238,7 +1270,7 @@ func TestRulesWithDynamicSampler(t *testing.T) {
 		}
 
 		sampler.Start()
-		rate, keep, reason, key := sampler.GetSampleRate(trace)
+		rate, keep, summarize, reason, key := sampler.GetSampleRate(trace)
 
 		assert.Equal(t, d.ExpectedRate, rate, d.Rules)
 		name := d.ExpectedName
@@ -1247,7 +1279,7 @@ func TestRulesWithDynamicSampler(t *testing.T) {
 		}
 		assert.Contains(t, reason, name)
 		assert.Equal(t, "200•,", key)
-
+		assert.Equal(t, d.ExpectedSummarize, summarize, d.Rules)
 		keyFields := sampler.GetKeyFields()
 		slices.Sort(keyFields)
 		assert.Equal(t, d.ExpectedKeyFields, keyFields)
@@ -1306,6 +1338,7 @@ func TestRulesWithEMADynamicSampler(t *testing.T) {
 			ExpectedKeep:      true,
 			ExpectedRate:      10,
 			ExpectedKeyFields: []string{"http.status_code", "rule_test"},
+			ExpectedSummarize: false,
 		},
 	}
 
@@ -1329,7 +1362,7 @@ func TestRulesWithEMADynamicSampler(t *testing.T) {
 		}
 
 		sampler.Start()
-		rate, keep, reason, key := sampler.GetSampleRate(trace)
+		rate, keep, summarize, reason, key := sampler.GetSampleRate(trace)
 
 		assert.Equal(t, d.ExpectedRate, rate, d.Rules)
 		name := d.ExpectedName
@@ -1338,7 +1371,7 @@ func TestRulesWithEMADynamicSampler(t *testing.T) {
 		}
 		assert.Contains(t, reason, name)
 		assert.Equal(t, "200•,", key)
-
+		assert.Equal(t, d.ExpectedSummarize, summarize, d.Rules)
 		keyFields := sampler.GetKeyFields()
 		slices.Sort(keyFields)
 		assert.Equal(t, d.ExpectedKeyFields, keyFields)
@@ -1354,15 +1387,17 @@ func TestRulesWithEMADynamicSampler(t *testing.T) {
 
 func TestRuleMatchesSpanMatchingSpan(t *testing.T) {
 	testCases := []struct {
-		name           string
-		spans          []*types.Span
-		keepSpanScope  bool
-		keepTraceScope bool
+		name              string
+		spans             []*types.Span
+		keepSpanScope     bool
+		keepTraceScope    bool
+		ExpectedSummarize bool
 	}{
 		{
-			name:           "all conditions match single span",
-			keepSpanScope:  true,
-			keepTraceScope: true,
+			name:              "all conditions match single span",
+			keepSpanScope:     true,
+			keepTraceScope:    true,
+			ExpectedSummarize: false,
 			spans: []*types.Span{
 				{
 					Event: types.Event{
@@ -1383,9 +1418,10 @@ func TestRuleMatchesSpanMatchingSpan(t *testing.T) {
 			},
 		},
 		{
-			name:           "all conditions do not match single span",
-			keepSpanScope:  false,
-			keepTraceScope: true,
+			name:              "all conditions do not match single span",
+			keepSpanScope:     false,
+			keepTraceScope:    true,
+			ExpectedSummarize: false,
 			spans: []*types.Span{
 				{
 					Event: types.Event{
@@ -1456,13 +1492,13 @@ func TestRuleMatchesSpanMatchingSpan(t *testing.T) {
 				}
 
 				sampler.Start()
-				rate, keep, _, _ := sampler.GetSampleRate(trace)
-
-				assert.Equal(t, uint(1), rate, rate)
+				rate, keep, summarize, _, _ := sampler.GetSampleRate(trace)
+				assert.Equal(t, tc.ExpectedSummarize, summarize)
+				assert.Equal(t, uint(1), rate)
 				if scope == "span" {
-					assert.Equal(t, tc.keepSpanScope, keep, keep)
+					assert.Equal(t, tc.keepSpanScope, keep)
 				} else {
-					assert.Equal(t, tc.keepTraceScope, keep, keep)
+					assert.Equal(t, tc.keepTraceScope, keep)
 				}
 			}
 		})
@@ -2038,8 +2074,9 @@ func TestRulesDatatypes(t *testing.T) {
 				trace.AddSpan(span)
 			}
 
-			rate, keep, _, _ := sampler.GetSampleRate(trace)
+			rate, keep, summarize, _, _ := sampler.GetSampleRate(trace)
 			assert.Equal(t, d.ExpectedRate, rate, d.Rules)
+			assert.Equal(t, d.ExpectedSummarize, summarize, d.Rules)
 			// because keep depends on sampling rate, we can only test expectedKeep when it should be false
 			if !d.ExpectedKeep {
 				assert.Equal(t, d.ExpectedKeep, keep, d.Rules)
@@ -2115,7 +2152,7 @@ func TestRegexpRules(t *testing.T) {
 				trace.AddSpan(span)
 			}
 
-			rate, _, _, _ := sampler.GetSampleRate(trace)
+			rate, _, _, _, _ := sampler.GetSampleRate(trace)
 			assert.Equal(t, d.rate, rate, d)
 		})
 	}
@@ -2186,9 +2223,9 @@ func TestRulesWithDeterministicSampler(t *testing.T) {
 		}
 
 		sampler.Start()
-		rate, keep, reason, key := sampler.GetSampleRate(trace)
+		rate, keep, summarize, reason, key := sampler.GetSampleRate(trace)
 		assert.Equal(t, "", key)
-
+		assert.Equal(t, d.ExpectedSummarize, summarize, d.Rules)
 		assert.Equal(t, d.ExpectedRate, rate, d.Rules)
 		name := d.ExpectedName
 		if name == "" {
@@ -2900,9 +2937,9 @@ func TestRulesRootSpanContext(t *testing.T) {
 			spans := trace.GetSpans()
 			assert.Len(t, spans, len(d.Spans), "should have the same number of spans as input")
 
-			rate, _, reason, key := sampler.GetSampleRate(trace)
+			rate, _, summarize, reason, key := sampler.GetSampleRate(trace)
 			assert.Equal(t, "", key)
-
+			assert.Equal(t, d.ExpectedSummarize, summarize, d.Rules)
 			assert.Equal(t, d.ExpectedRate, rate, d.Rules)
 			name := d.ExpectedName
 			if name == "" {

--- a/sample/sample.go
+++ b/sample/sample.go
@@ -14,7 +14,7 @@ import (
 )
 
 type Sampler interface {
-	GetSampleRate(trace *types.Trace) (rate uint, keep bool, reason string, key string)
+	GetSampleRate(trace *types.Trace) (rate uint, keep bool, summarize bool, reason string, key string)
 	GetKeyFields() []string
 	Start() error
 }

--- a/sample/totalthroughput.go
+++ b/sample/totalthroughput.go
@@ -79,7 +79,7 @@ func (d *TotalThroughputSampler) SetClusterSize(size int) {
 	}
 }
 
-func (d *TotalThroughputSampler) GetSampleRate(trace *types.Trace) (rate uint, keep bool, reason string, key string) {
+func (d *TotalThroughputSampler) GetSampleRate(trace *types.Trace) (rate uint, keep bool, summarize bool, reason string, key string) {
 	key, n := d.key.build(trace)
 	if n == maxKeyLength {
 		d.Logger.Debug().Logf("trace key hit max length of %d, truncating", maxKeyLength)
@@ -99,7 +99,19 @@ func (d *TotalThroughputSampler) GetSampleRate(trace *types.Trace) (rate uint, k
 	}).Logf("got sample rate and decision")
 
 	d.metricsRecorder.RecordMetrics(d.dynsampler, shouldKeep, rate)
-	return rate, shouldKeep, d.prefix, key
+
+	// Handle summarization based on configuration
+	summarize = false
+	switch d.Config.SummarizeMode {
+	case "all":
+		summarize = true
+	case "dropped":
+		summarize = !shouldKeep
+	case "kept":
+		summarize = shouldKeep
+	}
+
+	return rate, shouldKeep, summarize, d.prefix, key
 }
 
 func (d *TotalThroughputSampler) GetKeyFields() []string {

--- a/sample/windowed_throughput.go
+++ b/sample/windowed_throughput.go
@@ -75,7 +75,7 @@ func (d *WindowedThroughputSampler) SetClusterSize(size int) {
 	}
 }
 
-func (d *WindowedThroughputSampler) GetSampleRate(trace *types.Trace) (rate uint, keep bool, reason string, key string) {
+func (d *WindowedThroughputSampler) GetSampleRate(trace *types.Trace) (rate uint, keep bool, summarize bool, reason string, key string) {
 	key, n := d.key.build(trace)
 	if n == maxKeyLength {
 		d.Logger.Debug().Logf("trace key hit max length of %d, truncating", maxKeyLength)
@@ -95,8 +95,20 @@ func (d *WindowedThroughputSampler) GetSampleRate(trace *types.Trace) (rate uint
 	}).Logf("got sample rate and decision")
 	d.metricsRecorder.RecordMetrics(d.dynsampler, shouldKeep, rate)
 
-	return rate, shouldKeep, d.prefix, key
+	// Handle summarization based on configuration
+	summarize = false
+	switch d.Config.SummarizeMode {
+	case "all":
+		summarize = true
+	case "dropped":
+		summarize = !shouldKeep
+	case "kept":
+		summarize = shouldKeep
+	}
+
+	return rate, shouldKeep, summarize, d.prefix, key
 }
+
 func (d *WindowedThroughputSampler) GetKeyFields() []string {
 	return d.keyFields
 }

--- a/sample/windowed_throughput_test.go
+++ b/sample/windowed_throughput_test.go
@@ -39,7 +39,7 @@ func TestWindowedThroughputAddSampleRateKeyToTrace(t *testing.T) {
 		})
 	}
 	sampler.Start()
-	rate, _, reason, key := sampler.GetSampleRate(trace)
+	rate, _, summarize, reason, key := sampler.GetSampleRate(trace)
 
 	spans := trace.GetSpans()
 
@@ -47,5 +47,5 @@ func TestWindowedThroughputAddSampleRateKeyToTrace(t *testing.T) {
 	assert.Equal(t, uint(1), rate, "sample rate should be 1")
 	assert.Equal(t, "windowedthroughput", reason)
 	assert.Equal(t, "4•,200•,true•,/{slug}/fun•,", key)
-
+	assert.False(t, summarize, "summarize should be false")
 }

--- a/tools/convert/configDataNames.txt
+++ b/tools/convert/configDataNames.txt
@@ -1,5 +1,5 @@
 # Names of groups and fields in the new config file format.
-# Automatically generated on 2025-02-13 at 16:52:05 UTC.
+# Automatically generated on 2025-03-14 at 00:54:47 UTC.
 
 General:
   - ConfigurationVersion
@@ -55,6 +55,8 @@ Traces:
   - SendTicker
 
   - MaxExpiredTraces
+
+  - SummarySpanDataset
 
 
 Debugging:

--- a/tools/convert/minimal_config.yaml
+++ b/tools/convert/minimal_config.yaml
@@ -1,5 +1,5 @@
 # sample uncommented config file containing all possible fields
-# automatically generated on 2025-02-13 at 16:52:06 UTC
+# automatically generated on 2025-03-14 at 00:54:48 UTC
 General:
   ConfigurationVersion: 2
   MinRefineryVersion: "v2.0"
@@ -30,6 +30,7 @@ Traces:
   MaxBatchSize: 500
   SendTicker: 100ms
   MaxExpiredTraces: 5_000
+  SummarySpanDataset: "Summary Spans"
 Debugging:
   DebugServiceAddr: "localhost:6060"
   QueryAuthToken: "some-private-value"

--- a/tools/convert/templates/configV2.tmpl
+++ b/tools/convert/templates/configV2.tmpl
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created {{ now }} from {{ .Input }} using a template generated on 2025-02-13 at 16:52:04 UTC
+# created {{ now }} from {{ .Input }} using a template generated on 2025-03-14 at 00:54:47 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of
@@ -369,6 +369,17 @@ Traces:
     ## default: 5000
     ## Eligible for live reload.
     {{ nonDefaultOnly .Data "MaxExpiredTraces" "MaxExpiredTraces" 5000 }}
+
+    ## SummarySpanDataset is the dataset name for summary spans.
+    ##
+    ## When traces are summarized, the service.name of the spans isn't
+    ## applicable since traces tend to cross service boundaries. The summary
+    ## spans will be sent to the same environemnt as the trace was going to,
+    ## since it uses the same API key.
+    ##
+    ## default: Summary Spans
+    ## Eligible for live reload.
+    {{ nonDefaultOnly .Data "SummarySpanDataset" "SummarySpanDataset" "Summary Spans" }}
 
 ###############
 ## Debugging ##

--- a/types/event.go
+++ b/types/event.go
@@ -320,3 +320,82 @@ func (sp *Span) CacheImpact(traceTimeout time.Duration) int {
 func IsLegacyAPIKey(apiKey string) bool {
 	return huskyotlp.IsClassicApiKey(apiKey)
 }
+
+// SummarizeTrace flattens the trace into a single wide event based on the root span.
+// The metrics should ideally be collected during the initial sampling pass to avoid
+// an extra iteration.
+func (t *Trace) SummarizeTrace(minDuration time.Duration, metrics *TraceSummaryMetrics) {
+	if len(t.spans) == 0 || t.RootSpan == nil {
+		return
+	}
+
+	// Start with root span as our base
+	summary := t.RootSpan
+	summary.Data["meta.summarized"] = true
+	summary.Data["meta.original_span_count"] = len(t.spans)
+
+	// If metrics were collected during sampling pass, use them
+	if metrics != nil {
+		summary.Data["meta.total_duration_ms"] = metrics.TotalDuration
+		summary.Data["meta.max_span_duration_ms"] = metrics.MaxDuration
+		summary.Data["meta.error_count"] = metrics.ErrorCount
+		summary.Data["meta.high_latency_span_count"] = metrics.HighLatencyCount
+		summary.Data["meta.services"] = metrics.Services
+	} else {
+		// Fallback to collecting metrics now (less efficient)
+		var totalDuration float64
+		var maxDuration float64
+		var errorCount int64
+		var highLatencyCount int64
+		services := make(map[string]bool)
+
+		for _, sp := range t.spans {
+			if sp == t.RootSpan {
+				continue
+			}
+
+			if sp.Data != nil {
+				if duration, ok := sp.Data["duration_ms"].(float64); ok {
+					totalDuration += duration
+					if duration > maxDuration {
+						maxDuration = duration
+					}
+					if duration >= float64(minDuration/time.Millisecond) {
+						highLatencyCount++
+					}
+				}
+
+				if status, ok := sp.Data["status.code"].(int64); ok && status > 0 {
+					errorCount++
+				}
+				if errMsg, ok := sp.Data["error"]; ok && errMsg != nil {
+					errorCount++
+				}
+
+				if service, ok := sp.Data["service.name"].(string); ok {
+					services[service] = true
+				}
+			}
+		}
+
+		summary.Data["meta.total_duration_ms"] = totalDuration
+		summary.Data["meta.max_span_duration_ms"] = maxDuration
+		summary.Data["meta.error_count"] = errorCount
+		summary.Data["meta.high_latency_span_count"] = highLatencyCount
+		summary.Data["meta.services"] = services
+	}
+
+	// Replace all spans with just the summary
+	t.spans = []*Span{summary}
+	t.RootSpan = summary
+	t.DataSize = summary.GetDataSize()
+}
+
+// TraceSummaryMetrics holds the metrics collected during sampling pass
+type TraceSummaryMetrics struct {
+	TotalDuration    float64
+	MaxDuration      float64
+	ErrorCount       int64
+	HighLatencyCount int64
+	Services         map[string]bool
+}

--- a/types/event.go
+++ b/types/event.go
@@ -3,6 +3,7 @@ package types
 import (
 	"context"
 	"slices"
+	"strings"
 	"time"
 
 	huskyotlp "github.com/honeycombio/husky/otlp"
@@ -50,6 +51,7 @@ type Trace struct {
 	Sent             bool
 	keptReason       uint
 	DeciderShardAddr string
+	SummaryDataset   string
 
 	SendBy  time.Time
 	Retried bool
@@ -324,78 +326,138 @@ func IsLegacyAPIKey(apiKey string) bool {
 // SummarizeTrace flattens the trace into a single wide event based on the root span.
 // The metrics should ideally be collected during the initial sampling pass to avoid
 // an extra iteration.
-func (t *Trace) SummarizeTrace(minDuration time.Duration, metrics *TraceSummaryMetrics) {
+func (t *Trace) SummarizeTrace(slowSpanDuration time.Duration, decision TraceDecision) {
 	if len(t.spans) == 0 || t.RootSpan == nil {
 		return
 	}
 
+	var summary *Span
 	// Start with root span as our base
-	summary := t.RootSpan
-	summary.Data["meta.summarized"] = true
-	summary.Data["meta.original_span_count"] = len(t.spans)
-
-	// If metrics were collected during sampling pass, use them
-	if metrics != nil {
-		summary.Data["meta.total_duration_ms"] = metrics.TotalDuration
-		summary.Data["meta.max_span_duration_ms"] = metrics.MaxDuration
-		summary.Data["meta.error_count"] = metrics.ErrorCount
-		summary.Data["meta.high_latency_span_count"] = metrics.HighLatencyCount
-		summary.Data["meta.services"] = metrics.Services
+	if t.RootSpan.Data != nil {
+		summary = t.RootSpan
+		summary.Dataset = t.SummaryDataset
+		summary.Data["trace.root_span_id"] = summary.Data["trace.span_id"]
+		summary.Data["trace.span_id"] = summary.Data["trace.span_id"].(string) + "summary" // we need a new id in case the spans are kept.
 	} else {
-		// Fallback to collecting metrics now (less efficient)
-		var totalDuration float64
-		var maxDuration float64
-		var errorCount int64
-		var highLatencyCount int64
-		services := make(map[string]bool)
+		summary = &Span{
+			Event: Event{
+				Data: make(map[string]interface{}),
+			},
+		}
+		summary.Data["trace.span_id"] = t.spans[0].Data["trace.span_id"]
+		summary.Data["meta.summarized.missing_root_span"] = true
+	}
+	summary.Data["meta.summarized"] = true
+	summary.Data["meta.summarized.span_count"] = len(t.spans)
 
-		for _, sp := range t.spans {
-			if sp == t.RootSpan {
-				continue
+	// Fallback to collecting metrics now (less efficient)
+	var totalDuration float64
+	var earliestStart time.Time
+	var latestEnd time.Time
+	var errorCount int64
+	var highLatencyCount int64
+	services := make(map[string]bool)
+
+	for _, sp := range t.spans {
+		if sp == t.RootSpan {
+			continue
+		}
+
+		if sp.Timestamp.Before(earliestStart) {
+			earliestStart = sp.Timestamp
+		}
+
+		if sp.Data != nil {
+			if duration, ok := sp.Data["duration_ms"].(float64); ok {
+
+				endTime := sp.Timestamp.Add(time.Duration(duration) * time.Millisecond)
+				if endTime.After(latestEnd) {
+					latestEnd = endTime
+				}
+
+				if duration >= float64(slowSpanDuration/time.Millisecond) {
+					highLatencyCount++
+				}
 			}
 
-			if sp.Data != nil {
-				if duration, ok := sp.Data["duration_ms"].(float64); ok {
-					totalDuration += duration
-					if duration > maxDuration {
-						maxDuration = duration
-					}
-					if duration >= float64(minDuration/time.Millisecond) {
-						highLatencyCount++
-					}
-				}
+			if status, ok := sp.Data["status.code"].(int64); ok && status > 0 {
+				errorCount++
+			}
 
-				if status, ok := sp.Data["status.code"].(int64); ok && status > 0 {
-					errorCount++
-				}
-				if errMsg, ok := sp.Data["error"]; ok && errMsg != nil {
-					errorCount++
-				}
+			if errMsg, ok := sp.Data["error"]; ok && errMsg != nil {
+				errorCount++
+			}
 
-				if service, ok := sp.Data["service.name"].(string); ok {
-					services[service] = true
-				}
+			if service, ok := sp.Data["service.name"].(string); ok {
+				services[service] = true
 			}
 		}
 
-		summary.Data["meta.total_duration_ms"] = totalDuration
-		summary.Data["meta.max_span_duration_ms"] = maxDuration
-		summary.Data["meta.error_count"] = errorCount
-		summary.Data["meta.high_latency_span_count"] = highLatencyCount
-		summary.Data["meta.services"] = services
+		totalDuration = float64(latestEnd.Sub(earliestStart).Milliseconds())
+
+		summary.Data["meta.summarized.total_duration_ms"] = totalDuration
+		summary.Data["meta.summarized.error_count"] = errorCount
+		summary.Data["meta.summarized.high_latency_threshold_ms"] = slowSpanDuration
+		summary.Data["meta.summarized.high_latency_span_count"] = highLatencyCount
+
+		serviceList := make([]string, 0, len(services))
+		for service := range services {
+			serviceList = append(serviceList, service)
+		}
+		summary.Data["meta.summarized.services"] = strings.Join(serviceList, ",")
 	}
 
-	// Replace all spans with just the summary
-	t.spans = []*Span{summary}
-	t.RootSpan = summary
-	t.DataSize = summary.GetDataSize()
+	// send the summary to a specific dataset!
 }
 
-// TraceSummaryMetrics holds the metrics collected during sampling pass
-type TraceSummaryMetrics struct {
-	TotalDuration    float64
-	MaxDuration      float64
-	ErrorCount       int64
-	HighLatencyCount int64
-	Services         map[string]bool
+type TraceDecision struct {
+	TraceID string
+	// if we don'g need to immediately eject traces from the trace cache,
+	// we could remove this field. The TraceDecision type could be renamed to
+	// keptDecision
+	Kept            bool
+	Summarize       bool // If true, summarize the trace into the summary dataset, whether sent or not
+	Rate            uint
+	SamplerKey      string
+	SamplerSelector string
+	SendReason      string
+	HasRoot         bool
+	Reason          string
+	Count           uint32
+	EventCount      uint32
+	LinkCount       uint32
+
+	keptReasonIdx uint
+}
+
+func (td *TraceDecision) DescendantCount() uint32 {
+	return td.Count + td.EventCount + td.LinkCount
+}
+
+func (td *TraceDecision) SpanCount() uint32 {
+	return td.Count
+}
+
+func (td *TraceDecision) SpanEventCount() uint32 {
+	return td.EventCount
+}
+
+func (td *TraceDecision) SpanLinkCount() uint32 {
+	return td.LinkCount
+}
+
+func (td *TraceDecision) SampleRate() uint {
+	return td.Rate
+}
+
+func (td *TraceDecision) ID() string {
+	return td.TraceID
+}
+
+func (td *TraceDecision) KeptReason() uint {
+	return td.keptReasonIdx
+}
+
+func (td *TraceDecision) SetKeptReason(reasonIdx uint) {
+	td.keptReasonIdx = reasonIdx
 }

--- a/types/event.go
+++ b/types/event.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"context"
+	"errors"
 	"slices"
 	"strings"
 	"time"
@@ -326,26 +327,21 @@ func IsLegacyAPIKey(apiKey string) bool {
 // SummarizeTrace flattens the trace into a single wide event based on the root span.
 // The metrics should ideally be collected during the initial sampling pass to avoid
 // an extra iteration.
-func (t *Trace) SummarizeTrace(slowSpanDuration time.Duration, decision TraceDecision) {
+func (t *Trace) SummarizeTrace(slowSpanDuration time.Duration, decision TraceDecision) (summary *Span, err error) {
 	if len(t.spans) == 0 || t.RootSpan == nil {
-		return
+		return nil, errors.New("trace has no spans")
 	}
 
-	var summary *Span
 	// Start with root span as our base
 	if t.RootSpan.Data != nil {
 		summary = t.RootSpan
 		summary.Dataset = t.SummaryDataset
 		summary.Data["trace.root_span_id"] = summary.Data["trace.span_id"]
-		summary.Data["trace.span_id"] = summary.Data["trace.span_id"].(string) + "summary" // we need a new id in case the spans are kept.
+		summary.Data["trace.span_id"] = summary.Data["trace.span_id"].(string) + "-s" // we need a new id in case the spans are kept.
 	} else {
-		summary = &Span{
-			Event: Event{
-				Data: make(map[string]interface{}),
-			},
-		}
-		summary.Data["trace.span_id"] = t.spans[0].Data["trace.span_id"]
-		summary.Data["meta.summarized.missing_root_span"] = true
+		// suggested enhahcement to find the first "server" span
+		summary = t.spans[0]
+		summary.Data["Name"] = "Summary span"
 	}
 	summary.Data["meta.summarized"] = true
 	summary.Data["meta.summarized.span_count"] = len(t.spans)
@@ -379,11 +375,7 @@ func (t *Trace) SummarizeTrace(slowSpanDuration time.Duration, decision TraceDec
 					highLatencyCount++
 				}
 			}
-
-			if status, ok := sp.Data["status.code"].(int64); ok && status > 0 {
-				errorCount++
-			}
-
+			// I think this will find errors?
 			if errMsg, ok := sp.Data["error"]; ok && errMsg != nil {
 				errorCount++
 			}
@@ -392,22 +384,21 @@ func (t *Trace) SummarizeTrace(slowSpanDuration time.Duration, decision TraceDec
 				services[service] = true
 			}
 		}
-
-		totalDuration = float64(latestEnd.Sub(earliestStart).Milliseconds())
-
+	}
+	if totalDuration > 0 {
 		summary.Data["meta.summarized.total_duration_ms"] = totalDuration
 		summary.Data["meta.summarized.error_count"] = errorCount
 		summary.Data["meta.summarized.high_latency_threshold_ms"] = slowSpanDuration
 		summary.Data["meta.summarized.high_latency_span_count"] = highLatencyCount
-
-		serviceList := make([]string, 0, len(services))
-		for service := range services {
-			serviceList = append(serviceList, service)
-		}
-		summary.Data["meta.summarized.services"] = strings.Join(serviceList, ",")
 	}
 
-	// send the summary to a specific dataset!
+	serviceList := make([]string, 0, len(services))
+	for service := range services {
+		serviceList = append(serviceList, service)
+	}
+	summary.Data["meta.summarized.services"] = strings.Join(serviceList, ",")
+	// send the summary event back to the collect function so it can be sent.
+	return summary, nil
 }
 
 type TraceDecision struct {


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

When sending data through Refinery, maybe it'd be nice to have a summary of each trace. 

## Short description of the changes

This adds a new span that goes to a separate "Span Summary" dataset where you can see a single span for each trace that hits refinery and whatever refinery thought about it when it was being evaluated. 

## EXPERIMENTAL 

It has a lot of janky stuff right now that needs validation so it's a draft until we play with it with some realistic data and see what the summaries look like. 

