### PR TITLE
feat: Tell Load Balancers to Back Off

### DIFF
--- a/config/file_config.go
+++ b/config/file_config.go
@@ -417,6 +417,9 @@ type StressReliefConfig struct {
 	DeactivationLevel         uint     `yaml:"DeactivationLevel" default:"75"`
 	SamplingRate              uint64   `yaml:"SamplingRate" default:"100"`
 	MinimumActivationDuration Duration `yaml:"MinimumActivationDuration" default:"10s"`
+	InboundRejectionServer    string   `yaml:"InboundRejectionServer" default:"none"`
+	InboundRejectionTolerance uint     `yaml:"InboundRejectionTolerance" default:"5"`
+	RetryAfterSeconds         uint     `yaml:"RetryAfterSeconds" default:"5"`
 }
 
 type FileConfigError struct {

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -1885,7 +1885,6 @@ groups:
         summary: is a string indicating how to use Stress Relief.
         description: >
           This setting sets the Stress Relief mode.
-
           "never" means that Stress Relief will never activate.
 
           "monitor" is the recommended setting, and means that
@@ -1896,8 +1895,6 @@ groups:
           in an emergency situation.
 
       - name: ActivationLevel
-        v1group: StressRelief
-        v1name: ActivationLevel
         type: percentage
         valuetype: nondefault
         default: 90
@@ -1973,3 +1970,55 @@ groups:
           If this duration is `0`, then Refinery will not start in stressed
           mode, which will provide faster startup at the possible cost of
           startup instability.
+
+      - name: InboundRejectionServer
+        type: string
+        valuetype: enum
+        values: ["never", "all", "incoming", "peer"]
+        default: "never"
+        reload: true
+        summary: determines which server type should implement inbound request rejection during high stress.
+        description: >
+          Stress Relief mode must be set to `monitor` to use this ability.
+
+          Controls whether and where to implement stress-based request rejection.
+
+          When enabled, during routing inbound requests, it will check the current
+          stress levels and if the cluster is less stressed than the process, it
+          will reject the request with a 503 response and a Retry-After header.
+          This will tell the load balancer and clients to wait and try again later.
+
+          Do not use this if your clients will not perform retries. It will cause lost data.
+
+          'never' disables rejection, 'always' enables it on both incoming and peer servers,
+          'incoming' only on the incoming server, and 'peer' only on the peer server.
+
+      - name: InboundRejectionTolerance
+        type: int
+        valuetype: int
+        default: 5
+        validations:
+          - type: minimum
+            arg: 5
+          - type: maximum
+            arg: 100
+        reload: true
+        summary: The percentage above cluster average at which the node will reject requests
+        description: >
+          Inbound rejection will happen if the process's stress level is greater than
+          the cluster average plus this amount.
+
+          If the cluster average is 60% stressed and this is 5, the process will have to reach
+          65% stressed to reject requests.
+
+      - name: RetryAfterSeconds
+        type: int
+        valuetype: int
+        default: 5
+        reload: true
+        summary: the number of seconds clients should wait before retrying rejected requests.
+        description: >
+          If this is set to zero, it will use the TraceTimeout value.
+
+          When requests are rejected due to high stress, this value is sent in the
+          Retry-After header to indicate how long clients should wait before retrying.

--- a/route/route.go
+++ b/route/route.go
@@ -97,6 +97,15 @@ type Router struct {
 
 	environmentCache *environmentCache
 	hsrv             *healthserver.Server
+
+	// Cache for stress levels
+	stressLevels struct {
+		individual float64
+		cluster    float64
+		activated  float64
+		lastUpdate time.Time
+	}
+	stressLevelsMutex sync.RWMutex
 }
 
 type BatchResponse struct {
@@ -170,11 +179,20 @@ func (r *Router) LnS(incomingOrPeer string) {
 		r.Metrics.Register(metric)
 	}
 
+	// Initialize stress levels
+	r.updateStressLevels()
+
 	muxxer := mux.NewRouter()
 
 	muxxer.Use(r.setResponseHeaders)
 	muxxer.Use(r.requestLogger)
 	muxxer.Use(r.panicCatcher)
+
+	// Apply stress check based on config
+	rejectionServer := r.Config.GetStressReliefConfig().InboundRejectionServer
+	if rejectionServer == "always" || rejectionServer == r.incomingOrPeer {
+		muxxer.Use(r.stressCheck)
+	}
 
 	muxxer.HandleFunc("/alive", r.alive).Name("local health")
 	muxxer.HandleFunc("/ready", r.ready).Name("local readiness")
@@ -1102,4 +1120,76 @@ func addIncomingUserAgent(ev *types.Event, userAgent string) {
 	if userAgent != "" && ev.Data["meta.refinery.incoming_user_agent"] == nil {
 		ev.Data["meta.refinery.incoming_user_agent"] = userAgent
 	}
+}
+
+// updateStressLevels refreshes the cached stress level values
+func (r *Router) updateStressLevels() {
+	r.stressLevelsMutex.Lock()
+	defer r.stressLevelsMutex.Unlock()
+
+	individual, _ := r.Metrics.Get("individual_stress_level")
+	cluster, _ := r.Metrics.Get("cluster_stress_level")
+	activated, _ := r.Metrics.Get("stress_relief_activated")
+
+	r.stressLevels.individual = individual
+	r.stressLevels.cluster = cluster
+	r.stressLevels.activated = activated
+	r.stressLevels.lastUpdate = time.Now()
+}
+
+// getStressLevels returns the cached stress levels, updating them if they're older than 1 second
+func (r *Router) getStressLevels() (individual, cluster, activated float64) {
+	r.stressLevelsMutex.RLock()
+	if time.Since(r.stressLevels.lastUpdate) < time.Second {
+		individual = r.stressLevels.individual
+		cluster = r.stressLevels.cluster
+		activated = r.stressLevels.activated
+		r.stressLevelsMutex.RUnlock()
+		return
+	}
+	r.stressLevelsMutex.RUnlock()
+
+	r.updateStressLevels()
+	return r.stressLevels.individual, r.stressLevels.cluster, r.stressLevels.activated
+}
+
+// stressCheck is middleware that checks if this node's stress level is above average
+// and returns 503 Service Unavailable if it is
+func (r *Router) stressCheck(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		// Skip stress check for health endpoints
+		if req.URL.Path == "/alive" || req.URL.Path == "/ready" {
+			next.ServeHTTP(w, req)
+			return
+		}
+
+		// Get cached stress levels
+		individualStress, clusterStress, stressReliefActivated := r.getStressLevels()
+		activationLevel := float64(r.Config.GetStressReliefConfig().ActivationLevel)
+		tolerance := float64(r.Config.GetStressReliefConfig().InboundRejectionTolerance)
+		retryAfter := strconv.Itoa(int(r.Config.GetStressReliefConfig().RetryAfterSeconds))
+		if retryAfter == "0" {
+			retryAfter = strconv.Itoa(int(r.Config.GetTracesConfig().TraceTimeout))
+		}
+
+		// Allow traffic if:
+		// 0. already stressed
+		// 1. Individual stress is below 50, OR
+		// 2. Individual stress is not higher than cluster stress (plus tolerance), OR
+		// 3. Cluster stress is above stress relief activation threshold
+		if stressReliefActivated == 1 || individualStress < 50 || individualStress < clusterStress+tolerance || clusterStress >= activationLevel {
+			next.ServeHTTP(w, req)
+			return
+		}
+
+		w.Header().Set("Retry-After", retryAfter)
+		http.Error(w, "Service temporarily overloaded", http.StatusServiceUnavailable)
+		r.iopLogger.Debug().
+			WithField("individual_stress", individualStress).
+			WithField("cluster_stress", clusterStress).
+			WithField("stress_relief_activated", stressReliefActivated).
+			WithField("activation_level", activationLevel).
+			WithField("tolerance", tolerance).
+			Logf("rejecting request due to high stress")
+	})
 }

--- a/route/route.go
+++ b/route/route.go
@@ -146,6 +146,7 @@ var routerMetrics = []metrics.Metadata{
 	{Name: "_router_otlp", Type: metrics.Counter, Unit: metrics.Dimensionless, Description: "the number of batches of otlp requests received"},
 	{Name: "bytes_received_traces", Type: metrics.Counter, Unit: metrics.Bytes, Description: "the number of bytes received in trace events"},
 	{Name: "bytes_received_logs", Type: metrics.Counter, Unit: metrics.Bytes, Description: "the number of bytes received in log events"},
+	{Name: "_router_stress_rejected", Type: metrics.Counter, Unit: metrics.Dimensionless, Description: "the number of requests rejected due to uneven load across the cluster"},
 }
 
 // LnS spins up the Listen and Serve portion of the router. A router is
@@ -1184,6 +1185,7 @@ func (r *Router) stressCheck(next http.Handler) http.Handler {
 
 		w.Header().Set("Retry-After", retryAfter)
 		http.Error(w, "Service temporarily overloaded", http.StatusServiceUnavailable)
+		r.Metrics.Increment(r.incomingOrPeer + "_router_stress_rejected")
 		r.iopLogger.Debug().
 			WithField("individual_stress", individualStress).
 			WithField("cluster_stress", clusterStress).


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Short description of the changes

Sometimes you have a massive cluster. This cluster has hundreds of nodes. The load balancer sending in traffic is like, "I'm gonna send it all to this one node!"

Well, ALBs will respect the "Retry-After", so even if clients don't, you can throw a 503 real quick and the retry will get routed to a less stressed node in the cluster.

This _may_ be problematic if you have a retry limit of 3 and your client doesn't respect that header, it may hit 3 nodes that are hotter than average and then you're dropping data. 

[OpenTelemetry Exporters](https://opentelemetry.io/docs/specs/otel/protocol/exporter/#retry) should respect the retry-after header but will [definitely retry after a 503 response code](https://opentelemetry.io/docs/specs/otlp/#failures-1).

## Implementation

This is behind a configuration that won't be enabled by default.  

If you have stress relief in monitor, you'll have access to the metrics and can enable it with the following configuration:

```yaml
StressRelief:
  Mode: monitor
  ActivationLevel: 90
  DeactivationLevel: 80
  SamplingRate: 10
  MinimumActivationDuration: 30s
  MinimumStartupDuration: 10s
  InboundRejectionServer: incoming
  InboundRejectionTolerance: 5
  RetryAfterSeconds: 5
```

Configuration ergonomics are here because this will need to be tuned live since production traffic only hits production deployments. The three operative configurations are: 

### InboundRejectionServer: incoming

This has options to be set to none, all, incoming, or peer. Peer is optimistic but probably shouldn't be used unless we fix up libhoney-go so it will respect the Retry-After header.  It's certainly possible to do, but isn't in scope for this PR. 

Enabling it on `incoming` will allow the StressCheck middleware to fire and evaluate the situation before engaging the parsers and storage. 

### InboundRejectionTolerance: 5

This allows you to make your individual pods deal run more lopsided to reduce 503 errors. If your cluster runs really hot and you need the load balancer on point, like 100+ nodes pushing gigabytes per second, this should be like 1 or 2. If your cluster is lower stress or scaled for spikes, you can increase it to 10 or 15.

### RetryAfterSeconds: 5

This one sets the Retry-After header to a number of seconds so that any clients that respect it will wait that long and the load balancer will lay off the node for that long. 

Magical behavior: If you set it to zero, it will use the TraceTimeout setting since that would logically be when a lot of the load will be gone. This is probably excessive in most cases, but for VERY LARGE and VERY LOPSIDED deployments, it may make sense.

## Failure types

1. Client is set to not retry. Data loss
2. Client retries and several nodes in the cluster all reject the spans because they all think it's a fresh request and they're otherwise busy. Data loss
3. All of the nodes get stressed out a bit and use the Retry-After which prevents them from flipping over into stress relief mode, but the LB thinks all the nodes are broken and refuses to send data to any of them?  Hopefully the RejectionTolerance will prevent this but as things go into stress mode and their stress levels start falling, it could be a situation where the average stress drops and every node individually tells the LB it's busy.

## Alternatives

I noticed that the mini-load-balancing in #1525 doesn't seem to be sufficient to offload spans and we need the load balancer to participate. 

Also, happy to switch the response code from 503 to 429 if people think ALBs will respect that too. I'm not convinced. 