### PR TITLE
fix: add _sum to legacy metrics histograms

### DIFF
--- a/metrics/legacy.go
+++ b/metrics/legacy.go
@@ -275,7 +275,9 @@ func (h *LegacyMetrics) reportToHoneycomb(ctx context.Context) {
 					ev.AddField(histogram.name+"_p99", histogram.vals[p99Index])
 					ev.AddField(histogram.name+"_min", histogram.vals[0])
 					ev.AddField(histogram.name+"_max", histogram.vals[len(histogram.vals)-1])
-					ev.AddField(histogram.name+"_avg", average(histogram.vals))
+					avg, sum := averageAndSum(histogram.vals)
+					ev.AddField(histogram.name+"_avg", avg)
+					ev.AddField(histogram.name+"_sum", sum)
 					histogram.vals = histogram.vals[:0]
 				}
 				histogram.lock.Unlock()
@@ -313,6 +315,14 @@ func average(vals []float64) float64 {
 		total += val
 	}
 	return total / float64(len(vals))
+}
+
+func averageAndSum(vals []float64) (float64, float64) {
+	var total float64
+	for _, val := range vals {
+		total += val
+	}
+	return total / float64(len(vals)), total
 }
 
 func (h *LegacyMetrics) Register(metadata Metadata) {


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Legacy metrics were missing sums for histograms 

## Short description of the changes

- Adds sums to histograms for legacy metrics

