### PR TITLE
fix: use noop span when tracing is disabled

### DIFF
--- a/collect/collect.go
+++ b/collect/collect.go
@@ -717,7 +717,6 @@ func (i *InMemCollector) processSpan(ctx context.Context, sp *types.Span, source
 	if trace == nil {
 		// if the trace has already been sent, just pass along the span
 		if sr, keptReason, found := i.sampleTraceCache.CheckSpan(sp); found {
-			span.SetAttributes(attribute.String("disposition", "already_sent"))
 			i.Metrics.Increment("trace_sent_cache_hit")
 			// bump the count of records on this trace -- if the root span isn't
 			// the last late span, then it won't be perfect, but it will be better than
@@ -734,7 +733,6 @@ func (i *InMemCollector) processSpan(ctx context.Context, sp *types.Span, source
 
 		// trace hasn't already been sent (or this span is really old); let's
 		// create a new trace to hold it
-		span.SetAttributes(attribute.Bool("create_new_trace", true))
 		i.Metrics.Increment("trace_accepted")
 
 		timeout := tcfg.GetTraceTimeout()
@@ -766,7 +764,6 @@ func (i *InMemCollector) processSpan(ctx context.Context, sp *types.Span, source
 	// span.
 	if trace.Sent {
 		if sr, reason, found := i.sampleTraceCache.CheckSpan(sp); found {
-			span.SetAttributes(attribute.String("disposition", "already_sent"))
 			i.Metrics.Increment("trace_sent_cache_hit")
 			i.dealWithSentTrace(ctx, sr, reason, sp)
 			return
@@ -786,7 +783,6 @@ func (i *InMemCollector) processSpan(ctx context.Context, sp *types.Span, source
 
 	// great! trace is live. add the span.
 	trace.AddSpan(sp)
-	span.SetAttributes(attribute.String("disposition", "live_trace"))
 
 	var spanForwarded bool
 	// if this trace doesn't belong to us and it's not in sent state, we should forward a decision span to its decider
@@ -826,7 +822,6 @@ func (i *InMemCollector) processSpan(ctx context.Context, sp *types.Span, source
 		updatedSendBy := i.Clock.Now().Add(timeout)
 		// if the trace has already timed out, we should not update the send_by time
 		if trace.SendBy.After(updatedSendBy) {
-			span.SetAttributes(attribute.String("disposition", "marked_for_sending"))
 			trace.SendBy = updatedSendBy
 			i.cache.Set(trace)
 		}

--- a/internal/otelutil/otel_tracing.go
+++ b/internal/otelutil/otel_tracing.go
@@ -23,6 +23,7 @@ import (
 )
 
 // telemetry helpers
+var _, noopSpan = noop.NewTracerProvider().Tracer("").Start(context.Background(), "")
 
 func AddException(span trace.Span, err error) {
 	if !span.IsRecording() {
@@ -80,13 +81,16 @@ func Attributes(fields map[string]interface{}) []attribute.KeyValue {
 
 // Starts a span with no extra fields.
 func StartSpan(ctx context.Context, tracer trace.Tracer, name string) (context.Context, trace.Span) {
+	if isNoopTracer(tracer) {
+		return ctx, noopSpan
+	}
 	return tracer.Start(ctx, name)
 }
 
 // Starts a span with a single field.
 func StartSpanWith(ctx context.Context, tracer trace.Tracer, name string, field string, value interface{}) (context.Context, trace.Span) {
 	if isNoopTracer(tracer) {
-		return tracer.Start(ctx, name)
+		return ctx, noopSpan
 	}
 	return tracer.Start(ctx, name, trace.WithAttributes(Attributes(map[string]interface{}{field: value})...))
 }
@@ -94,7 +98,7 @@ func StartSpanWith(ctx context.Context, tracer trace.Tracer, name string, field 
 // Starts a span with multiple fields.
 func StartSpanMulti(ctx context.Context, tracer trace.Tracer, name string, fields map[string]interface{}) (context.Context, trace.Span) {
 	if isNoopTracer(tracer) {
-		return tracer.Start(ctx, name)
+		return ctx, noopSpan
 	}
 	return tracer.Start(ctx, name, trace.WithAttributes(Attributes(fields)...))
 }


### PR DESCRIPTION
## Which problem is this PR solving?

The go.opentelemetry.io/otel/trace/noop tracer still allocates by copying the parent context and setting the noop span as the current span. While this behavior is generally fine, it introduces unnecessary allocations in processSpan, which is a hot path in our trace ingestion pipeline.

These context allocations are significant enough to appear in memory profiles during benchmarking. 

## Short description of the changes

- return a global noop span if tracing is not enabled
- remove some not crucial instrumentation from `processSpan` function

