### PR TITLE
perf: optimize trace key generation with hash-based deduplication

### DIFF
--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -2699,7 +2699,8 @@ func setupBenchmarkCollector(b *testing.B, samplerConfig interface{}, sender *mo
 		GetSamplerTypeVal:  samplerConfig,
 		ParentIdFieldNames: []string{"trace.parent_id", "parentId"},
 		GetCollectionConfigVal: config.CollectionConfig{
-			ShutdownDelay: config.Duration(1 * time.Millisecond),
+			ShutdownDelay:      config.Duration(1 * time.Millisecond),
+			HealthCheckTimeout: config.Duration(100 * time.Millisecond),
 		},
 	}
 
@@ -2716,6 +2717,7 @@ func setupBenchmarkCollector(b *testing.B, samplerConfig interface{}, sender *mo
 	coll.outgoingTraces = make(chan sendableTrace, 100000)
 	coll.datasetSamplers = make(map[string]sample.Sampler)
 	coll.BlockOnAddSpan = true
+	coll.Health.Register(CollectorHealthKey, conf.GetHealthCheckTimeout())
 
 	// Start the collector's processing goroutines
 	go coll.collect()

--- a/go.mod
+++ b/go.mod
@@ -77,7 +77,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/dgryski/go-metro v0.0.0-20200812162917-85c65e2d0165 // indirect
+	github.com/dgryski/go-metro v0.0.0-20200812162917-85c65e2d0165
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a // indirect
 	github.com/facebookgo/limitgroup v0.0.0-20150612190941-6abd8d71ec01 // indirect

--- a/sample/trace_key.go
+++ b/sample/trace_key.go
@@ -116,9 +116,9 @@ type distinctValue struct {
 	fields []string
 	values []map[uint64]string
 
-	// totalUniqueCount keeps track of how many unique values we've seen so far
+	// totalUniqueCount keeps track of how many unique values we've seen so far for a trace key.
 	totalUniqueCount int
-	// maxDistinctValue is the maximum number of distinct values we will store
+	// maxDistinctValue is the maximum number of distinct values we will store for a trace key.
 	maxDistinctValue int
 }
 

--- a/sample/trace_key.go
+++ b/sample/trace_key.go
@@ -57,9 +57,7 @@ func (d *traceKey) build(trace *types.Trace) (string, int) {
 	spans := trace.GetSpans()
 	uniques := d.distinctValue
 	uniques.Reset(d.fields, maxKeyLength)
-	defer func() {
-		d.keyBuilder.Reset()
-	}()
+	d.keyBuilder.Reset()
 outer:
 	for i, field := range d.fields {
 		for _, span := range spans {

--- a/sample/trace_key.go
+++ b/sample/trace_key.go
@@ -74,8 +74,11 @@ outer:
 
 	var key strings.Builder
 	for i := range d.fields {
-		// if there's no values for this field, skip it
 		values := uniques.Values(i)
+		// if there's no values for this field, skip it
+		if len(values) == 0 {
+			continue
+		}
 		var prevStr string
 		for _, str := range values {
 			if str != prevStr {

--- a/sample/trace_key.go
+++ b/sample/trace_key.go
@@ -71,8 +71,6 @@ outer:
 	// ok, now we have a map of fields to a list of all unique values for that field.
 	// (unless it was huge, in which case we have a bunch of them)
 
-	// please change this so that strings.Builder can be reused between calls
-
 	for i := range d.fields {
 		values := d.distinctValue.Values(i)
 		// if there's no values for this field, skip it

--- a/sample/trace_key_test.go
+++ b/sample/trace_key_test.go
@@ -276,14 +276,22 @@ func TestDistinctValue_AddAsString(t *testing.T) {
 			// each field should have expected unique counts and values
 			expectedTotalCount := 0
 			for fieldIdx, expectedCount := range tt.expectedCounts {
-				require.Equal(t, expectedCount, len(dv.values[fieldIdx]), "Unexpected count for field index %d", fieldIdx)
+				assert.Equal(t, expectedCount, len(dv.values[fieldIdx]), "Unexpected count for field index %d", fieldIdx)
 				expectedTotalCount += expectedCount
 			}
 
-			require.Equal(t, expectedTotalCount, dv.totalUniqueCount, "Unexpected unique count")
+			assert.Equal(t, expectedTotalCount, dv.totalUniqueCount, "Unexpected unique count")
+
+			// run the dinstinct values through fmt.Sprintf("%v") to ensure it matches the expected string representation
+			// of the values
 			for fieldIdx, expectedValues := range tt.expectedValues {
 				values := dv.Values(fieldIdx)
-				require.ElementsMatch(t, expectedValues, values, "Unexpected distinct values")
+				assert.ElementsMatch(t, expectedValues, values, "Unexpected distinct values")
+				var expectedOutputs []string
+				for _, v := range dv.values[fieldIdx] {
+					expectedOutputs = append(expectedOutputs, fmt.Sprintf("%v", v))
+				}
+				assert.ElementsMatch(t, expectedOutputs, values, "field value doesn't match with fmt.Sprintf(\"%v\", fieldIdx)")
 			}
 		})
 	}

--- a/sample/trace_key_test.go
+++ b/sample/trace_key_test.go
@@ -142,10 +142,13 @@ func TestKeyLimits(t *testing.T) {
 
 func TestDistinctValue_AddAsString(t *testing.T) {
 	tests := []struct {
-		name           string
-		valuesToAdd    [][]any
-		expectedCounts []int      // Expected unique counts for each field
-		expectedValues [][]string // Expected distinct values for each field
+		name string
+		// Values to add in the format {fieldName, value}. Using an array here instead of a map because we need deterministic order for testing
+		valuesToAdd [][]any
+		// Expected unique counts for each field
+		expectedCounts []int
+		// Expected distinct values for each field
+		expectedValues [][]string
 	}{
 		{
 			name: "integer_and_string",

--- a/sample/trace_key_test.go
+++ b/sample/trace_key_test.go
@@ -162,9 +162,13 @@ func createTestTrace(t *testing.T, spans []testSpan) *types.Trace {
 
 	return trace
 }
+
 func TestDistinctValue_AddAsString(t *testing.T) {
 	fields := []string{"field1", "field2"}
-	dv := newDistinctValue(fields, 10)
+	dv := &distinctValue{
+		buf: make([]byte, 0, 1024),
+	}
+	dv.init(fields, 10)
 
 	tests := []struct {
 		name        string
@@ -235,7 +239,10 @@ func TestDistinctValue_AddAsString(t *testing.T) {
 
 func TestDistinctValue_MaxLimit(t *testing.T) {
 	maxValues := 3
-	dv := newDistinctValue([]string{"field"}, maxValues)
+	dv := &distinctValue{
+		buf: make([]byte, 0, 1024),
+	}
+	dv.init([]string{"field1"}, maxValues)
 
 	// Add up to the limit
 	for i := 0; i < maxValues-1; i++ {
@@ -249,7 +256,10 @@ func TestDistinctValue_MaxLimit(t *testing.T) {
 }
 
 func TestDistinctValue_Values(t *testing.T) {
-	dv := newDistinctValue([]string{"field1", "field2"}, 10)
+	dv := &distinctValue{
+		buf: make([]byte, 0, 1024),
+	}
+	dv.init([]string{"field1", "field2", "empty-field"}, 10)
 
 	// Add some mixed values
 	dv.AddAsString("banana", 0)
@@ -283,8 +293,7 @@ func TestDistinctValue_Values(t *testing.T) {
 
 	t.Run("Empty field", func(t *testing.T) {
 		// Field that has no values
-		dv := newDistinctValue([]string{"empty"}, 10)
-		values := dv.Values(0)
+		values := dv.Values(2)
 		require.Nil(t, values)
 	})
 }


### PR DESCRIPTION
## Which problem is this PR solving?

The trace key generation process was creating unnecessary memory allocations and putting pressure on garbage collection due to excessive string creation. This was particularly problematic for large traces with many spans that contains the same value for key fields.

## Short description of the changes

- Replaced string concatenation and `fmt.Sprintf` operations with a reusable byte buffer to minimize allocations
-  use uint64 values as map keys instead of strings
- add unit test

## Benchmark result
This is the benchmark result from running the `collect` loop which exercises this function
```
goos: darwin
goarch: arm64
pkg: github.com/honeycombio/refinery/collect
cpu: Apple M2 Max
                                                     │   old.txt    │          new-trace-key.txt          │
                                                     │    sec/op    │   sec/op     vs base                │
CollectorWithSamplers/deterministic/small_traces-12     79.72µ ± 3%   79.82µ ± 2%        ~ (p=0.971 n=10)
CollectorWithSamplers/deterministic/medium_traces-12    8.009m ± 4%   7.960m ± 3%        ~ (p=0.481 n=10)
CollectorWithSamplers/deterministic/large_traces-12     939.1m ± 3%   928.8m ± 3%        ~ (p=0.739 n=10)
CollectorWithSamplers/dynamic/small_traces-12          103.20µ ± 3%   87.85µ ± 4%  -14.87% (p=0.000 n=10)
CollectorWithSamplers/dynamic/medium_traces-12          9.409m ± 3%   8.266m ± 4%  -12.15% (p=0.000 n=10)
CollectorWithSamplers/dynamic/large_traces-12            1.173 ± 2%    1.063 ± 5%   -9.37% (p=0.000 n=10)
CollectorWithSamplers/emadynamic/small_traces-12       100.94µ ± 3%   81.08µ ± 3%  -19.67% (p=0.000 n=10)
CollectorWithSamplers/emadynamic/medium_traces-12       9.328m ± 2%   7.825m ± 2%  -16.11% (p=0.000 n=10)
CollectorWithSamplers/emadynamic/large_traces-12         1.153 ± 1%    1.019 ± 2%  -11.59% (p=0.000 n=10)
CollectorWithSamplers/rulesbased/small_traces-12        74.59µ ± 1%   75.36µ ± 7%        ~ (p=0.123 n=10)
CollectorWithSamplers/rulesbased/medium_traces-12       7.383m ± 1%   7.136m ± 2%   -3.34% (p=0.000 n=10)
CollectorWithSamplers/rulesbased/large_traces-12        927.6m ± 3%   922.9m ± 2%        ~ (p=0.218 n=10)
geomean                                                 9.222m        8.519m        -7.62%

                                                     │    old.txt    │          new-trace-key.txt           │
                                                     │     B/op      │     B/op      vs base                │
CollectorWithSamplers/deterministic/small_traces-12     6.193Ki ± 0%   6.194Ki ± 0%        ~ (p=0.700 n=10)
CollectorWithSamplers/deterministic/medium_traces-12    617.2Ki ± 0%   617.2Ki ± 0%        ~ (p=0.382 n=10)
CollectorWithSamplers/deterministic/large_traces-12     73.44Mi ± 0%   73.43Mi ± 0%        ~ (p=0.247 n=10)
CollectorWithSamplers/dynamic/small_traces-12          20.352Ki ± 0%   7.224Ki ± 0%  -64.50% (p=0.000 n=10)
CollectorWithSamplers/dynamic/medium_traces-12         1482.3Ki ± 0%   618.3Ki ± 0%  -58.28% (p=0.000 n=10)
CollectorWithSamplers/dynamic/large_traces-12          157.37Mi ± 0%   73.45Mi ± 0%  -53.33% (p=0.000 n=10)
CollectorWithSamplers/emadynamic/small_traces-12       20.461Ki ± 0%   7.306Ki ± 0%  -64.29% (p=0.000 n=10)
CollectorWithSamplers/emadynamic/medium_traces-12      1482.3Ki ± 0%   618.4Ki ± 0%  -58.29% (p=0.000 n=10)
CollectorWithSamplers/emadynamic/large_traces-12       157.37Mi ± 0%   73.44Mi ± 0%  -53.33% (p=0.000 n=10)
CollectorWithSamplers/rulesbased/small_traces-12        6.983Ki ± 0%   6.983Ki ± 0%        ~ (p=0.954 n=10)
CollectorWithSamplers/rulesbased/medium_traces-12       618.0Ki ± 0%   617.9Ki ± 0%   -0.00% (p=0.001 n=10)
CollectorWithSamplers/rulesbased/large_traces-12        73.44Mi ± 0%   73.44Mi ± 0%   -0.00% (p=0.043 n=10)
geomean                                                 1.044Mi        684.9Ki       -35.91%

                                                     │   old.txt   │           new-trace-key.txt           │
                                                     │  allocs/op  │  allocs/op   vs base                  │
CollectorWithSamplers/deterministic/small_traces-12     326.0 ± 0%    326.0 ± 0%        ~ (p=1.000 n=10) ¹
CollectorWithSamplers/deterministic/medium_traces-12   30.05k ± 0%   30.05k ± 0%        ~ (p=1.000 n=10)
CollectorWithSamplers/deterministic/large_traces-12    3.002M ± 0%   3.002M ± 0%        ~ (p=0.469 n=10)
CollectorWithSamplers/dynamic/small_traces-12           769.0 ± 0%    355.0 ± 0%  -53.84% (p=0.000 n=10)
CollectorWithSamplers/dynamic/medium_traces-12         70.10k ± 0%   30.09k ± 0%  -57.08% (p=0.000 n=10)
CollectorWithSamplers/dynamic/large_traces-12          7.002M ± 0%   3.002M ± 0%  -57.13% (p=0.000 n=10)
CollectorWithSamplers/emadynamic/small_traces-12        771.0 ± 0%    357.0 ± 0%  -53.70% (p=0.000 n=10)
CollectorWithSamplers/emadynamic/medium_traces-12      70.11k ± 0%   30.09k ± 0%  -57.08% (p=0.000 n=10)
CollectorWithSamplers/emadynamic/large_traces-12       7.002M ± 0%   3.002M ± 0%  -57.13% (p=0.000 n=10)
CollectorWithSamplers/rulesbased/small_traces-12        335.0 ± 0%    335.0 ± 0%        ~ (p=1.000 n=10) ¹
CollectorWithSamplers/rulesbased/medium_traces-12      30.06k ± 0%   30.06k ± 0%   -0.00% (p=0.005 n=10)
CollectorWithSamplers/rulesbased/large_traces-12       3.002M ± 0%   3.002M ± 0%   -0.00% (p=0.050 n=10)
geomean                                                47.35k        31.40k       -33.68%
```

benchmark result from trace_key.build function itself
```
goos: darwin
goarch: arm64
pkg: github.com/honeycombio/refinery/sample
cpu: Apple M2 Max
                                         │ old-trace-key-build.txt │       new-trace-key-build.txt       │
                                         │         sec/op          │   sec/op     vs base                │
TraceKeyBuild/small_trace_fields-12                   19.736µ ± 3%   4.659µ ± 1%  -76.40% (p=0.000 n=10)
TraceKeyBuild/large_trace_fields-12                   191.90m ± 3%   73.89m ± 1%  -61.49% (p=0.000 n=10)
TraceKeyBuild/small_trace_many_fields-12               56.11µ ± 2%   13.98µ ± 1%  -75.08% (p=0.000 n=10)
TraceKeyBuild/with_root_fields-12                     19.697µ ± 2%   4.850µ ± 0%  -75.38% (p=0.000 n=10)
TraceKeyBuild/high_cardinality-12                      19.52µ ± 1%   10.04µ ± 0%  -48.57% (p=0.000 n=10)
geomean                                                152.2µ        47.20µ       -68.99%

                                         │ old-trace-key-build.txt │        new-trace-key-build.txt        │
                                         │          B/op           │     B/op      vs base                 │
TraceKeyBuild/small_trace_fields-12                   13809.0 ± 0%     515.0 ± 0%   -96.27% (p=0.000 n=10)
TraceKeyBuild/large_trace_fields-12                88005373.0 ± 0%     652.0 ± 1%  -100.00% (p=0.000 n=10)
TraceKeyBuild/small_trace_many_fields-12             30.717Ki ± 0%   1.031Ki ± 0%   -96.64% (p=0.000 n=10)
TraceKeyBuild/with_root_fields-12                     14370.0 ± 0%     595.0 ± 0%   -95.86% (p=0.000 n=10)
TraceKeyBuild/high_cardinality-12                    13.284Ki ± 0%   1.383Ki ± 0%   -89.59% (p=0.000 n=10)
geomean                                               92.13Ki          785.3        -99.17%

                                         │ old-trace-key-build.txt │       new-trace-key-build.txt       │
                                         │        allocs/op        │ allocs/op   vs base                 │
TraceKeyBuild/small_trace_fields-12                    434.00 ± 0%   17.00 ± 0%   -96.08% (p=0.000 n=10)
TraceKeyBuild/large_trace_fields-12                4000035.00 ± 0%   18.00 ± 0%  -100.00% (p=0.000 n=10)
TraceKeyBuild/small_trace_many_fields-12              1284.00 ± 0%   47.00 ± 0%   -96.34% (p=0.000 n=10)
TraceKeyBuild/with_root_fields-12                      437.00 ± 0%   19.00 ± 0%   -95.65% (p=0.000 n=10)
TraceKeyBuild/high_cardinality-12                       319.0 ± 0%   101.0 ± 0%   -68.34% (p=0.000 n=10)
geomean                                                3.151k        30.77        -99.02%
```
