### PR TITLE
maint: upgrade dynsampler-go to 0.6.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/gorilla/mux v1.8.1
 	github.com/grafana/pyroscope-go/godeltaprof v0.1.8
 	github.com/hashicorp/golang-lru/v2 v2.0.7
-	github.com/honeycombio/dynsampler-go v0.6.0
+	github.com/honeycombio/dynsampler-go v0.6.3
 	github.com/honeycombio/hpsf v0.5.1-0.20250605195630-9b072f9dbd61
 	github.com/honeycombio/husky v0.36.0
 	github.com/honeycombio/libhoney-go v1.25.0

--- a/go.sum
+++ b/go.sum
@@ -119,8 +119,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3 h1:5ZPtiqj0JL5oKWmcsq4VMaAW5uk
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3/go.mod h1:ndYquD05frm2vACXE1nsccT4oJzjhw2arTS2cpUD1PI=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
-github.com/honeycombio/dynsampler-go v0.6.0 h1:fs4mrfeFGU5V+ClwpblFzbWqn4Apb+lKlE7Ja5zL22I=
-github.com/honeycombio/dynsampler-go v0.6.0/go.mod h1:pJqWFeoMN3syX74PEvlusieyGBbtIBjmTVjLc3thmK4=
+github.com/honeycombio/dynsampler-go v0.6.3 h1:myYNnqVbcJWac/dFfACWjobQFQcZXwkGL5o27eOm/o0=
+github.com/honeycombio/dynsampler-go v0.6.3/go.mod h1:mqCYD3JbAEgRvxu52Q0doTO3wKEUvEott8H8VMEpnQ0=
 github.com/honeycombio/hpsf v0.5.1-0.20250605195630-9b072f9dbd61 h1:cll8fstVhA805sKS5xjIVw/hKOz40qHpVvgAkg/h4hw=
 github.com/honeycombio/hpsf v0.5.1-0.20250605195630-9b072f9dbd61/go.mod h1:29/tpyeKw7tbT7mw1WCjMR6lqul7tmtNpuO0RICwzXk=
 github.com/honeycombio/husky v0.36.0 h1:IxVSFE4p+AHm/ip3qPNbTV1ZGf/0VQxUab8ah+nWVlw=


### PR DESCRIPTION
## Which problem is this PR solving?

We would like to take advantage of the https://github.com/honeycombio/dynsampler-go/pull/81 from the 0.6.3 release

## Short description of the changes

- upgrade dynsampler-go version

