### PR TITLE
test: enable DryRun in collect loop benchmark test

### DIFF
--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -2724,6 +2724,7 @@ func BenchmarkCollectorWithSamplers(b *testing.B) {
 
 func setupBenchmarkCollector(b *testing.B, samplerConfig interface{}, sender *mockSender) *InMemCollector {
 	conf := &config.MockConfig{
+		DryRun: true,
 		GetTracesConfigVal: config.TracesConfig{
 			SendTicker:   config.Duration(5 * time.Millisecond),
 			SendDelay:    config.Duration(1 * time.Millisecond),


### PR DESCRIPTION
## Which problem is this PR solving?

`EMADynamic` sampler can't maintain at SampleRate 1 due to probability. To ensure the consistency of the test result, enabling dyrun will allow all traces to be sent regardless of its sampling decision. 

## Short description of the changes

- enable `DryRun` in collect loop benchmark test

