### PR TITLE
fix: use sensible default value for HealthCheckTimeout and MaxExpiredTraces

### DIFF
--- a/collect/collect.go
+++ b/collect/collect.go
@@ -180,7 +180,7 @@ func (i *InMemCollector) Start() error {
 	// listen for config reloads
 	i.Config.RegisterReloadCallback(i.sendReloadSignal)
 
-	i.Health.Register(CollectorHealthKey, time.Duration(i.Config.GetCollectionConfig().HealthCheckTimeout))
+	i.Health.Register(CollectorHealthKey, i.Config.GetHealthCheckTimeout())
 
 	for _, metric := range inMemCollectorMetrics {
 		i.Metrics.Register(metric)

--- a/collect/collect.go
+++ b/collect/collect.go
@@ -180,7 +180,7 @@ func (i *InMemCollector) Start() error {
 	// listen for config reloads
 	i.Config.RegisterReloadCallback(i.sendReloadSignal)
 
-	i.Health.Register(CollectorHealthKey, time.Duration(imcConfig.HealthCheckTimeout))
+	i.Health.Register(CollectorHealthKey, time.Duration(i.Config.GetCollectionConfig().HealthCheckTimeout))
 
 	for _, metric := range inMemCollectorMetrics {
 		i.Metrics.Register(metric)

--- a/config.md
+++ b/config.md
@@ -3,7 +3,7 @@
 # Honeycomb Refinery Configuration Documentation
 
 This is the documentation for the configuration file for Honeycomb's Refinery.
-It was automatically generated on 2025-05-23 at 20:21:03 UTC.
+It was automatically generated on 2025-06-03 at 21:32:34 UTC.
 
 ## The Config file
 
@@ -391,12 +391,14 @@ MaxExpiredTraces is the maximum number of expired traces to process.
 This setting controls how many traces are processed when it is time to make a sampling decision.
 Up to this many traces will be processed every `SendTicker` duration.
 If this number is too small it will mean Refinery is spending less time calculating sampling decisions, resulting in data arriving at Honeycomb slower.
+Additionally, MaxExpiredTraces indirectly affects the system’s health check behavior.
+The HealthCheckTimeout will be automatically adjusted based on this value to ensure health checks remain accurate relative to the configured processing load.
 If your `collector_collect_loop_duration_ms` is above 3 seconds it is recommended to reduce this value and the `SendTicker` duration.
 This will mean Refinery makes fewer sampling decision calculations each `SendTicker` tick, but gets the chance to make decisions more often.
 
 - Eligible for live reload.
 - Type: `int`
-- Default: `5000`
+- Default: `3000`
 
 ## Debugging
 
@@ -1101,10 +1103,12 @@ HealthCheckTimeout controls the maximum duration allowed for collection health c
 The `HealthCheckTimeout` setting specifies the maximum duration allowed for the health checks of the collection subsystems to complete.
 If a subsystem does not respond within this timeout period, it will be marked as unhealthy.
 This timeout value should be set carefully to ensure that transient delays do not lead to unnecessary failure detection while still allowing for timely identification of actual health issues.
+This timeout should be configured to balance responsiveness and stability — allowing for timely detection of real health issues without being overly sensitive to brief or harmless delays.
+Refinery will adjust the timeout based on the configured `MaxExpiredTraces`, so that health checks remain effective under varying system conditions.
 
 - Not eligible for live reload.
 - Type: `duration`
-- Default: `3s`
+- Default: `15s`
 
 ## Buffer Sizes
 

--- a/config/config.go
+++ b/config/config.go
@@ -86,6 +86,9 @@ type Config interface {
 	// GetCollectionConfig returns the config specific to the InMemCollector
 	GetCollectionConfig() CollectionConfig
 
+	// GetHealthCheckTimeout returns the timeout for Refinery's internal health checks used in the collector
+	GetHealthCheckTimeout() time.Duration
+
 	// GetSamplerConfigForDestName returns the sampler type and name to use for
 	// the given destination (environment, or dataset in classic)
 	GetSamplerConfigForDestName(string) (interface{}, string)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -313,8 +313,8 @@ func TestReadDefaults(t *testing.T) {
 		t.Error("received", d, "expected", 100*time.Millisecond)
 	}
 
-	if d := c.GetTracesConfig().GetMaxExpiredTraces(); d != 5000 {
-		t.Error("received", d, "expected", 5000)
+	if d := c.GetTracesConfig().GetMaxExpiredTraces(); d != 3000 {
+		t.Error("received", d, "expected", 3000)
 	}
 
 	if d := c.GetPeerManagementType(); d != "file" {

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -440,7 +440,7 @@ groups:
       - name: MaxExpiredTraces
         type: int
         valuetype: nondefault
-        default: 5000
+        default: 3000
         reload: true
         firstVersion: 2.9
         validations:
@@ -453,6 +453,11 @@ groups:
           `SendTicker` duration. If this number is too small it will mean Refinery
           is spending less time calculating sampling decisions, resulting in data
           arriving at Honeycomb slower.
+
+          Additionally, MaxExpiredTraces indirectly affects the system’s health
+          check behavior. The HealthCheckTimeout will be automatically adjusted
+          based on this value to ensure health checks remain accurate relative to
+          the configured processing load.
 
           If your `collector_collect_loop_duration_ms` is above 3 seconds it is
           recommended to reduce this value and the `SendTicker` duration. This
@@ -1414,11 +1419,17 @@ groups:
         type: duration
         valuetype: nondefault
         firstversion: v2.8
-        default: 3s
+        default: 15s
         reload: false
         summary: controls the maximum duration allowed for collection health checks to complete.
         description: >
-          The `HealthCheckTimeout` setting specifies the maximum duration allowed for the health checks of the collection subsystems to complete. If a subsystem does not respond within this timeout period, it will be marked as unhealthy. This timeout value should be set carefully to ensure that transient delays do not lead to unnecessary failure detection while still allowing for timely identification of actual health issues.
+          The `HealthCheckTimeout` setting specifies the maximum duration allowed for the health checks of the collection subsystems to complete.
+          If a subsystem does not respond within this timeout period, it will be marked as unhealthy. This timeout value should be set carefully to
+          ensure that transient delays do not lead to unnecessary failure detection while still allowing for timely identification of actual health issues.
+
+          This timeout should be configured to balance responsiveness and stability — allowing for timely detection of real health issues without being
+          overly sensitive to brief or harmless delays. Refinery will adjust the timeout based on the configured `MaxExpiredTraces`, so that health checks
+          remain effective under varying system conditions.
 
       - name: MaxDropDecisionBatchSize
         type: int

--- a/config/mock.go
+++ b/config/mock.go
@@ -37,6 +37,7 @@ type MockConfig struct {
 	GetOTelMetricsConfigVal          OTelMetricsConfig
 	GetOTelTracingConfigVal          OTelTracingConfig
 	GetUpstreamBufferSizeVal         int
+	GetHealthCheckTimeoutVal         time.Duration
 	GetPeerBufferSizeVal             int
 	IdentifierInterfaceName          string
 	UseIPV6Identifier                bool
@@ -113,6 +114,13 @@ func (m *MockConfig) GetCollectionConfig() CollectionConfig {
 	defer m.Mux.RUnlock()
 
 	return m.GetCollectionConfigVal
+}
+
+func (m *MockConfig) GetHealthCheckTimeout() time.Duration {
+	m.Mux.RLock()
+	defer m.Mux.RUnlock()
+
+	return m.GetHealthCheckTimeoutVal
 }
 
 func (m *MockConfig) GetTracesConfig() TracesConfig {

--- a/config_complete.yaml
+++ b/config_complete.yaml
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created on 2025-05-23 at 20:21:03 UTC from ../../config.yaml using a template generated on 2025-05-23 at 20:20:07 UTC
+# created on 2025-06-03 at 21:32:34 UTC from ../../config.yaml using a template generated on 2025-06-03 at 21:32:28 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of
@@ -400,14 +400,18 @@ Traces:
     ## every `SendTicker` duration. If this number is too small it will mean
     ## Refinery is spending less time calculating sampling decisions,
     ## resulting in data arriving at Honeycomb slower.
+    ## Additionally, MaxExpiredTraces indirectly affects the system’s
+    ## health check behavior. The HealthCheckTimeout will be automatically
+    ## adjusted based on this value to ensure health checks remain accurate
+    ## relative to the configured processing load.
     ## If your `collector_collect_loop_duration_ms` is above 3 seconds it is
     ## recommended to reduce this value and the `SendTicker` duration. This
     ## will mean Refinery makes fewer sampling decision calculations each
     ## `SendTicker` tick, but gets the chance to make decisions more often.
     ##
-    ## default: 5000
+    ## default: 3000
     ## Eligible for live reload.
-    # MaxExpiredTraces: 5_000
+    # MaxExpiredTraces: 3_000
 
 ###############
 ## Debugging ##
@@ -1175,11 +1179,16 @@ Collection:
     ## carefully to ensure that transient delays do not lead to unnecessary
     ## failure detection while still allowing for timely identification of
     ## actual health issues.
+    ## This timeout should be configured to balance responsiveness and
+    ## stability — allowing for timely detection of real health issues
+    ## without being overly sensitive to brief or harmless delays. Refinery
+    ## will adjust the timeout based on the configured `MaxExpiredTraces`, so
+    ## that health checks remain effective under varying system conditions.
     ##
-    ## Accepts a duration string with units, like "3s".
-    ## default: 3s
+    ## Accepts a duration string with units, like "15s".
+    ## default: 15s
     ## Not eligible for live reload.
-    # HealthCheckTimeout: 3s
+    # HealthCheckTimeout: 15s
 
 ##################
 ## Buffer Sizes ##

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -136,7 +136,7 @@ func (h *Health) Register(subsystem string, timeout time.Duration) {
 		"source":  subsystem,
 		"timeout": timeout,
 	}
-	h.Logger.Debug().WithFields(fields).Logf("Registered Health ticker", subsystem, timeout)
+	h.Logger.Info().WithFields(fields).Logf("Registered Health ticker", subsystem, timeout)
 	if timeout < TickerTime {
 		h.Logger.Error().WithFields(fields).Logf("Registering a timeout less than the ticker time")
 	}

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -203,7 +203,7 @@ func (h *Health) checkAlive() bool {
 	for subsystem, a := range h.timeLeft {
 		if a == 0 {
 			if h.alives[subsystem] {
-				h.Logger.Error().WithField("subsystem", subsystem).Logf("IsAlive: subsystem dead due to timeout")
+				h.Logger.Error().WithFields(map[string]interface{}{"subsystem": subsystem, "timeout": h.timeouts[subsystem]}).Logf("IsAlive: subsystem dead due to timeout")
 				h.alives[subsystem] = false
 			}
 			return false
@@ -246,6 +246,7 @@ func (h *Health) checkReady() bool {
 			h.Logger.Info().WithFields(map[string]any{
 				"subsystem": subsystem,
 				"ready":     ready,
+				"timeout":   h.timeouts[subsystem],
 			}).Logf("Health.IsReady reporting subsystem not ready")
 		}
 		ready = ready && r

--- a/metrics.md
+++ b/metrics.md
@@ -3,7 +3,7 @@
 # Honeycomb Refinery Metrics Documentation
 
 This document contains the description of various metrics used in Refinery.
-It was automatically generated on 2025-05-22 at 19:38:37 UTC.
+It was automatically generated on 2025-06-03 at 21:32:33 UTC.
 
 Note: This document does not include metrics defined in the dynsampler-go dependency, as those metrics are generated dynamically at runtime. As a result, certain metrics may be missing or incomplete in this document, but they will still be available during execution with their full names.
 
@@ -93,6 +93,7 @@ Metrics in this table don't contain their expected prefixes. This is because the
 | _num_dropped | Counter | Dimensionless | Number of traces dropped by configured sampler |
 | _num_kept | Counter | Dimensionless | Number of traces kept by configured sampler |
 | _sample_rate | Histogram | Dimensionless | Sample rate for traces |
+| _sampler_key_cardinality | Histogram | Dimensionless | Number of unique keys being tracked by the sampler |
 | enqueue_errors | Counter | Dimensionless | The number of errors encountered when enqueueing events |
 | response_20x | Counter | Dimensionless | The number of successful responses from Honeycomb |
 | response_errors | Counter | Dimensionless | The number of errors encountered when sending events to Honeycomb |
@@ -106,7 +107,9 @@ Metrics in this table don't contain their expected prefixes. This is because the
 | _router_nonspan | Counter | Dimensionless | the number of non-span events received |
 | _router_peer | Counter | Dimensionless | the number of spans proxied to a peer |
 | _router_batch | Counter | Dimensionless | the number of batches of events received |
+| _router_batch_events | Counter | Dimensionless | the number of events received in batches |
 | _router_otlp | Counter | Dimensionless | the number of otlp requests received |
+| _router_otlp_events | Counter | Dimensionless | the number of events received in otlp requests |
 | bytes_received_traces | Counter | Bytes | the number of bytes received in trace events |
 | bytes_received_logs | Counter | Bytes | the number of bytes received in log events |
 | queue_length | Gauge | Dimensionless | number of events waiting to be sent to destination |

--- a/refinery_config.md
+++ b/refinery_config.md
@@ -368,12 +368,14 @@ Decreasing this will check the trace cache for timeouts more frequently.
 This setting controls how many traces are processed when it is time to make a sampling decision.
 Up to this many traces will be processed every `SendTicker` duration.
 If this number is too small it will mean Refinery is spending less time calculating sampling decisions, resulting in data arriving at Honeycomb slower.
+Additionally, MaxExpiredTraces indirectly affects the system’s health check behavior.
+The HealthCheckTimeout will be automatically adjusted based on this value to ensure health checks remain accurate relative to the configured processing load.
 If your `collector_collect_loop_duration_ms` is above 3 seconds it is recommended to reduce this value and the `SendTicker` duration.
 This will mean Refinery makes fewer sampling decision calculations each `SendTicker` tick, but gets the chance to make decisions more often.
 
 - Eligible for live reload.
 - Type: `int`
-- Default: `5000`
+- Default: `3000`
 
 ## Debugging
 
@@ -1085,10 +1087,12 @@ See `DryRun` for more information.
 The `HealthCheckTimeout` setting specifies the maximum duration allowed for the health checks of the collection subsystems to complete.
 If a subsystem does not respond within this timeout period, it will be marked as unhealthy.
 This timeout value should be set carefully to ensure that transient delays do not lead to unnecessary failure detection while still allowing for timely identification of actual health issues.
+This timeout should be configured to balance responsiveness and stability — allowing for timely detection of real health issues without being overly sensitive to brief or harmless delays.
+Refinery will adjust the timeout based on the configured `MaxExpiredTraces`, so that health checks remain effective under varying system conditions.
 
 - Not eligible for live reload.
 - Type: `duration`
-- Default: `3s`
+- Default: `15s`
 
 ## Buffer Sizes
 

--- a/sharder/deterministic_test.go
+++ b/sharder/deterministic_test.go
@@ -16,13 +16,13 @@ import (
 func TestWhichShard(t *testing.T) {
 	const traceID = "test"
 
-	peers := []string{
+	configuredPeers := []string{
 		"http://2.2.2.2:8081",
 		"http://3.3.3.3:8081",
 	}
 	config := &config.MockConfig{
 		GetPeerListenAddrVal: "127.0.0.1:8081",
-		GetPeersVal:          peers,
+		GetPeersVal:          configuredPeers,
 		PeerManagementType:   "file",
 	}
 	done := make(chan struct{})
@@ -30,6 +30,10 @@ func TestWhichShard(t *testing.T) {
 
 	filePeers := &peer.FilePeers{Cfg: config, Metrics: &metrics.NullMetrics{}, Logger: &logger.NullLogger{}}
 	require.NoError(t, filePeers.Start())
+	// the peer list should include itself
+	peers, err := filePeers.GetPeers()
+	require.NoError(t, err, "should be able to get peers from file peers")
+	require.Len(t, peers, 3, "should have 3 peers including self")
 
 	sharder := DeterministicSharder{
 		Config: config,

--- a/tools/convert/configDataNames.txt
+++ b/tools/convert/configDataNames.txt
@@ -1,5 +1,5 @@
 # Names of groups and fields in the new config file format.
-# Automatically generated on 2025-03-27 at 23:12:20 UTC.
+# Automatically generated on 2025-06-03 at 21:32:30 UTC.
 
 General:
   - ConfigurationVersion

--- a/tools/convert/metricsMeta.yaml
+++ b/tools/convert/metricsMeta.yaml
@@ -292,6 +292,10 @@ hasprefix:
       type: Histogram
       unit: Dimensionless
       description: Sample rate for traces
+    - name: _sampler_key_cardinality
+      type: Histogram
+      unit: Dimensionless
+      description: Number of unique keys being tracked by the sampler
     - name: enqueue_errors
       type: Counter
       unit: Dimensionless
@@ -344,10 +348,18 @@ hasprefix:
       type: Counter
       unit: Dimensionless
       description: the number of batches of events received
+    - name: _router_batch_events
+      type: Counter
+      unit: Dimensionless
+      description: the number of events received in batches
     - name: _router_otlp
       type: Counter
       unit: Dimensionless
       description: the number of otlp requests received
+    - name: _router_otlp_events
+      type: Counter
+      unit: Dimensionless
+      description: the number of events received in otlp requests
     - name: bytes_received_traces
       type: Counter
       unit: Bytes

--- a/tools/convert/minimal_config.yaml
+++ b/tools/convert/minimal_config.yaml
@@ -1,5 +1,5 @@
 # sample uncommented config file containing all possible fields
-# automatically generated on 2025-03-27 at 23:12:21 UTC
+# automatically generated on 2025-06-03 at 21:32:31 UTC
 General:
   ConfigurationVersion: 2
   MinRefineryVersion: "v2.0"
@@ -33,7 +33,7 @@ Traces:
   SpanLimit: 0
   MaxBatchSize: 500
   SendTicker: 100ms
-  MaxExpiredTraces: 5_000
+  MaxExpiredTraces: 3_000
 Debugging:
   DebugServiceAddr: "localhost:6060"
   QueryAuthToken: "some-private-value"
@@ -108,7 +108,7 @@ Collection:
   RedistributionDelay: 30s
   ShutdownDelay: 15s
   TraceLocalityMode: concentrated
-  HealthCheckTimeout: 3s
+  HealthCheckTimeout: 15s
 BufferSizes:
   UpstreamBufferSize: 10_000
   PeerBufferSize: 100_000

--- a/tools/convert/templates/configV2.tmpl
+++ b/tools/convert/templates/configV2.tmpl
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created {{ now }} from {{ .Input }} using a template generated on 2025-05-23 at 20:20:07 UTC
+# created {{ now }} from {{ .Input }} using a template generated on 2025-06-03 at 21:32:28 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of
@@ -399,14 +399,18 @@ Traces:
     ## every `SendTicker` duration. If this number is too small it will mean
     ## Refinery is spending less time calculating sampling decisions,
     ## resulting in data arriving at Honeycomb slower.
+    ## Additionally, MaxExpiredTraces indirectly affects the system’s
+    ## health check behavior. The HealthCheckTimeout will be automatically
+    ## adjusted based on this value to ensure health checks remain accurate
+    ## relative to the configured processing load.
     ## If your `collector_collect_loop_duration_ms` is above 3 seconds it is
     ## recommended to reduce this value and the `SendTicker` duration. This
     ## will mean Refinery makes fewer sampling decision calculations each
     ## `SendTicker` tick, but gets the chance to make decisions more often.
     ##
-    ## default: 5000
+    ## default: 3000
     ## Eligible for live reload.
-    {{ nonDefaultOnly .Data "MaxExpiredTraces" "MaxExpiredTraces" 5000 }}
+    {{ nonDefaultOnly .Data "MaxExpiredTraces" "MaxExpiredTraces" 3000 }}
 
 ###############
 ## Debugging ##
@@ -1170,11 +1174,16 @@ Collection:
     ## carefully to ensure that transient delays do not lead to unnecessary
     ## failure detection while still allowing for timely identification of
     ## actual health issues.
+    ## This timeout should be configured to balance responsiveness and
+    ## stability — allowing for timely detection of real health issues
+    ## without being overly sensitive to brief or harmless delays. Refinery
+    ## will adjust the timeout based on the configured `MaxExpiredTraces`, so
+    ## that health checks remain effective under varying system conditions.
     ##
-    ## Accepts a duration string with units, like "3s".
-    ## default: 3s
+    ## Accepts a duration string with units, like "15s".
+    ## default: 15s
     ## Not eligible for live reload.
-    {{ nonDefaultOnly .Data "HealthCheckTimeout" "HealthCheckTimeout" "3s" }}
+    {{ nonDefaultOnly .Data "HealthCheckTimeout" "HealthCheckTimeout" "15s" }}
 
 ##################
 ## Buffer Sizes ##


### PR DESCRIPTION
## Which problem is this PR solving?

The current default configuration in Refinery sets:

* HealthCheckTimeout = 3s
* MaxExpiredTraces = 5000

During load testing, we observed that processing a single expired trace through the sampler and flushing logic takes about 5ms. If Refinery were to actually process the full batch of 5000 traces in one sendExpiredTraces iteration, it would take about 25s. This processing time far exceeds the 3s default for HealthCheckTimeout


## Short description of the changes

- Decrease the default value for `MaxExpiredTraces` to 3000
- Adjust `HealthCheckTimeout` value based on `MaxExpiredTraces`
- Increase default `HealthCheckTimeout` to 15s

