### PR TITLE
fix: decision spans should not be processed through stress relief

### DIFF
--- a/collect/collect.go
+++ b/collect/collect.go
@@ -559,7 +559,7 @@ func (i *InMemCollector) redistributeTraces(ctx context.Context) {
 	})
 
 	i.Metrics.Gauge("trace_forwarded_on_peer_change", len(forwardedTraces))
-	if len(forwardedTraces) > 0 {
+	if len(forwardedTraces) > 0 && i.Config.GetCollectionConfig().TraceLocalityEnabled() {
 		i.cache.RemoveTraces(forwardedTraces)
 	}
 }


### PR DESCRIPTION
## Which problem is this PR solving?

In `distributed` mode, decision spans should not be sampled by stress relief. We also should not remove original traces on redistribution

## Short description of the changes

- skip decision spans in stress relief
- keep original spans on redistribution in distributed mode

