### PR TITLE
feat(transmit): use pubsub cluster for xmit/recv of peer comms

### DIFF
--- a/config.md
+++ b/config.md
@@ -1,7 +1,7 @@
 # Honeycomb Refinery Configuration Documentation
 
 This is the documentation for the configuration file for Honeycomb's Refinery.
-It was automatically generated on 2025-04-22 at 04:33:16 UTC.
+It was automatically generated on 2025-04-22 at 07:08:01 UTC.
 
 ## The Config file
 
@@ -854,6 +854,19 @@ The format is a list of strings of the form "scheme://host:port".
 - Not eligible for live reload.
 - Type: `stringarray`
 - Example: `http://192.168.1.11:8081,http://192.168.1.12:8081`
+
+### `PeerTransmission`
+
+PeerTransmission is the mechanism to use to transmit data between peers.
+
+Whether to use standard libhoney, or google pub/sub transmission.
+
+- Not eligible for live reload.
+- Type: `string`
+- Default: `libhoney`
+- Options: `google`, `libhoney`
+- Environment variable: `REFINERY_PEER_TRANSMISSION`
+- Command line switch: `--peer-transmission`
 
 ## Google Peer Management
 

--- a/config/config.go
+++ b/config/config.go
@@ -62,6 +62,8 @@ type Config interface {
 
 	GetPeerManagementType() string
 
+	GetPeerTransmission() string
+
 	GetRedisPeerManagement() RedisPeerManagementConfig
 
 	GetGooglePeerManagement() GooglePeerManagementConfig

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -296,6 +296,7 @@ type PeerManagementConfig struct {
 	IdentifierInterfaceName string   `yaml:"IdentifierInterfaceName"`
 	UseIPV6Identifier       bool     `yaml:"UseIPV6Identifier"`
 	Peers                   []string `yaml:"Peers"`
+	PeerTransmission        string   `yaml:"PeerTransmission"`
 }
 
 type RedisPeerManagementConfig struct {
@@ -797,6 +798,13 @@ func (f *fileConfig) GetGooglePeerManagement() GooglePeerManagementConfig {
 	defer f.mux.RUnlock()
 
 	return f.mainConfig.GooglePeerManagement
+}
+
+func (f *fileConfig) GetPeerTransmission() string {
+	f.mux.RLock()
+	defer f.mux.RUnlock()
+
+	return f.mainConfig.PeerManagement.PeerTransmission
 }
 
 func (f *fileConfig) GetIdentifierInterfaceName() string {

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -1052,6 +1052,22 @@ groups:
           This list is ignored when Type is "redis". The format is a list of
           strings of the form "scheme://host:port".
 
+      - name: PeerTransmission
+        v1group: PeerManagement
+        v1name: PeerTransmission
+        type: string
+        valuetype: choice
+        choices: ["google", "libhoney"]
+        default: "libhoney"
+        validations:
+          - type: choice
+        reload: false
+        envvar: REFINERY_PEER_TRANSMISSION
+        commandLine: peer-transmission
+        summary: is the mechanism to use to transmit data between peers.
+        description: >
+          Whether to use standard libhoney, or google pub/sub transmission.
+
   - name: GooglePeerManagement
     title: "Google Peer Management"
     description: >

--- a/config/mock.go
+++ b/config/mock.go
@@ -28,6 +28,7 @@ type MockConfig struct {
 	GetPeersVal                      []string
 	GetRedisPeerManagementVal        RedisPeerManagementConfig
 	GetGooglePeerManagementVal       GooglePeerManagementConfig
+	GetPeerTransmissionVal           string
 	GetSamplerTypeName               string
 	GetSamplerTypeVal                interface{}
 	GetMetricsTypeVal                string
@@ -218,6 +219,13 @@ func (m *MockConfig) GetGooglePeerManagement() GooglePeerManagementConfig {
 	defer m.Mux.RUnlock()
 
 	return m.GetGooglePeerManagementVal
+}
+
+func (m *MockConfig) GetPeerTransmission() string {
+	m.Mux.RLock()
+	defer m.Mux.RUnlock()
+
+	return m.GetPeerTransmissionVal
 }
 
 func (m *MockConfig) GetGeneralConfig() GeneralConfig {

--- a/config_complete.yaml
+++ b/config_complete.yaml
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created on 2025-04-22 at 04:33:15 UTC from ../../config.yaml using a template generated on 2025-04-22 at 04:33:13 UTC
+# created on 2025-04-22 at 07:08:01 UTC from ../../config.yaml using a template generated on 2025-04-22 at 07:07:59 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of
@@ -898,6 +898,16 @@ PeerManagement:
       # - http://192.168.1.11:8081
       # - http://192.168.1.12:8081
 
+    ## PeerTransmission is the mechanism to use to transmit data between
+    ## peers.
+    ##
+    ## Whether to use standard libhoney, or google pub/sub transmission.
+    ##
+    ## default: libhoney
+    ## Not eligible for live reload.
+    ## Options: google libhoney
+    # PeerTransmission: libhoney
+
 ############################
 ## Google Peer Management ##
 ############################
@@ -1284,8 +1294,8 @@ Specialized:
     ##
     ## Eligible for live reload.
     # AdditionalAttributes:
-      #  ClusterName: MyCluster
       #  environment: production
+      #  ClusterName: MyCluster
 
 ###############
 ## ID Fields ##

--- a/metrics.md
+++ b/metrics.md
@@ -1,7 +1,7 @@
 # Honeycomb Refinery Metrics Documentation
 
 This document contains the description of various metrics used in Refinery.
-It was automatically generated on 2025-04-22 at 04:33:15 UTC.
+It was automatically generated on 2025-04-22 at 07:08:01 UTC.
 
 Note: This document does not include metrics defined in the dynsampler-go dependency, as those metrics are generated dynamically at runtime. As a result, certain metrics may be missing or incomplete in this document, but they will still be available during execution with their full names.
 

--- a/metrics/multi_metrics_test.go
+++ b/metrics/multi_metrics_test.go
@@ -33,7 +33,6 @@ func getAndStartMultiMetrics(children ...Metrics) (*MultiMetrics, error) {
 	objects := []*inject.Object{
 		{Value: "version", Name: "version"},
 		{Value: &http.Transport{}, Name: "upstreamTransport"},
-		{Value: &http.Transport{}, Name: "peerTransport"},
 		{Value: &LegacyMetrics{}, Name: "legacyMetrics"},
 		{Value: &PromMetrics{}, Name: "promMetrics"},
 		{Value: &OTelMetrics{}, Name: "otelMetrics"},

--- a/refinery_config.md
+++ b/refinery_config.md
@@ -838,6 +838,19 @@ The format is a list of strings of the form "scheme://host:port".
 - Type: `stringarray`
 - Example: `http://192.168.1.11:8081,http://192.168.1.12:8081`
 
+### `PeerTransmission`
+
+`PeerTransmission` is the mechanism to use to transmit data between peers.
+
+Whether to use standard libhoney, or google pub/sub transmission.
+
+- Not eligible for live reload.
+- Type: `string`
+- Default: `libhoney`
+- Options: `google`, `libhoney`
+- Environment variable: `REFINERY_PEER_TRANSMISSION`
+- Command line switch: `--peer-transmission`
+
 ## Google Peer Management
 
 `GooglePeerManagement` controls how the Refinery cluster communicates between peers when using Google Pub/Sub.

--- a/route/route.go
+++ b/route/route.go
@@ -34,6 +34,7 @@ import (
 	_ "google.golang.org/grpc/encoding/gzip"
 
 	huskyotlp "github.com/honeycombio/husky/otlp"
+	"github.com/honeycombio/libhoney-go/transmission"
 
 	"github.com/honeycombio/refinery/collect"
 	"github.com/honeycombio/refinery/config"
@@ -574,6 +575,23 @@ func (router *Router) processOTLPRequest(
 	}
 
 	return nil
+}
+
+func (r *Router) ProcessEventDirect(ctx context.Context, ev transmission.Event, reqID any) error {
+	environment, err := r.getEnvironmentName(ev.APIKey)
+	if err != nil {
+		return err
+	}
+	return r.processEvent(&types.Event{
+		Context:     ctx,
+		APIHost:     ev.APIHost,
+		APIKey:      ev.APIKey,
+		Dataset:     ev.Dataset,
+		Environment: environment,
+		SampleRate:  ev.SampleRate,
+		Timestamp:   ev.Timestamp,
+		Data:        ev.Data,
+	}, reqID)
 }
 
 func (r *Router) processEvent(ev *types.Event, reqID interface{}) error {

--- a/rules.md
+++ b/rules.md
@@ -1,7 +1,7 @@
 # Honeycomb Refinery Rules Documentation
 
 This is the documentation for the rules configuration for Honeycomb's Refinery.
-It was automatically generated on 2025-04-22 at 04:33:16 UTC.
+It was automatically generated on 2025-04-22 at 07:08:01 UTC.
 
 ## The Rules file
 

--- a/tools/convert/configDataNames.txt
+++ b/tools/convert/configDataNames.txt
@@ -1,5 +1,5 @@
 # Names of groups and fields in the new config file format.
-# Automatically generated on 2025-04-22 at 04:33:13 UTC.
+# Automatically generated on 2025-04-22 at 07:07:59 UTC.
 
 General:
   - ConfigurationVersion
@@ -157,6 +157,8 @@ PeerManagement:
   - UseIPV6Identifier (originally PeerManagement.UseIPV6Identifier)
 
   - Peers (originally PeerManagement.Peers)
+
+  - PeerTransmission (originally PeerManagement.PeerTransmission)
 
 
 GooglePeerManagement:

--- a/tools/convert/minimal_config.yaml
+++ b/tools/convert/minimal_config.yaml
@@ -1,5 +1,5 @@
 # sample uncommented config file containing all possible fields
-# automatically generated on 2025-04-22 at 04:33:13 UTC
+# automatically generated on 2025-04-22 at 07:07:59 UTC
 General:
   ConfigurationVersion: 2
   MinRefineryVersion: "v2.0"
@@ -86,6 +86,7 @@ PeerManagement:
     - "http://192.168.1.11:8081"
     - "http://192.168.1.12:8081"
 
+  PeerTransmission: libhoney
 GooglePeerManagement:
   Topic: <nil>
   ProjectID: "crispy-badger-1234"

--- a/tools/convert/templates/configV2.tmpl
+++ b/tools/convert/templates/configV2.tmpl
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created {{ now }} from {{ .Input }} using a template generated on 2025-04-22 at 04:33:13 UTC
+# created {{ now }} from {{ .Input }} using a template generated on 2025-04-22 at 07:07:59 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of
@@ -893,6 +893,16 @@ PeerManagement:
     ##
     ## Not eligible for live reload.
     {{ renderStringarray .Data "Peers" "PeerManagement.Peers" "http://192.168.1.11:8081,http://192.168.1.12:8081" }}
+
+    ## PeerTransmission is the mechanism to use to transmit data between
+    ## peers.
+    ##
+    ## Whether to use standard libhoney, or google pub/sub transmission.
+    ##
+    ## default: libhoney
+    ## Not eligible for live reload.
+    ## Options: google libhoney
+    {{ choice .Data "PeerTransmission" "PeerManagement.PeerTransmission" (makeSlice "google" "libhoney") "libhoney" }}
 
 ############################
 ## Google Peer Management ##

--- a/transmit/google.go
+++ b/transmit/google.go
@@ -1,0 +1,71 @@
+package transmit
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/honeycombio/libhoney-go/transmission"
+
+	"github.com/honeycombio/refinery/config"
+	"github.com/honeycombio/refinery/logger"
+	"github.com/honeycombio/refinery/pubsub"
+)
+
+type GooglePeerTransmission struct {
+	Config config.Config `inject:""`
+	PubSub pubsub.PubSub `inject:""`
+	Logger logger.Logger `inject:""`
+
+	EventHandler func(context.Context, transmission.Event, any) error
+
+	responses        chan transmission.Response
+	blockOnResponses bool
+}
+
+var _ transmission.Sender = (*GooglePeerTransmission)(nil)
+
+func (t *GooglePeerTransmission) Start() error {
+	t.PubSub.Subscribe(context.Background(), fmt.Sprintf("peer-%s", t.Config.GetRedisIdentifier()), func(ctx context.Context, payload string) {
+		var ev transmission.Event
+		err := json.Unmarshal([]byte(payload), &ev)
+		if err != nil {
+			return
+		}
+		t.EventHandler(ctx, ev, nil)
+	})
+	return nil
+}
+
+func (t *GooglePeerTransmission) Stop() error {
+	return nil
+}
+
+func (t *GooglePeerTransmission) Add(ev *transmission.Event) {
+	serialized, err := ev.MarshalJSON()
+	if err != nil {
+		return
+	}
+	t.PubSub.Publish(context.Background(), fmt.Sprintf("peer-%s", ev.APIHost), string(serialized))
+}
+
+func (t *GooglePeerTransmission) Flush() error {
+	return nil
+}
+
+func (t *GooglePeerTransmission) TxResponses() chan transmission.Response {
+	return t.responses
+}
+
+func (t *GooglePeerTransmission) SendResponse(r transmission.Response) bool {
+	if t.blockOnResponses {
+		t.responses <- r
+	} else {
+		select {
+		case t.responses <- r:
+		default:
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Which problem is this PR solving?

- Follow-on to #1538 to implement pub/sub routing of peer comms to allow for operation in google cloud run or similar.

## Short description of the changes

- Allows optional, experimental, routing of peer comms over pub/sub topic.

