### PR TITLE
maint: Mark TraceLocalityMode as experimetnal

### DIFF
--- a/config.md
+++ b/config.md
@@ -1,7 +1,7 @@
 # Honeycomb Refinery Configuration Documentation
 
 This is the documentation for the configuration file for Honeycomb's Refinery.
-It was automatically generated on 2025-02-13 at 16:52:13 UTC.
+It was automatically generated on 2025-04-07 at 12:49:41 UTC.
 
 ## The Config file
 
@@ -1025,6 +1025,7 @@ This value should be set to a bit less than the normal timeout period for shutti
 
 TraceLocalityMode controls how Refinery handles spans that belong to the same trace in a clustered environment.
 
+This is an experimental configuration and should not be changed in production deployments.
 When `concentrated`, Refinery will route all spans that belong to the same trace to a single peer.
 This is the default behavior ("Trace Locality") and the way Refinery has worked in the past.
 When `distributed`, Refinery will instead keep spans on the node where they were received, and forward proxy spans that contain only the key information needed to make a trace decision.

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -1348,6 +1348,8 @@ groups:
         reload: false
         summary: controls how Refinery handles spans that belong to the same trace in a clustered environment.
         description: >
+          This is an experimental configuration and should not be changed in production deployments.
+
           When `concentrated`, Refinery will route all spans that belong to the same trace to a single peer. This is the
           default behavior ("Trace Locality") and the way Refinery has worked in the past. When `distributed`, Refinery
           will instead keep spans on the node where they were received, and forward proxy spans that contain only

--- a/config_complete.yaml
+++ b/config_complete.yaml
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created on 2025-03-25 at 13:08:15 UTC from ../../config.yaml using a template generated on 2025-03-25 at 13:08:03 UTC
+# created on 2025-04-07 at 12:49:41 UTC from ../../config.yaml using a template generated on 2025-04-07 at 12:49:36 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of
@@ -1086,6 +1086,8 @@ Collection:
     ## TraceLocalityMode controls how Refinery handles spans that belong to
     ## the same trace in a clustered environment.
     ##
+    ## This is an experimental configuration and should not be changed in
+    ## production deployments.
     ## When `concentrated`, Refinery will route all spans that belong to the
     ## same trace to a single peer. This is the default behavior ("Trace
     ## Locality") and the way Refinery has worked in the past. When
@@ -1198,8 +1200,8 @@ Specialized:
     ##
     ## Eligible for live reload.
     # AdditionalAttributes:
-      #  environment: production
       #  ClusterName: MyCluster
+      #  environment: production
 
 ###############
 ## ID Fields ##

--- a/refinery_config.md
+++ b/refinery_config.md
@@ -1010,6 +1010,7 @@ This value should be set to a bit less than the normal timeout period for shutti
 
 `TraceLocalityMode` controls how Refinery handles spans that belong to the same trace in a clustered environment.
 
+This is an experimental configuration and should not be changed in production deployments.
 When `concentrated`, Refinery will route all spans that belong to the same trace to a single peer.
 This is the default behavior ("Trace Locality") and the way Refinery has worked in the past.
 When `distributed`, Refinery will instead keep spans on the node where they were received, and forward proxy spans that contain only the key information needed to make a trace decision.

--- a/tools/convert/templates/configV2.tmpl
+++ b/tools/convert/templates/configV2.tmpl
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created {{ now }} from {{ .Input }} using a template generated on 2025-02-13 at 16:52:04 UTC
+# created {{ now }} from {{ .Input }} using a template generated on 2025-04-07 at 12:49:36 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of
@@ -1081,6 +1081,8 @@ Collection:
     ## TraceLocalityMode controls how Refinery handles spans that belong to
     ## the same trace in a clustered environment.
     ##
+    ## This is an experimental configuration and should not be changed in
+    ## production deployments.
     ## When `concentrated`, Refinery will route all spans that belong to the
     ## same trace to a single peer. This is the default behavior ("Trace
     ## Locality") and the way Refinery has worked in the past. When


### PR DESCRIPTION
## Which problem is this PR solving?

TraceLocalityMode is experimental and not recommended for production deployments yet. This updates the docs to indicates it's stability level

## Short description of the changes
- Update TraceLocalityMode to indicate it's experimental and regenerate docs

