### PR TITLE
maint: relocate pure function config.IsLegacyAPIKey() to the file defining the Config interface

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -198,3 +198,38 @@ func WithRulesData(in configData) ReloadedConfigDataOption {
 		c.rules = append(c.rules, in)
 	}
 }
+
+func IsLegacyAPIKey(key string) bool {
+	keyLen := len(key)
+
+	switch keyLen {
+	case 32:
+		// Check if all characters are hex digits (0-9, a-f)
+		for i := 0; i < keyLen; i++ {
+			c := key[i]
+			if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+				return false
+			}
+		}
+		return true
+	case 64:
+		// Check the prefix pattern "hc[a-z]ic_"
+		if key[:2] != "hc" || key[3:6] != "ic_" {
+			return false
+		}
+		if key[2] < 'a' || key[2] > 'z' {
+			return false
+		}
+
+		// Check if the remaining characters are alphanumeric lowercase
+		for i := 6; i < keyLen; i++ {
+			c := key[i]
+			if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'z')) {
+				return false
+			}
+		}
+		return true
+	default:
+		return false
+	}
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1251,6 +1251,8 @@ func TestIsLegacyKey(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result := config.IsLegacyAPIKey(tc.key)
 			assert.Equal(t, tc.expected, result, "Expected IsLegacyApiKey(%q) to return %v", tc.key, tc.expected)
+			huskysResult := otlp.IsClassicApiKey(tc.key)
+			assert.Equal(t, huskysResult, result, "Expect IsLegacyApiKey() output to match husky's IsClassicApiKey()")
 		})
 	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/honeycombio/husky/otlp"
 	"github.com/honeycombio/refinery/config"
 	"github.com/honeycombio/refinery/internal/configwatcher"
 	"github.com/honeycombio/refinery/logger"
@@ -1201,4 +1202,81 @@ func TestHealthCheckTimeout(t *testing.T) {
 		})
 	}
 
+}
+
+func TestIsLegacyKey(t *testing.T) {
+	testCases := []struct {
+		name     string
+		key      string
+		expected bool
+	}{
+		// 32-character classic API keys (hex digits only)
+		{name: "valid 32-char classic key - all lowercase", key: "a1b2c3d4e5f67890abcdef1234567890", expected: true},
+		{name: "valid 32-char classic key - all numbers", key: "12345678901234567890123456789012", expected: true},
+		{name: "valid 32-char classic key - all lowercase letters", key: "abcdefabcdefabcdefabcdefabcdefab", expected: true},
+		{name: "valid 32-char classic key - mixed hex", key: "0123456789abcdef0123456789abcdef", expected: true},
+		{name: "invalid 32-char key - uppercase letters", key: "A1B2C3D4E5F67890ABCDEF1234567890", expected: false},
+		{name: "invalid 32-char key - contains g", key: "a1b2c3d4e5f67890abcdefg234567890", expected: false},
+		{name: "invalid 32-char key - contains special chars", key: "a1b2c3d4e5f67890abcdef123456789!", expected: false},
+		{name: "invalid 32-char key - contains space", key: "a1b2c3d4e5f67890abcdef12345 7890", expected: false},
+
+		// 64-character classic ingest keys (pattern: ^hc[a-z]ic_[0-9a-z]*$)
+		{name: "valid 64-char ingest key - hcaic", key: "hcaic_1234567890123456789012345678901234567890123456789012345678", expected: true},
+		{name: "valid 64-char ingest key - hcbic", key: "hcbic_abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234", expected: true},
+		{name: "valid 64-char ingest key - hczic", key: "hczic_0123456789abcdef0123456789abcdef0123456789abcdef0123456789", expected: true},
+		{name: "valid 64-char ingest key - mixed", key: "hcxic_1234567890123456789012345678901234567890123456789012345678", expected: true},
+		{name: "invalid 64-char ingest key - wrong prefix", key: "hc1ic_1234567890123456789012345678901234567890123456789012345678", expected: false},
+		{name: "invalid 64-char ingest key - uppercase in prefix", key: "hcAic_1234567890123456789012345678901234567890123456789012345678", expected: false},
+		{name: "invalid 64-char ingest key - missing underscore", key: "hcaic1234567890123456789012345678901234567890123456789012345678", expected: false},
+		{name: "invalid 64-char ingest key - uppercase in suffix", key: "hcaic_1234567890123456789012345678901234567890123456789012345A78", expected: false},
+		{name: "invalid 64-char ingest key - special char in suffix", key: "hcaic_123456789012345678901234567890123456789012345678901234567!", expected: false},
+
+		// Edge cases for length
+		{name: "empty key", key: "", expected: false},
+		{name: "too short - 31 chars", key: "a1b2c3d4e5f67890abcdef123456789", expected: false},
+		{name: "too long - 33 chars", key: "a1b2c3d4e5f67890abcdef12345678901", expected: false},
+		{name: "too short - 63 chars", key: "hcaic_123456789012345678901234567890123456789012345678901234567", expected: false},
+		{name: "too long - 65 chars", key: "hcaic_12345678901234567890123456789012345678901234567890123456789", expected: false},
+
+		// Non-classic keys (E&S keys should return false)
+		{name: "E&S key", key: "abc123DEF456ghi789jklm", expected: false},
+		{name: "E&S ingest key", key: "hcxik_1234567890123456789012345678901234567890123456789012345678", expected: false},
+
+		// Invalid patterns
+		{name: "random string", key: "this-is-not-a-key", expected: false},
+		{name: "numbers only but wrong length", key: "123456789012", expected: false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := config.IsLegacyAPIKey(tc.key)
+			assert.Equal(t, tc.expected, result, "Expected IsLegacyApiKey(%q) to return %v", tc.key, tc.expected)
+		})
+	}
+}
+
+func BenchmarkIsLegacyAPIKey(b *testing.B) {
+	tests := []struct {
+		name string
+		key  string
+	}{
+		{"Valid classic key", "a1b2c3d4e5f67890abcdef1234567890"},
+		{"Invalid classic key", "abcdef0123456789abcdef01234567zz"},
+		{"Valid ingest key", "hcaic_1234567890123456789012345678901234567890123456789012345678"},
+		{"Invalid ingest key", "hcaic_1234567890123456789012345678901234567890123456789012345678"},
+	}
+
+	for _, tt := range tests {
+		b.Run(tt.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = config.IsLegacyAPIKey(tt.key)
+			}
+		})
+
+		b.Run(tt.name+"/husky", func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = otlp.IsClassicApiKey(tt.key)
+			}
+		})
+	}
 }

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -1115,38 +1115,3 @@ func (f *fileConfig) GetAdditionalAttributes() map[string]string {
 
 	return f.mainConfig.Specialized.AdditionalAttributes
 }
-
-func IsLegacyAPIKey(key string) bool {
-	keyLen := len(key)
-
-	switch keyLen {
-	case 32:
-		// Check if all characters are hex digits (0-9, a-f)
-		for i := 0; i < keyLen; i++ {
-			c := key[i]
-			if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
-				return false
-			}
-		}
-		return true
-	case 64:
-		// Check the prefix pattern "hc[a-z]ic_"
-		if key[:2] != "hc" || key[3:6] != "ic_" {
-			return false
-		}
-		if key[2] < 'a' || key[2] > 'z' {
-			return false
-		}
-
-		// Check if the remaining characters are alphanumeric lowercase
-		for i := 6; i < keyLen; i++ {
-			c := key[i]
-			if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'z')) {
-				return false
-			}
-		}
-		return true
-	default:
-		return false
-	}
-}

--- a/config/file_config_test.go
+++ b/config/file_config_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/honeycombio/husky/otlp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -246,83 +245,6 @@ func TestGetSamplingKeyFieldsForDestName(t *testing.T) {
 				"getSamplingKeyFieldsForDestName(%q) = %v, want %v",
 				tc.destName, result, tc.expected,
 			)
-		})
-	}
-}
-
-func TestIsLegacyKey(t *testing.T) {
-	testCases := []struct {
-		name     string
-		key      string
-		expected bool
-	}{
-		// 32-character classic API keys (hex digits only)
-		{name: "valid 32-char classic key - all lowercase", key: "a1b2c3d4e5f67890abcdef1234567890", expected: true},
-		{name: "valid 32-char classic key - all numbers", key: "12345678901234567890123456789012", expected: true},
-		{name: "valid 32-char classic key - all lowercase letters", key: "abcdefabcdefabcdefabcdefabcdefab", expected: true},
-		{name: "valid 32-char classic key - mixed hex", key: "0123456789abcdef0123456789abcdef", expected: true},
-		{name: "invalid 32-char key - uppercase letters", key: "A1B2C3D4E5F67890ABCDEF1234567890", expected: false},
-		{name: "invalid 32-char key - contains g", key: "a1b2c3d4e5f67890abcdefg234567890", expected: false},
-		{name: "invalid 32-char key - contains special chars", key: "a1b2c3d4e5f67890abcdef123456789!", expected: false},
-		{name: "invalid 32-char key - contains space", key: "a1b2c3d4e5f67890abcdef12345 7890", expected: false},
-
-		// 64-character classic ingest keys (pattern: ^hc[a-z]ic_[0-9a-z]*$)
-		{name: "valid 64-char ingest key - hcaic", key: "hcaic_1234567890123456789012345678901234567890123456789012345678", expected: true},
-		{name: "valid 64-char ingest key - hcbic", key: "hcbic_abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234", expected: true},
-		{name: "valid 64-char ingest key - hczic", key: "hczic_0123456789abcdef0123456789abcdef0123456789abcdef0123456789", expected: true},
-		{name: "valid 64-char ingest key - mixed", key: "hcxic_1234567890123456789012345678901234567890123456789012345678", expected: true},
-		{name: "invalid 64-char ingest key - wrong prefix", key: "hc1ic_1234567890123456789012345678901234567890123456789012345678", expected: false},
-		{name: "invalid 64-char ingest key - uppercase in prefix", key: "hcAic_1234567890123456789012345678901234567890123456789012345678", expected: false},
-		{name: "invalid 64-char ingest key - missing underscore", key: "hcaic1234567890123456789012345678901234567890123456789012345678", expected: false},
-		{name: "invalid 64-char ingest key - uppercase in suffix", key: "hcaic_1234567890123456789012345678901234567890123456789012345A78", expected: false},
-		{name: "invalid 64-char ingest key - special char in suffix", key: "hcaic_123456789012345678901234567890123456789012345678901234567!", expected: false},
-
-		// Edge cases for length
-		{name: "empty key", key: "", expected: false},
-		{name: "too short - 31 chars", key: "a1b2c3d4e5f67890abcdef123456789", expected: false},
-		{name: "too long - 33 chars", key: "a1b2c3d4e5f67890abcdef12345678901", expected: false},
-		{name: "too short - 63 chars", key: "hcaic_123456789012345678901234567890123456789012345678901234567", expected: false},
-		{name: "too long - 65 chars", key: "hcaic_12345678901234567890123456789012345678901234567890123456789", expected: false},
-
-		// Non-classic keys (E&S keys should return false)
-		{name: "E&S key", key: "abc123DEF456ghi789jklm", expected: false},
-		{name: "E&S ingest key", key: "hcxik_1234567890123456789012345678901234567890123456789012345678", expected: false},
-
-		// Invalid patterns
-		{name: "random string", key: "this-is-not-a-key", expected: false},
-		{name: "numbers only but wrong length", key: "123456789012", expected: false},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			result := IsLegacyAPIKey(tc.key)
-			assert.Equal(t, tc.expected, result, "Expected IsClassicApiKey(%q) to return %v", tc.key, tc.expected)
-		})
-	}
-}
-
-func BenchmarkIsLegacyAPIKey(b *testing.B) {
-	tests := []struct {
-		name string
-		key  string
-	}{
-		{"Valid classic key", "a1b2c3d4e5f67890abcdef1234567890"},
-		{"Invalid classic key", "abcdef0123456789abcdef01234567zz"},
-		{"Valid ingest key", "hcaic_1234567890123456789012345678901234567890123456789012345678"},
-		{"Invalid ingest key", "hcaic_1234567890123456789012345678901234567890123456789012345678"},
-	}
-
-	for _, tt := range tests {
-		b.Run(tt.name, func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
-				_ = IsLegacyAPIKey(tt.key)
-			}
-		})
-
-		b.Run(tt.name+"/husky", func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
-				_ = otlp.IsClassicApiKey(tt.key)
-			}
 		})
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- I was confused briefly about the location of config.IsLegacyAPIKey(). 

## Short description of the changes

- Since it does not require anything from a real implementation of the Config interface, move the pure function to the file that defines the interface.
- Avoid implementation drift: add an assertion to the test cases to confirm Refinery's legacy key detection behavior matches the key detection in the husky library. 

It's my hope that we can make the same performance improvement to the key detection in husky and remove this implementation from Refinery. Until then, make sure the two libraries agree on what's a legacy key.

