### PR TITLE
maint: Add stronger warning about TraceLocalityMode

### DIFF
--- a/config.md
+++ b/config.md
@@ -3,7 +3,7 @@
 # Honeycomb Refinery Configuration Documentation
 
 This is the documentation for the configuration file for Honeycomb's Refinery.
-It was automatically generated on 2025-05-14 at 16:44:26 UTC.
+It was automatically generated on 2025-05-23 at 20:21:03 UTC.
 
 ## The Config file
 
@@ -1078,7 +1078,8 @@ This value should be set to a bit less than the normal timeout period for shutti
 
 TraceLocalityMode controls how Refinery handles spans that belong to the same trace in a clustered environment.
 
-This is an experimental configuration setting and should not be changed in production deployments.
+This feature is experimental, in active development, and not intended for broad customer use at this time.
+**Distributed mode is UNSUPPORTED without prior coordination with the Honeycomb product engineering team.**
 When `concentrated`, Refinery will route all spans that belong to the same trace to a single peer.
 This is the default behavior ("Trace Locality") and the way Refinery has worked in the past.
 When `distributed`, Refinery will instead keep spans on the node where they were received, and forward proxy spans that contain only the key information needed to make a trace decision.

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -1394,7 +1394,8 @@ groups:
         reload: false
         summary: controls how Refinery handles spans that belong to the same trace in a clustered environment.
         description: >
-          This is an experimental configuration setting and should not be changed in production deployments.
+          This feature is experimental, in active development, and not intended for broad customer use at this time.
+          **Distributed mode is UNSUPPORTED without prior coordination with the Honeycomb product engineering team.**
 
           When `concentrated`, Refinery will route all spans that belong to the same trace to a single peer. This is the
           default behavior ("Trace Locality") and the way Refinery has worked in the past. When `distributed`, Refinery

--- a/config_complete.yaml
+++ b/config_complete.yaml
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created on 2025-04-10 at 19:03:55 UTC from ../../config.yaml using a template generated on 2025-04-10 at 19:03:51 UTC
+# created on 2025-05-23 at 20:21:03 UTC from ../../config.yaml using a template generated on 2025-05-23 at 20:20:07 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of
@@ -1139,8 +1139,10 @@ Collection:
     ## TraceLocalityMode controls how Refinery handles spans that belong to
     ## the same trace in a clustered environment.
     ##
-    ## This is an experimental configuration setting and should not be
-    ## changed in production deployments.
+    ## This feature is experimental, in active development, and not intended
+    ## for broad customer use at this time. **Distributed mode is UNSUPPORTED
+    ## without prior coordination with the Honeycomb product engineering
+    ## team.**
     ## When `concentrated`, Refinery will route all spans that belong to the
     ## same trace to a single peer. This is the default behavior ("Trace
     ## Locality") and the way Refinery has worked in the past. When

--- a/refinery_config.md
+++ b/refinery_config.md
@@ -1062,7 +1062,8 @@ This value should be set to a bit less than the normal timeout period for shutti
 
 `TraceLocalityMode` controls how Refinery handles spans that belong to the same trace in a clustered environment.
 
-This is an experimental configuration setting and should not be changed in production deployments.
+This feature is experimental, in active development, and not intended for broad customer use at this time.
+**Distributed mode is UNSUPPORTED without prior coordination with the Honeycomb product engineering team.**
 When `concentrated`, Refinery will route all spans that belong to the same trace to a single peer.
 This is the default behavior ("Trace Locality") and the way Refinery has worked in the past.
 When `distributed`, Refinery will instead keep spans on the node where they were received, and forward proxy spans that contain only the key information needed to make a trace decision.

--- a/tools/convert/templates/configV2.tmpl
+++ b/tools/convert/templates/configV2.tmpl
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created {{ now }} from {{ .Input }} using a template generated on 2025-04-10 at 19:03:51 UTC
+# created {{ now }} from {{ .Input }} using a template generated on 2025-05-23 at 20:20:07 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of
@@ -1134,8 +1134,10 @@ Collection:
     ## TraceLocalityMode controls how Refinery handles spans that belong to
     ## the same trace in a clustered environment.
     ##
-    ## This is an experimental configuration setting and should not be
-    ## changed in production deployments.
+    ## This feature is experimental, in active development, and not intended
+    ## for broad customer use at this time. **Distributed mode is UNSUPPORTED
+    ## without prior coordination with the Honeycomb product engineering
+    ## team.**
     ## When `concentrated`, Refinery will route all spans that belong to the
     ## same trace to a single peer. This is the default behavior ("Trace
     ## Locality") and the way Refinery has worked in the past. When


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Folks don't always notice the warning that TraceLocalityMode is currently experimental, and are surprised to learn it's not supported. After consulting with support teams, we've selected update wording that's made to be more noticeable, similar to what we've done with a more recently added experimental/internal feature, OpAMP support.

## Short description of the changes

- This PR follows the pattern of https://github.com/honeycombio/refinery/pull/1522, updating `config/metadata/configMeta.yaml` and `refinery_config.md`, then using `make all` in `tools/convert` to generate the other three files.

