### PR TITLE
feat: add message size limits to DirectTransmission

### DIFF
--- a/logger/mock.go
+++ b/logger/mock.go
@@ -2,12 +2,14 @@ package logger
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/honeycombio/refinery/config"
 )
 
 type MockLogger struct {
 	Events []*MockLoggerEvent
+	mutex  sync.Mutex
 }
 
 var _ = Logger((*MockLogger)(nil))
@@ -86,5 +88,7 @@ func (e *MockLoggerEvent) Logf(f string, args ...interface{}) {
 	default:
 		panic("unexpected log level")
 	}
+	e.l.mutex.Lock()
 	e.l.Events = append(e.l.Events, e)
+	e.l.mutex.Unlock()
 }

--- a/transmit/direct_transmit_test.go
+++ b/transmit/direct_transmit_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/facebookgo/inject"
 	"github.com/klauspost/compress/zstd"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -170,6 +171,24 @@ func getErrorEvents(mockLogger *logger.MockLogger) []*logger.MockLoggerEvent {
 		}
 	}
 	return errorEvents
+}
+
+func TestDirectTransmitDependencyInjection(t *testing.T) {
+	var g inject.Graph
+	err := g.Provide(
+		&inject.Object{Value: &DirectTransmission{}},
+
+		&inject.Object{Value: &config.MockConfig{}},
+		&inject.Object{Value: &logger.NullLogger{}},
+		&inject.Object{Value: http.DefaultTransport, Name: "upstreamTransport"},
+		&inject.Object{Value: "test", Name: "version"},
+	)
+	if err != nil {
+		t.Error(err)
+	}
+	if err := g.Populate(); err != nil {
+		t.Error(err)
+	}
 }
 
 func TestDirectTransmissionErrorHandling(t *testing.T) {


### PR DESCRIPTION
## Which problem is this PR solving?
DirectTransmission needs to honor the same API limitations that libhoney does.

## Short description of the changes
Reviewers: lots of whitespace change in this one, you'll want to ignore whitespace.

Adds a maximum payload size, and a maximum serialized event size, to DirectTransmission, with the same behavior as libhoney's Honeycomb transmission.

Also slightly cleans up and improves testing.
