### PR TITLE
fix: use unique port number for integration test

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.23.2
+golang 1.24.1

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -362,7 +362,7 @@ func TestAppIntegrationWithUnauthorizedKey(t *testing.T) {
 
 func TestAppIntegrationEmptyEvent(t *testing.T) {
 	t.Parallel()
-	port := 11000
+	port := 16000
 	redisDB := 8
 
 	sender := &transmission.MockSender{}


### PR DESCRIPTION
## Which problem is this PR solving?

Integration tests are running in parallel. We need to use unique port for each of them

## Short description of the changes

- use unique port number for `TestAppIntegrationEmptyEvent`

