### PR TITLE
perf: remove dynamic string creation for metric names

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -54,6 +54,8 @@ func (a *App) Start() error {
 	}
 	a.IncomingRouter.SetVersion(a.Version)
 	a.PeerRouter.SetVersion(a.Version)
+	a.IncomingRouter.SetType(route.RouterTypeIncoming)
+	a.PeerRouter.SetType(route.RouterTypePeer)
 
 	record_hashes("loaded configuration at startup")
 	a.Config.RegisterReloadCallback(func(configHash, rulesHash string) {
@@ -62,8 +64,8 @@ func (a *App) Start() error {
 
 	// launch our main routers to listen for incoming event traffic from both peers
 	// and external sources
-	a.IncomingRouter.LnS("incoming")
-	a.PeerRouter.LnS("peer")
+	a.IncomingRouter.LnS()
+	a.PeerRouter.LnS()
 
 	// only enable the opamp agent if it's configured
 	if a.Config.GetOpAMPConfig().Enabled {

--- a/app/app.go
+++ b/app/app.go
@@ -9,6 +9,7 @@ import (
 	"github.com/honeycombio/refinery/logger"
 	"github.com/honeycombio/refinery/metrics"
 	"github.com/honeycombio/refinery/route"
+	"github.com/honeycombio/refinery/types"
 )
 
 type App struct {
@@ -54,8 +55,8 @@ func (a *App) Start() error {
 	}
 	a.IncomingRouter.SetVersion(a.Version)
 	a.PeerRouter.SetVersion(a.Version)
-	a.IncomingRouter.SetType(route.RouterTypeIncoming)
-	a.PeerRouter.SetType(route.RouterTypePeer)
+	a.IncomingRouter.SetType(types.RouterTypeIncoming)
+	a.PeerRouter.SetType(types.RouterTypePeer)
 
 	record_hashes("loaded configuration at startup")
 	a.Config.RegisterReloadCallback(func(configHash, rulesHash string) {

--- a/collect/collect.go
+++ b/collect/collect.go
@@ -119,6 +119,8 @@ type InMemCollector struct {
 	dropDecisionBuffer chan TraceDecision
 	keptDecisionBuffer chan TraceDecision
 	hostname           string
+
+	routerPeerMetricNames map[string]string
 }
 
 var inMemCollectorMetrics = []metrics.Metadata{
@@ -186,6 +188,8 @@ func (i *InMemCollector) Start() error {
 	for _, metric := range inMemCollectorMetrics {
 		i.Metrics.Register(metric)
 	}
+
+	i.routerPeerMetricNames = map[string]string{"peer": "peer_router_peer", "incoming": "incoming_router_peer"}
 
 	sampleCacheConfig := i.Config.GetSampleCacheConfig()
 	var err error
@@ -789,7 +793,7 @@ func (i *InMemCollector) processSpan(ctx context.Context, sp *types.Span, source
 	var spanForwarded bool
 	// if this trace doesn't belong to us and it's not in sent state, we should forward a decision span to its decider
 	if !trace.Sent && !isMyTrace {
-		i.Metrics.Increment(source + "_router_peer")
+		i.Metrics.Increment(i.routerPeerMetricNames[source])
 		i.Logger.Debug().
 			WithString("peer", targetShard.GetAddress()).
 			Logf("Sending span to peer")

--- a/collect/collect.go
+++ b/collect/collect.go
@@ -796,10 +796,10 @@ func (i *InMemCollector) processSpan(ctx context.Context, sp *types.Span, source
 	var spanForwarded bool
 	// if this trace doesn't belong to us and it's not in sent state, we should forward a decision span to its decider
 	if !trace.Sent && !isMyTrace {
-		if source.IsPeer() {
-			i.Metrics.Increment(peerRouterPeerMetricName)
-		} else {
+		if source.IsIncoming() {
 			i.Metrics.Increment(incomingRouterPeerMetricName)
+		} else {
+			i.Metrics.Increment(peerRouterPeerMetricName)
 		}
 		i.Logger.Debug().
 			WithString("peer", targetShard.GetAddress()).

--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -2518,7 +2518,7 @@ func TestSpanLimitSendByPreservation(t *testing.T) {
 			APIKey:  legacyAPIKey,
 		},
 	}
-	coll.processSpan(context.Background(), lateSpan, "incoming")
+	coll.processSpan(context.Background(), lateSpan, types.RouterTypeIncoming)
 
 	updatedTrace := coll.cache.Get(traceID)
 	require.Equal(t, trace.SendBy.Unix(), updatedTrace.SendBy.Unix())

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -2,7 +2,6 @@ package metrics
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/honeycombio/refinery/config"
 )
@@ -107,36 +106,3 @@ const (
 	Microseconds  Unit = "us"
 	Percent       Unit = "%"
 )
-
-type ComputedMetricNames struct {
-	names       map[string]string
-	defaultName string
-}
-
-func NewComputedMetricNames(prefix string, metrics []Metadata) ComputedMetricNames {
-	names := make(map[string]string)
-	for _, metric := range metrics {
-		if strings.HasPrefix(metric.Name, "_") {
-			names[metric.Name] = prefix + metric.Name
-		}
-	}
-	return ComputedMetricNames{
-		names:       names,
-		defaultName: prefix + "_unknown",
-	}
-}
-
-func (cmn *ComputedMetricNames) Get(name string) string {
-	if name == "" {
-		return cmn.defaultName
-	}
-	if fullName, ok := cmn.names[name]; ok && fullName != "" {
-		return fullName
-	}
-
-	return cmn.defaultName
-}
-
-func (cmn *ComputedMetricNames) Len() int {
-	return len(cmn.names)
-}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/honeycombio/refinery/config"
 )
@@ -106,3 +107,36 @@ const (
 	Microseconds  Unit = "us"
 	Percent       Unit = "%"
 )
+
+type ComputedMetricNames struct {
+	names       map[string]string
+	defaultName string
+}
+
+func NewComputedMetricNames(prefix string, metrics []Metadata) ComputedMetricNames {
+	names := make(map[string]string)
+	for _, metric := range metrics {
+		if strings.HasPrefix(metric.Name, "_") {
+			names[metric.Name] = prefix + metric.Name
+		}
+	}
+	return ComputedMetricNames{
+		names:       names,
+		defaultName: prefix + "_unknown",
+	}
+}
+
+func (cmn *ComputedMetricNames) Get(name string) string {
+	if name == "" {
+		return cmn.defaultName
+	}
+	if fullName, ok := cmn.names[name]; ok && fullName != "" {
+		return fullName
+	}
+
+	return cmn.defaultName
+}
+
+func (cmn *ComputedMetricNames) Len() int {
+	return len(cmn.names)
+}

--- a/route/otlp_logs_test.go
+++ b/route/otlp_logs_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/honeycombio/refinery/metrics"
 	"github.com/honeycombio/refinery/sharder"
 	"github.com/honeycombio/refinery/transmit"
+	"github.com/honeycombio/refinery/types"
 	"github.com/klauspost/compress/zstd"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -67,7 +68,7 @@ func TestLogsOTLPHandler(t *testing.T) {
 			Logger: logger,
 		},
 		Collector:  mockCollector,
-		routerType: RouterTypeIncoming,
+		routerType: types.RouterTypeIncoming,
 		Tracer:     noop.Tracer{},
 	}
 	logsServer := NewLogsServer(router)

--- a/route/otlp_logs_test.go
+++ b/route/otlp_logs_test.go
@@ -66,9 +66,9 @@ func TestLogsOTLPHandler(t *testing.T) {
 		Sharder: &sharder.SingleServerSharder{
 			Logger: logger,
 		},
-		Collector:      mockCollector,
-		incomingOrPeer: "incoming",
-		Tracer:         noop.Tracer{},
+		Collector:  mockCollector,
+		routerType: RouterTypeIncoming,
+		Tracer:     noop.Tracer{},
 	}
 	logsServer := NewLogsServer(router)
 

--- a/route/proxy.go
+++ b/route/proxy.go
@@ -11,7 +11,7 @@ import (
 // response, blocking until it gets one. This is used for all non-event traffic
 // (eg team api key verification, markers, etc.)
 func (r *Router) proxy(w http.ResponseWriter, req *http.Request) {
-	r.Metrics.Increment(r.incomingOrPeer + "_router_proxied")
+	r.Metrics.Increment(r.metricsNames.routerProxied)
 	r.Logger.Debug().Logf("proxying request for %s", req.URL.Path)
 	upstreamTarget := r.Config.GetHoneycombAPI()
 	forwarded := req.Header.Get("X-Forwarded-For")

--- a/route/route.go
+++ b/route/route.go
@@ -174,7 +174,7 @@ var routerMetrics = []metrics.Metadata{
 	{Name: "bytes_received_logs", Type: metrics.Counter, Unit: metrics.Bytes, Description: "the number of bytes received in log events"},
 }
 
-func (r *Router) computeMetricsNames() {
+func (r *Router) registerMetricNames() {
 	for _, metric := range routerMetrics {
 		fullname := r.routerType.String() + metric.Name
 		switch metric.Name {
@@ -202,6 +202,8 @@ func (r *Router) computeMetricsNames() {
 			r.metricsNames.routerOtlpEvents = fullname
 		}
 
+		metric.Name = fullname
+		r.Metrics.Register(metric)
 	}
 }
 
@@ -242,7 +244,7 @@ func (r *Router) LnS() {
 		return
 	}
 
-	r.computeMetricsNames()
+	r.registerMetricNames()
 
 	muxxer := mux.NewRouter()
 

--- a/route/route.go
+++ b/route/route.go
@@ -98,7 +98,7 @@ type Router struct {
 
 	environmentCache *environmentCache
 	hsrv             *healthserver.Server
-	metricsMap       map[string]string
+	metricsMap       metrics.ComputedMetricNames
 }
 
 type BatchResponse struct {
@@ -167,14 +167,7 @@ func (r *Router) LnS(incomingOrPeer string) {
 		return
 	}
 
-	for _, metric := range routerMetrics {
-		if strings.HasPrefix(metric.Name, "_") {
-			fullname := r.incomingOrPeer + metric.Name
-			r.metricsMap[metric.Name] = fullname
-			metric.Name = fullname
-		}
-		r.Metrics.Register(metric)
-	}
+	r.metricsMap = metrics.NewComputedMetricNames(r.incomingOrPeer, routerMetrics)
 
 	muxxer := mux.NewRouter()
 
@@ -387,7 +380,7 @@ func (r *Router) marshalToFormat(w http.ResponseWriter, obj interface{}, format 
 
 // event is handler for /1/event/
 func (r *Router) event(w http.ResponseWriter, req *http.Request) {
-	r.Metrics.Increment(r.metricsMap["_router_event"])
+	r.Metrics.Increment(r.metricsMap.Get("_router_event"))
 
 	ctx := req.Context()
 	bodyBuffer, err := r.readAndCloseMaybeCompressedBody(req)
@@ -455,7 +448,7 @@ func (r *Router) requestToEvent(ctx context.Context, req *http.Request, reqBod [
 }
 
 func (r *Router) batch(w http.ResponseWriter, req *http.Request) {
-	r.Metrics.Increment(r.metricsMap["_router_batch"])
+	r.Metrics.Increment(r.metricsMap.Get("_router_batch"))
 
 	ctx := req.Context()
 	reqID := ctx.Value(types.RequestIDContextKey{})
@@ -475,7 +468,7 @@ func (r *Router) batch(w http.ResponseWriter, req *http.Request) {
 		r.handlerReturnWithError(w, ErrJSONFailed, err)
 		return
 	}
-	r.Metrics.Count(r.incomingOrPeer+"_router_batch_events", int64(len(batchedEvents.events)))
+	r.Metrics.Count(r.metricsMap.Get("_router_batch_events"), int64(len(batchedEvents.events)))
 
 	dataset, err := getDatasetFromRequest(req)
 	if err != nil {
@@ -542,7 +535,7 @@ func (router *Router) processOTLPRequest(
 	var requestID types.RequestIDContextKey
 	apiHost := router.Config.GetHoneycombAPI()
 
-	router.Metrics.Increment(router.metricsMap["_router_otlp"])
+	router.Metrics.Increment(router.metricsMap.Get("_router_otlp"))
 
 	// get environment name - will be empty for legacy keys
 	environment, err := router.getEnvironmentName(apiKey)
@@ -570,7 +563,7 @@ func (router *Router) processOTLPRequest(
 			}
 		}
 	}
-	router.Metrics.Count(router.incomingOrPeer+"_router_otlp_events", int64(totalEvents))
+	router.Metrics.Count(router.metricsMap.Get("_router_otlp_events"), int64(totalEvents))
 
 	return nil
 }
@@ -584,7 +577,7 @@ func (r *Router) processEvent(ev *types.Event, reqID interface{}) error {
 
 	// record the event bytes size
 	// we do this early so can include all event types (span, event, log, etc)
-	r.Metrics.Histogram(r.incomingOrPeer+"_router_event_bytes", float64(ev.GetDataSize()))
+	r.Metrics.Histogram(r.metricsMap.Get("_router_event_bytes"), float64(ev.GetDataSize()))
 
 	// An error here is effectively a parsing error, so return it up the stack.
 	if err := ev.Data.ExtractMetadata(); err != nil {
@@ -599,7 +592,7 @@ func (r *Router) processEvent(ev *types.Event, reqID interface{}) error {
 
 	if ev.Data.MetaTraceID == "" {
 		// not part of a trace. send along upstream
-		r.Metrics.Increment(r.metricsMap["_router_nonspan"])
+		r.Metrics.Increment(r.metricsMap.Get("_router_nonspan"))
 		debugLog.WithString("api_host", ev.APIHost).
 			WithString("dataset", ev.Dataset).
 			Logf("sending non-trace event from batch")
@@ -650,7 +643,7 @@ func (r *Router) processEvent(ev *types.Event, reqID interface{}) error {
 		// Figure out if we should handle this span locally or pass on to a peer
 		targetShard := r.Sharder.WhichShard(ev.Data.MetaTraceID)
 		if !targetShard.Equals(r.Sharder.MyShard()) {
-			r.Metrics.Increment(r.metricsMap["_router_peer"])
+			r.Metrics.Increment(r.metricsMap.Get("_router_peer"))
 			debugLog.
 				WithString("peer", targetShard.GetAddress()).
 				WithField("isprobe", isProbe).
@@ -680,12 +673,12 @@ func (r *Router) processEvent(ev *types.Event, reqID interface{}) error {
 		err = r.Collector.AddSpanFromPeer(span)
 	}
 	if err != nil {
-		r.Metrics.Increment(r.metricsMap["_router_dropped"])
+		r.Metrics.Increment(r.metricsMap.Get("_router_dropped"))
 		debugLog.Logf("Dropping span from batch, channel full")
 		return err
 	}
 
-	r.Metrics.Increment(r.metricsMap["_router_span"])
+	r.Metrics.Increment(r.metricsMap.Get("_router_span"))
 
 	debugLog.WithField("source", r.incomingOrPeer).Logf("Accepting span from batch for collection into a trace")
 	return nil

--- a/route/route_test.go
+++ b/route/route_test.go
@@ -843,55 +843,55 @@ func TestAddIncomingUserAgent(t *testing.T) {
 
 func TestProcessEventMetrics(t *testing.T) {
 	tests := []struct {
-		name           string
-		incomingOrPeer string
-		opampEnabled   bool
-		recordUsage    config.DefaultTrue
-		signalType     string
-		expectedCount  int64
-		metricName     string
+		name          string
+		routerType    RouterType
+		opampEnabled  bool
+		recordUsage   config.DefaultTrue
+		signalType    string
+		expectedCount int64
+		metricName    string
 	}{
 		{
-			name:           "log event with opamp enabled and record usage",
-			incomingOrPeer: "incoming",
-			opampEnabled:   true,
-			recordUsage:    config.DefaultTrue(true),
-			signalType:     "log",
-			expectedCount:  91,
-			metricName:     "bytes_received_logs",
+			name:          "log event with opamp enabled and record usage",
+			routerType:    RouterTypeIncoming,
+			opampEnabled:  true,
+			recordUsage:   config.DefaultTrue(true),
+			signalType:    "log",
+			expectedCount: 91,
+			metricName:    "bytes_received_logs",
 		},
 		{
-			name:           "trace event with opamp enabled and record usage",
-			incomingOrPeer: "incoming",
-			opampEnabled:   true,
-			recordUsage:    config.DefaultTrue(true),
-			signalType:     "trace",
-			expectedCount:  93,
-			metricName:     "bytes_received_traces",
+			name:          "trace event with opamp enabled and record usage",
+			routerType:    RouterTypeIncoming,
+			opampEnabled:  true,
+			recordUsage:   config.DefaultTrue(true),
+			signalType:    "trace",
+			expectedCount: 93,
+			metricName:    "bytes_received_traces",
 		},
 		{
-			name:           "log event with opamp disabled",
-			incomingOrPeer: "incoming",
-			opampEnabled:   false,
-			recordUsage:    config.DefaultTrue(true),
-			signalType:     "log",
-			expectedCount:  0,
+			name:          "log event with opamp disabled",
+			routerType:    RouterTypeIncoming,
+			opampEnabled:  false,
+			recordUsage:   config.DefaultTrue(true),
+			signalType:    "log",
+			expectedCount: 0,
 		},
 		{
-			name:           "log event with record usage disabled",
-			incomingOrPeer: "incoming",
-			opampEnabled:   true,
-			recordUsage:    config.DefaultTrue(false),
-			signalType:     "log",
-			expectedCount:  0,
+			name:          "log event with record usage disabled",
+			routerType:    RouterTypeIncoming,
+			opampEnabled:  true,
+			recordUsage:   config.DefaultTrue(false),
+			signalType:    "log",
+			expectedCount: 0,
 		},
 		{
-			name:           "log event from peer",
-			incomingOrPeer: "peer",
-			opampEnabled:   true,
-			recordUsage:    config.DefaultTrue(true),
-			signalType:     "log",
-			expectedCount:  0,
+			name:          "log event from peer",
+			routerType:    RouterTypePeer,
+			opampEnabled:  true,
+			recordUsage:   config.DefaultTrue(true),
+			signalType:    "log",
+			expectedCount: 0,
 		},
 	}
 
@@ -928,8 +928,8 @@ func TestProcessEventMetrics(t *testing.T) {
 				PeerTransmission:     mockPeer,
 				Collector:            collect.NewMockCollector(),
 				Sharder:              mockSharder,
-				incomingOrPeer:       tt.incomingOrPeer,
-				iopLogger:            iopLogger{Logger: &logger.NullLogger{}, incomingOrPeer: tt.incomingOrPeer},
+				routerType:           tt.routerType,
+				iopLogger:            iopLogger{Logger: &logger.NullLogger{}, incomingOrPeer: tt.routerType.String()},
 			}
 			router.computeMetricsNames()
 
@@ -998,8 +998,8 @@ func newBatchRouter(t testing.TB) *Router {
 		UpstreamTransmission: mockTransmission,
 		Collector:            mockCollector,
 		Sharder:              mockSharder,
-		incomingOrPeer:       "incoming",
-		iopLogger:            iopLogger{Logger: &logger.NullLogger{}, incomingOrPeer: "incoming"},
+		routerType:           RouterTypeIncoming,
+		iopLogger:            iopLogger{Logger: &logger.NullLogger{}, incomingOrPeer: RouterTypeIncoming.String()},
 		environmentCache:     newEnvironmentCache(time.Second, func(key string) (string, error) { return "test", nil }),
 	}
 	r.computeMetricsNames()

--- a/route/route_test.go
+++ b/route/route_test.go
@@ -931,7 +931,7 @@ func TestProcessEventMetrics(t *testing.T) {
 				routerType:           tt.routerType,
 				iopLogger:            iopLogger{Logger: &logger.NullLogger{}, incomingOrPeer: tt.routerType.String()},
 			}
-			router.computeMetricsNames()
+			router.registerMetricNames()
 
 			// Create test event with traceID and signal type
 			event := &types.Event{
@@ -1002,7 +1002,7 @@ func newBatchRouter(t testing.TB) *Router {
 		iopLogger:            iopLogger{Logger: &logger.NullLogger{}, incomingOrPeer: RouterTypeIncoming.String()},
 		environmentCache:     newEnvironmentCache(time.Second, func(key string) (string, error) { return "test", nil }),
 	}
-	r.computeMetricsNames()
+	r.registerMetricNames()
 	return r
 }
 

--- a/route/route_test.go
+++ b/route/route_test.go
@@ -844,7 +844,7 @@ func TestAddIncomingUserAgent(t *testing.T) {
 func TestProcessEventMetrics(t *testing.T) {
 	tests := []struct {
 		name          string
-		routerType    RouterType
+		routerType    types.RouterType
 		opampEnabled  bool
 		recordUsage   config.DefaultTrue
 		signalType    string
@@ -853,7 +853,7 @@ func TestProcessEventMetrics(t *testing.T) {
 	}{
 		{
 			name:          "log event with opamp enabled and record usage",
-			routerType:    RouterTypeIncoming,
+			routerType:    types.RouterTypeIncoming,
 			opampEnabled:  true,
 			recordUsage:   config.DefaultTrue(true),
 			signalType:    "log",
@@ -862,7 +862,7 @@ func TestProcessEventMetrics(t *testing.T) {
 		},
 		{
 			name:          "trace event with opamp enabled and record usage",
-			routerType:    RouterTypeIncoming,
+			routerType:    types.RouterTypeIncoming,
 			opampEnabled:  true,
 			recordUsage:   config.DefaultTrue(true),
 			signalType:    "trace",
@@ -871,7 +871,7 @@ func TestProcessEventMetrics(t *testing.T) {
 		},
 		{
 			name:          "log event with opamp disabled",
-			routerType:    RouterTypeIncoming,
+			routerType:    types.RouterTypeIncoming,
 			opampEnabled:  false,
 			recordUsage:   config.DefaultTrue(true),
 			signalType:    "log",
@@ -879,7 +879,7 @@ func TestProcessEventMetrics(t *testing.T) {
 		},
 		{
 			name:          "log event with record usage disabled",
-			routerType:    RouterTypeIncoming,
+			routerType:    types.RouterTypeIncoming,
 			opampEnabled:  true,
 			recordUsage:   config.DefaultTrue(false),
 			signalType:    "log",
@@ -887,7 +887,7 @@ func TestProcessEventMetrics(t *testing.T) {
 		},
 		{
 			name:          "log event from peer",
-			routerType:    RouterTypePeer,
+			routerType:    types.RouterTypePeer,
 			opampEnabled:  true,
 			recordUsage:   config.DefaultTrue(true),
 			signalType:    "log",
@@ -998,8 +998,8 @@ func newBatchRouter(t testing.TB) *Router {
 		UpstreamTransmission: mockTransmission,
 		Collector:            mockCollector,
 		Sharder:              mockSharder,
-		routerType:           RouterTypeIncoming,
-		iopLogger:            iopLogger{Logger: &logger.NullLogger{}, incomingOrPeer: RouterTypeIncoming.String()},
+		routerType:           types.RouterTypeIncoming,
+		iopLogger:            iopLogger{Logger: &logger.NullLogger{}, incomingOrPeer: types.RouterTypeIncoming.String()},
 		environmentCache:     newEnvironmentCache(time.Second, func(key string) (string, error) { return "test", nil }),
 	}
 	r.registerMetricNames()

--- a/route/route_test.go
+++ b/route/route_test.go
@@ -924,6 +924,7 @@ func TestProcessEventMetrics(t *testing.T) {
 				Config:               mockConfig,
 				Logger:               &logger.NullLogger{},
 				Metrics:              mockMetrics,
+				metricsMap:           metrics.NewComputedMetricNames(tt.incomingOrPeer, routerMetrics),
 				UpstreamTransmission: mockUpstream,
 				PeerTransmission:     mockPeer,
 				Collector:            collect.NewMockCollector(),
@@ -994,6 +995,7 @@ func newBatchRouter(t testing.TB) *Router {
 	return &Router{
 		Config:               mockConfig,
 		Metrics:              &mockMetrics,
+		metricsMap:           metrics.NewComputedMetricNames("incoming", routerMetrics),
 		UpstreamTransmission: mockTransmission,
 		Collector:            mockCollector,
 		Sharder:              mockSharder,

--- a/route/route_test.go
+++ b/route/route_test.go
@@ -924,7 +924,6 @@ func TestProcessEventMetrics(t *testing.T) {
 				Config:               mockConfig,
 				Logger:               &logger.NullLogger{},
 				Metrics:              mockMetrics,
-				metricsMap:           metrics.NewComputedMetricNames(tt.incomingOrPeer, routerMetrics),
 				UpstreamTransmission: mockUpstream,
 				PeerTransmission:     mockPeer,
 				Collector:            collect.NewMockCollector(),
@@ -932,6 +931,7 @@ func TestProcessEventMetrics(t *testing.T) {
 				incomingOrPeer:       tt.incomingOrPeer,
 				iopLogger:            iopLogger{Logger: &logger.NullLogger{}, incomingOrPeer: tt.incomingOrPeer},
 			}
+			router.computeMetricsNames()
 
 			// Create test event with traceID and signal type
 			event := &types.Event{
@@ -992,10 +992,9 @@ func newBatchRouter(t testing.TB) *Router {
 		Self: &sharder.TestShard{Addr: "http://localhost:8080"},
 	}
 
-	return &Router{
+	r := &Router{
 		Config:               mockConfig,
 		Metrics:              &mockMetrics,
-		metricsMap:           metrics.NewComputedMetricNames("incoming", routerMetrics),
 		UpstreamTransmission: mockTransmission,
 		Collector:            mockCollector,
 		Sharder:              mockSharder,
@@ -1003,6 +1002,8 @@ func newBatchRouter(t testing.TB) *Router {
 		iopLogger:            iopLogger{Logger: &logger.NullLogger{}, incomingOrPeer: "incoming"},
 		environmentCache:     newEnvironmentCache(time.Second, func(key string) (string, error) { return "test", nil }),
 	}
+	r.computeMetricsNames()
+	return r
 }
 
 func createBatchEvents(mockCfg config.Config) *batchedEvents {

--- a/sample/deterministic.go
+++ b/sample/deterministic.go
@@ -32,11 +32,7 @@ func (d *DeterministicSampler) Start() error {
 	if d.Metrics == nil {
 		d.Metrics = &metrics.NullMetrics{}
 	}
-	d.metricNames = samplerMetricNames{
-		numDropped: "deterministic_num_dropped",
-		numKept:    "deterministic_num_kept",
-	}
-
+	d.metricNames = newSamplerMetricNames("deterministic")
 	// Get the actual upper bound - the largest possible value divided by
 	// the sample rate. In the case where the sample rate is 1, this should
 	// sample every value.

--- a/sample/deterministic.go
+++ b/sample/deterministic.go
@@ -32,7 +32,7 @@ func (d *DeterministicSampler) Start() error {
 	if d.Metrics == nil {
 		d.Metrics = &metrics.NullMetrics{}
 	}
-	d.metricNames = newSamplerMetricNames("deterministic")
+	d.metricNames = newSamplerMetricNames("deterministic", d.Metrics)
 	// Get the actual upper bound - the largest possible value divided by
 	// the sample rate. In the case where the sample rate is 1, this should
 	// sample every value.

--- a/sample/rules.go
+++ b/sample/rules.go
@@ -22,7 +22,7 @@ type RulesBasedSampler struct {
 	keyFields     []string
 	nonRootFields []string
 
-	metricNames map[string]string
+	metricNames metrics.ComputedMetricNames
 }
 
 const RootPrefix = "root."
@@ -37,12 +37,7 @@ func (s *RulesBasedSampler) Start() error {
 	prefix := "rulesbased"
 
 	ruleBasedSamplerMetrics = append(ruleBasedSamplerMetrics, samplerMetrics...)
-	for _, metric := range ruleBasedSamplerMetrics {
-		fullname := prefix + metric.Name
-		s.metricNames[metric.Name] = fullname
-		metric.Name = fullname
-		s.Metrics.Register(metric)
-	}
+	s.metricNames = metrics.NewComputedMetricNames(prefix, ruleBasedSamplerMetrics)
 
 	s.samplers = make(map[string]Sampler)
 	s.keyFields, s.nonRootFields = getKeyFields(s.Config.GetSamplingFields())
@@ -154,16 +149,16 @@ func (s *RulesBasedSampler) GetSampleRate(trace *types.Trace) (rate uint, keep b
 				rate = uint(rule.SampleRate)
 				keep = !rule.Drop && rule.SampleRate > 0 && rand.Intn(rule.SampleRate) == 0
 				reason += rule.Name
-				s.Metrics.Histogram(s.metricNames["_sample_rate"], float64(rate))
+				s.Metrics.Histogram(s.metricNames.Get("_sample_rate"), float64(rate))
 			}
 
 			if keep {
-				s.Metrics.Increment(s.metricNames["_num_kept"])
+				s.Metrics.Increment(s.metricNames.Get("_num_kept"))
 			} else {
-				s.Metrics.Increment(s.metricNames["_num_dropped"])
+				s.Metrics.Increment(s.metricNames.Get("_num_dropped"))
 				if rule.Drop {
 					// If we dropped because of an explicit drop rule, then increment that too.
-					s.Metrics.Increment(s.metricNames["_num_dropped_by_drop_rule"])
+					s.Metrics.Increment(s.metricNames.Get("_num_dropped_by_drop_rule"))
 				}
 			}
 			logger.WithFields(map[string]interface{}{

--- a/sample/rules.go
+++ b/sample/rules.go
@@ -27,16 +27,11 @@ type RulesBasedSampler struct {
 
 const RootPrefix = "root."
 
-var ruleBasedSamplerMetrics = []metrics.Metadata{
-	{Name: "rulebased_num_dropped_by_drop_rule", Type: metrics.Counter, Unit: metrics.Dimensionless, Description: "Number of traces dropped by the drop rule"},
-}
-
 func (s *RulesBasedSampler) Start() error {
 	s.Logger.Debug().Logf("Starting RulesBasedSampler")
 	defer func() { s.Logger.Debug().Logf("Finished starting RulesBasedSampler") }()
 
-	ruleBasedSamplerMetrics = append(ruleBasedSamplerMetrics, samplerMetrics...)
-	s.metricNames = newSamplerMetricNames("rulesbased")
+	s.metricNames = newSamplerMetricNames("rulesbased", s.Metrics)
 
 	s.samplers = make(map[string]Sampler)
 	s.keyFields, s.nonRootFields = getKeyFields(s.Config.GetSamplingFields())

--- a/sample/rules.go
+++ b/sample/rules.go
@@ -28,7 +28,7 @@ type RulesBasedSampler struct {
 const RootPrefix = "root."
 
 var ruleBasedSamplerMetrics = []metrics.Metadata{
-	{Name: "_num_dropped_by_drop_rule", Type: metrics.Counter, Unit: metrics.Dimensionless, Description: "Number of traces dropped by the drop rule"},
+	{Name: "rulebased_num_dropped_by_drop_rule", Type: metrics.Counter, Unit: metrics.Dimensionless, Description: "Number of traces dropped by the drop rule"},
 }
 
 func (s *RulesBasedSampler) Start() error {
@@ -36,13 +36,7 @@ func (s *RulesBasedSampler) Start() error {
 	defer func() { s.Logger.Debug().Logf("Finished starting RulesBasedSampler") }()
 
 	ruleBasedSamplerMetrics = append(ruleBasedSamplerMetrics, samplerMetrics...)
-	s.metricNames = samplerMetricNames{
-		numDropped:            "rulesbased_num_dropped",
-		numKept:               "rulesbased_num_kept",
-		sampleRate:            "rulesbased_sample_rate",
-		samplerKeyCardinality: "rulesbased_sampler_key_cardinality",
-		numDroppedByDropRule:  "rulesbased_num_dropped_by_drop_rule",
-	}
+	s.metricNames = newSamplerMetricNames("rulesbased")
 
 	s.samplers = make(map[string]Sampler)
 	s.keyFields, s.nonRootFields = getKeyFields(s.Config.GetSamplingFields())

--- a/sample/sample.go
+++ b/sample/sample.go
@@ -151,7 +151,7 @@ func (d *dynsamplerMetricsRecorder) RegisterMetrics(sampler dynsampler.Sampler) 
 			val:        val,
 		}
 	}
-	d.computeMetricsNames()
+	d.metricNames = newSamplerMetricNames(d.prefix)
 }
 
 func (d *dynsamplerMetricsRecorder) RecordMetrics(sampler dynsampler.Sampler, kept bool, rate uint, numTraceKey int) {
@@ -175,13 +175,6 @@ func (d *dynsamplerMetricsRecorder) RecordMetrics(sampler dynsampler.Sampler, ke
 	}
 	d.met.Histogram(d.metricNames.samplerKeyCardinality, float64(numTraceKey))
 	d.met.Histogram(d.metricNames.sampleRate, float64(rate))
-}
-
-func (d *dynsamplerMetricsRecorder) computeMetricsNames() {
-	d.metricNames.numDropped = d.prefix + "_num_dropped"
-	d.metricNames.numKept = d.prefix + "_num_kept"
-	d.metricNames.sampleRate = d.prefix + "_sample_rate"
-	d.metricNames.samplerKeyCardinality = d.prefix + "_sampler_key_cardinality"
 }
 
 // getKeyFields returns the fields that should be used as keys for the sampler.
@@ -214,9 +207,21 @@ func getKeyFields(fields []string) ([]string, []string) {
 // sampler implementations. This is used to avoid allocation from string concatenation
 // in the hot path of sampling.
 type samplerMetricNames struct {
+	prefix                string
 	numKept               string
 	numDropped            string
 	sampleRate            string
 	samplerKeyCardinality string
 	numDroppedByDropRule  string
+}
+
+func newSamplerMetricNames(prefix string) samplerMetricNames {
+	return samplerMetricNames{
+		prefix:                prefix,
+		numKept:               prefix + "_num_kept",
+		numDropped:            prefix + "_num_dropped",
+		sampleRate:            prefix + "_sample_rate",
+		samplerKeyCardinality: prefix + "_sampler_key_cardinality",
+		numDroppedByDropRule:  prefix + "_num_dropped_by_drop_rule",
+	}
 }

--- a/sample/sample.go
+++ b/sample/sample.go
@@ -133,7 +133,7 @@ type dynsamplerMetricsRecorder struct {
 	// Stores the last recorded internal metrics produced by dynsampler-go
 	lastMetrics map[string]internalDysamplerMetric
 	met         metrics.Metrics
-	metricNames dynsamplerMetrics
+	metricNames samplerMetricNames
 }
 
 // RegisterMetrics registers the metrics that will be recorded by this package.
@@ -210,9 +210,13 @@ func getKeyFields(fields []string) ([]string, []string) {
 	return append(new, nonRootFields...), nonRootFields
 }
 
-type dynsamplerMetrics struct {
+// samplerMetricNames is a struct that holds the names of metrics used by the
+// sampler implementations. This is used to avoid allocation from string concatenation
+// in the hot path of sampling.
+type samplerMetricNames struct {
 	numKept               string
 	numDropped            string
 	sampleRate            string
 	samplerKeyCardinality string
+	numDroppedByDropRule  string
 }

--- a/sample/sample_test.go
+++ b/sample/sample_test.go
@@ -391,7 +391,6 @@ func TestDynsamplerMetricsRecorder_RegisterMetrics(t *testing.T) {
 		// Verify internal state
 		assert.Equal(t, "test_", recorder.dynPrefix)
 		assert.Len(t, recorder.lastMetrics, 3)
-		assert.Equal(t, 4, recorder.metricNames.Len())
 
 		assert.Equal(t, internalDysamplerMetric{
 			metricType: metrics.Gauge,
@@ -404,10 +403,10 @@ func TestDynsamplerMetricsRecorder_RegisterMetrics(t *testing.T) {
 		}, recorder.lastMetrics["test_counter_count"])
 
 		// Check metric names mapping
-		assert.Equal(t, "test_num_dropped", recorder.metricNames.Get("_num_dropped"))
-		assert.Equal(t, "test_num_kept", recorder.metricNames.Get("_num_kept"))
-		assert.Equal(t, "test_sample_rate", recorder.metricNames.Get("_sample_rate"))
-		assert.Equal(t, "test_sampler_key_cardinality", recorder.metricNames.Get("_sampler_key_cardinality"))
+		assert.Equal(t, "test_num_dropped", recorder.metricNames.numDropped)
+		assert.Equal(t, "test_num_kept", recorder.metricNames.numKept)
+		assert.Equal(t, "test_sample_rate", recorder.metricNames.sampleRate)
+		assert.Equal(t, "test_sampler_key_cardinality", recorder.metricNames.samplerKeyCardinality)
 
 		mockSampler.AssertExpectations(t)
 	})
@@ -423,14 +422,12 @@ func TestDynsamplerMetricsRecorder_RegisterMetrics(t *testing.T) {
 			prefix:      "empty",
 			lastMetrics: make(map[string]internalDysamplerMetric),
 			met:         mockMetrics,
-			metricNames: metrics.NewComputedMetricNames("empty_", samplerMetrics),
 		}
 
 		recorder.RegisterMetrics(mockSampler)
 
 		assert.Equal(t, "empty_", recorder.dynPrefix)
 		assert.Len(t, recorder.lastMetrics, 0)
-		assert.Equal(t, recorder.metricNames.Len(), 4)
 
 		mockSampler.AssertExpectations(t)
 	})

--- a/sample/sample_test.go
+++ b/sample/sample_test.go
@@ -391,7 +391,7 @@ func TestDynsamplerMetricsRecorder_RegisterMetrics(t *testing.T) {
 		// Verify internal state
 		assert.Equal(t, "test_", recorder.dynPrefix)
 		assert.Len(t, recorder.lastMetrics, 3)
-		assert.Len(t, recorder.metricNames, 4)
+		assert.Equal(t, 4, recorder.metricNames.Len())
 
 		assert.Equal(t, internalDysamplerMetric{
 			metricType: metrics.Gauge,
@@ -404,16 +404,10 @@ func TestDynsamplerMetricsRecorder_RegisterMetrics(t *testing.T) {
 		}, recorder.lastMetrics["test_counter_count"])
 
 		// Check metric names mapping
-		assert.Equal(t, "test_num_dropped", recorder.metricNames["_num_dropped"])
-		assert.Equal(t, "test_num_kept", recorder.metricNames["_num_kept"])
-		assert.Equal(t, "test_sample_rate", recorder.metricNames["_sample_rate"])
-		assert.Equal(t, "test_sampler_key_cardinality", recorder.metricNames["_sampler_key_cardinality"])
-
-		// Verify metrics were registered
-		assert.Contains(t, mockMetrics.Registrations, "test_gauge_metric")
-		assert.Equal(t, "gauge", mockMetrics.Registrations["test_gauge_metric"])
-		assert.Contains(t, mockMetrics.Registrations, "test_counter_count")
-		assert.Equal(t, "counter", mockMetrics.Registrations["test_counter_count"])
+		assert.Equal(t, "test_num_dropped", recorder.metricNames.Get("_num_dropped"))
+		assert.Equal(t, "test_num_kept", recorder.metricNames.Get("_num_kept"))
+		assert.Equal(t, "test_sample_rate", recorder.metricNames.Get("_sample_rate"))
+		assert.Equal(t, "test_sampler_key_cardinality", recorder.metricNames.Get("_sampler_key_cardinality"))
 
 		mockSampler.AssertExpectations(t)
 	})
@@ -429,17 +423,14 @@ func TestDynsamplerMetricsRecorder_RegisterMetrics(t *testing.T) {
 			prefix:      "empty",
 			lastMetrics: make(map[string]internalDysamplerMetric),
 			met:         mockMetrics,
-			metricNames: make(map[string]string),
+			metricNames: metrics.NewComputedMetricNames("empty_", samplerMetrics),
 		}
 
 		recorder.RegisterMetrics(mockSampler)
 
 		assert.Equal(t, "empty_", recorder.dynPrefix)
 		assert.Len(t, recorder.lastMetrics, 0)
-		assert.Len(t, recorder.metricNames, 4)
-
-		// Should still register the 4 standard sampler metrics
-		assert.Len(t, mockMetrics.Registrations, 4)
+		assert.Equal(t, recorder.metricNames.Len(), 4)
 
 		mockSampler.AssertExpectations(t)
 	})

--- a/types/router_types.go
+++ b/types/router_types.go
@@ -1,0 +1,28 @@
+package types
+
+// RouterType defines which type of traffic a component is handling.
+type RouterType int
+
+const (
+	RouterTypeIncoming RouterType = iota
+	RouterTypePeer
+)
+
+func (rt RouterType) String() string {
+	switch rt {
+	case RouterTypeIncoming:
+		return "incoming"
+	case RouterTypePeer:
+		return "peer"
+	default:
+		return "unknown"
+	}
+}
+
+func (rt RouterType) IsIncoming() bool {
+	return rt == RouterTypeIncoming
+}
+
+func (rt RouterType) IsPeer() bool {
+	return rt == RouterTypePeer
+}

--- a/types/router_types.go
+++ b/types/router_types.go
@@ -1,21 +1,20 @@
 package types
 
-// RouterType defines which type of traffic a component is handling.
-type RouterType string
+// RouterType is a type that represents whether an event is incoming or from a peer.
+type RouterType bool
 
 const (
-	RouterTypeIncoming RouterType = "incoming"
-	RouterTypePeer     RouterType = "peer"
+	RouterTypeIncoming RouterType = true
+	RouterTypePeer     RouterType = false
 )
 
 func (rt RouterType) String() string {
-	return string(rt)
+	if rt {
+		return "incoming"
+	}
+	return "peer"
 }
 
 func (rt RouterType) IsIncoming() bool {
 	return rt == RouterTypeIncoming
-}
-
-func (rt RouterType) IsPeer() bool {
-	return rt == RouterTypePeer
 }

--- a/types/router_types.go
+++ b/types/router_types.go
@@ -1,22 +1,15 @@
 package types
 
 // RouterType defines which type of traffic a component is handling.
-type RouterType int
+type RouterType string
 
 const (
-	RouterTypeIncoming RouterType = iota
-	RouterTypePeer
+	RouterTypeIncoming RouterType = "incoming"
+	RouterTypePeer     RouterType = "peer"
 )
 
 func (rt RouterType) String() string {
-	switch rt {
-	case RouterTypeIncoming:
-		return "incoming"
-	case RouterTypePeer:
-		return "peer"
-	default:
-		return "unknown"
-	}
+	return string(rt)
 }
 
 func (rt RouterType) IsIncoming() bool {


### PR DESCRIPTION
## Which problem is this PR solving?

When a string is dynamically created, it's allocated on the heap. This creates pressure on the GC which is biggest performance issue Refinery is currently battling with

## Short description of the changes

- Only compute necessary metric names once during startup
- store the computed result as struct fields for quicker access

## Benchmarks
```
**OLD**
goos: darwin
goarch: arm64
pkg: github.com/honeycombio/refinery/route
cpu: Apple M2 Max
BenchmarkRouterBatch-12    	5418073	     8647 ns/op	  17322 B/op	     41 allocs/op
PASS
ok  	github.com/honeycombio/refinery/route	47.190s

**NEW**
goos: darwin
goarch: arm64
pkg: github.com/honeycombio/refinery/route
cpu: Apple M2 Max
BenchmarkRouterBatch-12    	5644776	     8416 ns/op	  17092 B/op	     33 allocs/op
PASS
ok  	github.com/honeycombio/refinery/route	47.861s
```

