### PR TITLE
perf: fix encoded type of map keys

### DIFF
--- a/types/payload.go
+++ b/types/payload.go
@@ -311,7 +311,12 @@ func (p Payload) MarshalMsg(buf []byte) ([]byte, error) {
 			if err != nil {
 				return buf, err
 			}
-			buf = msgp.AppendBytes(buf, keyBytes)
+
+			// Why AppendStringFromBytes? Because maps keys _can_ be a binary
+			// type, but msgp expects them to be a string type. The fallback to
+			// the binary read in ReadMapKeyZC which we use to read these
+			// allocates garbage memory.
+			buf = msgp.AppendStringFromBytes(buf, keyBytes)
 			buf = append(buf, raw...)
 		}
 	}


### PR DESCRIPTION
## Which problem is this PR solving?
We're encoding messagepack map keys as type bin, which works but causes small garbage allocations on every read. Found this when experimenting with DirectTransmission.

## Short description of the changes
This just changes the method used to encode map keys.
