### PR TITLE
perf: more scalable DirectTransmission batching

### DIFF
--- a/transmit/direct_transmit.go
+++ b/transmit/direct_transmit.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/jonboulle/clockwork"
 	"github.com/sourcegraph/conc/pool"
 	"github.com/tinylib/msgp/msgp"
 	"github.com/vmihailenco/msgpack/v5"
@@ -59,6 +60,7 @@ type DirectTransmission struct {
 	// constructed, not injected
 	Metrics   metrics.Metrics
 	Transport *http.Transport
+	Clock     clockwork.Clock
 
 	// Type is peer or upstream, and used only for naming metrics
 	Name string
@@ -67,12 +69,13 @@ type DirectTransmission struct {
 	MaxBatchSize int
 	BatchTimeout time.Duration
 
-	// Slice-based batching
-	eventBatches map[transmitKey]*eventBatch
-	batchMutex   sync.RWMutex
-	batchPool    *pool.Pool
-	ticker       *time.Ticker
-	done         chan struct{}
+	// Double-buffer slice-based batching
+	batches    [2]map[transmitKey]*eventBatch
+	hotIndex   int // 0 or 1, indicates which map is currently hot
+	batchMutex sync.RWMutex
+	batchPool  *pool.Pool
+	done       chan struct{}
+	shutdownWG sync.WaitGroup
 
 	httpClient *http.Client
 	userAgent  string
@@ -80,13 +83,17 @@ type DirectTransmission struct {
 
 func NewDirectTransmission(m metrics.Metrics, name string, maxBatchSize int, batchTimeout time.Duration, transport *http.Transport) *DirectTransmission {
 	return &DirectTransmission{
-		Metrics:        m,
-		Name:           name,
-		MaxBatchSize:   maxBatchSize,
-		BatchTimeout:   batchTimeout,
-		Transport:      transport,
-		eventBatches:   make(map[transmitKey]*eventBatch),
-		done:           make(chan struct{}),
+		Metrics:      m,
+		Name:         name,
+		MaxBatchSize: maxBatchSize,
+		BatchTimeout: batchTimeout,
+		Transport:    transport,
+		Clock:        clockwork.NewRealClock(),
+		batches: [2]map[transmitKey]*eventBatch{
+			make(map[transmitKey]*eventBatch),
+			make(map[transmitKey]*eventBatch),
+		},
+		done: make(chan struct{}),
 	}
 }
 
@@ -101,9 +108,8 @@ func (d *DirectTransmission) Start() error {
 	// Create a pool for concurrent batch sending
 	d.batchPool = pool.New().WithMaxGoroutines(maxConcurrentBatches)
 
-	// Start the ticker for periodic batch dispatch
-	d.ticker = time.NewTicker(d.BatchTimeout)
-	go d.periodicBatchDispatch()
+	d.shutdownWG.Add(1)
+	go d.dispatchOldBatches()
 
 	return nil
 }
@@ -116,7 +122,7 @@ func (d *DirectTransmission) EnqueueEvent(ev *types.Event) {
 		Logf("transmit sending event")
 
 	// Store enqueue time for queue time metrics
-	ev.EnqueuedUnixMicro = time.Now().UnixMicro()
+	ev.EnqueuedUnixMicro = d.Clock.Now().UnixMicro()
 
 	key := transmitKey{
 		apiHost: ev.APIHost,
@@ -124,21 +130,23 @@ func (d *DirectTransmission) EnqueueEvent(ev *types.Event) {
 		dataset: ev.Dataset,
 	}
 
-	// First check if batch exists without write lock
+	// First check if batch exists in hot map without write lock
 	d.batchMutex.RLock()
-	batch, exists := d.eventBatches[key]
+	hotMap := d.batches[d.hotIndex]
+	batch, exists := hotMap[key]
 	d.batchMutex.RUnlock()
 
 	if !exists {
 		// Need to create new batch
 		d.batchMutex.Lock()
 		// Double-check after acquiring write lock
-		batch, exists = d.eventBatches[key]
+		hotMap = d.batches[d.hotIndex]
+		batch, exists = hotMap[key]
 		if !exists {
 			batch = &eventBatch{
 				events: make([]*types.Event, 0, d.MaxBatchSize),
 			}
-			d.eventBatches[key] = batch
+			hotMap[key] = batch
 		}
 		d.batchMutex.Unlock()
 	}
@@ -178,11 +186,6 @@ func (d *DirectTransmission) RegisterMetrics() {
 }
 
 func (d *DirectTransmission) Stop() error {
-	// Stop the ticker
-	if d.ticker != nil {
-		d.ticker.Stop()
-	}
-	
 	// Only close done if it was initialized
 	if d.done != nil {
 		select {
@@ -193,9 +196,11 @@ func (d *DirectTransmission) Stop() error {
 		}
 	}
 
+	// Wait for the periodic dispatch goroutine to exit
+	d.shutdownWG.Wait()
+
 	// Dispatch all remaining batches
 	d.dispatchAllBatches()
-
 
 	// Wait for all batch sends to complete
 	if d.batchPool != nil {
@@ -332,7 +337,7 @@ func (d *DirectTransmission) sendBatch(wholeBatch []*types.Event) {
 		req.Header.Set("User-Agent", d.userAgent)
 
 		resp, err := d.httpClient.Do(req)
-		dequeuedAt := time.Now()
+		dequeuedAt := d.Clock.Now()
 
 		if err != nil {
 			d.Logger.Error().WithField("err", err.Error()).Logf("http POST failed")
@@ -412,48 +417,45 @@ func (d *DirectTransmission) sendBatch(wholeBatch []*types.Event) {
 	}
 }
 
-// periodicBatchDispatch runs on a ticker and dispatches all pending batches
-func (d *DirectTransmission) periodicBatchDispatch() {
+// dispatchOldBatches runs on a ticker and dispatches all pending batches
+func (d *DirectTransmission) dispatchOldBatches() {
+	defer d.shutdownWG.Done()
+
+	ticker := d.Clock.NewTicker(d.BatchTimeout)
+	defer ticker.Stop()
+
 	for {
 		select {
-		case <-d.ticker.C:
-			d.dispatchAllBatches()
+		case <-ticker.Chan():
+			// Swap hot and cold by switching the index
+			d.batchMutex.Lock()
+			coldIndex := d.hotIndex
+			d.hotIndex = 1 - d.hotIndex // Toggle between 0 and 1
+			// Clear the new hot map
+			d.batches[d.hotIndex] = make(map[transmitKey]*eventBatch)
+			d.batchMutex.Unlock()
+
+			// Dispatch all batches from the cold map
+			d.dispatchBatchesFromMap(d.batches[coldIndex])
 		case <-d.done:
 			return
 		}
 	}
 }
 
-// dispatchAllBatches sends all pending batches
-func (d *DirectTransmission) dispatchAllBatches() {
-	// Get snapshot of all keys
-	d.batchMutex.RLock()
-	keys := make([]transmitKey, 0, len(d.eventBatches))
-	for k := range d.eventBatches {
-		keys = append(keys, k)
-	}
-	d.batchMutex.RUnlock()
-
-	// Dispatch each batch
-	for _, key := range keys {
-		d.batchMutex.RLock()
-		batch, exists := d.eventBatches[key]
-		d.batchMutex.RUnlock()
-
-		if !exists {
-			continue
-		}
-
+// dispatchBatchesFromMap sends all batches from the given map
+func (d *DirectTransmission) dispatchBatchesFromMap(batchMap map[transmitKey]*eventBatch) {
+	// No need to lock the map since we own it, but we need to lock each batch
+	for _, batch := range batchMap {
 		batch.mutex.Lock()
 		if len(batch.events) > 0 {
-			// Copy events and reset batch
-			eventsCopy := make([]*types.Event, len(batch.events))
-			copy(eventsCopy, batch.events)
-			batch.events = batch.events[:0]
+			// Copy events to avoid closure capture issues
+			events := make([]*types.Event, len(batch.events))
+			copy(events, batch.events)
 			batch.mutex.Unlock()
 
 			d.batchPool.Go(func() {
-				d.sendBatch(eventsCopy)
+				d.sendBatch(events)
 			})
 		} else {
 			batch.mutex.Unlock()
@@ -461,6 +463,19 @@ func (d *DirectTransmission) dispatchAllBatches() {
 	}
 }
 
+// dispatchAllBatches sends all pending batches from both maps
+func (d *DirectTransmission) dispatchAllBatches() {
+	// Swap hot and cold by switching the index
+	d.batchMutex.Lock()
+	coldIndex := d.hotIndex
+	d.hotIndex = 1 - d.hotIndex
+	// Clear the new hot map
+	d.batches[d.hotIndex] = make(map[transmitKey]*eventBatch)
+	d.batchMutex.Unlock()
+
+	// Dispatch the cold batches
+	d.dispatchBatchesFromMap(d.batches[coldIndex])
+}
 
 type batchedEvent struct {
 	time       time.Time     `msg:"time"`

--- a/transmit/direct_transmit.go
+++ b/transmit/direct_transmit.go
@@ -135,10 +135,7 @@ func (d *DirectTransmission) EnqueueEvent(ev *types.Event) {
 		batch, exists = d.eventBatches[key]
 		if !exists {
 			// Need to create new batch
-			batch = &eventBatch{
-				events:    make([]*types.Event, 0, d.MaxBatchSize),
-				startTime: d.Clock.Now(),
-			}
+			batch = &eventBatch{}
 			d.eventBatches[key] = batch
 		}
 		d.batchMutex.Unlock()

--- a/transmit/direct_transmit_test.go
+++ b/transmit/direct_transmit_test.go
@@ -546,6 +546,9 @@ func TestDirectTransmission(t *testing.T) {
 
 	// At this point, time hasn't advanced so we should't get any incomplete batches.
 	require.Eventually(t, func() bool {
+		// 4 events waiting for timeout
+		// 1 event yet to be enqueued
+		// 1 event is too large to send
 		return len(testServer.getEvents()) == len(allEvents)-6
 	}, 100*time.Millisecond, time.Millisecond)
 
@@ -554,6 +557,8 @@ func TestDirectTransmission(t *testing.T) {
 
 	// Now the ticker should fire and we should send old events.
 	require.Eventually(t, func() bool {
+		// 1 event yet to be enqueued
+		// 1 event is too large to send
 		return len(testServer.getEvents()) == len(allEvents)-2
 	}, 100*time.Millisecond, time.Millisecond)
 
@@ -563,6 +568,7 @@ func TestDirectTransmission(t *testing.T) {
 	require.NoError(t, err)
 
 	// Group events by dataset
+	// 1 event is too large to send
 	expectedEvents := len(allEvents) - 1
 	receivedEvents := testServer.getEvents()
 	require.Len(t, receivedEvents, expectedEvents)

--- a/transmit/direct_transmit_test.go
+++ b/transmit/direct_transmit_test.go
@@ -545,7 +545,6 @@ func TestDirectTransmission(t *testing.T) {
 	}
 
 	// At this point, time hasn't advanced so we should't get any incomplete batches.
-	time.Sleep(time.Millisecond)
 	require.Eventually(t, func() bool {
 		return len(testServer.getEvents()) == len(allEvents)-6
 	}, 100*time.Millisecond, time.Millisecond)

--- a/transmit/direct_transmit_test.go
+++ b/transmit/direct_transmit_test.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/facebookgo/inject"
-	"github.com/jonboulle/clockwork"
 	"github.com/klauspost/compress/zstd"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -998,78 +997,4 @@ func BenchmarkTransmissionComparison(b *testing.B) {
 			})
 		})
 	}
-}
-
-func TestDirectTransmissionDoubleBuffer(t *testing.T) {
-	testServer := newTestDirectAPIServer(t, 100)
-	metrics := &metrics.MockMetrics{}
-	metrics.Start()
-
-	// Create a fake clock
-	fakeClock := clockwork.NewFakeClock()
-
-	// Use a longer batch timeout to ensure we can control timing
-	dt := NewDirectTransmission(metrics, "test", 100, 500*time.Millisecond, http.DefaultTransport.(*http.Transport))
-	dt.Config = &config.MockConfig{}
-	dt.Logger = &logger.NullLogger{}
-	dt.Version = "test-version"
-	dt.Clock = fakeClock // Use the fake clock
-
-	err := dt.Start()
-	require.NoError(t, err)
-
-	// Send first event
-	event1 := &types.Event{
-		Context:     context.Background(),
-		APIHost:     testServer.server.URL,
-		APIKey:      "test-key",
-		Dataset:     "test-dataset",
-		SampleRate:  1,
-		Timestamp:   fakeClock.Now(),
-		Data:        types.NewPayload(map[string]any{"event": "first"}),
-	}
-	dt.EnqueueEvent(event1)
-
-	// Advance time a bit but less than batch timeout
-	fakeClock.Advance(100 * time.Millisecond)
-
-	// Send second event - with double buffering, this should go into
-	// the same batch as the first event, not be sent immediately
-	event2 := &types.Event{
-		Context:     context.Background(),
-		APIHost:     testServer.server.URL,
-		APIKey:      "test-key",
-		Dataset:     "test-dataset",
-		SampleRate:  1,
-		Timestamp:   fakeClock.Now(),
-		Data:        types.NewPayload(map[string]any{"event": "second"}),
-	}
-	dt.EnqueueEvent(event2)
-
-	// At this point, no events should have been sent yet
-	receivedEvents := testServer.getEvents()
-	assert.Len(t, receivedEvents, 0, "No events should be sent yet")
-
-	// Advance time to trigger the batch timeout
-	fakeClock.Advance(400 * time.Millisecond)
-
-	// Give the goroutine a moment to process
-	assert.Eventually(t, func() bool {
-		return len(testServer.getEvents()) == 2
-	}, 100*time.Millisecond, 10*time.Millisecond, "Both events should be sent together")
-
-	// Now both events should have been sent together
-	receivedEvents = testServer.getEvents()
-	assert.Len(t, receivedEvents, 2, "Both events should be sent together")
-
-	// Verify both events were received
-	eventData := make([]string, 0)
-	for _, e := range receivedEvents {
-		eventData = append(eventData, e.Data["event"].(string))
-	}
-	assert.Contains(t, eventData, "first")
-	assert.Contains(t, eventData, "second")
-
-	err = dt.Stop()
-	require.NoError(t, err)
 }

--- a/transmit/direct_transmit_test.go
+++ b/transmit/direct_transmit_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/facebookgo/inject"
+	"github.com/jonboulle/clockwork"
 	"github.com/klauspost/compress/zstd"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -459,6 +460,9 @@ func TestDirectTransmission(t *testing.T) {
 	dt.Logger = mockLogger
 	dt.Version = "test-version"
 
+	clock := clockwork.NewFakeClock()
+	dt.Clock = clock
+
 	err := dt.Start()
 	require.NoError(t, err)
 	defer dt.Stop()
@@ -514,7 +518,7 @@ func TestDirectTransmission(t *testing.T) {
 		allEvents = append(allEvents, event)
 	}
 
-	// Dataset C: 2 events (should create 1 batch via timeout)
+	// Dataset C: 2 events (1 batch via timeout, 1 via stop)
 	for i := range 2 {
 		eventData := types.NewPayload(map[string]any{
 			"trace.trace_id": fmt.Sprintf("trace-c-%d", i),
@@ -535,10 +539,27 @@ func TestDirectTransmission(t *testing.T) {
 		allEvents = append(allEvents, event)
 	}
 
-	// Send all events, the stop to make sure everything is fully flushed.
-	for _, event := range allEvents {
+	// Send all but one of our events.
+	for _, event := range allEvents[:len(allEvents)-1] {
 		dt.EnqueueEvent(event)
 	}
+
+	// At this point, time hasn't advanced so we should't get any incomplete batches.
+	time.Sleep(time.Millisecond)
+	require.Eventually(t, func() bool {
+		return len(testServer.getEvents()) == len(allEvents)-6
+	}, 100*time.Millisecond, time.Millisecond)
+
+	// Now everything should dispatch.
+	clock.Advance(50 * time.Millisecond)
+
+	// Now the ticker should fire and we should send old events.
+	require.Eventually(t, func() bool {
+		return len(testServer.getEvents()) == len(allEvents)-2
+	}, 100*time.Millisecond, time.Millisecond)
+
+	// Send the last event - should get dispatched during Stop()
+	dt.EnqueueEvent(allEvents[len(allEvents)-1])
 	err = dt.Stop()
 	require.NoError(t, err)
 
@@ -684,6 +705,114 @@ func TestDirectTransmissionBatchSizeLimit(t *testing.T) {
 	assert.Equal(t, float64(len(allEvents)-expectedEvents), errors)
 	assert.Equal(t, float64(0), queuedItems)
 	assert.Equal(t, expectedEvents, mockMetrics.GetHistogramCount(histogramQueueTime))
+}
+
+func TestDirectTransmissionBatchTiming(t *testing.T) {
+	testServer := newTestDirectAPIServer(t, 100)
+	metrics := &metrics.MockMetrics{}
+	metrics.Start()
+
+	// Create a fake clock
+	fakeClock := clockwork.NewFakeClock()
+
+	// Use a 400ms batch timeout for testing
+	dt := NewDirectTransmission(metrics, "test", 100, 400*time.Millisecond, http.DefaultTransport.(*http.Transport))
+	dt.Config = &config.MockConfig{}
+	dt.Logger = &logger.NullLogger{}
+	dt.Version = "test-version"
+	dt.Clock = fakeClock // Use the fake clock
+
+	err := dt.Start()
+	require.NoError(t, err)
+
+	// Send first event at time 0
+	event1 := &types.Event{
+		Context:    context.Background(),
+		APIHost:    testServer.server.URL,
+		APIKey:     "test-key",
+		Dataset:    "test-dataset",
+		SampleRate: 1,
+		Timestamp:  fakeClock.Now(),
+		Data:       types.NewPayload(map[string]any{"event": "first", "time": 0}),
+	}
+	dt.EnqueueEvent(event1)
+
+	// Advance time by 100ms (1/4 of batch timeout) - ticker should fire but batch should not be sent
+	fakeClock.Advance(100 * time.Millisecond)
+	assert.Eventually(t, func() bool {
+		return len(testServer.getEvents()) == 0
+	}, 100*time.Millisecond, time.Millisecond, "Batch should not be sent yet (only 100ms old)")
+
+	// Send second event at 100ms
+	event2 := &types.Event{
+		Context:    context.Background(),
+		APIHost:    testServer.server.URL,
+		APIKey:     "test-key",
+		Dataset:    "test-dataset",
+		SampleRate: 1,
+		Timestamp:  fakeClock.Now(),
+		Data:       types.NewPayload(map[string]any{"event": "second", "time": 100}),
+	}
+	dt.EnqueueEvent(event2)
+
+	// Advance time by another 100ms (200ms total) - ticker fires again, batch still not old enough
+	fakeClock.Advance(100 * time.Millisecond)
+	assert.Eventually(t, func() bool {
+		return len(testServer.getEvents()) == 0
+	}, 100*time.Millisecond, time.Millisecond, "Batch should not be sent yet (only 200ms old)")
+
+	// Advance time by another 100ms (300ms total) - ticker fires, still not old enough
+	fakeClock.Advance(100 * time.Millisecond)
+	assert.Eventually(t, func() bool {
+		return len(testServer.getEvents()) == 0
+	}, 100*time.Millisecond, time.Millisecond, "Batch should not be sent yet (only 300ms old)")
+
+	// Advance time by another 100ms (400ms total) - ticker fires, batch is now old enough
+	fakeClock.Advance(100 * time.Millisecond)
+
+	// Wait for batch to be sent
+	assert.Eventually(t, func() bool {
+		return len(testServer.getEvents()) == 2
+	}, 100*time.Millisecond, time.Millisecond, "Batch should be sent after 400ms")
+
+	receivedEvents := testServer.getEvents()
+	assert.Len(t, receivedEvents, 2, "Both events should be sent together")
+
+	// Verify both events were received
+	eventData := make([]string, 0)
+	for _, e := range receivedEvents {
+		eventData = append(eventData, e.Data["event"].(string))
+	}
+	assert.Contains(t, eventData, "first")
+	assert.Contains(t, eventData, "second")
+
+	// Send a third event - this should start a new batch
+	event3 := &types.Event{
+		Context:    context.Background(),
+		APIHost:    testServer.server.URL,
+		APIKey:     "test-key",
+		Dataset:    "test-dataset",
+		SampleRate: 1,
+		Timestamp:  fakeClock.Now(),
+		Data:       types.NewPayload(map[string]any{"event": "third", "time": 400}),
+	}
+	dt.EnqueueEvent(event3)
+
+	// Advance time by 300ms - not enough for the new batch to be sent
+	fakeClock.Advance(300 * time.Millisecond)
+	assert.Eventually(t, func() bool {
+		return len(testServer.getEvents()) == 2
+	}, 100*time.Millisecond, time.Millisecond, "Third event should not be sent yet")
+
+	// Advance time by another 100ms (400ms since third event) - now it should be sent
+	fakeClock.Advance(100 * time.Millisecond)
+
+	assert.Eventually(t, func() bool {
+		return len(testServer.getEvents()) == 3
+	}, 100*time.Millisecond, time.Millisecond, "Third event should be sent after its batch timeout")
+
+	err = dt.Stop()
+	require.NoError(t, err)
 }
 
 // Lightweight benchmark HTTP server
@@ -921,7 +1050,7 @@ func BenchmarkTransmissionComparison(b *testing.B) {
 				expectedCount := int64(b.N)
 				if !assert.Eventually(b, func() bool {
 					return server.GetEventCount() == expectedCount
-				}, 2*time.Second, 10*time.Millisecond) {
+				}, 2*time.Second, time.Millisecond) {
 					receivedCount := server.GetEventCount()
 					b.Errorf("Expected %d events, but server received %d", expectedCount, receivedCount)
 				}
@@ -989,7 +1118,7 @@ func BenchmarkTransmissionComparison(b *testing.B) {
 				expectedCount := int64(b.N)
 				if !assert.Eventually(b, func() bool {
 					return server.GetEventCount() == expectedCount
-				}, 2*time.Second, 10*time.Millisecond) {
+				}, 2*time.Second, time.Millisecond) {
 					receivedCount := server.GetEventCount()
 					b.Errorf("Expected %d events, but server received %d", expectedCount, receivedCount)
 				}


### PR DESCRIPTION
## Which problem is this PR solving?
In the original implementation, goroutine and timer proliferation were a concern.

## Short description of the changes
Note: based on #1604

This replaces a whole bunch of channel and goroutine contention with a whole bunch of lock contention. I think that's going to be ok because the stuff we do while holding the lock is very cheap, and ultimately less than what libhoney was doing. It bechmarks well - the remaining allocation here is mostly in the http transport (including the test server itself) and there's not much to be done about that.

```
benchmark                                               old ns/op     new ns/op     delta
BenchmarkTransmissionComparison/high_card/direct-12     1101          702           -36.23%
BenchmarkTransmissionComparison/low_card/direct-12      894           640           -28.39%

benchmark                                               old allocs     new allocs     delta
BenchmarkTransmissionComparison/high_card/direct-12     3              2              -33.33%
BenchmarkTransmissionComparison/low_card/direct-12      3              2              -33.33%

benchmark                                               old bytes     new bytes     delta
BenchmarkTransmissionComparison/high_card/direct-12     5035          3050          -39.42%
BenchmarkTransmissionComparison/low_card/direct-12      4864          3211          -33.98%
```