### PR TITLE
fix: update trace_id field to meta.trace_id

### DIFF
--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -2205,10 +2205,9 @@ func TestCreateDecisionSpan(t *testing.T) {
 			"meta.refinery.min_span":       true,
 			"meta.refinery.root":           false,
 			"meta.refinery.span_data_size": 87,
-			"trace_id":                     traceID1,
-
-			"http.status_code": 200,
-			"test":             1,
+			"meta.trace_id":                traceID1,
+			"http.status_code":             200,
+			"test":                         1,
 		},
 	}
 

--- a/route/route.go
+++ b/route/route.go
@@ -1068,7 +1068,7 @@ func isRootSpan(ev *types.Event, cfg config.Config) bool {
 }
 
 func extractTraceID(traceIdFieldNames []string, ev *types.Event) string {
-	if trID, ok := ev.Data["trace_id"]; ok {
+	if trID, ok := ev.Data["meta.trace_id"]; ok {
 		return trID.(string)
 	}
 

--- a/types/event.go
+++ b/types/event.go
@@ -267,7 +267,7 @@ func (sp *Span) ExtractDecisionContext() *Event {
 	decisionCtx := sp.Event
 	dataSize := sp.Event.GetDataSize()
 	decisionCtx.Data = map[string]interface{}{
-		"trace_id":                     sp.TraceID,
+		"meta.trace_id":                sp.TraceID,
 		"meta.refinery.root":           sp.IsRoot,
 		"meta.refinery.min_span":       true,
 		"meta.annotation_type":         sp.AnnotationType(),

--- a/types/event_test.go
+++ b/types/event_test.go
@@ -156,7 +156,7 @@ func TestSpan_ExtractDecisionContext(t *testing.T) {
 	assert.Equal(t, ev.SampleRate, got.SampleRate)
 	assert.Equal(t, ev.Timestamp, got.Timestamp)
 	assert.Equal(t, map[string]interface{}{
-		"trace_id":                     sp.TraceID,
+		"meta.trace_id":                sp.TraceID,
 		"meta.refinery.root":           true,
 		"meta.refinery.min_span":       true,
 		"meta.annotation_type":         SpanAnnotationTypeSpanEvent,


### PR DESCRIPTION
## Which problem is this PR solving?

- This fixes a bug identified when span data processed by refinery includes a `trace_id` attribute. This change updates the field to `meta.trace_id` which should avoid collisions with existing instrumentation that sets `trace_id`.

## Short description of the changes

- Update `trace_id` field for internal decisions to `meta.trace_id`
- Update the tests

