### PR TITLE
perf: use read lock in Prometheus metrics Down operation

### DIFF
--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -140,9 +140,9 @@ func (p *PromMetrics) Up(name string) {
 }
 
 func (p *PromMetrics) Down(name string) {
-	p.lock.Lock()
+	p.lock.RLock()
 	gaugeIface, ok := p.metrics[name]
-	p.lock.Unlock()
+	p.lock.RUnlock()
 
 	if ok {
 		if gauge, ok := gaugeIface.(prometheus.Gauge); ok {


### PR DESCRIPTION
## Which problem is this PR solving?

We missed a spot in the prometheus metrics when switching from write lock to read lock.

## Short description of the changes

- use read lock in Down when retrieving a gauge by name

