### PR TITLE
perf: use concrete type for Counter, Gauge, and Histogram metrics

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -44,8 +44,8 @@ func (a *App) Start() error {
 		}
 		cfgMetric := config.ConfigHashMetrics(cfgHash)
 		ruleMetric := config.ConfigHashMetrics(rulesHash)
-		a.Metrics.Gauge("config_hash", cfgMetric)
-		a.Metrics.Gauge("rule_config_hash", ruleMetric)
+		a.Metrics.Gauge("config_hash", float64(cfgMetric))
+		a.Metrics.Gauge("rule_config_hash", float64(ruleMetric))
 	}
 
 	a.Logger.Debug().Logf("Starting up App...")

--- a/collect/cache/cuckoo.go
+++ b/collect/cache/cuckoo.go
@@ -114,7 +114,7 @@ outer:
 	c.mut.Unlock()
 	timeout.Stop()
 	qlt := time.Since(lockStart)
-	c.met.Histogram(AddQueueLockTime, qlt.Microseconds())
+	c.met.Histogram(AddQueueLockTime, float64(qlt.Microseconds()))
 }
 
 // Add puts a traceID into the filter. We need this to be fast
@@ -152,7 +152,7 @@ func (c *CuckooTraceChecker) Maintain() {
 	if c.future != nil {
 		c.met.Gauge(FutureLoadFactor, c.future.LoadFactor())
 	}
-	c.met.Gauge(CurrentCapacity, c.capacity)
+	c.met.Gauge(CurrentCapacity, float64(c.capacity))
 	c.mut.RUnlock()
 
 	// once the current one is half loaded, we can start using the future one too

--- a/collect/cache/cuckooSentCache.go
+++ b/collect/cache/cuckooSentCache.go
@@ -211,7 +211,7 @@ func (c *cuckooSentCache) monitor() {
 			// Length() returns the number of items in the cache and it will
 			// clean up any expired items.
 			numOfDroppedIDs := c.recentDroppedIDs.Length()
-			c.met.Gauge("cache_recent_dropped_traces", numOfDroppedIDs)
+			c.met.Gauge("cache_recent_dropped_traces", float64(numOfDroppedIDs))
 		case <-c.done:
 			return
 		}

--- a/collect/stressRelief.go
+++ b/collect/stressRelief.go
@@ -419,7 +419,7 @@ func (s *StressRelief) Recalc() uint {
 	localLevel := uint(maximumLevel)
 
 	clusterStressLevel := s.clusterStressLevel(localLevel)
-	s.RefineryMetrics.Gauge("cluster_stress_level", clusterStressLevel)
+	s.RefineryMetrics.Gauge("cluster_stress_level", float64(clusterStressLevel))
 
 	s.lock.Lock()
 	defer s.lock.Unlock()
@@ -432,7 +432,7 @@ func (s *StressRelief) Recalc() uint {
 		overallStressLevel = clusterStressLevel
 	}
 	s.overallStressLevel = overallStressLevel
-	s.RefineryMetrics.Gauge("stress_level", s.overallStressLevel)
+	s.RefineryMetrics.Gauge("stress_level", float64(s.overallStressLevel))
 
 	s.reason = reason
 	s.formula = formula

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -185,8 +185,8 @@ func (h *Health) Ready(subsystem string, ready bool) {
 		h.alives[subsystem] = true
 		h.Logger.Info().WithField("subsystem", subsystem).Logf("Health.Ready reporting subsystem alive")
 	}
-	h.Metrics.Gauge("is_ready", h.checkReady())
-	h.Metrics.Gauge("is_alive", h.checkAlive())
+	h.Metrics.Gauge("is_ready", metrics.ConvertBoolToFloat(h.checkReady()))
+	h.Metrics.Gauge("is_alive", metrics.ConvertBoolToFloat(h.checkAlive()))
 }
 
 // IsAlive returns true if all registered subsystems are alive

--- a/metrics/legacy.go
+++ b/metrics/legacy.go
@@ -45,7 +45,7 @@ type LegacyMetrics struct {
 type counter struct {
 	lock sync.Mutex
 	name string
-	val  int
+	val  int64
 }
 
 type gauge struct {
@@ -383,12 +383,12 @@ func createUpdown(name string) *updown {
 	}
 }
 
-func (h *LegacyMetrics) Count(name string, n interface{}) {
+func (h *LegacyMetrics) Count(name string, n int64) {
 	counter := getOrAdd(&h.lock, name, h.counters, createCounter)
 
 	// update value, using counter's lock
 	counter.lock.Lock()
-	counter.val = counter.val + int(ConvertNumeric(n))
+	counter.val = counter.val + n
 	counter.lock.Unlock()
 }
 
@@ -396,21 +396,21 @@ func (h *LegacyMetrics) Increment(name string) {
 	h.Count(name, 1)
 }
 
-func (h *LegacyMetrics) Gauge(name string, val interface{}) {
+func (h *LegacyMetrics) Gauge(name string, val float64) {
 	gauge := getOrAdd(&h.lock, name, h.gauges, createGauge)
 
 	// update value, using gauge's lock
 	gauge.lock.Lock()
-	gauge.val = ConvertNumeric(val)
+	gauge.val = val
 	gauge.lock.Unlock()
 }
 
-func (h *LegacyMetrics) Histogram(name string, obs interface{}) {
+func (h *LegacyMetrics) Histogram(name string, obs float64) {
 	histogram := getOrAdd(&h.lock, name, h.histograms, createHistogram)
 
 	// update value, using histogram's lock
 	histogram.lock.Lock()
-	histogram.vals = append(histogram.vals, ConvertNumeric(obs))
+	histogram.vals = append(histogram.vals, obs)
 	histogram.lock.Unlock()
 }
 
@@ -437,6 +437,6 @@ func (h *LegacyMetrics) Store(name string, val float64) {
 
 	// update value, using constant's lock
 	constant.lock.Lock()
-	constant.val = ConvertNumeric(val)
+	constant.val = val
 	constant.lock.Unlock()
 }

--- a/metrics/legacy_test.go
+++ b/metrics/legacy_test.go
@@ -35,7 +35,7 @@ func Test_getOrAdd_counter(t *testing.T) {
 	wg.Wait()
 
 	var ctr *counter = getOrAdd(lock, "foo", metrics, createCounter)
-	assert.Equal(t, nthreads*1000, ctr.val)
+	assert.Equal(t, int64(nthreads*1000), ctr.val)
 }
 
 func Test_getOrAdd_gauge(t *testing.T) {

--- a/metrics/libhoney_metrics.go
+++ b/metrics/libhoney_metrics.go
@@ -1,0 +1,73 @@
+package metrics
+
+import (
+	"github.com/honeycombio/libhoney-go/transmission"
+)
+
+var _ transmission.Metrics = (*LibhoneyMetricsWrapper)(nil)
+
+// LibhoneyMetricsWrapper is a wrapper around Refinery's Metrics and implements the
+// libhoney-go transmission.Metrics interface.
+type LibhoneyMetricsWrapper struct {
+	*MetricsPrefixer
+}
+
+func (l *LibhoneyMetricsWrapper) Register(metadata Metadata) {
+	l.Metrics.Register(metadata)
+}
+
+func (l *LibhoneyMetricsWrapper) Increment(name string) {
+	l.Metrics.Increment(name)
+}
+
+func (l *LibhoneyMetricsWrapper) Gauge(name string, val interface{}) {
+	f := ConvertNumeric(val)
+	l.Metrics.Gauge(name, f)
+}
+
+func (l *LibhoneyMetricsWrapper) Count(name string, val interface{}) {
+	f := ConvertNumeric(val)
+	l.Metrics.Count(name, int64(f))
+}
+
+func (l *LibhoneyMetricsWrapper) Histogram(name string, obs interface{}) {
+	f := ConvertNumeric(obs)
+	l.Metrics.Histogram(name, f)
+}
+
+// ConvertNumeric converts various numeric types to float64.
+// This is useful for converting values from libhoney-go since it expects
+// the Gauge, Count, and Histogram methods to accept values with any type.
+func ConvertNumeric(val interface{}) float64 {
+	switch n := val.(type) {
+	case int:
+		return float64(n)
+	case uint:
+		return float64(n)
+	case int64:
+		return float64(n)
+	case uint64:
+		return float64(n)
+	case int32:
+		return float64(n)
+	case uint32:
+		return float64(n)
+	case int16:
+		return float64(n)
+	case uint16:
+		return float64(n)
+	case int8:
+		return float64(n)
+	case uint8:
+		return float64(n)
+	case float64:
+		return n
+	case float32:
+		return float64(n)
+	case bool:
+		if n {
+			return 1
+		}
+	}
+	return 0
+}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -35,50 +35,23 @@ import (
 type Metrics interface {
 	// Register declares a metric; metricType should be one of counter, gauge, histogram, updown
 	Register(metadata Metadata)
-	Increment(name string)                  // for counters
-	Gauge(name string, val interface{})     // for gauges
-	Count(name string, n interface{})       // for counters
-	Histogram(name string, obs interface{}) // for histogram
-	Up(name string)                         // for updown
-	Down(name string)                       // for updown
-	Get(name string) (float64, bool)        // for reading back a counter or a gauge
-	Store(name string, val float64)         // for storing a rarely-changing value not sent as a metric
+	Increment(name string)              // for counters
+	Gauge(name string, val float64)     // for gauges
+	Count(name string, n int64)         // for counters
+	Histogram(name string, obs float64) // for histogram
+	Up(name string)                     // for updown
+	Down(name string)                   // for updown
+	Get(name string) (float64, bool)    // for reading back a counter or a gauge
+	Store(name string, val float64)     // for storing a rarely-changing value not sent as a metric
 }
 
 func GetMetricsImplementation(c config.Config) *MultiMetrics {
 	return NewMultiMetrics()
 }
 
-func ConvertNumeric(val interface{}) float64 {
-	switch n := val.(type) {
-	case int:
-		return float64(n)
-	case uint:
-		return float64(n)
-	case int64:
-		return float64(n)
-	case uint64:
-		return float64(n)
-	case int32:
-		return float64(n)
-	case uint32:
-		return float64(n)
-	case int16:
-		return float64(n)
-	case uint16:
-		return float64(n)
-	case int8:
-		return float64(n)
-	case uint8:
-		return float64(n)
-	case float64:
-		return n
-	case float32:
-		return float64(n)
-	case bool:
-		if n {
-			return 1
-		}
+func ConvertBoolToFloat(val bool) float64 {
+	if val {
+		return 1
 	}
 	return 0
 }

--- a/metrics/metricsnamer.go
+++ b/metrics/metricsnamer.go
@@ -39,15 +39,15 @@ func (p *MetricsPrefixer) Increment(name string) {
 	p.Metrics.Increment(p.prefix + name)
 }
 
-func (p *MetricsPrefixer) Gauge(name string, val interface{}) {
+func (p *MetricsPrefixer) Gauge(name string, val float64) {
 	p.Metrics.Gauge(p.prefix+name, val)
 }
 
-func (p *MetricsPrefixer) Count(name string, val interface{}) {
+func (p *MetricsPrefixer) Count(name string, val int64) {
 	p.Metrics.Count(p.prefix+name, val)
 }
 
-func (p *MetricsPrefixer) Histogram(name string, obs interface{}) {
+func (p *MetricsPrefixer) Histogram(name string, obs float64) {
 	p.Metrics.Histogram(p.prefix+name, obs)
 }
 

--- a/metrics/mock.go
+++ b/metrics/mock.go
@@ -8,7 +8,7 @@ var _ Metrics = (*MockMetrics)(nil)
 // verify expected behavior
 type MockMetrics struct {
 	Registrations     map[string]string
-	CounterIncrements map[string]int
+	CounterIncrements map[string]int64
 	GaugeRecords      map[string]float64
 	Histograms        map[string][]float64
 	UpdownIncrements  map[string]int
@@ -20,7 +20,7 @@ type MockMetrics struct {
 // Start initializes all metrics or resets all metrics to zero
 func (m *MockMetrics) Start() {
 	m.Registrations = make(map[string]string)
-	m.CounterIncrements = make(map[string]int)
+	m.CounterIncrements = make(map[string]int64)
 	m.GaugeRecords = make(map[string]float64)
 	m.Histograms = make(map[string][]float64)
 	m.UpdownIncrements = make(map[string]int)
@@ -43,19 +43,19 @@ func (m *MockMetrics) Increment(name string) {
 
 	m.CounterIncrements[name] += 1
 }
-func (m *MockMetrics) Gauge(name string, val interface{}) {
+func (m *MockMetrics) Gauge(name string, val float64) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
-	m.GaugeRecords[name] = ConvertNumeric(val)
+	m.GaugeRecords[name] = val
 }
-func (m *MockMetrics) Count(name string, val interface{}) {
+func (m *MockMetrics) Count(name string, val int64) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
-	m.CounterIncrements[name] += int(ConvertNumeric(val))
+	m.CounterIncrements[name] += val
 }
-func (m *MockMetrics) Histogram(name string, val interface{}) {
+func (m *MockMetrics) Histogram(name string, val float64) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
@@ -63,7 +63,7 @@ func (m *MockMetrics) Histogram(name string, val interface{}) {
 	if !ok {
 		m.Histograms[name] = make([]float64, 0)
 	}
-	m.Histograms[name] = append(m.Histograms[name], ConvertNumeric(val))
+	m.Histograms[name] = append(m.Histograms[name], val)
 }
 func (m *MockMetrics) Up(name string) {
 	m.lock.Lock()

--- a/metrics/multi_metrics.go
+++ b/metrics/multi_metrics.go
@@ -81,25 +81,25 @@ func (m *MultiMetrics) Increment(name string) { // for counters
 	m.values[name]++
 }
 
-func (m *MultiMetrics) Gauge(name string, val interface{}) { // for gauges
+func (m *MultiMetrics) Gauge(name string, val float64) { // for gauges
 	for _, ch := range m.children {
 		ch.Gauge(name, val)
 	}
 	m.lock.Lock()
 	defer m.lock.Unlock()
-	m.values[name] = ConvertNumeric(val)
+	m.values[name] = val
 }
 
-func (m *MultiMetrics) Count(name string, n interface{}) { // for counters
+func (m *MultiMetrics) Count(name string, n int64) { // for counters
 	for _, ch := range m.children {
 		ch.Count(name, n)
 	}
 	m.lock.Lock()
 	defer m.lock.Unlock()
-	m.values[name] += ConvertNumeric(n)
+	m.values[name] += float64(n)
 }
 
-func (m *MultiMetrics) Histogram(name string, obs interface{}) { // for histogram
+func (m *MultiMetrics) Histogram(name string, obs float64) { // for histogram
 	for _, ch := range m.children {
 		ch.Histogram(name, obs)
 	}

--- a/metrics/nullmetrics.go
+++ b/metrics/nullmetrics.go
@@ -9,12 +9,12 @@ type NullMetrics struct{}
 func (n *NullMetrics) Start() {}
 func (n *NullMetrics) Stop()  {}
 
-func (n *NullMetrics) Register(metadata Metadata)             {}
-func (n *NullMetrics) Increment(name string)                  {}
-func (n *NullMetrics) Gauge(name string, val interface{})     {}
-func (n *NullMetrics) Count(name string, val interface{})     {}
-func (n *NullMetrics) Histogram(name string, obs interface{}) {}
-func (n *NullMetrics) Up(name string)                         {}
-func (n *NullMetrics) Down(name string)                       {}
-func (n *NullMetrics) Store(name string, value float64)       {}
-func (n *NullMetrics) Get(name string) (float64, bool)        { return 0, true }
+func (n *NullMetrics) Register(metadata Metadata)         {}
+func (n *NullMetrics) Increment(name string)              {}
+func (n *NullMetrics) Gauge(name string, val float64)     {}
+func (n *NullMetrics) Count(name string, val int64)       {}
+func (n *NullMetrics) Histogram(name string, obs float64) {}
+func (n *NullMetrics) Up(name string)                     {}
+func (n *NullMetrics) Down(name string)                   {}
+func (n *NullMetrics) Store(name string, value float64)   {}
+func (n *NullMetrics) Get(name string) (float64, bool)    { return 0, true }

--- a/metrics/otel_metrics.go
+++ b/metrics/otel_metrics.go
@@ -248,7 +248,7 @@ func (o *OTelMetrics) Increment(name string) {
 	o.values[name]++
 }
 
-func (o *OTelMetrics) Gauge(name string, val interface{}) {
+func (o *OTelMetrics) Gauge(name string, val float64) {
 	o.lock.Lock()
 	defer o.lock.Unlock()
 
@@ -261,10 +261,10 @@ func (o *OTelMetrics) Gauge(name string, val interface{}) {
 			return
 		}
 	}
-	o.values[name] = ConvertNumeric(val)
+	o.values[name] = val
 }
 
-func (o *OTelMetrics) Count(name string, val interface{}) {
+func (o *OTelMetrics) Count(name string, val int64) {
 	o.lock.Lock()
 	defer o.lock.Unlock()
 
@@ -276,12 +276,11 @@ func (o *OTelMetrics) Count(name string, val interface{}) {
 			return
 		}
 	}
-	f := ConvertNumeric(val)
-	ctr.Add(context.Background(), int64(f))
-	o.values[name] += f
+	ctr.Add(context.Background(), val)
+	o.values[name] += float64(val)
 }
 
-func (o *OTelMetrics) Histogram(name string, val interface{}) {
+func (o *OTelMetrics) Histogram(name string, val float64) {
 	o.lock.Lock()
 	defer o.lock.Unlock()
 
@@ -293,9 +292,8 @@ func (o *OTelMetrics) Histogram(name string, val interface{}) {
 			return
 		}
 	}
-	f := ConvertNumeric(val)
-	h.Record(context.Background(), f)
-	o.values[name] += f
+	h.Record(context.Background(), val)
+	o.values[name] += val
 }
 
 func (o *OTelMetrics) Up(name string) {

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -105,37 +105,35 @@ func (p *PromMetrics) Increment(name string) {
 		}
 	}
 }
-func (p *PromMetrics) Count(name string, n interface{}) {
+func (p *PromMetrics) Count(name string, n int64) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
 	if counterIface, ok := p.metrics[name]; ok {
 		if counter, ok := counterIface.(prometheus.Counter); ok {
-			f := ConvertNumeric(n)
-			counter.Add(f)
-			p.values[name] += f
+			counter.Add(float64(n))
+			p.values[name] += float64(n)
 		}
 	}
 }
-func (p *PromMetrics) Gauge(name string, val interface{}) {
+func (p *PromMetrics) Gauge(name string, val float64) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
 	if gaugeIface, ok := p.metrics[name]; ok {
 		if gauge, ok := gaugeIface.(prometheus.Gauge); ok {
-			f := ConvertNumeric(val)
-			gauge.Set(f)
-			p.values[name] = f
+			gauge.Set(val)
+			p.values[name] = val
 		}
 	}
 }
-func (p *PromMetrics) Histogram(name string, obs interface{}) {
+func (p *PromMetrics) Histogram(name string, obs float64) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
 	if histIface, ok := p.metrics[name]; ok {
 		if hist, ok := histIface.(prometheus.Histogram); ok {
-			hist.Observe(ConvertNumeric(obs))
+			hist.Observe(obs)
 		}
 	}
 }

--- a/pubsub/pubsub_local.go
+++ b/pubsub/pubsub_local.go
@@ -76,7 +76,7 @@ func (ps *LocalPubSub) Publish(ctx context.Context, topic, message string) error
 	ps.mut.Lock()
 	ps.ensureTopic(topic)
 	ps.Metrics.Count("local_pubsub_published", 1)
-	ps.Metrics.Count("local_pubsub_received", len(ps.topics[topic]))
+	ps.Metrics.Count("local_pubsub_received", int64(len(ps.topics[topic])))
 	// make a copy of our subs so we don't hold the lock while calling them
 	subs := make([]*LocalSubscription, 0, len(ps.topics[topic]))
 	subs = append(subs, ps.topics[topic]...)

--- a/route/route_test.go
+++ b/route/route_test.go
@@ -810,7 +810,7 @@ func TestProcessEventMetrics(t *testing.T) {
 		opampEnabled   bool
 		recordUsage    config.DefaultTrue
 		signalType     string
-		expectedCount  int
+		expectedCount  int64
 		metricName     string
 	}{
 		{
@@ -914,7 +914,7 @@ func TestProcessEventMetrics(t *testing.T) {
 			}
 			size := span.GetDataSize()
 			if tt.expectedCount > 0 {
-				assert.Equal(t, tt.expectedCount, size)
+				assert.Equal(t, tt.expectedCount, int64(size))
 			}
 
 			// Call processEvent
@@ -1046,8 +1046,8 @@ func TestRouterBatch(t *testing.T) {
 	}
 
 	mockMetrics := router.Metrics.(*metrics.MockMetrics)
-	assert.Equal(t, 1, mockMetrics.CounterIncrements["incoming_router_batch"])
-	assert.Equal(t, 3, mockMetrics.CounterIncrements["incoming_router_batch_events"])
+	assert.Equal(t, int64(1), mockMetrics.CounterIncrements["incoming_router_batch"])
+	assert.Equal(t, int64(3), mockMetrics.CounterIncrements["incoming_router_batch_events"])
 
 	var spans []*types.Span
 	for len(spans) < len(batchEvents) {

--- a/sample/sample.go
+++ b/sample/sample.go
@@ -152,7 +152,7 @@ func (d *dynsamplerMetricsRecorder) RecordMetrics(sampler dynsampler.Sampler, ke
 			d.met.Count(name, delta)
 			d.lastMetrics[name] = val
 		case metrics.Gauge:
-			d.met.Gauge(name, val)
+			d.met.Gauge(name, float64(val))
 		}
 	}
 

--- a/transmit/transmit.go
+++ b/transmit/transmit.go
@@ -208,7 +208,7 @@ func (d *DefaultTransmission) processResponses(
 				d.Metrics.Increment(counterResponse20x)
 			}
 			d.Metrics.Down(updownQueuedItems)
-			d.Metrics.Histogram(histogramQueueTime, dequeuedAt-enqueuedAt)
+			d.Metrics.Histogram(histogramQueueTime, float64(dequeuedAt-enqueuedAt))
 		case <-ctx.Done():
 			return
 		}


### PR DESCRIPTION
## Which problem is this PR solving?

Use concrete type as input when recording Counter, Gauge, and Histogram metrics. This is to prevent allocation on the heap caused by converting a concrete type to `interface{}`

## Short description of the changes

- Use `float64` as input type for Gauge and Histogram
- Use `int64` as input type for Counter
- Implement a wrapper for libhoney internal metrics since transmission.Metrics requires input being passed in as `interface{}`

