### PR TITLE
fix: wait for goroutines to finish before shutting down

### DIFF
--- a/collect/cache/cuckoo.go
+++ b/collect/cache/cuckoo.go
@@ -35,6 +35,9 @@ type CuckooTraceChecker struct {
 	capacity uint
 	met      metrics.Metrics
 	addch    chan string
+
+	done       chan struct{}
+	shutdownWG sync.WaitGroup
 }
 
 const (
@@ -59,6 +62,7 @@ func NewCuckooTraceChecker(capacity uint, m metrics.Metrics) *CuckooTraceChecker
 		future:   nil,
 		met:      m,
 		addch:    make(chan string, AddQueueDepth),
+		done:     make(chan struct{}),
 	}
 	for _, metric := range cuckooTraceCheckerMetrics {
 		m.Register(metric)
@@ -66,17 +70,36 @@ func NewCuckooTraceChecker(capacity uint, m metrics.Metrics) *CuckooTraceChecker
 
 	// To try to avoid blocking on Add, we have a goroutine that pulls from a
 	// channel and adds to the filter.
+	c.shutdownWG.Add(1)
 	go func() {
+		defer c.shutdownWG.Done()
+
 		ticker := time.NewTicker(AddQueueSleepTime)
-		for range ticker.C {
-			// as long as there's anything still in the channel, keep trying to drain it
-			for len(c.addch) > 0 {
-				c.drain()
+		for {
+			select {
+			case <-ticker.C:
+				for len(c.addch) > 0 {
+					c.drain()
+				}
+			case <-c.done:
+				return
+
 			}
 		}
 	}()
 
 	return c
+}
+
+func (c *CuckooTraceChecker) Stop() {
+	// stop the goroutine that drains the add channel
+	close(c.done)
+	c.shutdownWG.Wait()
+
+	// make sure we drain the channel one last time
+	for len(c.addch) > 0 {
+		c.drain()
+	}
 }
 
 // This function records all the traces that were in the channel at the start of

--- a/collect/collect.go
+++ b/collect/collect.go
@@ -1103,8 +1103,11 @@ func (i *InMemCollector) Stop() error {
 	// stop liveness check
 	// so that no new traces are accepted
 	i.Health.Unregister(CollectorHealthKey)
-
 	i.mutex.Lock()
+
+	for _, sampler := range i.datasetSamplers {
+		sampler.Stop()
+	}
 
 	if !i.Config.GetCollectionConfig().DisableRedistribution {
 		peers, err := i.Peers.GetPeers()

--- a/sample/deterministic.go
+++ b/sample/deterministic.go
@@ -66,3 +66,5 @@ func (d *DeterministicSampler) GetSampleRate(trace *types.Trace) (rate uint, kee
 func (d *DeterministicSampler) GetKeyFields() []string {
 	return d.Config.GetSamplingFields()
 }
+
+func (d *DeterministicSampler) Stop() {}

--- a/sample/dynamic.go
+++ b/sample/dynamic.go
@@ -63,6 +63,10 @@ func (d *DynamicSampler) Start() error {
 	return nil
 }
 
+func (d *DynamicSampler) Stop() {
+	d.dynsampler.Stop()
+}
+
 func (d *DynamicSampler) GetSampleRate(trace *types.Trace) (rate uint, keep bool, reason string, key string) {
 	key, n := d.key.build(trace)
 	if n == maxKeyLength {

--- a/sample/dynamic_ema.go
+++ b/sample/dynamic_ema.go
@@ -72,6 +72,10 @@ func (d *EMADynamicSampler) Start() error {
 	return nil
 }
 
+func (d *EMADynamicSampler) Stop() {
+	d.dynsampler.Stop()
+}
+
 func (d *EMADynamicSampler) GetSampleRate(trace *types.Trace) (rate uint, keep bool, reason string, key string) {
 	key, n := d.key.build(trace)
 	if n == maxKeyLength {

--- a/sample/ema_throughput.go
+++ b/sample/ema_throughput.go
@@ -81,6 +81,10 @@ func (d *EMAThroughputSampler) Start() error {
 	return nil
 }
 
+func (d *EMAThroughputSampler) Stop() {
+	d.dynsampler.Stop()
+}
+
 func (d *EMAThroughputSampler) SetClusterSize(size int) {
 	if d.useClusterSize {
 		d.clusterSize = size

--- a/sample/rules.go
+++ b/sample/rules.go
@@ -88,6 +88,14 @@ func (s *RulesBasedSampler) Start() error {
 	return nil
 }
 
+func (s *RulesBasedSampler) Stop() {
+	for _, sampler := range s.samplers {
+		if sampler != nil {
+			sampler.Stop()
+		}
+	}
+}
+
 func (s *RulesBasedSampler) SetClusterSize(size int) {
 	for _, sampler := range s.samplers {
 		if sampler, ok := sampler.(ClusterSizer); ok {

--- a/sample/sample.go
+++ b/sample/sample.go
@@ -17,6 +17,7 @@ type Sampler interface {
 	GetSampleRate(trace *types.Trace) (rate uint, keep bool, reason string, key string)
 	GetKeyFields() []string
 	Start() error
+	Stop()
 }
 
 type ClusterSizer interface {

--- a/sample/totalthroughput.go
+++ b/sample/totalthroughput.go
@@ -72,6 +72,10 @@ func (d *TotalThroughputSampler) Start() error {
 	return nil
 }
 
+func (d *TotalThroughputSampler) Stop() {
+	d.dynsampler.Stop()
+}
+
 func (d *TotalThroughputSampler) SetClusterSize(size int) {
 	if d.useClusterSize {
 		d.clusterSize = size

--- a/sample/windowed_throughput.go
+++ b/sample/windowed_throughput.go
@@ -68,6 +68,10 @@ func (d *WindowedThroughputSampler) Start() error {
 	return nil
 }
 
+func (d *WindowedThroughputSampler) Stop() {
+	d.dynsampler.Stop()
+}
+
 func (d *WindowedThroughputSampler) SetClusterSize(size int) {
 	if d.useClusterSize {
 		d.clusterSize = size


### PR DESCRIPTION
## Which problem is this PR solving?

While this issue may not affect deployed instances of Refinery, it impacts the developer experience when running tests. Previously, some goroutines were not properly shut down after calling the shutdown function. This resulted in noisy and cluttered profiles during test runs, making it difficult to analyze performance or debug issues effectively.

## Short description of the changes

- wait for goroutines created by various components to finish before return from `Stop()`

