### PR TITLE
maint: clean up payload code and testing, fix broken benchmark

### DIFF
--- a/route/route_test.go
+++ b/route/route_test.go
@@ -1212,7 +1212,7 @@ func createBatchEventsWithLargeAttributes(numEvents int, cfg config.Config) *bat
 func BenchmarkRouterBatch(b *testing.B) {
 	router := newBatchRouter(b)
 	batchEvents := createBatchEventsWithLargeAttributes(3, router.Config)
-	batchMsgpack, err := msgpack.Marshal(batchEvents)
+	batchMsgpack, err := msgpack.Marshal(batchEvents.events)
 	require.NoError(b, err)
 
 	mockCollector := router.Collector.(*collect.MockCollector)

--- a/types/payload.go
+++ b/types/payload.go
@@ -75,47 +75,38 @@ type metadataField struct {
 }
 
 var metadataFields = map[string]metadataField{
-	MetaSignalType:                stringField(MetaSignalType, func(p *Payload) any { return &p.MetaSignalType }),
-	MetaTraceID:                   stringField(MetaTraceID, func(p *Payload) any { return &p.MetaTraceID }),
-	MetaAnnotationType:            stringField(MetaAnnotationType, func(p *Payload) any { return &p.MetaAnnotationType }),
-	MetaRefineryProbe:             boolField(MetaRefineryProbe, func(p *Payload) any { return &p.MetaRefineryProbe }),
-	MetaRefineryRoot:              boolField(MetaRefineryRoot, func(p *Payload) any { return &p.MetaRefineryRoot }),
-	MetaRefineryIncomingUserAgent: stringField(MetaRefineryIncomingUserAgent, func(p *Payload) any { return &p.MetaRefineryIncomingUserAgent }),
-	MetaRefinerySendBy:            int64Field(MetaRefinerySendBy, func(p *Payload) any { return &p.MetaRefinerySendBy }),
-	MetaRefinerySpanDataSize:      int64Field(MetaRefinerySpanDataSize, func(p *Payload) any { return &p.MetaRefinerySpanDataSize }),
-	MetaRefineryMinSpan:           boolField(MetaRefineryMinSpan, func(p *Payload) any { return &p.MetaRefineryMinSpan }),
-	MetaRefineryForwarded:         stringField(MetaRefineryForwarded, func(p *Payload) any { return &p.MetaRefineryForwarded }),
-	MetaRefineryExpiredTrace:      boolField(MetaRefineryExpiredTrace, func(p *Payload) any { return &p.MetaRefineryExpiredTrace }),
+	MetaSignalType:                stringField(MetaSignalType, func(p *Payload) *string { return &p.MetaSignalType }),
+	MetaTraceID:                   stringField(MetaTraceID, func(p *Payload) *string { return &p.MetaTraceID }),
+	MetaAnnotationType:            stringField(MetaAnnotationType, func(p *Payload) *string { return &p.MetaAnnotationType }),
+	MetaRefineryProbe:             boolField(MetaRefineryProbe, func(p *Payload) *nullableBool { return &p.MetaRefineryProbe }),
+	MetaRefineryRoot:              boolField(MetaRefineryRoot, func(p *Payload) *nullableBool { return &p.MetaRefineryRoot }),
+	MetaRefineryIncomingUserAgent: stringField(MetaRefineryIncomingUserAgent, func(p *Payload) *string { return &p.MetaRefineryIncomingUserAgent }),
+	MetaRefinerySendBy:            int64Field(MetaRefinerySendBy, func(p *Payload) *int64 { return &p.MetaRefinerySendBy }),
+	MetaRefinerySpanDataSize:      int64Field(MetaRefinerySpanDataSize, func(p *Payload) *int64 { return &p.MetaRefinerySpanDataSize }),
+	MetaRefineryMinSpan:           boolField(MetaRefineryMinSpan, func(p *Payload) *nullableBool { return &p.MetaRefineryMinSpan }),
+	MetaRefineryForwarded:         stringField(MetaRefineryForwarded, func(p *Payload) *string { return &p.MetaRefineryForwarded }),
+	MetaRefineryExpiredTrace:      boolField(MetaRefineryExpiredTrace, func(p *Payload) *nullableBool { return &p.MetaRefineryExpiredTrace }),
 
-	MetaRefineryLocalHostname:      stringField(MetaRefineryLocalHostname, func(p *Payload) any { return &p.MetaRefineryLocalHostname }),
-	MetaStressed:                   boolField(MetaStressed, func(p *Payload) any { return &p.MetaStressed }),
-	MetaRefineryReason:             stringField(MetaRefineryReason, func(p *Payload) any { return &p.MetaRefineryReason }),
-	MetaRefinerySendReason:         stringField(MetaRefinerySendReason, func(p *Payload) any { return &p.MetaRefinerySendReason }),
-	MetaSpanEventCount:             int64Field(MetaSpanEventCount, func(p *Payload) any { return &p.MetaSpanEventCount }),
-	MetaSpanLinkCount:              int64Field(MetaSpanLinkCount, func(p *Payload) any { return &p.MetaSpanLinkCount }),
-	MetaSpanCount:                  int64Field(MetaSpanCount, func(p *Payload) any { return &p.MetaSpanCount }),
-	MetaEventCount:                 int64Field(MetaEventCount, func(p *Payload) any { return &p.MetaEventCount }),
-	MetaRefineryOriginalSampleRate: int64Field(MetaRefineryOriginalSampleRate, func(p *Payload) any { return &p.MetaRefineryOriginalSampleRate }),
-	MetaRefineryShutdownSend:       boolField(MetaRefineryShutdownSend, func(p *Payload) any { return &p.MetaRefineryShutdownSend }),
-	MetaRefinerySampleKey:          stringField(MetaRefinerySampleKey, func(p *Payload) any { return &p.MetaRefinerySampleKey }),
+	MetaRefineryLocalHostname:      stringField(MetaRefineryLocalHostname, func(p *Payload) *string { return &p.MetaRefineryLocalHostname }),
+	MetaStressed:                   boolField(MetaStressed, func(p *Payload) *nullableBool { return &p.MetaStressed }),
+	MetaRefineryReason:             stringField(MetaRefineryReason, func(p *Payload) *string { return &p.MetaRefineryReason }),
+	MetaRefinerySendReason:         stringField(MetaRefinerySendReason, func(p *Payload) *string { return &p.MetaRefinerySendReason }),
+	MetaSpanEventCount:             int64Field(MetaSpanEventCount, func(p *Payload) *int64 { return &p.MetaSpanEventCount }),
+	MetaSpanLinkCount:              int64Field(MetaSpanLinkCount, func(p *Payload) *int64 { return &p.MetaSpanLinkCount }),
+	MetaSpanCount:                  int64Field(MetaSpanCount, func(p *Payload) *int64 { return &p.MetaSpanCount }),
+	MetaEventCount:                 int64Field(MetaEventCount, func(p *Payload) *int64 { return &p.MetaEventCount }),
+	MetaRefineryOriginalSampleRate: int64Field(MetaRefineryOriginalSampleRate, func(p *Payload) *int64 { return &p.MetaRefineryOriginalSampleRate }),
+	MetaRefineryShutdownSend:       boolField(MetaRefineryShutdownSend, func(p *Payload) *nullableBool { return &p.MetaRefineryShutdownSend }),
+	MetaRefinerySampleKey:          stringField(MetaRefinerySampleKey, func(p *Payload) *string { return &p.MetaRefinerySampleKey }),
 }
 
-// fieldPtr provides a pointer to a specific field in the Payload struct.
-// Must be gauranteed to always return the expected type, and never return nil.
-// Hey, you might be saying, the whole point of all of this is to avoid
-// putting these field values into type any. Which is true, but this puts a
-// POINTER to the field into any, which is fine when the value is already
-// on the heap, which generally our Payloads will be.
-type fieldPtr func(p *Payload) any
-
 // Helpers to set up metadataField entries based on the supplied key and
-// fieldPtr function. This adds some extra type assertions but these are quite
-// cheap, and avoids quite a lot of repetitive code for each field.
-func stringField(key string, ptr fieldPtr) metadataField {
+// ptr function to get access to the correct field.
+func stringField(key string, ptr func(*Payload) *string) metadataField {
 	return metadataField{
 		expectedType: FieldTypeString,
 		get: func(p *Payload) (value any, ok bool) {
-			strPtr := ptr(p).(*string)
+			strPtr := ptr(p)
 			if *strPtr != "" {
 				return *strPtr, true
 			}
@@ -123,16 +114,16 @@ func stringField(key string, ptr fieldPtr) metadataField {
 		},
 		set: func(p *Payload, value any) {
 			if v, ok := value.(string); ok {
-				strPtr := ptr(p).(*string)
+				strPtr := ptr(p)
 				*strPtr = v
 			}
 		},
 		exist: func(p *Payload) bool {
-			strPtr := ptr(p).(*string)
+			strPtr := ptr(p)
 			return *strPtr != ""
 		},
 		appendMsgp: func(p *Payload, in []byte) (out []byte, ok bool) {
-			strPtr := ptr(p).(*string)
+			strPtr := ptr(p)
 			if *strPtr != "" {
 				out = msgp.AppendString(in, key)
 				out = msgp.AppendString(out, *strPtr)
@@ -141,18 +132,18 @@ func stringField(key string, ptr fieldPtr) metadataField {
 			return in, false
 		},
 		unmarshalMsgp: func(p *Payload, in []byte) (out []byte, err error) {
-			strPtr := ptr(p).(*string)
+			strPtr := ptr(p)
 			*strPtr, out, err = msgp.ReadStringBytes(in)
 			return out, err
 		},
 	}
 }
 
-func boolField(key string, ptr fieldPtr) metadataField {
+func boolField(key string, ptr func(*Payload) *nullableBool) metadataField {
 	return metadataField{
 		expectedType: FieldTypeBool,
 		get: func(p *Payload) (value any, ok bool) {
-			boolPtr := ptr(p).(*nullableBool)
+			boolPtr := ptr(p)
 			if boolPtr.HasValue {
 				return boolPtr.Value, true
 			}
@@ -160,16 +151,16 @@ func boolField(key string, ptr fieldPtr) metadataField {
 		},
 		set: func(p *Payload, value any) {
 			if v, ok := value.(bool); ok {
-				boolPtr := ptr(p).(*nullableBool)
+				boolPtr := ptr(p)
 				boolPtr.Set(v)
 			}
 		},
 		exist: func(p *Payload) bool {
-			boolPtr := ptr(p).(*nullableBool)
+			boolPtr := ptr(p)
 			return boolPtr.HasValue
 		},
 		appendMsgp: func(p *Payload, in []byte) (out []byte, ok bool) {
-			boolPtr := ptr(p).(*nullableBool)
+			boolPtr := ptr(p)
 			if boolPtr.HasValue {
 				out = msgp.AppendString(in, key)
 				out = msgp.AppendBool(out, boolPtr.Value)
@@ -181,7 +172,7 @@ func boolField(key string, ptr fieldPtr) metadataField {
 			var val bool
 			val, out, err = msgp.ReadBoolBytes(in)
 			if err == nil {
-				boolPtr := ptr(p).(*nullableBool)
+				boolPtr := ptr(p)
 				boolPtr.Set(val)
 			}
 			return out, err
@@ -189,11 +180,11 @@ func boolField(key string, ptr fieldPtr) metadataField {
 	}
 }
 
-func int64Field(key string, ptr fieldPtr) metadataField {
+func int64Field(key string, ptr func(*Payload) *int64) metadataField {
 	return metadataField{
 		expectedType: FieldTypeInt64,
 		get: func(p *Payload) (value any, ok bool) {
-			intPtr := ptr(p).(*int64)
+			intPtr := ptr(p)
 			if *intPtr != 0 {
 				return *intPtr, true
 			}
@@ -201,16 +192,16 @@ func int64Field(key string, ptr fieldPtr) metadataField {
 		},
 		set: func(p *Payload, value any) {
 			if v, ok := value.(int64); ok {
-				intPtr := ptr(p).(*int64)
+				intPtr := ptr(p)
 				*intPtr = v
 			}
 		},
 		exist: func(p *Payload) bool {
-			intPtr := ptr(p).(*int64)
+			intPtr := ptr(p)
 			return *intPtr != 0
 		},
 		appendMsgp: func(p *Payload, in []byte) (out []byte, ok bool) {
-			intPtr := ptr(p).(*int64)
+			intPtr := ptr(p)
 			if *intPtr != 0 {
 				out = msgp.AppendString(in, key)
 				out = msgp.AppendInt64(out, *intPtr)
@@ -219,7 +210,7 @@ func int64Field(key string, ptr fieldPtr) metadataField {
 			return in, false
 		},
 		unmarshalMsgp: func(p *Payload, in []byte) (out []byte, err error) {
-			intPtr := ptr(p).(*int64)
+			intPtr := ptr(p)
 			*intPtr, out, err = msgp.ReadInt64Bytes(in)
 			return out, err
 		},

--- a/types/payload_test.go
+++ b/types/payload_test.go
@@ -15,8 +15,8 @@ import (
 )
 
 func TestMetadataFieldsHaveMetaPrefix(t *testing.T) {
-	for _, field := range metadataFields {
-		assert.True(t, strings.HasPrefix(field.key, "meta."))
+	for key := range metadataFields {
+		assert.True(t, strings.HasPrefix(key, "meta."))
 	}
 }
 
@@ -273,6 +273,9 @@ func TestPayloadUnmarshalMsg(t *testing.T) {
 			"meta.refinery.probe":  false,
 			"trace.trace_id":       "custom-trace-456", // Custom trace ID field
 			"span.parent_id":       "",                 // Empty parent ID should make it root
+
+			// Incorrect type for a meta field, this field should just be ignored.
+			MetaRefineryIncomingUserAgent: 4,
 		}
 
 		// Marshal to msgpack
@@ -334,6 +337,7 @@ func TestPayloadUnmarshalMsg(t *testing.T) {
 		assert.Empty(t, remainder2)
 	})
 }
+
 func TestPayloadGetSetExistMetadataSync(t *testing.T) {
 	t.Run("Set updates metadata fields", func(t *testing.T) {
 		ph := NewPayload(&config.MockConfig{}, nil)

--- a/types/payload_test.go
+++ b/types/payload_test.go
@@ -31,6 +31,10 @@ func TestPayload(t *testing.T) {
 		"meta.refinery.root":     true,
 		"meta.refinery.min_span": false,
 		"meta.annotation_type":   "span_event",
+
+		// This is the wrong type, it should just be ignored and dropped from the data.
+		// TODO enable on this is implemented.
+		// "meta.refinery.send_by": "never",
 	}
 	mockCfg := &config.MockConfig{
 		TraceIdFieldNames: []string{"trace.trace_id"},
@@ -60,6 +64,9 @@ func TestPayload(t *testing.T) {
 		assert.True(t, ph.Exists("meta.annotation_type"))
 		assert.Equal(t, "span_event", ph.Get("meta.annotation_type"))
 
+		assert.Nil(t, ph.Get("meta.refinery.send_by"))
+		assert.False(t, ph.Exists("meta.refinery.send_by"))
+
 		// Test dedicated fields - should be populated from initial data or unmarshal
 		assert.Equal(t, "test-trace-123", ph.MetaTraceID, "MetaTraceID should be populated")
 		assert.True(t, ph.MetaRefineryRoot.HasValue, "MetaRefineryRoot should be set")
@@ -67,6 +74,7 @@ func TestPayload(t *testing.T) {
 		assert.True(t, ph.MetaRefineryMinSpan.HasValue, "MetaRefineryMinSpan should be set")
 		assert.Equal(t, false, ph.MetaRefineryMinSpan.Value, "MetaRefineryMinSpan should be populated")
 		assert.Equal(t, "span_event", ph.MetaAnnotationType, "MetaAnnotationType should be populated")
+		assert.Equal(t, int64(0), ph.MetaRefinerySendBy)
 
 		ph.Set("key5", "newvalue")
 		assert.True(t, ph.Exists("key5"))

--- a/types/payload_test.go
+++ b/types/payload_test.go
@@ -33,8 +33,7 @@ func TestPayload(t *testing.T) {
 		"meta.annotation_type":   "span_event",
 
 		// This is the wrong type, it should just be ignored and dropped from the data.
-		// TODO enable on this is implemented.
-		// "meta.refinery.send_by": "never",
+		"meta.refinery.send_by": "never",
 	}
 	mockCfg := &config.MockConfig{
 		TraceIdFieldNames: []string{"trace.trace_id"},
@@ -103,6 +102,7 @@ func TestPayload(t *testing.T) {
 		expected["key5"] = "newvalue"
 		expected["meta.refinery.span_data_size"] = int64(1234)
 		expected["meta.refinery.incoming_user_agent"] = "test-agent/1.0"
+		delete(expected, "meta.refinery.send_by")
 		found := maps.Collect(ph.All())
 		assert.Equal(t, expected, found)
 
@@ -123,7 +123,6 @@ func TestPayload(t *testing.T) {
 		// round-tripping through JSON turns our ints into floats
 		expectedFromJSON := maps.Collect(ph.All())
 		expectedFromJSON["key2"] = 42.0
-		expectedFromJSON["meta.refinery.span_data_size"] = 1234.0
 		assert.EqualValues(t, expectedFromJSON, maps.Collect(fromJSON.All()))
 	}
 

--- a/types/payload_test.go
+++ b/types/payload_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/honeycombio/refinery/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tinylib/msgp/msgp"
 	"github.com/vmihailenco/msgpack/v5"
 )
 
@@ -234,58 +233,54 @@ func TestPayloadExtractMetadataError(t *testing.T) {
 	})
 }
 
-func TestPayloadMetaAnnotationType(t *testing.T) {
-	t.Run("handles string values", func(t *testing.T) {
-		ph := NewPayload(&config.MockConfig{}, map[string]any{
-			"meta.annotation_type": "span_event",
-		})
-		err := ph.ExtractMetadata()
-		require.NoError(t, err)
-
-		assert.Equal(t, "span_event", ph.MetaAnnotationType)
-		assert.Equal(t, "span_event", ph.Get("meta.annotation_type"))
-	})
-
-	t.Run("marshaling preserves type", func(t *testing.T) {
-		// Test string marshaling
-		ph1 := NewPayload(&config.MockConfig{}, nil)
-		ph1.MetaAnnotationType = "span_event"
-
-		msgpData, err := ph1.MarshalMsg(nil)
-		require.NoError(t, err)
-
-		ph2 := NewPayload(&config.MockConfig{}, nil)
-		_, err = ph2.UnmarshalMsg(msgpData)
-		require.NoError(t, err)
-
-		assert.Equal(t, "span_event", ph2.MetaAnnotationType)
-	})
-}
-
 func TestPayloadUnmarshalMsg(t *testing.T) {
 	t.Run("extracts metadata during unmarshal", func(t *testing.T) {
-		// Create test data with metadata fields
+		// Create test data with all metadata fields
 		data := map[string]any{
-			"regular_field":        "value1",
+			// Regular fields
+			"regular_field": "value1",
+			"another_field": 42,
+
+			// Core metadata fields
 			"meta.signal_type":     "trace",
 			"meta.annotation_type": "span_event",
-			"meta.refinery.root":   true,
-			"meta.refinery.probe":  false,
-			"trace.trace_id":       "custom-trace-456", // Custom trace ID field
-			"span.parent_id":       "",                 // Empty parent ID should make it root
 
-			// Incorrect type for a meta field, this field should just be ignored.
-			MetaRefineryIncomingUserAgent: 4,
+			// Refinery boolean fields
+			"meta.refinery.probe":         true,
+			"meta.refinery.min_span":      true,
+			"meta.refinery.expired_trace": false,
+			"meta.refinery.shutdown_send": true,
+			"meta.stressed":               true,
+
+			// Refinery string fields
+			"meta.refinery.incoming_user_agent": "test-agent/1.0",
+			"meta.refinery.forwarded":           "192.168.1.1",
+			"meta.refinery.local_hostname":      "test-host",
+			"meta.refinery.reason":              "deterministic",
+			"meta.refinery.send_reason":         "trace_timeout",
+			"meta.refinery.sample_key":          "sample-key-123",
+
+			// Refinery int64 fields
+			"meta.refinery.send_by":              int64(1234567890),
+			"meta.refinery.span_data_size":       int64(2048),
+			"meta.span_event_count":              int64(5),
+			"meta.span_link_count":               int64(3),
+			"meta.span_count":                    int64(10),
+			"meta.event_count":                   int64(15),
+			"meta.refinery.original_sample_rate": int64(100),
+
+			// Custom trace/parent fields
+			"trace.trace_id": "custom-trace-456", // Custom trace ID field
+			"span.parent_id": "",                 // Empty parent ID should make it root
 		}
 
-		// Marshal to msgpack
 		msgpData, err := msgpack.Marshal(data)
 		require.NoError(t, err)
 
 		// Create payload and unmarshal with metadata extraction
 		p := Payload{
 			config: &config.MockConfig{
-				TraceIdFieldNames:  []string{"trace.trace_id"},
+				TraceIdFieldNames:  []string{"wrong", "trace.trace_id"},
 				ParentIdFieldNames: []string{"span.parent_id"},
 			},
 		}
@@ -293,17 +288,45 @@ func TestPayloadUnmarshalMsg(t *testing.T) {
 		require.NoError(t, err)
 		assert.Empty(t, remainder)
 
-		// Verify metadata was extracted
+		// Verify core metadata was extracted
 		assert.Equal(t, "trace", p.MetaSignalType)
-		assert.Equal(t, "custom-trace-456", p.MetaTraceID) // Should use custom field
+		assert.Equal(t, "custom-trace-456", p.MetaTraceID) // Should use custom field over meta.trace_id
 		assert.Equal(t, "span_event", p.MetaAnnotationType)
-		assert.True(t, p.MetaRefineryRoot.HasValue)
-		assert.True(t, p.MetaRefineryRoot.Value)
+
+		// Verify boolean metadata fields
 		assert.True(t, p.MetaRefineryProbe.HasValue)
-		assert.False(t, p.MetaRefineryProbe.Value)
+		assert.True(t, p.MetaRefineryProbe.Value)
+		assert.True(t, p.MetaRefineryRoot.HasValue)
+		assert.True(t, p.MetaRefineryRoot.Value) // Should be true because empty parent ID
+		assert.True(t, p.MetaRefineryMinSpan.HasValue)
+		assert.True(t, p.MetaRefineryMinSpan.Value)
+		assert.True(t, p.MetaRefineryExpiredTrace.HasValue)
+		assert.False(t, p.MetaRefineryExpiredTrace.Value)
+		assert.True(t, p.MetaRefineryShutdownSend.HasValue)
+		assert.True(t, p.MetaRefineryShutdownSend.Value)
+		assert.True(t, p.MetaStressed.HasValue)
+		assert.True(t, p.MetaStressed.Value)
+
+		// Verify string metadata fields
+		assert.Equal(t, "test-agent/1.0", p.MetaRefineryIncomingUserAgent)
+		assert.Equal(t, "192.168.1.1", p.MetaRefineryForwarded)
+		assert.Equal(t, "test-host", p.MetaRefineryLocalHostname)
+		assert.Equal(t, "deterministic", p.MetaRefineryReason)
+		assert.Equal(t, "trace_timeout", p.MetaRefinerySendReason)
+		assert.Equal(t, "sample-key-123", p.MetaRefinerySampleKey)
+
+		// Verify int64 metadata fields
+		assert.Equal(t, int64(1234567890), p.MetaRefinerySendBy)
+		assert.Equal(t, int64(2048), p.MetaRefinerySpanDataSize)
+		assert.Equal(t, int64(5), p.MetaSpanEventCount)
+		assert.Equal(t, int64(3), p.MetaSpanLinkCount)
+		assert.Equal(t, int64(10), p.MetaSpanCount)
+		assert.Equal(t, int64(15), p.MetaEventCount)
+		assert.Equal(t, int64(100), p.MetaRefineryOriginalSampleRate)
 
 		// Verify regular fields are still accessible
 		assert.Equal(t, "value1", p.Get("regular_field"))
+		assert.Equal(t, int64(42), p.Get("another_field")) // should preserve int type
 	})
 
 	t.Run("handles remainder correctly", func(t *testing.T) {
@@ -425,79 +448,6 @@ func TestPayloadGetSetExistMetadataSync(t *testing.T) {
 		assert.Nil(t, ph.Get("meta.refinery.expired_trace"))
 		assert.False(t, ph.Exists("meta.refinery.expired_trace"))
 	})
-}
-
-func TestUnmarshalMsgWithMetadata(t *testing.T) {
-	// Create test data with metadata fields
-	data := map[string]interface{}{
-		"trace.trace_id":                    "test-trace-123",
-		"trace.parent_id":                   "parent-456",
-		"meta.signal_type":                  "span",
-		"meta.annotation_type":              "span_event",
-		"meta.refinery.probe":               true,
-		"meta.refinery.root":                false,
-		"meta.refinery.incoming_user_agent": "test-agent",
-		"meta.refinery.send_by":             int64(1234567890),
-		"meta.refinery.span_data_size":      int64(1024),
-		"meta.refinery.min_span":            true,
-		"meta.refinery.forwarded":           "192.168.1.1",
-		"meta.refinery.expired_trace":       false,
-		"regular_field":                     "value",
-		"another_field":                     42,
-	}
-
-	// Marshal the data to msgpack
-	var buf []byte
-	buf = msgp.AppendMapHeader(buf, uint32(len(data)))
-	for k, v := range data {
-		buf = msgp.AppendString(buf, k)
-		switch val := v.(type) {
-		case string:
-			buf = msgp.AppendString(buf, val)
-		case int64:
-			buf = msgp.AppendInt64(buf, val)
-		case int:
-			buf = msgp.AppendInt(buf, val)
-		case bool:
-			buf = msgp.AppendBool(buf, val)
-		}
-	}
-
-	// Test the optimized unmarshal
-	p := Payload{
-		config: &config.MockConfig{
-			TraceIdFieldNames:  []string{"trace.trace_id", "traceId"},
-			ParentIdFieldNames: []string{"span.parent_id", "parentId"},
-		},
-	}
-
-	remaining, err := p.UnmarshalMsg(buf)
-	require.NoError(t, err)
-	assert.Empty(t, remaining)
-
-	// Verify metadata was extracted correctly
-	assert.Equal(t, "test-trace-123", p.MetaTraceID)
-	assert.Equal(t, "span", p.MetaSignalType)
-	assert.Equal(t, "span_event", p.MetaAnnotationType)
-	assert.True(t, p.MetaRefineryProbe.HasValue)
-	assert.True(t, p.MetaRefineryProbe.Value)
-	assert.True(t, p.MetaRefineryRoot.HasValue)
-	assert.False(t, p.MetaRefineryRoot.Value)
-	assert.Equal(t, "test-agent", p.MetaRefineryIncomingUserAgent)
-	assert.Equal(t, int64(1234567890), p.MetaRefinerySendBy)
-	assert.Equal(t, int64(1024), p.MetaRefinerySpanDataSize)
-	assert.True(t, p.MetaRefineryMinSpan.HasValue)
-	assert.True(t, p.MetaRefineryMinSpan.Value)
-	assert.Equal(t, "192.168.1.1", p.MetaRefineryForwarded)
-	assert.True(t, p.MetaRefineryExpiredTrace.HasValue)
-	assert.False(t, p.MetaRefineryExpiredTrace.Value)
-
-	// Verify HasExtractedMetadata returns true
-	assert.True(t, p.hasExtractedMetadata)
-
-	// Verify we can still access regular fields
-	assert.Equal(t, "value", p.Get("regular_field"))
-	assert.Equal(t, int64(42), p.Get("another_field"))
 }
 
 func BenchmarkPayload(b *testing.B) {


### PR DESCRIPTION
## Which problem is this PR solving?
All our metadata warmup code wasn't 100% baked when landed.

## Short description of the changes
Restructures the big `metadataFields` table to make it much more compact.

Makes `metadataFields` a map for (hopefully) faster lookups when checking a single field by key, which seems important now that this is a longer list of fields.

More consistently ignores metadata field values which are in the `memoizedFields` map, and prevents them being added via `Set`. This means you can no longer manually set a meta field in the payload to a value of the wrong type, nor will we blindly copy these values from input to output during serialization. Probably won't come up in this codebase but we'll be better off with a single source of truth on these values.

Fixes broken BenchmarkRouterBatch

Cleans up some redundant test code and adds unmarshal testing for all metadata fields in Payload.
