### PR TITLE
maint: record sampler key cardinality as metric

### DIFF
--- a/sample/dynamic.go
+++ b/sample/dynamic.go
@@ -81,7 +81,7 @@ func (d *DynamicSampler) GetSampleRate(trace *types.Trace) (rate uint, keep bool
 		"trace_id":    trace.TraceID,
 		"span_count":  count,
 	}).Logf("got sample rate and decision")
-	d.metricsRecorder.RecordMetrics(d.dynsampler, shouldKeep, rate)
+	d.metricsRecorder.RecordMetrics(d.dynsampler, shouldKeep, rate, n)
 	return rate, shouldKeep, d.prefix, key
 }
 

--- a/sample/dynamic_ema.go
+++ b/sample/dynamic_ema.go
@@ -90,7 +90,7 @@ func (d *EMADynamicSampler) GetSampleRate(trace *types.Trace) (rate uint, keep b
 		"trace_id":    trace.TraceID,
 		"span_count":  count,
 	}).Logf("got sample rate and decision")
-	d.metricsRecorder.RecordMetrics(d.dynsampler, shouldKeep, rate)
+	d.metricsRecorder.RecordMetrics(d.dynsampler, shouldKeep, rate, n)
 
 	return rate, shouldKeep, d.prefix, key
 }

--- a/sample/ema_throughput.go
+++ b/sample/ema_throughput.go
@@ -106,7 +106,7 @@ func (d *EMAThroughputSampler) GetSampleRate(trace *types.Trace) (rate uint, kee
 		"trace_id":    trace.TraceID,
 		"span_count":  count,
 	}).Logf("got sample rate and decision")
-	d.metricsRecorder.RecordMetrics(d.dynsampler, shouldKeep, rate)
+	d.metricsRecorder.RecordMetrics(d.dynsampler, shouldKeep, rate, n)
 	return rate, shouldKeep, d.prefix, key
 }
 

--- a/sample/sample.go
+++ b/sample/sample.go
@@ -111,7 +111,7 @@ var samplerMetrics = []metrics.Metadata{
 	{Name: "_num_dropped", Type: metrics.Counter, Unit: metrics.Dimensionless, Description: "Number of traces dropped by configured sampler"},
 	{Name: "_num_kept", Type: metrics.Counter, Unit: metrics.Dimensionless, Description: "Number of traces kept by configured sampler"},
 	{Name: "_sample_rate", Type: metrics.Histogram, Unit: metrics.Dimensionless, Description: "Sample rate for traces"},
-	{Name: "_trace_key_length", Type: metrics.Histogram, Unit: metrics.Dimensionless, Description: "Number of unique trace keys"},
+	{Name: "_sampler_key_cardinality", Type: metrics.Histogram, Unit: metrics.Dimensionless, Description: "Number of unique keys being tracked by the sampler"},
 }
 
 func getMetricType(name string) metrics.MetricType {
@@ -161,6 +161,6 @@ func (d *dynsamplerMetricsRecorder) RecordMetrics(sampler dynsampler.Sampler, ke
 	} else {
 		d.met.Increment(d.prefix + "_num_dropped")
 	}
-	d.met.Histogram(d.prefix+"_trace_key_length", float64(numTraceKey))
+	d.met.Histogram(d.prefix+"_sampler_key_cardinality", float64(numTraceKey))
 	d.met.Histogram(d.prefix+"_sample_rate", float64(rate))
 }

--- a/sample/sample.go
+++ b/sample/sample.go
@@ -111,6 +111,7 @@ var samplerMetrics = []metrics.Metadata{
 	{Name: "_num_dropped", Type: metrics.Counter, Unit: metrics.Dimensionless, Description: "Number of traces dropped by configured sampler"},
 	{Name: "_num_kept", Type: metrics.Counter, Unit: metrics.Dimensionless, Description: "Number of traces kept by configured sampler"},
 	{Name: "_sample_rate", Type: metrics.Histogram, Unit: metrics.Dimensionless, Description: "Sample rate for traces"},
+	{Name: "_trace_key_length", Type: metrics.Histogram, Unit: metrics.Dimensionless, Description: "Number of unique trace keys"},
 }
 
 func getMetricType(name string) metrics.MetricType {
@@ -143,7 +144,7 @@ func (d *dynsamplerMetricsRecorder) RegisterMetrics(sampler dynsampler.Sampler) 
 
 }
 
-func (d *dynsamplerMetricsRecorder) RecordMetrics(sampler dynsampler.Sampler, kept bool, rate uint) {
+func (d *dynsamplerMetricsRecorder) RecordMetrics(sampler dynsampler.Sampler, kept bool, rate uint, numTraceKey int) {
 	for name, val := range sampler.GetMetrics(d.prefix + "_") {
 		switch getMetricType(name) {
 		case metrics.Counter:
@@ -160,5 +161,6 @@ func (d *dynsamplerMetricsRecorder) RecordMetrics(sampler dynsampler.Sampler, ke
 	} else {
 		d.met.Increment(d.prefix + "_num_dropped")
 	}
+	d.met.Histogram(d.prefix+"_trace_key_length", float64(numTraceKey))
 	d.met.Histogram(d.prefix+"_sample_rate", float64(rate))
 }

--- a/sample/totalthroughput.go
+++ b/sample/totalthroughput.go
@@ -98,7 +98,7 @@ func (d *TotalThroughputSampler) GetSampleRate(trace *types.Trace) (rate uint, k
 		"span_count":  count,
 	}).Logf("got sample rate and decision")
 
-	d.metricsRecorder.RecordMetrics(d.dynsampler, shouldKeep, rate)
+	d.metricsRecorder.RecordMetrics(d.dynsampler, shouldKeep, rate, n)
 	return rate, shouldKeep, d.prefix, key
 }
 

--- a/sample/windowed_throughput.go
+++ b/sample/windowed_throughput.go
@@ -93,7 +93,7 @@ func (d *WindowedThroughputSampler) GetSampleRate(trace *types.Trace) (rate uint
 		"trace_id":    trace.TraceID,
 		"span_count":  count,
 	}).Logf("got sample rate and decision")
-	d.metricsRecorder.RecordMetrics(d.dynsampler, shouldKeep, rate)
+	d.metricsRecorder.RecordMetrics(d.dynsampler, shouldKeep, rate, n)
 
 	return rate, shouldKeep, d.prefix, key
 }


### PR DESCRIPTION
## Which problem is this PR solving?

- closes #1365 

## Short description of the changes

- add a new metric, `<sampler-type>_trace_key_length`, for dynamic samplers to record the number of unique value in a trace key

