### PR TITLE
docs: update _router_otlp description

### DIFF
--- a/metrics.md
+++ b/metrics.md
@@ -3,7 +3,7 @@
 # Honeycomb Refinery Metrics Documentation
 
 This document contains the description of various metrics used in Refinery.
-It was automatically generated on 2025-05-14 at 18:23:59 UTC.
+It was automatically generated on 2025-05-22 at 19:38:37 UTC.
 
 Note: This document does not include metrics defined in the dynsampler-go dependency, as those metrics are generated dynamically at runtime. As a result, certain metrics may be missing or incomplete in this document, but they will still be available during execution with their full names.
 
@@ -106,7 +106,7 @@ Metrics in this table don't contain their expected prefixes. This is because the
 | _router_nonspan | Counter | Dimensionless | the number of non-span events received |
 | _router_peer | Counter | Dimensionless | the number of spans proxied to a peer |
 | _router_batch | Counter | Dimensionless | the number of batches of events received |
-| _router_otlp | Counter | Dimensionless | the number of batches of otlp requests received |
+| _router_otlp | Counter | Dimensionless | the number of otlp requests received |
 | bytes_received_traces | Counter | Bytes | the number of bytes received in trace events |
 | bytes_received_logs | Counter | Bytes | the number of bytes received in log events |
 | queue_length | Gauge | Dimensionless | number of events waiting to be sent to destination |

--- a/route/route.go
+++ b/route/route.go
@@ -134,7 +134,7 @@ var routerMetrics = []metrics.Metadata{
 	{Name: "_router_nonspan", Type: metrics.Counter, Unit: metrics.Dimensionless, Description: "the number of non-span events received"},
 	{Name: "_router_peer", Type: metrics.Counter, Unit: metrics.Dimensionless, Description: "the number of spans proxied to a peer"},
 	{Name: "_router_batch", Type: metrics.Counter, Unit: metrics.Dimensionless, Description: "the number of batches of events received"},
-	{Name: "_router_otlp", Type: metrics.Counter, Unit: metrics.Dimensionless, Description: "the number of batches of otlp requests received"},
+	{Name: "_router_otlp", Type: metrics.Counter, Unit: metrics.Dimensionless, Description: "the number of otlp requests received"},
 	{Name: "bytes_received_traces", Type: metrics.Counter, Unit: metrics.Bytes, Description: "the number of bytes received in trace events"},
 	{Name: "bytes_received_logs", Type: metrics.Counter, Unit: metrics.Bytes, Description: "the number of bytes received in log events"},
 }

--- a/tools/convert/metricsMeta.yaml
+++ b/tools/convert/metricsMeta.yaml
@@ -347,7 +347,7 @@ hasprefix:
     - name: _router_otlp
       type: Counter
       unit: Dimensionless
-      description: the number of batches of otlp requests received
+      description: the number of otlp requests received
     - name: bytes_received_traces
       type: Counter
       unit: Bytes


### PR DESCRIPTION
## Which problem is this PR solving?

- copy-paste error on docs for `_router_otlp` metrics.

## Short description of the changes

- update description in code
- update `metricsMeta.yaml` directly
- run `make all` from `tools/convert` directory and commit only change for this metric (other changes get updated when releasing)

