### PR TITLE
fix: implement missing libhoney metrics in DirectTransmit

### DIFF
--- a/transmit/direct_transmit.go
+++ b/transmit/direct_transmit.go
@@ -43,6 +43,7 @@ const (
 	updownQueuedItems           = "_queued_items"
 	histogramQueueTime          = "_queue_time"
 	gaugeQueueLength            = "_queue_length"
+	counterSendErrors           = "_send_errors"
 	counterSendRetries          = "_send_retries"
 	counterBatchesSent          = "_batches_sent"
 	counterMessagesSent         = "_messages_sent"
@@ -75,6 +76,7 @@ var transmissionMetrics = []metrics.Metadata{
 	{Name: updownQueuedItems, Type: metrics.UpDown, Unit: metrics.Dimensionless, Description: "The number of events queued for transmission to Honeycomb"},
 	{Name: histogramQueueTime, Type: metrics.Histogram, Unit: metrics.Microseconds, Description: "The time spent in the queue before being sent to Honeycomb"},
 	{Name: gaugeQueueLength, Type: metrics.Gauge, Unit: metrics.Dimensionless, Description: "number of events waiting to be sent to destination"},
+	{Name: counterSendErrors, Type: metrics.Counter, Unit: metrics.Dimensionless, Description: "number of errors encountered while sending events to destination"},
 	{Name: counterSendRetries, Type: metrics.Counter, Unit: metrics.Dimensionless, Description: "number of times a batch of events was retried"},
 	{Name: counterBatchesSent, Type: metrics.Counter, Unit: metrics.Dimensionless, Description: "number of batches of events sent to destination"},
 	{Name: counterMessagesSent, Type: metrics.Counter, Unit: metrics.Dimensionless, Description: "number of messages sent to destination"},
@@ -89,6 +91,7 @@ type metricKeys struct {
 	counterResponseErrors string
 
 	gaugeQueueLength            string
+	counterSendErrors           string
 	counterSendRetries          string
 	counterBatchesSent          string
 	counterMessagesSent         string
@@ -259,19 +262,22 @@ func (d *DirectTransmission) RegisterMetrics() {
 		// Below are metrics previously associated with the libhoney transmission used to send data upstream or to peers.
 		// Even though libhoney isn't used, include the prefix in these metric names to avoid breaking existing Refinery operations boards & queries.
 		case gaugeQueueLength:
-			fullName = "libhoney" + m.Name
+			fullName = "libhoney_" + fullName
 			d.metricKeys.gaugeQueueLength = fullName
+		case counterSendErrors:
+			fullName = "libhoney_" + fullName
+			d.metricKeys.counterSendErrors = fullName
 		case counterSendRetries:
-			fullName = "libhoney" + m.Name
+			fullName = "libhoney_" + fullName
 			d.metricKeys.counterSendRetries = fullName
 		case counterBatchesSent:
-			fullName = "libhoney" + m.Name
+			fullName = "libhoney_" + fullName
 			d.metricKeys.counterBatchesSent = fullName
 		case counterMessagesSent:
-			fullName = "libhoney" + m.Name
+			fullName = "libhoney_" + fullName
 			d.metricKeys.counterMessagesSent = fullName
 		case counterResponseDecodeErrors:
-			fullName = "libhoney" + m.Name
+			fullName = "libhoney_" + fullName
 			d.metricKeys.counterResponseDecodeErrors = fullName
 		}
 		m.Name = fullName // Update the metric name to include the transmit type

--- a/transmit/direct_transmit_test.go
+++ b/transmit/direct_transmit_test.go
@@ -509,6 +509,18 @@ func TestDirectTransmission(t *testing.T) {
 	require.NoError(t, err)
 	defer dt.Stop()
 	dt.RegisterMetrics()
+	assert.Equal(t, "upstream_queued_items", dt.metricKeys.updownQueuedItems)
+	assert.Equal(t, "upstream_response_20x", dt.metricKeys.counterResponse20x)
+	assert.Equal(t, "upstream_response_errors", dt.metricKeys.counterResponseErrors)
+	assert.Equal(t, "upstream_enqueue_errors", dt.metricKeys.counterEnqueueErrors)
+	assert.Equal(t, "upstream_queue_time", dt.metricKeys.histogramQueueTime)
+
+	assert.Equal(t, "libhoney_upstream_send_errors", dt.metricKeys.counterSendErrors)
+	assert.Equal(t, "libhoney_upstream_send_retries", dt.metricKeys.counterSendRetries)
+	assert.Equal(t, "libhoney_upstream_batches_sent", dt.metricKeys.counterBatchesSent)
+	assert.Equal(t, "libhoney_upstream_messages_sent", dt.metricKeys.counterMessagesSent)
+	assert.Equal(t, "libhoney_upstream_queue_length", dt.metricKeys.gaugeQueueLength)
+	assert.Equal(t, "libhoney_upstream_response_decode_errors", dt.metricKeys.counterResponseDecodeErrors)
 
 	now := time.Now().UTC()
 	cfg := &config.MockConfig{

--- a/types/payload_test.go
+++ b/types/payload_test.go
@@ -36,7 +36,8 @@ func TestPayload(t *testing.T) {
 		"meta.refinery.send_by": "never",
 	}
 	mockCfg := &config.MockConfig{
-		TraceIdFieldNames: []string{"trace.trace_id"},
+		TraceIdFieldNames:  []string{"trace.trace_id"},
+		ParentIdFieldNames: []string{"trace.parent_id", "parentId"},
 	}
 
 	ph := NewPayload(mockCfg, data)


### PR DESCRIPTION
## Which problem is this PR solving?

When we first replaced `transmit` + `libhoney` with `directTransmit`, we didn't implement the existing libhoney internal metrics. One of the internal libhoney metrics is required by Stress Relief. 

This PR does _not_ implement the `libhoney_*_send_retries` metric since we currently don't have retry logic yet. That will be added in a follow up PR when retry logic is added.

## Short description of the changes

- Implement below metrics
  - libhoney_upstream/peer_queue_length
  - libhoney_upstream/peer_batches_sent
  - libhoney_upstream/peer_messages_sent
  - libhoney_upstream/peer_response_decode_errors
 


