### PR TITLE
perf: reduce lock contention for internal metrics

### DIFF
--- a/cmd/refinery/main.go
+++ b/cmd/refinery/main.go
@@ -188,9 +188,9 @@ func main() {
 
 	// we need to include all the metrics types so we can inject them in case they're needed
 	// but we only want to instantiate the ones that are enabled with non-null values
-	var legacyMetrics metrics.Metrics = &metrics.NullMetrics{}
-	var promMetrics metrics.Metrics = &metrics.NullMetrics{}
-	var oTelMetrics metrics.Metrics = &metrics.NullMetrics{}
+	var legacyMetrics metrics.MetricsBackend = &metrics.NullMetrics{}
+	var promMetrics metrics.MetricsBackend = &metrics.NullMetrics{}
+	var oTelMetrics metrics.MetricsBackend = &metrics.NullMetrics{}
 	if c.GetLegacyMetricsConfig().Enabled {
 		legacyMetrics = &metrics.LegacyMetrics{}
 	}

--- a/logger/honeycomb.go
+++ b/logger/honeycomb.go
@@ -48,11 +48,12 @@ func (h *HoneycombLogger) Start() error {
 	} else {
 		loggerTx = &transmission.Honeycomb{
 			// logs are often sent in flurries; flush every half second
-			MaxBatchSize:        100,
-			BatchTimeout:        500 * time.Millisecond,
-			UserAgentAddition:   "refinery/" + h.Version + " (metrics)",
-			Transport:           h.UpstreamTransport,
-			PendingWorkCapacity: libhoney.DefaultPendingWorkCapacity,
+			MaxBatchSize:          100,
+			BatchTimeout:          500 * time.Millisecond,
+			UserAgentAddition:     "refinery/" + h.Version + " (metrics)",
+			Transport:             h.UpstreamTransport,
+			PendingWorkCapacity:   libhoney.DefaultPendingWorkCapacity,
+			EnableMsgpackEncoding: true,
 		}
 	}
 

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -14,8 +14,8 @@ import (
 // objects. This allows us to support multiple metrics backends at once.
 //
 // The user can configure which metrics backends are enabled, and which are not.
-// The StoreMetrics object is always enabled, and is the first child of the
-// MultiMetrics object. This is because we always want StressRelief to be able
+// Metrics contains two more methods for retrieving metrics data: Get() and Store().
+// This is because we always want StressRelief to be able
 // to retrieve metrics data even if the user has not configured any other
 // metrics backends.
 //
@@ -33,6 +33,12 @@ import (
 // used in combination with other metrics. This is mainly to support
 // StressRelief.
 type Metrics interface {
+	MetricsBackend
+	Get(name string) (float64, bool) // for reading back a counter or a gauge
+	Store(name string, val float64)  // for storing a rarely-changing value not sent as a metric
+}
+
+type MetricsBackend interface {
 	// Register declares a metric; metricType should be one of counter, gauge, histogram, updown
 	Register(metadata Metadata)
 	Increment(name string)              // for counters
@@ -41,8 +47,6 @@ type Metrics interface {
 	Histogram(name string, obs float64) // for histogram
 	Up(name string)                     // for updown
 	Down(name string)                   // for updown
-	Get(name string) (float64, bool)    // for reading back a counter or a gauge
-	Store(name string, val float64)     // for storing a rarely-changing value not sent as a metric
 }
 
 func GetMetricsImplementation(c config.Config) *MultiMetrics {

--- a/metrics/multi_metrics.go
+++ b/metrics/multi_metrics.go
@@ -16,18 +16,18 @@ var _ Metrics = (*MultiMetrics)(nil)
 // which can then be retrieved with Get(). This is for use with StressRelief and OpAMP agent. It
 // does not track histograms, which are reset after each scrape.
 type MultiMetrics struct {
-	Config        config.Config `inject:""`
-	LegacyMetrics Metrics       `inject:"legacyMetrics"`
-	PromMetrics   Metrics       `inject:"promMetrics"`
-	OTelMetrics   Metrics       `inject:"otelMetrics"`
-	children      []Metrics
+	Config        config.Config  `inject:""`
+	LegacyMetrics MetricsBackend `inject:"legacyMetrics"`
+	PromMetrics   MetricsBackend `inject:"promMetrics"`
+	OTelMetrics   MetricsBackend `inject:"otelMetrics"`
+	children      []MetricsBackend
 	values        map[string]float64
 	lock          sync.RWMutex
 }
 
 func NewMultiMetrics() *MultiMetrics {
 	return &MultiMetrics{
-		children: []Metrics{},
+		children: []MetricsBackend{},
 		values:   make(map[string]float64),
 	}
 }
@@ -52,14 +52,14 @@ func (m *MultiMetrics) Start() error {
 	return nil
 }
 
-func (m *MultiMetrics) AddChild(met Metrics) {
+func (m *MultiMetrics) AddChild(met MetricsBackend) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 	m.children = append(m.children, met)
 }
 
 // This is not safe for concurrent use!
-func (m *MultiMetrics) Children() []Metrics {
+func (m *MultiMetrics) Children() []MetricsBackend {
 	return m.children
 }
 

--- a/metrics/multi_metrics_test.go
+++ b/metrics/multi_metrics_test.go
@@ -132,8 +132,8 @@ func BenchmarkConcurrentAccess(b *testing.B) {
 
 	mm, err := getAndStartMultiMetrics(
 		legacyMetrics,
-		//promMetrics,
-		//otelMetrics,
+		promMetrics,
+		otelMetrics,
 	)
 	if err != nil {
 		b.Fatalf("Failed to setup MultiMetrics: %v", err)

--- a/metrics/multi_metrics_test.go
+++ b/metrics/multi_metrics_test.go
@@ -25,7 +25,7 @@ func (d dummyLogger) Errorf(format string, v ...interface{}) {
 	fmt.Println()
 }
 
-func getAndStartMultiMetrics(children ...Metrics) (*MultiMetrics, error) {
+func getAndStartMultiMetrics(children ...MetricsBackend) (*MultiMetrics, error) {
 	mm := NewMultiMetrics()
 	for _, child := range children {
 		mm.AddChild(child)

--- a/metrics/multi_metrics_test.go
+++ b/metrics/multi_metrics_test.go
@@ -132,8 +132,8 @@ func BenchmarkConcurrentAccess(b *testing.B) {
 
 	mm, err := getAndStartMultiMetrics(
 		legacyMetrics,
-		promMetrics,
-		otelMetrics,
+		//promMetrics,
+		//otelMetrics,
 	)
 	if err != nil {
 		b.Fatalf("Failed to setup MultiMetrics: %v", err)

--- a/metrics/otel_metrics.go
+++ b/metrics/otel_metrics.go
@@ -35,15 +35,12 @@ type OTelMetrics struct {
 	meter        metric.Meter
 	shutdownFunc func(ctx context.Context) error
 
-	counters   map[string]metric.Int64Counter
-	gauges     map[string]metric.Float64ObservableGauge
-	histograms map[string]metric.Float64Histogram
-	updowns    map[string]metric.Int64UpDownCounter
-
-	// values keeps a map of all the non-histogram metrics and their current value
-	// so that we can retrieve them with Get()
-	values map[string]float64
-	lock   sync.RWMutex
+	lock             sync.RWMutex
+	counters         map[string]metric.Int64Counter
+	gauges           map[string]metric.Float64Gauge
+	histograms       map[string]metric.Float64Histogram
+	updowns          map[string]metric.Int64UpDownCounter
+	observableGauges map[string]metric.Float64ObservableGauge
 }
 
 // Start initializes all metrics or resets all metrics to zero
@@ -54,11 +51,10 @@ func (o *OTelMetrics) Start() error {
 	defer o.lock.Unlock()
 
 	o.counters = make(map[string]metric.Int64Counter)
-	o.gauges = make(map[string]metric.Float64ObservableGauge)
+	o.gauges = make(map[string]metric.Float64Gauge)
 	o.histograms = make(map[string]metric.Float64Histogram)
 	o.updowns = make(map[string]metric.Int64UpDownCounter)
-
-	o.values = make(map[string]float64)
+	o.observableGauges = make(map[string]metric.Float64ObservableGauge)
 
 	ctx := context.Background()
 
@@ -155,7 +151,7 @@ func (o *OTelMetrics) Start() error {
 		return err
 	}
 
-	o.gauges[name] = g
+	o.observableGauges[name] = g
 
 	name = "memory_inuse"
 	// This is just reporting the gauge we already track under a different name.
@@ -169,7 +165,7 @@ func (o *OTelMetrics) Start() error {
 	if err != nil {
 		return err
 	}
-	o.gauges[name] = g
+	o.observableGauges[name] = g
 
 	startTime := time.Now()
 	name = "process_uptime_seconds"
@@ -181,7 +177,7 @@ func (o *OTelMetrics) Start() error {
 	if err != nil {
 		return err
 	}
-	o.gauges[name] = g
+	o.observableGauges[name] = g
 
 	return nil
 }
@@ -245,7 +241,6 @@ func (o *OTelMetrics) Increment(name string) {
 		}
 	}
 	ctr.Add(context.Background(), 1)
-	o.values[name]++
 }
 
 func (o *OTelMetrics) Gauge(name string, val float64) {
@@ -261,7 +256,6 @@ func (o *OTelMetrics) Gauge(name string, val float64) {
 			return
 		}
 	}
-	o.values[name] = val
 }
 
 func (o *OTelMetrics) Count(name string, val int64) {
@@ -277,7 +271,6 @@ func (o *OTelMetrics) Count(name string, val int64) {
 		}
 	}
 	ctr.Add(context.Background(), val)
-	o.values[name] += float64(val)
 }
 
 func (o *OTelMetrics) Histogram(name string, val float64) {
@@ -293,7 +286,6 @@ func (o *OTelMetrics) Histogram(name string, val float64) {
 		}
 	}
 	h.Record(context.Background(), val)
-	o.values[name] += val
 }
 
 func (o *OTelMetrics) Up(name string) {
@@ -309,7 +301,6 @@ func (o *OTelMetrics) Up(name string) {
 		}
 	}
 	ud.Add(context.Background(), 1)
-	o.values[name]++
 }
 
 func (o *OTelMetrics) Down(name string) {
@@ -325,22 +316,14 @@ func (o *OTelMetrics) Down(name string) {
 		}
 	}
 	ud.Add(context.Background(), -1)
-	o.values[name]--
 }
 
 func (o *OTelMetrics) Store(name string, value float64) {
-	o.lock.Lock()
-	defer o.lock.Unlock()
-
-	o.values[name] = value
+	return
 }
 
 func (o *OTelMetrics) Get(name string) (float64, bool) {
-	o.lock.RLock()
-	defer o.lock.RUnlock()
-
-	val, ok := o.values[name]
-	return val, ok
+	return 0, false
 }
 
 // initCounter initializes a new counter metric with the given metadata
@@ -364,24 +347,11 @@ func (o *OTelMetrics) initCounter(metadata Metadata) (metric.Int64Counter, error
 
 // initGauge initializes a new gauge metric with the given metadata
 // It should be used while holding the metrics lock.
-func (o *OTelMetrics) initGauge(metadata Metadata) (metric.Float64ObservableGauge, error) {
+func (o *OTelMetrics) initGauge(metadata Metadata) (metric.Float64Gauge, error) {
 	unit := string(metadata.Unit)
-	var f metric.Float64Callback = func(_ context.Context, result metric.Float64Observer) error {
-		// this callback is invoked from outside this function call, so we
-		// need to Rlock when we read the values map. We don't know how long
-		// Observe() takes, so we make a copy of the value and unlock before
-		// calling Observe.
-		o.lock.RLock()
-		v := o.values[metadata.Name]
-		o.lock.RUnlock()
-
-		result.Observe(v)
-		return nil
-	}
-	g, err := o.meter.Float64ObservableGauge(metadata.Name,
+	g, err := o.meter.Float64Gauge(metadata.Name,
 		metric.WithUnit(unit),
 		metric.WithDescription(metadata.Description),
-		metric.WithFloat64Callback(f),
 	)
 	if err != nil {
 		return nil, err

--- a/metrics/otel_metrics.go
+++ b/metrics/otel_metrics.go
@@ -247,7 +247,8 @@ func (o *OTelMetrics) Gauge(name string, val float64) {
 	o.lock.Lock()
 	defer o.lock.Unlock()
 
-	if _, ok := o.gauges[name]; !ok {
+	g, ok := o.gauges[name]
+	if !ok {
 		_, err := o.initGauge(Metadata{
 			Name: name,
 		})
@@ -256,6 +257,8 @@ func (o *OTelMetrics) Gauge(name string, val float64) {
 			return
 		}
 	}
+
+	g.Record(context.Background(), val)
 }
 
 func (o *OTelMetrics) Count(name string, val int64) {

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -13,7 +13,7 @@ import (
 	"github.com/honeycombio/refinery/logger"
 )
 
-var _ Metrics = (*PromMetrics)(nil)
+var _ MetricsBackend = (*PromMetrics)(nil)
 
 type PromMetrics struct {
 	Config config.Config `inject:""`
@@ -80,10 +80,6 @@ func (p *PromMetrics) Register(metadata Metadata) {
 	}
 
 	p.metrics[metadata.Name] = newmet
-}
-
-func (p *PromMetrics) Get(name string) (float64, bool) {
-	return 0, false
 }
 
 func (p *PromMetrics) Increment(name string) {
@@ -153,8 +149,4 @@ func (p *PromMetrics) Down(name string) {
 			gauge.Dec()
 		}
 	}
-}
-
-func (p *PromMetrics) Store(name string, val float64) {
-	return
 }


### PR DESCRIPTION
## Which problem is this PR solving?

Refinery supports three metrics backends: libhoney (Honeycomb), OpenTelemetry (OTel), and Prometheus. Users can enable one or more of these backends simultaneously through the MultiMetrics wrapper.

Currently, each metrics implementation—including MultiMetrics—maintains its own internal locks and in-memory copies of metrics. This leads to unnecessary duplication, especially for metrics critical to the Stress Relief system, where we only need a single shared in-memory representation.

Additionally:
- OTel and Prometheus implementations are already thread-safe and do not require extra synchronization.
- The libhoney implementation previously relied on a mutex for concurrency control. This PR updates it to use atomic operations instead, reducing lock contention and improving performance under load.

## Short description of the changes

- Replace mutex with atomic operation for all metrics except histogram in libhoney metrics
- Remove inmemory metrics value in both OTel and Prometheus since MultiMetrics is storing them already
- Only hold locks for map access to retrieve a metric by name in OTel and Prometheus metrics
- Enable msgpack encoding for libhoney metrics and logger.
- Add tests and benchmark tests

## Benchmark
```
goos: darwin
goarch: arm64
pkg: github.com/honeycombio/refinery/metrics
cpu: Apple M2 Max
                                         │   old.txt    │                new.txt                │
                                         │    sec/op    │    sec/op     vs base                 │
ConcurrentAccess/ConcurrentCounters-12     437.2n ± ∞ ¹   354.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
ConcurrentAccess/ConcurrentGauges-12       353.7n ± ∞ ¹   238.9n ± ∞ ¹        ~ (p=1.000 n=1) ²
ConcurrentAccess/ConcurrentHistograms-12   482.7n ± ∞ ¹   356.8n ± ∞ ¹        ~ (p=1.000 n=1) ²
ConcurrentAccess/ConcurrentMixed-12        483.6n ± ∞ ¹   368.9n ± ∞ ¹        ~ (p=1.000 n=1) ²
geomean                                    435.9n         324.8n        -25.48%
```
