### PR TITLE
feat: add support for REFINERY_HONEYCOMB_LOGGER_ADDITIONAL_FIELDS to honeycomb logger

### DIFF
--- a/config/cmdenv.go
+++ b/config/cmdenv.go
@@ -26,34 +26,35 @@ import (
 // that this system uses reflection to establish the relationship between the
 // config struct and the command line options.
 type CmdEnv struct {
-	ConfigLocations       []string   `short:"c" long:"config" env:"REFINERY_CONFIG" env-delim:"," default:"/etc/refinery/refinery.yaml" description:"config file or URL to load; can be specified more than once"`
-	RulesLocations        []string   `short:"r" long:"rules_config" env:"REFINERY_RULES_CONFIG" env-delim:"," default:"/etc/refinery/rules.yaml" description:"config file or URL to load; can be specified more than once"`
-	HTTPListenAddr        string     `long:"http-listen-address" env:"REFINERY_HTTP_LISTEN_ADDRESS" description:"HTTP listen address for incoming event traffic"`
-	PeerListenAddr        string     `long:"peer-listen-address" env:"REFINERY_PEER_LISTEN_ADDRESS" description:"Peer listen address for communication between Refinery instances"`
-	GRPCListenAddr        string     `long:"grpc-listen-address" env:"REFINERY_GRPC_LISTEN_ADDRESS" description:"gRPC listen address for OTLP traffic"`
-	RedisHost             string     `long:"redis-host" env:"REFINERY_REDIS_HOST" description:"Redis host address"`
-	RedisClusterHosts     []string   `long:"redis-cluster-hosts" env:"REFINERY_REDIS_CLUSTER_HOSTS" env-delim:"," description:"Redis cluster host addresses"`
-	RedisUsername         string     `long:"redis-username" env:"REFINERY_REDIS_USERNAME" description:"Redis username. Setting this value via a flag may expose credentials - it is recommended to use the env var or a configuration file."`
-	RedisPassword         string     `long:"redis-password" env:"REFINERY_REDIS_PASSWORD" description:"Redis password. Setting this value via a flag may expose credentials - it is recommended to use the env var or a configuration file."`
-	RedisAuthCode         string     `long:"redis-auth-code" env:"REFINERY_REDIS_AUTH_CODE" description:"Redis AUTH code. Setting this value via a flag may expose credentials - it is recommended to use the env var or a configuration file."`
-	HoneycombAPI          string     `long:"honeycomb-api" env:"REFINERY_HONEYCOMB_API" description:"Honeycomb API URL"`
-	HoneycombAPIKey       string     `long:"honeycomb-api-key" env:"REFINERY_HONEYCOMB_API_KEY" description:"Honeycomb API key (for logger and metrics). Setting this value via a flag may expose credentials - it is recommended to use the env var or a configuration file."`
-	HoneycombLoggerAPIKey string     `long:"logger-api-key" env:"REFINERY_HONEYCOMB_LOGGER_API_KEY" description:"Honeycomb logger API key. Setting this value via a flag may expose credentials - it is recommended to use the env var or a configuration file."`
-	LegacyMetricsAPIKey   string     `long:"legacy-metrics-api-key" env:"REFINERY_HONEYCOMB_METRICS_API_KEY" description:"API key for legacy Honeycomb metrics. Setting this value via a flag may expose credentials - it is recommended to use the env var or a configuration file."`
-	OpAMPEndpoint         string     `long:"opamp-server-url" env:"REFINERY_OPAMP_ENDPOINT" description:"URL of the OpAMP server to use for remote management."`
-	TelemetryEndpoint     string     `long:"telemetry-endpoint" env:"REFINERY_TELEMETRY_ENDPOINT" description:"Endpoint to send Refinery's internal telemetry to. This is separate from the Honeycomb API endpoint and is used for sending metrics about Refinery's performance."`
-	OTelMetricsAPIKey     string     `long:"otel-metrics-api-key" env:"REFINERY_OTEL_METRICS_API_KEY" description:"API key for OTel metrics if being sent to Honeycomb. Setting this value via a flag may expose credentials - it is recommended to use the env var or a configuration file."`
-	OTelTracesAPIKey      string     `long:"otel-traces-api-key" env:"REFINERY_OTEL_TRACES_API_KEY" description:"API key for OTel traces if being sent to Honeycomb. Setting this value via a flag may expose credentials - it is recommended to use the env var or a configuration file."`
-	QueryAuthToken        string     `long:"query-auth-token" env:"REFINERY_QUERY_AUTH_TOKEN" description:"Token for debug/management queries. Setting this value via a flag may expose credentials - it is recommended to use the env var or a configuration file."`
-	AvailableMemory       MemorySize `long:"available-memory" env:"REFINERY_AVAILABLE_MEMORY" description:"The maximum memory available for Refinery to use (ex: 4GiB)."`
-	SendKey               string     `long:"send-key" env:"REFINERY_SEND_KEY" description:"The Honeycomb API key that Refinery can use to send data to Honeycomb."`
-	Debug                 bool       `short:"d" long:"debug" description:"Runs debug service (on the first open port between localhost:6060 and :6069 by default)"`
-	Version               bool       `short:"v" long:"version" description:"Print version number and exit"`
-	InterfaceNames        bool       `long:"interface-names" description:"Print system's network interface names and exit."`
-	Validate              bool       `short:"V" long:"validate" description:"Validate the configuration files, writing results to stdout, and exit with 0 if valid, 1 if invalid."`
-	NoValidate            bool       `long:"no-validate" description:"Do not attempt to validate the configuration files. Makes --validate meaningless."`
-	WriteConfig           string     `long:"write-config" description:"After applying defaults, environment variables, and command line values, write the loaded configuration to the specified file as YAML and exit."`
-	WriteRules            string     `long:"write-rules" description:"After applying defaults, write the loaded rules to the specified file as YAML and exit."`
+	ConfigLocations                     []string          `short:"c" long:"config" env:"REFINERY_CONFIG" env-delim:"," default:"/etc/refinery/refinery.yaml" description:"config file or URL to load; can be specified more than once"`
+	RulesLocations                      []string          `short:"r" long:"rules_config" env:"REFINERY_RULES_CONFIG" env-delim:"," default:"/etc/refinery/rules.yaml" description:"config file or URL to load; can be specified more than once"`
+	HTTPListenAddr                      string            `long:"http-listen-address" env:"REFINERY_HTTP_LISTEN_ADDRESS" description:"HTTP listen address for incoming event traffic"`
+	PeerListenAddr                      string            `long:"peer-listen-address" env:"REFINERY_PEER_LISTEN_ADDRESS" description:"Peer listen address for communication between Refinery instances"`
+	GRPCListenAddr                      string            `long:"grpc-listen-address" env:"REFINERY_GRPC_LISTEN_ADDRESS" description:"gRPC listen address for OTLP traffic"`
+	RedisHost                           string            `long:"redis-host" env:"REFINERY_REDIS_HOST" description:"Redis host address"`
+	RedisClusterHosts                   []string          `long:"redis-cluster-hosts" env:"REFINERY_REDIS_CLUSTER_HOSTS" env-delim:"," description:"Redis cluster host addresses"`
+	RedisUsername                       string            `long:"redis-username" env:"REFINERY_REDIS_USERNAME" description:"Redis username. Setting this value via a flag may expose credentials - it is recommended to use the env var or a configuration file."`
+	RedisPassword                       string            `long:"redis-password" env:"REFINERY_REDIS_PASSWORD" description:"Redis password. Setting this value via a flag may expose credentials - it is recommended to use the env var or a configuration file."`
+	RedisAuthCode                       string            `long:"redis-auth-code" env:"REFINERY_REDIS_AUTH_CODE" description:"Redis AUTH code. Setting this value via a flag may expose credentials - it is recommended to use the env var or a configuration file."`
+	HoneycombAPI                        string            `long:"honeycomb-api" env:"REFINERY_HONEYCOMB_API" description:"Honeycomb API URL"`
+	HoneycombAPIKey                     string            `long:"honeycomb-api-key" env:"REFINERY_HONEYCOMB_API_KEY" description:"Honeycomb API key (for logger and metrics). Setting this value via a flag may expose credentials - it is recommended to use the env var or a configuration file."`
+	HoneycombLoggerAPIKey               string            `long:"logger-api-key" env:"REFINERY_HONEYCOMB_LOGGER_API_KEY" description:"Honeycomb logger API key. Setting this value via a flag may expose credentials - it is recommended to use the env var or a configuration file."`
+	HoneycombLoggerAdditionalAttributes map[string]string `long:"logger-additional-attributes" env:"REFINERY_HONEYCOMB_LOGGER_ADDITIONAL_ATTRIBUTES" env-delim:"," description:"Additional attributes to add to all logs written by the Honeycomb logger. When supplying via a environment variable, the value should be a string of comma-separated key-value pairs. When supplying via the command line, the value should be a key value pair. If multiple key-value pairs are needed, each should be supplied via its own command line flag. The key-value pairs must use ':' as the separator."`
+	LegacyMetricsAPIKey                 string            `long:"legacy-metrics-api-key" env:"REFINERY_HONEYCOMB_METRICS_API_KEY" description:"API key for legacy Honeycomb metrics. Setting this value via a flag may expose credentials - it is recommended to use the env var or a configuration file."`
+	OpAMPEndpoint                       string            `long:"opamp-server-url" env:"REFINERY_OPAMP_ENDPOINT" description:"URL of the OpAMP server to use for remote management."`
+	TelemetryEndpoint                   string            `long:"telemetry-endpoint" env:"REFINERY_TELEMETRY_ENDPOINT" description:"Endpoint to send Refinery's internal telemetry to. This is separate from the Honeycomb API endpoint and is used for sending metrics about Refinery's performance."`
+	OTelMetricsAPIKey                   string            `long:"otel-metrics-api-key" env:"REFINERY_OTEL_METRICS_API_KEY" description:"API key for OTel metrics if being sent to Honeycomb. Setting this value via a flag may expose credentials - it is recommended to use the env var or a configuration file."`
+	OTelTracesAPIKey                    string            `long:"otel-traces-api-key" env:"REFINERY_OTEL_TRACES_API_KEY" description:"API key for OTel traces if being sent to Honeycomb. Setting this value via a flag may expose credentials - it is recommended to use the env var or a configuration file."`
+	QueryAuthToken                      string            `long:"query-auth-token" env:"REFINERY_QUERY_AUTH_TOKEN" description:"Token for debug/management queries. Setting this value via a flag may expose credentials - it is recommended to use the env var or a configuration file."`
+	AvailableMemory                     MemorySize        `long:"available-memory" env:"REFINERY_AVAILABLE_MEMORY" description:"The maximum memory available for Refinery to use (ex: 4GiB)."`
+	SendKey                             string            `long:"send-key" env:"REFINERY_SEND_KEY" description:"The Honeycomb API key that Refinery can use to send data to Honeycomb."`
+	Debug                               bool              `short:"d" long:"debug" description:"Runs debug service (on the first open port between localhost:6060 and :6069 by default)"`
+	Version                             bool              `short:"v" long:"version" description:"Print version number and exit"`
+	InterfaceNames                      bool              `long:"interface-names" description:"Print system's network interface names and exit."`
+	Validate                            bool              `short:"V" long:"validate" description:"Validate the configuration files, writing results to stdout, and exit with 0 if valid, 1 if invalid."`
+	NoValidate                          bool              `long:"no-validate" description:"Do not attempt to validate the configuration files. Makes --validate meaningless."`
+	WriteConfig                         string            `long:"write-config" description:"After applying defaults, environment variables, and command line values, write the loaded configuration to the specified file as YAML and exit."`
+	WriteRules                          string            `long:"write-rules" description:"After applying defaults, write the loaded rules to the specified file as YAML and exit."`
 }
 
 func NewCmdEnvOptions(args []string) (*CmdEnv, error) {
@@ -130,41 +131,43 @@ func applyCmdEnvTags(s reflect.Value, fielder getFielder) error {
 					}
 
 					// don't overwrite values that are already set
-					if !value.IsZero() {
-						// ensure that the types match
-						if fieldType.Type != value.Type() {
-							return fmt.Errorf("programming error -- types don't match for field: %s (%v and %v)",
-								fieldType.Name, fieldType.Type, value.Type())
+					if value.IsZero() || ((value.Kind() == reflect.Map || value.Kind() == reflect.Slice) && value.Len() == 0) {
+						continue
+					}
+
+					// ensure that the types match
+					if fieldType.Type != value.Type() {
+						return fmt.Errorf("programming error -- types don't match for field: %s (%v and %v)",
+							fieldType.Name, fieldType.Type, value.Type())
+					}
+
+					if value.Kind() == reflect.Slice {
+						delimiter := fielder.GetDelimiter(tag)
+						if delimiter == "" {
+							return fmt.Errorf("programming error -- missing delimiter for slice field: %s", fieldType.Name)
 						}
 
-						if value.Kind() == reflect.Slice {
-							delimiter := fielder.GetDelimiter(tag)
-							if delimiter == "" {
-								return fmt.Errorf("programming error -- missing delimiter for slice field: %s", fieldType.Name)
-							}
-
-							rawValue, ok := value.Index(0).Interface().(string)
-							if !ok {
-								return fmt.Errorf("programming error -- slice field must be a string: %s", fieldType.Name)
-							}
-
-							// split the value on the delimiter
-							values := strings.Split(rawValue, delimiter)
-							// create a new slice of the same type as the field
-							slice := reflect.MakeSlice(field.Type(), len(values), len(values))
-							// iterate over the values and set them
-							for i, v := range values {
-								slice.Index(i).SetString(v)
-							}
-							// set the field
-							field.Set(slice)
-							break
+						rawValue, ok := value.Index(0).Interface().(string)
+						if !ok {
+							return fmt.Errorf("programming error -- slice field must be a string: %s", fieldType.Name)
 						}
-						// now we can set it
-						field.Set(value)
-						// and we're done with this field
+
+						// split the value on the delimiter
+						values := strings.Split(rawValue, delimiter)
+						// create a new slice of the same type as the field
+						slice := reflect.MakeSlice(field.Type(), len(values), len(values))
+						// iterate over the values and set them
+						for i, v := range values {
+							slice.Index(i).SetString(v)
+						}
+						// set the field
+						field.Set(slice)
 						break
 					}
+					// now we can set it
+					field.Set(value)
+					// and we're done with this field
+					break
 				}
 			}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -641,6 +641,11 @@ func TestHoneycombLoggerConfig(t *testing.T) {
 		"HoneycombLogger.Dataset", "loggerDataset",
 		"HoneycombLogger.SamplerEnabled", true,
 		"HoneycombLogger.SamplerThroughput", 5,
+		"HoneycombLogger.AdditionalAttributes", map[string]string{
+			"name":    "foo",
+			"other":   "bar",
+			"another": "OneHundred",
+		},
 	)
 	rm := makeYAML("ConfigVersion", 2)
 	config, rules := createTempConfigs(t, cm, rm)
@@ -658,6 +663,7 @@ func TestHoneycombLoggerConfig(t *testing.T) {
 	assert.Equal(t, "loggerDataset", loggerConfig.Dataset)
 	assert.Equal(t, true, loggerConfig.GetSamplerEnabled())
 	assert.Equal(t, 5, loggerConfig.SamplerThroughput)
+	assert.Equal(t, map[string]string{"name": "foo", "other": "bar", "another": "OneHundred"}, loggerConfig.AdditionalAttributes)
 }
 
 func TestHoneycombLoggerConfigDefaults(t *testing.T) {
@@ -677,6 +683,7 @@ func TestHoneycombLoggerConfigDefaults(t *testing.T) {
 
 	assert.Equal(t, true, loggerConfig.GetSamplerEnabled())
 	assert.Equal(t, 10, loggerConfig.SamplerThroughput)
+	assert.Len(t, loggerConfig.AdditionalAttributes, 0)
 }
 
 func TestHoneycombGRPCConfigDefaults(t *testing.T) {

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -239,11 +239,12 @@ type LoggerConfig struct {
 }
 
 type HoneycombLoggerConfig struct {
-	APIHost           string       `yaml:"APIHost" default:"https://api.honeycomb.io" cmdenv:"TelemetryEndpoint"`
-	APIKey            string       `yaml:"APIKey" cmdenv:"HoneycombLoggerAPIKey,HoneycombAPIKey"`
-	Dataset           string       `yaml:"Dataset" default:"Refinery Logs"`
-	SamplerEnabled    *DefaultTrue `yaml:"SamplerEnabled" default:"true"` // Avoid pointer woe on access, use GetSamplerEnabled() instead.
-	SamplerThroughput int          `yaml:"SamplerThroughput" default:"10"`
+	APIHost              string            `yaml:"APIHost" default:"https://api.honeycomb.io" cmdenv:"TelemetryEndpoint"`
+	APIKey               string            `yaml:"APIKey" cmdenv:"HoneycombLoggerAPIKey,HoneycombAPIKey"`
+	Dataset              string            `yaml:"Dataset" default:"Refinery Logs"`
+	SamplerEnabled       *DefaultTrue      `yaml:"SamplerEnabled" default:"true"` // Avoid pointer woe on access, use GetSamplerEnabled() instead.
+	SamplerThroughput    int               `yaml:"SamplerThroughput" default:"10"`
+	AdditionalAttributes map[string]string `yaml:"AdditionalAttributes" default:"" cmdenv:"HoneycombLoggerAdditionalAttributes"`
 }
 
 // GetSamplerEnabled returns whether configuration has enabled sampling of

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -646,6 +646,23 @@ groups:
           unique logs arrive at Honeycomb at least once per sampling
           period.
 
+      - name: AdditionalAttributes
+        type: map
+        valuetype: map
+        example: "pipeline.id:12345,rollout.id:67890"
+        reload: false
+        validations:
+          - type: elementType
+            arg: string
+        summary: Additional attributes to add to all logs written by the Honeycomb logger.
+        envvar: REFINERY_HONEYCOMB_LOGGER_ADDITIONAL_ATTRIBUTES
+        commandline: logger-additional-attributes
+        description: >
+           When supplying via a environment variable, the value should be a string of comma-separated key-value pairs. 
+           When supplying via the command line, the value should be a key value pair. 
+           If multiple key-value pairs are needed, each should be supplied via its own command line flag.
+           The key-value pairs must use ':' as the separator.
+
   - name: StdoutLogger
     title: "Stdout Logger"
     description: contains configuration for logging to `stdout`. Only used if `Logger.Type` is "stdout".

--- a/logger/honeycomb.go
+++ b/logger/honeycomb.go
@@ -81,6 +81,7 @@ func (h *HoneycombLogger) Start() error {
 	}
 	h.libhClient = libhClient
 
+	h.addResourceAttributes()
 	h.libhClient.AddField("refinery_version", h.Version)
 	if hostname, err := os.Hostname(); err == nil {
 		h.libhClient.AddField("hostname", hostname)
@@ -89,7 +90,6 @@ func (h *HoneycombLogger) Start() error {
 	h.libhClient.AddDynamicField("process_uptime_seconds", func() interface{} {
 		return time.Since(startTime) / time.Second
 	})
-	h.addResourceAttributes()
 
 	h.builder = h.libhClient.NewBuilder()
 

--- a/logger/honeycomb.go
+++ b/logger/honeycomb.go
@@ -105,11 +105,12 @@ func (h *HoneycombLogger) Start() error {
 	return nil
 }
 
-// Add support for the OTEL_RESOURCE_ATTRIBUTES env var.
+// Add support for the REFINERY_HONEYCOMB_LOGGER_ADDITIONAL_FIELDS env var which allows
+// specifying comma-separated key-value pairs to be added to outgoing logs as fields.
+// The key value pairs must be separated by `=`.
 // Credit to https://github.com/open-telemetry/opentelemetry-go/blob/553779c161e9bb7bbc1670b3a92a1bf3ceefb859/sdk/resource/env.go#L67-L95
-// for OTEL_RESOURCE_ATTRIBUTES spec-compliant implementation.
 func (h *HoneycombLogger) addResourceAttributes() {
-	attrs := strings.TrimSpace(os.Getenv("OTEL_RESOURCE_ATTRIBUTES"))
+	attrs := strings.TrimSpace(os.Getenv("REFINERY_HONEYCOMB_LOGGER_ADDITIONAL_FIELDS"))
 	if attrs == "" {
 		return
 	}

--- a/logger/honeycomb.go
+++ b/logger/honeycomb.go
@@ -122,6 +122,8 @@ func (h *HoneycombLogger) addResourceAttributes() {
 		key := strings.TrimSpace(k)
 		val, err := url.PathUnescape(strings.TrimSpace(v))
 		if err != nil {
+			// Retain original value if decoding fails, otherwise it will be
+			// an empty string.
 			val = v
 		}
 		h.libhClient.AddField(key, val)

--- a/logger/honeycomb.go
+++ b/logger/honeycomb.go
@@ -3,9 +3,7 @@ package logger
 import (
 	"fmt"
 	"net/http"
-	"net/url"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/honeycombio/dynsampler-go"
@@ -110,24 +108,9 @@ func (h *HoneycombLogger) Start() error {
 // The key value pairs must be separated by `=`.
 // Credit to https://github.com/open-telemetry/opentelemetry-go/blob/553779c161e9bb7bbc1670b3a92a1bf3ceefb859/sdk/resource/env.go#L67-L95
 func (h *HoneycombLogger) addResourceAttributes() {
-	attrs := strings.TrimSpace(os.Getenv("REFINERY_HONEYCOMB_LOGGER_ADDITIONAL_FIELDS"))
-	if attrs == "" {
-		return
-	}
-	pairs := strings.Split(attrs, ",")
-	for _, p := range pairs {
-		k, v, found := strings.Cut(p, "=")
-		if !found {
-			continue
-		}
-		key := strings.TrimSpace(k)
-		val, err := url.PathUnescape(strings.TrimSpace(v))
-		if err != nil {
-			// Retain original value if decoding fails, otherwise it will be
-			// an empty string.
-			val = v
-		}
-		h.libhClient.AddField(key, val)
+	attrs := h.Config.GetHoneycombLoggerConfig().AdditionalAttributes
+	for k, v := range attrs {
+		h.libhClient.AddField(k, v)
 	}
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?

- Allows the honeycomb logger to support adding attributes from the `OTEL_RESOURCE_ATTRIBUTES` env var to all exported logs.

## Short description of the changes

- add logic for extracting attributes from the `OTEL_RESOURCE_ATTRIBUTES` env var

