### PR TITLE
fix: panic caused by empty traces after redistribution

### DIFF
--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -1920,7 +1920,9 @@ func TestRedistributeTraces(t *testing.T) {
 	assert.Len(t, peerEvents, 1)
 	assert.Equal(t, s.Other.GetAddress(), peerEvents[0].APIHost)
 
+	coll.mutex.Lock()
 	result := coll.cache.Get(myTraceID)
+	coll.mutex.Unlock()
 	assert.Nil(t, result, "trace should be removed from cache after redistribution")
 
 	conf.Mux.Lock()

--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -1923,7 +1923,9 @@ func TestRedistributeTraces(t *testing.T) {
 	result := coll.cache.Get(myTraceID)
 	assert.Nil(t, result, "trace should be removed from cache after redistribution")
 
+	conf.Mux.Lock()
 	conf.GetCollectionConfigVal.TraceLocalityMode = "distributed"
+	conf.Mux.Unlock()
 	myTrace2 := &types.Trace{
 		TraceID:          myTraceID,
 		Dataset:          dataset,


### PR DESCRIPTION
## Which problem is this PR solving?

When a trace only contains decision spans, it should be remove from the cache after a redistribution.
```
│ panic: runtime error: index out of range [0] with length 0                                                                                                                         │
│                                                                                                                                                                                    │
│ goroutine 141 [running]:                                                                                                                                                           │
│ github.com/honeycombio/refinery/collect.(*InMemCollector).sendExpiredTracesInCache(0x400036cc00, {0x10ad278?, 0x401e5725a0?}, {0x0?, 0x10cd8a0?, 0x19e3840?})                      │
│     github.com/honeycombio/refinery/collect/collect.go:653 +0x9e8                                                                                                                  │
│ github.com/honeycombio/refinery/collect.(*InMemCollector).collect(0x400036cc00)                                                                                                    │
│     github.com/honeycombio/refinery/collect/collect.go:442 +0x540                                                                                                                  │
│ created by github.com/honeycombio/refinery/collect.(*InMemCollector).Start in goroutine 1                                                                                          │
│     github.com/honeycombio/refinery/collect/collect.go:227 +0xc08   
```

## Short description of the changes

- remove empty traces in redistributeTraces
- add tests

