### PR TITLE
feat: switch to DirectTransmission in refinery main

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -274,8 +274,7 @@ func newStartedApp(
 	if mockTransmission != nil {
 		upstreamTransmission = mockTransmission
 	} else {
-		// Create DirectTransmission instead of DefaultTransmission
-		upstreamTransmission = transmit.NewDirectTransmission(metricsr, "upstream", 500, 100*time.Millisecond, http.DefaultTransport.(*http.Transport))
+		upstreamTransmission = transmit.NewDirectTransmission(metricsr, http.DefaultTransport.(*http.Transport), "upstream", 500, 100*time.Millisecond, true)
 	}
 
 	// Always create real peer transmission using DirectTransmission
@@ -285,7 +284,7 @@ func newStartedApp(
 			Timeout: 3 * time.Second,
 		}).Dial,
 	}
-	peerTransmissionWrapper := transmit.NewDirectTransmission(metricsr, "peer", int(cfg.GetTracesConfigVal.MaxBatchSize), 100*time.Millisecond, peerTransport)
+	peerTransmissionWrapper := transmit.NewDirectTransmission(metricsr, peerTransport, "peer", int(cfg.GetTracesConfigVal.MaxBatchSize), 100*time.Millisecond, false)
 
 	var g inject.Graph
 	err = g.Provide(

--- a/cmd/refinery/main.go
+++ b/cmd/refinery/main.go
@@ -180,7 +180,7 @@ func main() {
 		true,
 	)
 	peerTransmission := transmit.NewDirectTransmission(
-		upstreamMetricsRecorder,
+		peerMetricsRecorder,
 		peerTransport,
 		"peer",
 		int(c.GetTracesConfig().GetMaxBatchSize()),

--- a/cmd/refinery/main.go
+++ b/cmd/refinery/main.go
@@ -22,8 +22,6 @@ import (
 	"github.com/facebookgo/startstop"
 	"github.com/google/uuid"
 	"github.com/honeycombio/husky"
-	libhoney "github.com/honeycombio/libhoney-go"
-	"github.com/honeycombio/libhoney-go/transmission"
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
 
@@ -172,46 +170,23 @@ func main() {
 	upstreamMetricsWrapper := &metrics.LibhoneyMetricsWrapper{MetricsPrefixer: upstreamMetricsRecorder}
 	peerMetricsWrapper := &metrics.LibhoneyMetricsWrapper{MetricsPrefixer: peerMetricsRecorder}
 
-	userAgentAddition := "refinery/" + version
-	upstreamClient, err := libhoney.NewClient(libhoney.ClientConfig{
-		Transmission: &transmission.Honeycomb{
-			MaxBatchSize:          c.GetTracesConfig().GetMaxBatchSize(),
-			BatchTimeout:          time.Duration(c.GetTracesConfig().GetBatchTimeout()),
-			MaxConcurrentBatches:  libhoney.DefaultMaxConcurrentBatches,
-			PendingWorkCapacity:   uint(c.GetUpstreamBufferSize()),
-			UserAgentAddition:     userAgentAddition,
-			Transport:             upstreamTransport,
-			BlockOnSend:           true,
-			EnableMsgpackEncoding: true,
-			Metrics:               upstreamMetricsWrapper,
-		},
-	})
-	if err != nil {
-		fmt.Printf("unable to initialize upstream libhoney client")
-		os.Exit(1)
-	}
-
-	peerClient, err := libhoney.NewClient(libhoney.ClientConfig{
-		Transmission: &transmission.Honeycomb{
-			MaxBatchSize:          c.GetTracesConfig().GetMaxBatchSize(),
-			BatchTimeout:          time.Duration(c.GetTracesConfig().GetBatchTimeout()),
-			MaxConcurrentBatches:  libhoney.DefaultMaxConcurrentBatches,
-			PendingWorkCapacity:   uint(c.GetPeerBufferSize()),
-			UserAgentAddition:     userAgentAddition,
-			Transport:             peerTransport,
-			DisableCompression:    !c.GetCompressPeerCommunication(),
-			EnableMsgpackEncoding: true,
-			Metrics:               peerMetricsWrapper,
-		},
-	})
-	if err != nil {
-		fmt.Printf("unable to initialize peer libhoney client")
-		os.Exit(1)
-	}
-
 	stressRelief := &collect.StressRelief{Done: done}
-	upstreamTransmission := transmit.NewDefaultTransmission(upstreamClient, upstreamMetricsRecorder, "upstream")
-	peerTransmission := transmit.NewDefaultTransmission(peerClient, upstreamMetricsRecorder, "peer")
+	upstreamTransmission := transmit.NewDirectTransmission(
+		upstreamMetricsRecorder,
+		upstreamTransport,
+		"upstream",
+		int(c.GetTracesConfig().GetMaxBatchSize()),
+		time.Duration(c.GetTracesConfig().GetBatchTimeout()),
+		true,
+	)
+	peerTransmission := transmit.NewDirectTransmission(
+		upstreamMetricsRecorder,
+		peerTransport,
+		"peer",
+		int(c.GetTracesConfig().GetMaxBatchSize()),
+		time.Duration(c.GetTracesConfig().GetBatchTimeout()),
+		c.GetCompressPeerCommunication(),
+	)
 
 	// we need to include all the metrics types so we can inject them in case they're needed
 	// but we only want to instantiate the ones that are enabled with non-null values


### PR DESCRIPTION
## Which problem is this PR solving?
I think it's time to try it out.

## Short description of the changes
Note: based on #1605 - last of the series.

Adds support for zstd compression and enables DirectTransmission in refinery proper. Also contains a bit of miscellaneous cleanup.
