### PR TITLE
fix: close redis pubsub connection on shutdown

### DIFF
--- a/pubsub/pubsub_goredis.go
+++ b/pubsub/pubsub_goredis.go
@@ -164,6 +164,7 @@ func (ps *GoRedisPubSub) Subscribe(ctx context.Context, topic string, callback S
 		for {
 			select {
 			case <-sub.done:
+				sub.pubsub.Close()
 				return
 			case msg := <-redisch:
 				if msg == nil {


### PR DESCRIPTION
## Which problem is this PR solving?

We have seen below error message showing up during shutdown. This is due to redis pubsub connection wasn't closed before we close redis client.
`discarding bad PubSub connection: read tcp [::1]:51264->[::1]:6379: use of closed network connection`

## Short description of the changes

- close pubusb connection on shutdown

