### PR TITLE
perf: use a buffer pool for http body reads

### DIFF
--- a/route/route.go
+++ b/route/route.go
@@ -692,7 +692,7 @@ var httpBodyBufferPool = sync.Pool{
 	},
 }
 
-// When finished with the returned buffer, callers should return it to bufferPool.
+// When finished with the returned buffer, callers should return it to httpBodyBufferPool.
 // Reads the body and immediately closes it, releasing resources as soon as possible.
 func (r *Router) readAndCloseMaybeCompressedBody(req *http.Request) (*bytes.Buffer, error) {
 	defer req.Body.Close()

--- a/route/route.go
+++ b/route/route.go
@@ -385,22 +385,16 @@ func (r *Router) marshalToFormat(w http.ResponseWriter, obj interface{}, format 
 // event is handler for /1/event/
 func (r *Router) event(w http.ResponseWriter, req *http.Request) {
 	r.Metrics.Increment(r.incomingOrPeer + "_router_event")
-	defer req.Body.Close()
 
 	ctx := req.Context()
-	bodyReader, err := r.getMaybeCompressedBody(req)
+	bodyBuffer, err := r.readAndCloseMaybeCompressedBody(req)
 	if err != nil {
 		r.handlerReturnWithError(w, ErrPostBody, err)
 		return
 	}
+	defer httpBodyBufferPool.Put(bodyBuffer)
 
-	reqBod, err := io.ReadAll(bodyReader)
-	if err != nil {
-		r.handlerReturnWithError(w, ErrPostBody, err)
-		return
-	}
-
-	ev, err := r.requestToEvent(ctx, req, reqBod)
+	ev, err := r.requestToEvent(ctx, req, bodyBuffer.Bytes())
 	if err != nil {
 		r.handlerReturnWithError(w, ErrReqToEvent, err)
 		return
@@ -459,28 +453,22 @@ func (r *Router) requestToEvent(ctx context.Context, req *http.Request, reqBod [
 
 func (r *Router) batch(w http.ResponseWriter, req *http.Request) {
 	r.Metrics.Increment(r.incomingOrPeer + "_router_batch")
-	defer req.Body.Close()
 
 	ctx := req.Context()
 	reqID := ctx.Value(types.RequestIDContextKey{})
 	debugLog := r.iopLogger.Debug().WithField("request_id", reqID)
 
-	bodyReader, err := r.getMaybeCompressedBody(req)
+	bodyBuffer, err := r.readAndCloseMaybeCompressedBody(req)
 	if err != nil {
 		r.handlerReturnWithError(w, ErrPostBody, err)
 		return
 	}
-
-	reqBod, err := io.ReadAll(bodyReader)
-	if err != nil {
-		r.handlerReturnWithError(w, ErrPostBody, err)
-		return
-	}
+	defer httpBodyBufferPool.Put(bodyBuffer)
 
 	batchedEvents := make(batchedEvents, 0)
-	err = unmarshal(req, reqBod, &batchedEvents)
+	err = unmarshal(req, bodyBuffer.Bytes(), &batchedEvents)
 	if err != nil {
-		debugLog.WithField("error", err.Error()).WithField("request.url", req.URL).WithField("json_body", string(reqBod)).Logf("error parsing json")
+		debugLog.WithField("error", err.Error()).WithField("request.url", req.URL).WithField("json_body", string(bodyBuffer.Bytes())).Logf("error parsing json")
 		r.handlerReturnWithError(w, ErrJSONFailed, err)
 		return
 	}
@@ -695,7 +683,20 @@ func (r *Router) processEvent(ev *types.Event, reqID interface{}) error {
 	return nil
 }
 
-func (r *Router) getMaybeCompressedBody(req *http.Request) (io.Reader, error) {
+// A pool of buffers for HTTP bodies; there's no sorting by size here, since
+// the assumption is that over time these will converge on the largest typical
+// body size used in this environment.
+var httpBodyBufferPool = sync.Pool{
+	New: func() any {
+		return new(bytes.Buffer)
+	},
+}
+
+// When finished with the returned buffer, callers should return it to bufferPool.
+// Reads the body and immediately closes it, releasing resources as soon as possible.
+func (r *Router) readAndCloseMaybeCompressedBody(req *http.Request) (*bytes.Buffer, error) {
+	defer req.Body.Close()
+
 	var reader io.Reader
 	switch req.Header.Get("Content-Encoding") {
 	case "gzip":
@@ -704,12 +705,7 @@ func (r *Router) getMaybeCompressedBody(req *http.Request) (io.Reader, error) {
 			return nil, err
 		}
 		defer gzipReader.Close()
-
-		buf := &bytes.Buffer{}
-		if _, err := io.Copy(buf, io.LimitReader(gzipReader, HTTPMessageSizeMax)); err != nil {
-			return nil, err
-		}
-		reader = buf
+		reader = gzipReader
 	case "zstd":
 		zReader := <-r.zstdDecoders
 		defer func(zReader *zstd.Decoder) {
@@ -721,16 +717,19 @@ func (r *Router) getMaybeCompressedBody(req *http.Request) (io.Reader, error) {
 		if err != nil {
 			return nil, err
 		}
-		buf := &bytes.Buffer{}
-		if _, err := io.Copy(buf, io.LimitReader(zReader, HTTPMessageSizeMax)); err != nil {
-			return nil, err
-		}
-
-		reader = buf
+		reader = zReader
 	default:
 		reader = req.Body
 	}
-	return reader, nil
+
+	buf := httpBodyBufferPool.Get().(*bytes.Buffer)
+	buf.Reset()
+	if _, err := io.Copy(buf, io.LimitReader(reader, HTTPMessageSizeMax)); err != nil {
+		httpBodyBufferPool.Put(buf)
+		return nil, err
+	}
+
+	return buf, nil
 }
 
 // getEventTime tries to guess the time format in our time header!

--- a/route/route_test.go
+++ b/route/route_test.go
@@ -56,7 +56,7 @@ func TestDecompression(t *testing.T) {
 		Body:   io.NopCloser(pReader),
 		Header: http.Header{},
 	}
-	reader, err := router.getMaybeCompressedBody(req)
+	reader, err := router.readAndCloseMaybeCompressedBody(req)
 	if err != nil {
 		t.Errorf("unexpected err: %s", err.Error())
 	}
@@ -79,7 +79,7 @@ func TestDecompression(t *testing.T) {
 
 	req.Body = io.NopCloser(buf)
 	req.Header.Set("Content-Encoding", "gzip")
-	reader, err = router.getMaybeCompressedBody(req)
+	reader, err = router.readAndCloseMaybeCompressedBody(req)
 	if err != nil {
 		t.Errorf("unexpected err: %s", err.Error())
 	}
@@ -105,7 +105,7 @@ func TestDecompression(t *testing.T) {
 
 	req.Body = io.NopCloser(buf)
 	req.Header.Set("Content-Encoding", "zstd")
-	reader, err = router.getMaybeCompressedBody(req)
+	reader, err = router.readAndCloseMaybeCompressedBody(req)
 	if err != nil {
 		t.Errorf("unexpected err: %s", err.Error())
 	}


### PR DESCRIPTION
## Which problem is this PR solving?
It sure is expensive allocating these big buffers for every HTTP read, especially given that their size is initially unknown (at least when compressed.) We also copied compressed bodies twice, which was totally unnecessary.

We also did not apply any body size limit to uncompressed payloads.

## Short description of the changes
The main change here is to keep a pool of buffers for the HTTP bodies, allowing us to easily avoid potentially large allocations. It also restructures the read so that we only read the body contents at most once, and applies the size limit to uncompressed payloads.

For our optimized Payload path, this does mean we need to make new copies of the relevant sections of the body for storage with the Payload. However, this is better than what we did before, because it's less memory, the size is known a priori, and it solves the problem of a single Event hanging onto a reference to the entire buffer from a much larger batch.

We could take this further and also recycle Payload's messagepack buffer, but that requires accurately identifying each and every place where an Event goes out of scope - a job I'd rather leave to the garbage collector, at least for now.