### PR TITLE
fix: only execute Gosched in tests

### DIFF
--- a/collect/collect.go
+++ b/collect/collect.go
@@ -443,7 +443,6 @@ func (i *InMemCollector) collect() {
 				i.sendExpiredTracesInCache(ctx, i.Clock.Now())
 				i.checkAlloc(ctx)
 
-				// maybe only do this if in test mode?
 				// Briefly unlock the cache, to allow test access.
 				if i.TestMode {
 					// This is a bit of a hack, but it allows us to test

--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -63,6 +63,7 @@ func newTestCollector(conf config.Config, transmission transmit.Transmission, pe
 	redistributeNotifier := newRedistributeNotifier(&logger.NullLogger{}, &metrics.NullMetrics{}, clock, redistributionDelay)
 
 	c := &InMemCollector{
+		TestMode:         true,
 		Config:           conf,
 		Clock:            clock,
 		Logger:           &logger.NullLogger{},


### PR DESCRIPTION
## Which problem is this PR solving?

the mutex for collector is accessed by both the shutdown process and the collect goroutine. If the timing aligns just right, they can contend for the same lock, causing the Gosched span to appear as if it’s taking 60 seconds.

## Short description of the changes

- only execute `Gosched` in tests

