### PR TITLE
test: add benchmark for transmission

### DIFF
--- a/transmit/direct_transmit.go
+++ b/transmit/direct_transmit.go
@@ -239,6 +239,8 @@ func (d *DirectTransmission) sendBatch(batch []*types.Event) {
 	dequeuedAt := time.Now()
 
 	if err != nil {
+		d.Logger.Error().WithField("error", err.Error()).Logf("http POST failed")
+
 		// Network/connection error - affects all events in batch
 		for _, ev := range batch {
 			queueTime := dequeuedAt.UnixMicro() - ev.EnqueuedUnixMicro
@@ -311,7 +313,6 @@ func (d *DirectTransmission) sendBatch(batch []*types.Event) {
 			d.handleEventError(ev, resp.StatusCode, queueTime, "", bodyBytes)
 		}
 	}
-
 }
 
 // TODO this needs to be modified to not exceed maximum event and batch sizes,


### PR DESCRIPTION
## Which problem is this PR solving?
I need to evaluate relative performance of the transmission system, in addition to correctness.

## Short description of the changes
Adds a new benchmark for transmission, direct (new) vs default (libhoney). There's a lot of boilerplate here, but note I've set a pretty low maximum connection count in the http client (just for this benchmark, for now) - without this both implementations managed to overwhelm Mac OS, resulting in http dial errors.

Despite our concerns about the naive DirectTransmission implementation, the results are stark:
```
BenchmarkTransmissionComparison/high_card/direct-8  	 5000000	       833.2 ns/op	    4680 B/op	       3 allocs/op
BenchmarkTransmissionComparison/high_card/default-8 	 5000000	     10300 ns/op	   43035 B/op	     213 allocs/op
BenchmarkTransmissionComparison/low_card/direct-8   	 5000000	      2831 ns/op	    4614 B/op	       3 allocs/op
BenchmarkTransmissionComparison/low_card/default-8  	 5000000	      4805 ns/op	   36047 B/op	      90 allocs/op
```
This may seem implausible, but this is the payoff for the lazy messagepack deserialization: serializing and sending these events is now trivial. Although note this is a best-case scenario in that regard, in that no additional fields have been overwritten or added to the event.