### PR TITLE
maint: use hpsf for strings

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	hpsf "github.com/honeycombio/hpsf/pkg/config"
 	"github.com/honeycombio/refinery/config"
 	"github.com/honeycombio/refinery/internal/health"
 	"github.com/honeycombio/refinery/metrics"
@@ -318,8 +319,8 @@ func (agent *Agent) composeEffectiveConfig() *protobufs.EffectiveConfig {
 	return &protobufs.EffectiveConfig{
 		ConfigMap: &protobufs.AgentConfigMap{
 			ConfigMap: map[string]*protobufs.AgentConfigFile{
-				"refinery_config": {Body: configYAML},
-				"refinery_rules":  {Body: rulesYAML},
+				string(hpsf.RefineryConfigType): {Body: configYAML},
+				string(hpsf.RefineryRulesType):  {Body: rulesYAML},
 			},
 		},
 	}
@@ -384,10 +385,10 @@ func (agent *Agent) updateRemoteConfig(ctx context.Context, msg *types.MessageDa
 		}
 
 		var opts []config.ReloadedConfigDataOption
-		if c, ok := confMap["refinery_rules"]; ok {
+		if c, ok := confMap[string(hpsf.RefineryRulesType)]; ok {
 			opts = append(opts, config.WithRulesData(config.NewConfigData(c.GetBody(), config.FormatYAML, "opamp://rules")))
 		}
-		if c, ok := confMap["refinery_config"]; ok {
+		if c, ok := confMap[string(hpsf.RefineryConfigType)]; ok {
 			opts = append(opts, config.WithConfigData(config.NewConfigData(c.GetBody(), config.FormatYAML, "opamp://config")))
 		}
 

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	hpsf "github.com/honeycombio/hpsf/pkg/config"
 	"github.com/honeycombio/refinery/config"
 	"github.com/honeycombio/refinery/internal/health"
 	"github.com/honeycombio/refinery/logger"
@@ -53,7 +54,7 @@ func TestAgentOnMessage_RemoteConfig(t *testing.T) {
 		{
 			name: "new refinery config from remote config",
 			configMap: map[string]*protobufs.AgentConfigFile{
-				"refinery_config": {
+				string(hpsf.RefineryConfigType): {
 					Body:        []byte(`{"Logger":{"Level":"debug"}}`),
 					ContentType: "text/yaml",
 				},
@@ -65,11 +66,11 @@ func TestAgentOnMessage_RemoteConfig(t *testing.T) {
 		{
 			name: "new refinery rules from remote config",
 			configMap: map[string]*protobufs.AgentConfigFile{
-				"refinery_config": {
+				string(hpsf.RefineryConfigType): {
 					Body:        []byte(`{"Logger":{"Level":"debug"}}`),
 					ContentType: "text/yaml",
 				},
-				"refinery_rules": {
+				string(hpsf.RefineryRulesType): {
 					Body: []byte(`{"rules":[{"name":"test","type":"fake"]}`),
 				},
 			},
@@ -80,11 +81,11 @@ func TestAgentOnMessage_RemoteConfig(t *testing.T) {
 		{
 			name: "same remote config should not cause reload",
 			configMap: map[string]*protobufs.AgentConfigFile{
-				"refinery_config": {
+				string(hpsf.RefineryConfigType): {
 					Body:        []byte(`{"Logger":{"Level":"debug"}}`),
 					ContentType: "text/yaml",
 				},
-				"refinery_rules": {
+				string(hpsf.RefineryRulesType): {
 					Body: []byte(`{"rules":[{"name":"test","type":"fake"]}`),
 				},
 			},

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.24.0
 
 require (
 	github.com/agnivade/levenshtein v1.2.1
-	github.com/honeycombio/hpsf v0.5.1-0.20250605195630-9b072f9dbd61
 	github.com/creasty/defaults v1.8.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/dgryski/go-wyhash v0.0.0-20191203203029-c4841ae36371
@@ -15,6 +14,7 @@ require (
 	github.com/grafana/pyroscope-go/godeltaprof v0.1.8
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/honeycombio/dynsampler-go v0.6.0
+	github.com/honeycombio/hpsf v0.5.1-0.20250605195630-9b072f9dbd61
 	github.com/honeycombio/husky v0.36.0
 	github.com/honeycombio/libhoney-go v1.25.0
 	github.com/jessevdk/go-flags v1.6.1

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.24.0
 
 require (
 	github.com/agnivade/levenshtein v1.2.1
+	github.com/honeycombio/hpsf v0.5.1-0.20250605195630-9b072f9dbd61
 	github.com/creasty/defaults v1.8.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/dgryski/go-wyhash v0.0.0-20191203203029-c4841ae36371

--- a/go.sum
+++ b/go.sum
@@ -121,6 +121,7 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/honeycombio/dynsampler-go v0.6.0 h1:fs4mrfeFGU5V+ClwpblFzbWqn4Apb+lKlE7Ja5zL22I=
 github.com/honeycombio/dynsampler-go v0.6.0/go.mod h1:pJqWFeoMN3syX74PEvlusieyGBbtIBjmTVjLc3thmK4=
+github.com/honeycombio/hpsf v0.5.1-0.20250605195630-9b072f9dbd61/go.mod h1:29/tpyeKw7tbT7mw1WCjMR6lqul7tmtNpuO0RICwzXk=
 github.com/honeycombio/husky v0.36.0 h1:IxVSFE4p+AHm/ip3qPNbTV1ZGf/0VQxUab8ah+nWVlw=
 github.com/honeycombio/husky v0.36.0/go.mod h1:glSzr4Mq5tMkcUZRRg9s+YUshPy8kRO+2F17cKazI98=
 github.com/honeycombio/libhoney-go v1.25.0 h1:r33tlX90HtafK0bgRcjfNnsrJ9ZMTKuI/1DYaOFCc1o=

--- a/go.sum
+++ b/go.sum
@@ -121,6 +121,7 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/honeycombio/dynsampler-go v0.6.0 h1:fs4mrfeFGU5V+ClwpblFzbWqn4Apb+lKlE7Ja5zL22I=
 github.com/honeycombio/dynsampler-go v0.6.0/go.mod h1:pJqWFeoMN3syX74PEvlusieyGBbtIBjmTVjLc3thmK4=
+github.com/honeycombio/hpsf v0.5.1-0.20250605195630-9b072f9dbd61 h1:cll8fstVhA805sKS5xjIVw/hKOz40qHpVvgAkg/h4hw=
 github.com/honeycombio/hpsf v0.5.1-0.20250605195630-9b072f9dbd61/go.mod h1:29/tpyeKw7tbT7mw1WCjMR6lqul7tmtNpuO0RICwzXk=
 github.com/honeycombio/husky v0.36.0 h1:IxVSFE4p+AHm/ip3qPNbTV1ZGf/0VQxUab8ah+nWVlw=
 github.com/honeycombio/husky v0.36.0/go.mod h1:glSzr4Mq5tMkcUZRRg9s+YUshPy8kRO+2F17cKazI98=


### PR DESCRIPTION
## Which problem is this PR solving?

- use [hpsf](https://github.com/honeycombio/hpsf/blob/9b072f9dbd61d72f6647ee95193419f270b19661/pkg/config/component.go#L10-L14) for string definitions instead of hard coded strings

## Short description of the changes

- update `refinery_rules` and `refinery_config` to use HPSF config types instead.

