### PR TITLE
fix: Add valuetype to rules datatype

### DIFF
--- a/config/metadata/rulesMeta.yaml
+++ b/config/metadata/rulesMeta.yaml
@@ -705,6 +705,7 @@ groups:
           which should all be of the same datatype.
       - name: Datatype
         type: string
+        valuetype: choice
         validations:
           - type: choice
         choices:

--- a/refinery_rules.md
+++ b/refinery_rules.md
@@ -575,6 +575,7 @@ This is especially useful when a field like `http status code` may be rendered a
 The best practice is to always specify `Datatype`; this avoids ambiguity, allows for more accurate comparisons, and offers a minor performance improvement.
 
 - Type: `string`
+- Options: `string`, `int`, `float`, `bool`
 
 ## Total Throughput Sampler
 

--- a/rules.md
+++ b/rules.md
@@ -1,7 +1,7 @@
 # Honeycomb Refinery Rules Documentation
 
 This is the documentation for the rules configuration for Honeycomb's Refinery.
-It was automatically generated on 2025-04-10 at 19:03:56 UTC.
+It was automatically generated on 2025-05-14 at 13:50:49 UTC.
 
 ## The Rules file
 
@@ -615,6 +615,8 @@ This is especially useful when a field like `http status code` may be rendered a
 The best practice is to always specify `Datatype`; this avoids ambiguity, allows for more accurate comparisons, and offers a minor performance improvement.
 
 Type: `string`
+
+- Options: `string`, `int`, `float`, `bool`
 
 ---
 ## Total Throughput Sampler


### PR DESCRIPTION
## Which problem is this PR solving?

Updates the rule's datatype parameter to set it's `valuetype` to `choice`. This ensure the valid choices are rendered when generating documentation.

## Short description of the changes
- Add `valuetype: choice` to rule datatype parameter
- Run `make docrules` to regenerate rules markdown files

