### PR TITLE
fix: make TestStableMaxAlloc less flaky

### DIFF
--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -790,8 +790,8 @@ func TestStableMaxAlloc(t *testing.T) {
 	var mem runtime.MemStats
 	runtime.ReadMemStats(&mem)
 	// Set MaxAlloc, which should cause cache evictions.
+	conf.SetMaxAlloc(config.MemorySize(mem.Alloc * 995 / 1000))
 	coll.reloadConfigs()
-	conf.SetMaxAlloc(config.MemorySize(mem.Alloc * 99 / 100))
 
 	// TODO: enable this once we want to turn on DisableTraceLocality
 	//	orphanPeerTrace := coll.cache.Get(peerTraceIDs[0])


### PR DESCRIPTION
## Which problem is this PR solving?

The TestStableMaxAlloc is flaky due to when the GC occurred and when new allocation happened in the test process.

This PR decreases the amount of trace the test needs to evict so that Refinery can detect the memory allocation change sooner rather than later.

## Short description of the changes

- Change the MacAlloc config before calling reloadConfigs
- change the configured MaxAlloc in test so that we don't need to evict as much traces

