### PR TITLE
maint: remove metro hash and use wyhash instead

### DIFF
--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -2724,6 +2724,7 @@ func BenchmarkCollectorWithSamplers(b *testing.B) {
 
 func setupBenchmarkCollector(b *testing.B, samplerConfig interface{}, sender *mockSender) *InMemCollector {
 	conf := &config.MockConfig{
+		DryRun: true,
 		GetTracesConfigVal: config.TracesConfig{
 			SendTicker:   config.Duration(5 * time.Millisecond),
 			SendDelay:    config.Duration(1 * time.Millisecond),

--- a/go.mod
+++ b/go.mod
@@ -80,7 +80,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/dgryski/go-metro v0.0.0-20200812162917-85c65e2d0165
+	github.com/dgryski/go-metro v0.0.0-20200812162917-85c65e2d0165 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a // indirect
 	github.com/facebookgo/limitgroup v0.0.0-20150612190941-6abd8d71ec01 // indirect

--- a/sample/trace_key.go
+++ b/sample/trace_key.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/dgryski/go-metro"
+	"github.com/dgryski/go-wyhash"
 	"github.com/honeycombio/refinery/types"
 )
 
@@ -180,7 +180,7 @@ func (d *distinctValue) AddAsString(value any, fieldIdx int) bool {
 		d.buf = append(d.buf, fmt.Sprintf("%v", v)...)
 	}
 
-	hash := metro.Hash64(d.buf, 0)
+	hash := wyhash.Hash(d.buf, 0)
 	if _, exists := d.values[fieldIdx][hash]; !exists {
 		d.totalUniqueCount++
 		if d.totalUniqueCount >= d.maxDistinctValue {


### PR DESCRIPTION
## Which problem is this PR solving?

We already have a hashing algorithm for hashing. We don't need another one

## Short description of the changes

- remove metro hash in trace_key.go and use existing wyhash instead

