### PR TITLE
maint: Add autogenerated comment to config templates

### DIFF
--- a/config.md
+++ b/config.md
@@ -1,7 +1,9 @@
+<!-- Do not edit manually. This is an AUTO-GENERATED file. -->
+
 # Honeycomb Refinery Configuration Documentation
 
 This is the documentation for the configuration file for Honeycomb's Refinery.
-It was automatically generated on 2025-04-10 at 19:03:55 UTC.
+It was automatically generated on 2025-05-14 at 16:44:26 UTC.
 
 ## The Config file
 

--- a/metrics.md
+++ b/metrics.md
@@ -1,7 +1,9 @@
+<!-- Do not edit manually. This is an AUTO-GENERATED file. -->
+
 # Honeycomb Refinery Metrics Documentation
 
 This document contains the description of various metrics used in Refinery.
-It was automatically generated on 2025-03-27 at 23:12:22 UTC.
+It was automatically generated on 2025-05-14 at 18:23:59 UTC.
 
 Note: This document does not include metrics defined in the dynsampler-go dependency, as those metrics are generated dynamically at runtime. As a result, certain metrics may be missing or incomplete in this document, but they will still be available during execution with their full names.
 

--- a/refinery_config.md
+++ b/refinery_config.md
@@ -1,3 +1,5 @@
+<!-- Do not edit manually. This is an AUTO-GENERATED file. -->
+
 ## Refinery Config File
 
 The Refinery `config` file is a YAML file.

--- a/refinery_rules.md
+++ b/refinery_rules.md
@@ -1,3 +1,5 @@
+<!-- Do not edit manually. This is an AUTO-GENERATED file. -->
+
 ## Refinery Rules file
 
 The Refinery `rules` file is a YAML file.

--- a/rules.md
+++ b/rules.md
@@ -1,7 +1,9 @@
+<!-- Do not edit manually. This is an AUTO-GENERATED file. -->
+
 # Honeycomb Refinery Rules Documentation
 
 This is the documentation for the rules configuration for Honeycomb's Refinery.
-It was automatically generated on 2025-05-14 at 13:50:49 UTC.
+It was automatically generated on 2025-05-14 at 16:44:26 UTC.
 
 ## The Rules file
 

--- a/tools/convert/templates/cfg_docrepo.tmpl
+++ b/tools/convert/templates/cfg_docrepo.tmpl
@@ -1,4 +1,6 @@
 {{- $file := . -}}
+<!-- Do not edit manually. This is an AUTO-GENERATED file. -->
+
 # Honeycomb Refinery Configuration Documentation
 
 This is the documentation for the configuration file for Honeycomb's Refinery.

--- a/tools/convert/templates/cfg_docsite.tmpl
+++ b/tools/convert/templates/cfg_docsite.tmpl
@@ -1,4 +1,6 @@
 {{- $file := . -}}
+<!-- Do not edit manually. This is an AUTO-GENERATED file. -->
+
 ## Refinery Config File
 
 The Refinery `config` file is a YAML file.

--- a/tools/convert/templates/metrics.tmpl
+++ b/tools/convert/templates/metrics.tmpl
@@ -1,3 +1,5 @@
+<!-- Do not edit manually. This is an AUTO-GENERATED file. -->
+
 # Honeycomb Refinery Metrics Documentation
 
 This document contains the description of various metrics used in Refinery.

--- a/tools/convert/templates/rules_docrepo.tmpl
+++ b/tools/convert/templates/rules_docrepo.tmpl
@@ -1,4 +1,6 @@
 {{- $file := . -}}
+<!-- Do not edit manually. This is an AUTO-GENERATED file. -->
+
 # Honeycomb Refinery Rules Documentation
 
 This is the documentation for the rules configuration for Honeycomb's Refinery.

--- a/tools/convert/templates/rules_docsite.tmpl
+++ b/tools/convert/templates/rules_docsite.tmpl
@@ -1,4 +1,6 @@
 {{- $file := . -}}
+<!-- Do not edit manually. This is an AUTO-GENERATED file. -->
+
 ## Refinery Rules file
 
 The Refinery `rules` file is a YAML file.


### PR DESCRIPTION
## Which problem is this PR solving?

Updates the generated config and rules files to include a markdown comment at the top of the file to indicate they are generated and should not be edited manually.

I confirmed our docs website can handle these markdown comments.

## Short description of the changes
- Update config and rules templates to add an auto generated message
- Regenerate config and rules files to get updated content