### PR TITLE
test: add BenchmarkRouterBatch/otlp

### DIFF
--- a/route/route_test.go
+++ b/route/route_test.go
@@ -1212,7 +1212,7 @@ func createBatchEventsWithLargeAttributes(numEvents int, cfg config.Config) *bat
 func BenchmarkRouterBatch(b *testing.B) {
 	router := newBatchRouter(b)
 	batchEvents := createBatchEventsWithLargeAttributes(3, router.Config)
-	batchMsgpack, err := msgpack.Marshal(batchEvents)
+	batchMsgpack, err := msgpack.Marshal(batchEvents.events)
 	require.NoError(b, err)
 
 	mockCollector := router.Collector.(*collect.MockCollector)


### PR DESCRIPTION
## Which problem is this PR solving?
We need a benchmark for OTLP trace ingestion

## Short description of the changes
Adds a sub-benchmark. We've got some work to do:

```
BenchmarkRouterBatch/msgpack    121971     9660 ns/op    19699 B/op     50 allocs/op
BenchmarkRouterBatch/otlp         7180   163270 ns/op   256411 B/op   1852 allocs/op
```
