### PR TITLE
fix: only calculate span count and annotation type once

### DIFF
--- a/collect/cache/cuckooSentCache.go
+++ b/collect/cache/cuckooSentCache.go
@@ -88,7 +88,7 @@ func (t *keptTraceCacheEntry) SpanCount() uint {
 // Count records additional spans in the cache record.
 func (t *keptTraceCacheEntry) Count(s *types.Span) {
 	t.eventCount++
-	switch s.AnnotationType() {
+	switch s.AnnotationType {
 	case types.SpanAnnotationTypeSpanEvent:
 		t.spanEventCount++
 	case types.SpanAnnotationTypeLink:

--- a/route/route.go
+++ b/route/route.go
@@ -612,9 +612,10 @@ func (r *Router) processEvent(ev *types.Event, reqID interface{}) error {
 	debugLog = debugLog.WithString("trace_id", traceID)
 
 	span := &types.Span{
-		Event:   *ev,
-		TraceID: traceID,
-		IsRoot:  isRootSpan(ev, r.Config),
+		Event:          *ev,
+		TraceID:        traceID,
+		IsRoot:         isRootSpan(ev, r.Config),
+		AnnotationType: -1,
 	}
 
 	// only record bytes received for incoming traffic when opamp is enabled and record usage is set to true

--- a/types/event_test.go
+++ b/types/event_test.go
@@ -117,11 +117,12 @@ func TestSpan_AnnotationType(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			sp := &Span{
+				AnnotationType: SpanAnnotationTypeUnSet,
 				Event: Event{
 					Data: tt.data,
 				},
 			}
-			if got := sp.AnnotationType(); got != tt.want {
+			if got := GetSpanAnnotationType(sp); got != tt.want {
 				t.Errorf("Span.AnnotationType() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
## Which problem is this PR solving?

Benchmarking revealed that AnnotationType was being called excessively — once for every span, per count type. This happens because each span metadata calculation iterates through the entire span list and re-evaluates the annotation type for each span.

This PR improves performance by calculating the annotation type once per span and caching the result. Subsequent metadata calculations reuse the cached value.

## Short description of the changes

- cache `AnnotationType` value on each span
- cache `spanCount`, `spanEventCount`, and `spanLinkCount` on traces

Before:
<img width="1613" alt="Screenshot 2025-06-09 at 6 47 22 PM" src="https://github.com/user-attachments/assets/d98e8104-b01b-4c9b-aa29-68847526c8f9" />

After:

<img width="842" alt="Screenshot 2025-06-09 at 6 54 32 PM" src="https://github.com/user-attachments/assets/a292f499-f4ba-4d2e-ad5d-98d29bee80fa" />

