### PR TITLE
ci: extend deadline for a wait in a flaky test

### DIFF
--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -1157,9 +1157,12 @@ func TestAddSpanCount(t *testing.T) {
 	coll.AddSpanFromPeer(span)
 	coll.AddSpanFromPeer(decisionSpan)
 
-	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-		assert.Equal(collect, traceID, coll.getFromCache(traceID).TraceID, "after adding the span, we should have a trace in the cache with the right trace ID")
-	}, conf.GetTracesConfig().GetSendTickerValue()*6, conf.GetTracesConfig().GetSendTickerValue()*2)
+	assert.EventuallyWithT(t,
+		func(collect *assert.CollectT) { assert.Equal(collect, traceID, coll.getFromCache(traceID).TraceID) },
+		conf.GetTracesConfig().GetSendTickerValue()*60, // waitFor
+		conf.GetTracesConfig().GetSendTickerValue()*2,  // tick
+		"within a reasonable time, cache should contain a traceID matching the one from the span we added",
+	)
 	assert.Equal(t, 0, len(transmission.GetBlock(0)), "adding a non-root span should not yet send the span")
 
 	// ok now let's add the root span and verify that both got sent


### PR DESCRIPTION
## Which problem is this PR solving?

The eventually assertion in TestAddSpanCount would flake in CI[1] and occasionally in local dev when put under duress. 

## Short description of the changes

Extend the deadline to reduce flakiness (and some code formatting for readability).

[1: example CI failure](https://app.circleci.com/pipelines/github/honeycombio/refinery/5191/workflows/c8021ab7-9a98-4cb2-bf48-bdf68a08b9d3/jobs/17051/steps?invite=true#step-107-52566_42)