### PR TITLE
fix: update refinery to report effective config on update

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -318,8 +318,8 @@ func (agent *Agent) composeEffectiveConfig() *protobufs.EffectiveConfig {
 	return &protobufs.EffectiveConfig{
 		ConfigMap: &protobufs.AgentConfigMap{
 			ConfigMap: map[string]*protobufs.AgentConfigFile{
-				"config": {Body: []byte(configYAML)},
-				"rules":  {Body: []byte(rulesYAML)},
+				"refinery_config": {Body: []byte(configYAML)},
+				"refinery_rules":  {Body: []byte(rulesYAML)},
 			},
 		},
 	}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -403,6 +403,10 @@ func (agent *Agent) updateRemoteConfig(ctx context.Context, msg *types.MessageDa
 			} else {
 				agent.logger.Logger.Info().WithField("rules", agent.effectiveConfig.GetAllSamplerRules().Samplers).Logf("Successfully reloaded config")
 				agent.reportConfigStatus(protobufs.RemoteConfigStatuses_RemoteConfigStatuses_APPLIED, "")
+				err = agent.opampClient.UpdateEffectiveConfig(ctx)
+				if err != nil {
+					agent.logger.Errorf(ctx, "failed to update the effective config: %v", err)
+				}
 			}
 		}
 	}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -401,7 +401,6 @@ func (agent *Agent) updateRemoteConfig(ctx context.Context, msg *types.MessageDa
 				agent.logger.Errorf(ctx, "Failed to reload config: %v", err)
 				agent.reportConfigStatus(protobufs.RemoteConfigStatuses_RemoteConfigStatuses_FAILED, err.Error())
 			} else {
-				agent.logger.Logger.Info().WithField("rules", agent.effectiveConfig.GetAllSamplerRules().Samplers).Logf("Successfully reloaded config")
 				agent.reportConfigStatus(protobufs.RemoteConfigStatuses_RemoteConfigStatuses_APPLIED, "")
 				err = agent.opampClient.UpdateEffectiveConfig(ctx)
 				if err != nil {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -385,7 +385,6 @@ func (agent *Agent) updateRemoteConfig(ctx context.Context, msg *types.MessageDa
 
 		var opts []config.ReloadedConfigDataOption
 		if c, ok := confMap["refinery_rules"]; ok {
-			agent.logger.Logger.Info().WithField("refinery_rules", string(confMap["refinery_rules"].Body)).Logf("new refinery rules")
 			opts = append(opts, config.WithRulesData(config.NewConfigData(c.GetBody(), config.FormatYAML, "opamp://rules")))
 		}
 		if c, ok := confMap["refinery_config"]; ok {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -318,8 +318,8 @@ func (agent *Agent) composeEffectiveConfig() *protobufs.EffectiveConfig {
 	return &protobufs.EffectiveConfig{
 		ConfigMap: &protobufs.AgentConfigMap{
 			ConfigMap: map[string]*protobufs.AgentConfigFile{
-				"refinery_config": {Body: []byte(configYAML)},
-				"refinery_rules":  {Body: []byte(rulesYAML)},
+				"refinery_config": {Body: configYAML},
+				"refinery_rules":  {Body: rulesYAML},
 			},
 		},
 	}

--- a/config/config_serializer.go
+++ b/config/config_serializer.go
@@ -7,15 +7,22 @@ import (
 )
 
 // SerializeToYAML serializes the Config to a YAML string
-func SerializeToYAML(cfg Config) (string, error) {
+func SerializeToYAML(cfg Config) (string, string, error) {
 	// Create a configContents struct and populate it from the Config interface
 	contents := populateConfigContents(cfg)
 
 	yamlBytes, err := yaml.Marshal(contents)
 	if err != nil {
-		return "", fmt.Errorf("error serializing config to YAML: %w", err)
+		return "", "", fmt.Errorf("error serializing config to YAML: %w", err)
 	}
-	return string(yamlBytes), nil
+
+	rules := cfg.GetAllSamplerRules()
+	rulesYamlBytes, err := yaml.Marshal(rules)
+	if err != nil {
+		return "", "", fmt.Errorf("error serializing rules to YAML: %w", err)
+	}
+
+	return string(yamlBytes), string(rulesYamlBytes), nil
 }
 
 // populateConfigContents creates a configContents struct from a Config interface

--- a/config/config_serializer.go
+++ b/config/config_serializer.go
@@ -7,22 +7,22 @@ import (
 )
 
 // SerializeToYAML serializes the Config to a YAML string
-func SerializeToYAML(cfg Config) (string, string, error) {
+func SerializeToYAML(cfg Config) ([]byte, []byte, error) {
 	// Create a configContents struct and populate it from the Config interface
 	contents := populateConfigContents(cfg)
 
 	yamlBytes, err := yaml.Marshal(contents)
 	if err != nil {
-		return "", "", fmt.Errorf("error serializing config to YAML: %w", err)
+		return nil, nil, fmt.Errorf("error serializing config to YAML: %w", err)
 	}
 
 	rules := cfg.GetAllSamplerRules()
 	rulesYamlBytes, err := yaml.Marshal(rules)
 	if err != nil {
-		return "", "", fmt.Errorf("error serializing rules to YAML: %w", err)
+		return nil, nil, fmt.Errorf("error serializing rules to YAML: %w", err)
 	}
 
-	return string(yamlBytes), string(rulesYamlBytes), nil
+	return yamlBytes, rulesYamlBytes, nil
 }
 
 // populateConfigContents creates a configContents struct from a Config interface


### PR DESCRIPTION
## Which problem is this PR solving?

Refinery only reports the config not the rules, and only reports effective config on first connection.

- Closes https://github.com/honeycombio/pipeline-team/issues/292

## Short description of the changes

- update refinery to report effective config after successfully applying a new remote config
- update effective config report to include refinery rules.

