### PR TITLE
fix: correct type for processing a span from a peer

### DIFF
--- a/collect/collect.go
+++ b/collect/collect.go
@@ -434,7 +434,7 @@ func (i *InMemCollector) collect() {
 				span.End()
 				return
 			}
-			i.processSpan(ctx, sp, types.RouterTypeIncoming)
+			i.processSpan(ctx, sp, types.RouterTypePeer)
 		default:
 			select {
 			case msg, ok := <-i.dropDecisionMessages:


### PR DESCRIPTION
## Which problem is this PR solving?

Spans arriving via the `i.fromPeer` channel could get counted in metrics as _incoming_ instead of _peer_ router spans.

## Short description of the changes

Correct the mismatch introduced when we changed the source/router-type from a string (`"peer"`) to a Go type (`types.RouterTypePeer`).

