### PR TITLE
fix: use configured identifier for host address resolution in file peer

### DIFF
--- a/internal/peer/file_test.go
+++ b/internal/peer/file_test.go
@@ -19,7 +19,7 @@ func TestFilePeers(t *testing.T) {
 		t.Error(err)
 	}
 
-	if d, _ := p.GetPeers(); !(len(d) == 1 && d[0] == "peer") {
+	if d, _ := p.GetPeers(); !(len(d) == 2 && d[0] == "peer") {
 		t.Error("received", d, "expected", "[peer]")
 	}
 }

--- a/internal/peer/peers.go
+++ b/internal/peer/peers.go
@@ -1,7 +1,15 @@
 package peer
 
 import (
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+
 	"github.com/facebookgo/startstop"
+	"github.com/honeycombio/refinery/config"
+	"github.com/honeycombio/refinery/logger"
 )
 
 // Peers holds the collection of peers for the cluster
@@ -12,4 +20,82 @@ type Peers interface {
 	Ready() error
 	// make it injectable
 	startstop.Starter
+}
+
+func publicAddr(logger logger.Logger, cfg config.Config) (string, error) {
+	// compute the public version of my peer listen address
+	listenAddr := cfg.GetPeerListenAddr()
+	// first, extract the port
+	_, port, err := net.SplitHostPort(listenAddr)
+
+	if err != nil {
+		return "", err
+	}
+
+	var myIdentifier string
+
+	// If RedisIdentifier is set, use as identifier.
+	if redisIdentifier := cfg.GetRedisIdentifier(); redisIdentifier != "" {
+		myIdentifier = redisIdentifier
+		logger.Info().WithField("identifier", myIdentifier).Logf("using specified RedisIdentifier from config")
+	} else {
+		// Otherwise, determine identifier from network interface.
+		myIdentifier, err = getIdentifierFromInterface(logger, cfg)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	publicListenAddr := fmt.Sprintf("http://%s:%s", myIdentifier, port)
+
+	return publicListenAddr, nil
+}
+
+// getIdentifierFromInterface returns a string that uniquely identifies this
+// host in the network. If an interface is specified, it will scan it to
+// determine an identifier from the first IP address on that interface.
+// Otherwise, it will use the hostname.
+func getIdentifierFromInterface(logger logger.Logger, cfg config.Config) (string, error) {
+	myIdentifier, _ := os.Hostname()
+	identifierInterfaceName := cfg.GetIdentifierInterfaceName()
+
+	if identifierInterfaceName != "" {
+		ifc, err := net.InterfaceByName(identifierInterfaceName)
+		if err != nil {
+			logger.Error().WithField("interface", identifierInterfaceName).
+				Logf("IdentifierInterfaceName set but couldn't find interface by that name")
+			return "", err
+		}
+		addrs, err := ifc.Addrs()
+		if err != nil {
+			logger.Error().WithField("interface", identifierInterfaceName).
+				Logf("IdentifierInterfaceName set but couldn't list addresses")
+			return "", err
+		}
+		var ipStr string
+		for _, addr := range addrs {
+			// ParseIP doesn't know what to do with the suffix
+			ip := net.ParseIP(strings.Split(addr.String(), "/")[0])
+			ipv6 := cfg.GetUseIPV6Identifier()
+			if ipv6 && ip.To16() != nil {
+				ipStr = fmt.Sprintf("[%s]", ip.String())
+				break
+			}
+			if !ipv6 && ip.To4() != nil {
+				ipStr = ip.String()
+				break
+			}
+		}
+		if ipStr == "" {
+			err = errors.New("could not find a valid IP to use from interface")
+			logger.Error().WithField("interface", ifc.Name).
+				Logf("IdentifierInterfaceName set but couldn't find a valid IP to use from interface")
+			return "", err
+		}
+		myIdentifier = ipStr
+		logger.Info().WithField("identifier", myIdentifier).WithField("interface", ifc.Name).
+			Logf("using identifier from interface")
+	}
+
+	return myIdentifier, nil
 }

--- a/internal/peer/peers_test.go
+++ b/internal/peer/peers_test.go
@@ -29,6 +29,7 @@ func newPeers(c config.Config) (Peers, error) {
 	case "file":
 		peers = &FilePeers{
 			Cfg:     c,
+			Logger:  &logger.NullLogger{},
 			Metrics: &metrics.NullMetrics{},
 		}
 		// we know FilePeers doesn't need to be Started, so as long as we gave it a Cfg above,
@@ -60,6 +61,7 @@ func newPeers(c config.Config) (Peers, error) {
 		{Value: c},
 		{Value: peers},
 		{Value: pubsubber},
+		{Value: noop.Tracer{}, Name: "tracer"},
 		{Value: &metrics.NullMetrics{}, Name: "metrics"},
 		{Value: &logger.NullLogger{}},
 		{Value: clockwork.NewFakeClock()},

--- a/internal/peer/pubsub_test.go
+++ b/internal/peer/pubsub_test.go
@@ -28,7 +28,7 @@ func Test_publicAddr(t *testing.T) {
 				Config: tt.c,
 				Logger: &logger.NullLogger{},
 			}
-			got, err := peers.publicAddr()
+			got, err := publicAddr(peers.Logger, peers.Config)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("publicAddr() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/sharder/deterministic_test.go
+++ b/sharder/deterministic_test.go
@@ -241,9 +241,7 @@ func TestShardDrop(t *testing.T) {
 		npeers := i*10 + 5
 		t.Run(fmt.Sprintf("drop npeers=%d", npeers), func(t *testing.T) {
 			for retry := 0; retry < 2; retry++ {
-				peers := []string{
-					"http://" + selfPeerAddr,
-				}
+				peers := make([]string, 0, npeers)
 				for i := 1; i < npeers; i++ {
 					peers = append(peers, fmt.Sprintf("http://2.2.2.%d/:8081", i))
 				}


### PR DESCRIPTION
## Which problem is this PR solving?

- fix: #1506 

## Short description of the changes

- Resolve node's public address based on configured identifier in `file` peer mode

