### PR TITLE
perf: cleanup superfluous allocations during event unmarshal

### DIFF
--- a/route/batched_event.go
+++ b/route/batched_event.go
@@ -1,0 +1,120 @@
+package route
+
+import (
+	"bytes"
+	"time"
+
+	"github.com/honeycombio/refinery/types"
+	"github.com/tinylib/msgp/msgp"
+)
+
+type batchedEvent struct {
+	Timestamp        string        `json:"time"`
+	MsgPackTimestamp *time.Time    `msgpack:"time,omitempty"`
+	SampleRate       int64         `json:"samplerate" msgpack:"samplerate"`
+	Data             types.Payload `json:"data" msgpack:"data"`
+}
+
+func (b *batchedEvent) getEventTime() time.Time {
+	if b.MsgPackTimestamp != nil {
+		return b.MsgPackTimestamp.UTC()
+	}
+
+	return getEventTime(b.Timestamp)
+}
+
+func (b *batchedEvent) getSampleRate() uint {
+	if b.SampleRate == 0 {
+		return defaultSampleRate
+	}
+	return uint(b.SampleRate)
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+// Based on generated code from the msgp tool, but modified for clarity and to
+// the unnecessary unsafe string conversion.
+// For instructions on how to generate this sort of code, see
+// https://pkg.go.dev/github.com/tinylib/msgp#section-readme
+func (b *batchedEvent) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	var fieldsRemaining uint32
+	fieldsRemaining, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for fieldsRemaining > 0 {
+		fieldsRemaining--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch {
+		case bytes.Equal(field, []byte("time")):
+			if msgp.IsNil(bts) {
+				bts, err = msgp.ReadNilBytes(bts)
+				if err != nil {
+					return
+				}
+				b.MsgPackTimestamp = nil
+			} else {
+				if b.MsgPackTimestamp == nil {
+					b.MsgPackTimestamp = new(time.Time)
+				}
+				*b.MsgPackTimestamp, bts, err = msgp.ReadTimeBytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "MsgPackTimestamp")
+					return
+				}
+			}
+		case bytes.Equal(field, []byte("samplerate")):
+			b.SampleRate, bts, err = msgp.ReadInt64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "SampleRate")
+				return
+			}
+		case bytes.Equal(field, []byte("data")):
+			bts, err = b.Data.UnmarshalMsg(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Data")
+				return
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+// Create a type for []batchedEvent so we can give it an unmarshaler.
+type batchedEvents []batchedEvent
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (b *batchedEvents) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var totalValues uint32
+	totalValues, bts, err = msgp.ReadArrayHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	if cap(*b) >= int(totalValues) {
+		*b = (*b)[:totalValues]
+	} else {
+		*b = make(batchedEvents, totalValues)
+	}
+	for i := range *b {
+		bts, err = (*b)[i].UnmarshalMsg(bts)
+		if err != nil {
+			err = msgp.WrapError(err, i)
+			return
+		}
+	}
+	o = bts
+	return
+}

--- a/route/batched_event.go
+++ b/route/batched_event.go
@@ -32,7 +32,7 @@ func (b *batchedEvent) getSampleRate() uint {
 
 // UnmarshalMsg implements msgp.Unmarshaler
 // Based on generated code from the msgp tool, but modified for clarity and to
-// the unnecessary unsafe string conversion.
+// avoid the unnecessary unsafe string conversion.
 // For instructions on how to generate this sort of code, see
 // https://pkg.go.dev/github.com/tinylib/msgp#section-readme
 func (b *batchedEvent) UnmarshalMsg(bts []byte) (o []byte, err error) {

--- a/route/batched_event_test.go
+++ b/route/batched_event_test.go
@@ -1,0 +1,54 @@
+package route
+
+import (
+	"maps"
+	"testing"
+	"time"
+
+	"github.com/honeycombio/refinery/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vmihailenco/msgpack/v5"
+)
+
+func TestBatchedEventRoundTrip(t *testing.T) {
+	timestamp := time.Now()
+
+	events := batchedEvents{
+		{
+			MsgPackTimestamp: &timestamp,
+			Data: types.NewPayload(map[string]any{
+				"string_field": "test_value",
+				"int_field":    int64(42),
+				"float_field":  3.14159,
+				"bool_field":   true,
+				"nil_field":    nil,
+			}),
+		},
+		{
+			MsgPackTimestamp: &timestamp,
+			SampleRate:       200,
+			Data: types.NewPayload(map[string]any{
+				"another_string": "hello world",
+				"negative_int":   int64(-123),
+				"large_float":    1234.5678,
+				"false_bool":     false,
+				"nil_value":      nil,
+			}),
+		},
+	}
+
+	serialized, err := msgpack.Marshal(events)
+	require.NoError(t, err)
+
+	var deserialized batchedEvents
+	_, err = deserialized.UnmarshalMsg(serialized)
+	require.NoError(t, err)
+
+	require.Len(t, deserialized, 2)
+	for i := range deserialized {
+		assert.WithinDuration(t, timestamp, *deserialized[i].MsgPackTimestamp, 0)
+		assert.Equal(t, events[i].SampleRate, deserialized[i].SampleRate)
+		assert.Equal(t, maps.Collect(events[i].Data.All()), maps.Collect(deserialized[i].Data.All()))
+	}
+}

--- a/route/batched_event_test.go
+++ b/route/batched_event_test.go
@@ -51,4 +51,19 @@ func TestBatchedEventRoundTrip(t *testing.T) {
 		assert.Equal(t, events[i].SampleRate, deserialized[i].SampleRate)
 		assert.Equal(t, maps.Collect(events[i].Data.All()), maps.Collect(deserialized[i].Data.All()))
 	}
+
+	// Test overwriting with another unmarshal, with swapped events order.
+	events[0], events[1] = events[1], events[0]
+	serialized, err = msgpack.Marshal(events)
+	require.NoError(t, err)
+
+	deserialized = deserialized[:0]
+	_, err = deserialized.UnmarshalMsg(serialized)
+	require.NoError(t, err)
+	require.Len(t, deserialized, 2)
+	for i := range deserialized {
+		assert.WithinDuration(t, timestamp, *deserialized[i].MsgPackTimestamp, 0)
+		assert.Equal(t, events[i].SampleRate, deserialized[i].SampleRate)
+		assert.Equal(t, maps.Collect(events[i].Data.All()), maps.Collect(deserialized[i].Data.All()))
+	}
 }

--- a/types/msgp_payload_map.go
+++ b/types/msgp_payload_map.go
@@ -41,7 +41,7 @@ func (m *MsgpPayloadMap) Size() int {
 }
 
 func (m *MsgpPayloadMap) Iterate() (msgpPayloadMapIter, error) {
-	if m == nil {
+	if m == nil || len(m.rawData) == 0 {
 		return msgpPayloadMapIter{}, nil
 	}
 	n, remaining, err := msgp.ReadMapHeaderBytes(m.rawData)

--- a/types/msgp_payload_map_test.go
+++ b/types/msgp_payload_map_test.go
@@ -150,9 +150,11 @@ func TestMsgpPayloadMap_ErrorCases(t *testing.T) {
 	_, err = arrayPayloadMap.Iterate()
 	assert.Error(t, err)
 
-	// Test empty data
+	// Test empty data - iterating is ok, but EOFs immediately.
 	emptyPayloadMap := NewMessagePackPayloadMap(nil)
-	_, err = emptyPayloadMap.Iterate()
+	iter, err := emptyPayloadMap.Iterate()
+	assert.NoError(t, err)
+	_, _, err = iter.NextKey()
 	assert.Error(t, err)
 
 	// Test truncated data, should fail on the second value.
@@ -182,7 +184,7 @@ func TestMsgpPayloadMap_ErrorCases(t *testing.T) {
 	require.NoError(t, err)
 
 	payloadMap := NewMessagePackPayloadMap(encoded)
-	iter, err := payloadMap.Iterate()
+	iter, err = payloadMap.Iterate()
 	require.NoError(t, err)
 
 	for {

--- a/types/payload.go
+++ b/types/payload.go
@@ -34,7 +34,7 @@ func (p *Payload) UnmarshalMsgpack(data []byte) error {
 // UnmarshalMsg implements msgp.Unmarshaler, similar to above but expects to be
 // part of a larger message.
 func (p *Payload) UnmarshalMsg(bts []byte) (o []byte, err error) {
-	// Oddly the msgp library doesn't export the interal size method it uses
+	// Oddly the msgp library doesn't export the internal size method it uses
 	// to skip data. So we will derived it from the returned slice.
 	remainder, err := msgp.Skip(bts)
 	if err != nil {


### PR DESCRIPTION
## Which problem is this PR solving?
Waste in the existing unmarshal() implementation remaining from the following PR:
- #1586

## Short description of the changes
Skips the expensive Reader-based vmihailenco/msgpack.Decoder implementation for the common case of messagepack batches. Also de-pointerifies Payload's internal MsgpPayloadMap which was another heap allocation for no good reason. This is in no way comprehensive; there is other fat to trim in the batch ingest path.

```
benchmark                   old ns/op     new ns/op     delta
BenchmarkRouterBatch-12     5857          3724          -36.42%

benchmark                   old allocs     new allocs     delta
BenchmarkRouterBatch-12     69             44             -36.23%

benchmark                   old bytes     new bytes     delta
BenchmarkRouterBatch-12     5535          3550          -35.86%
```