### PR TITLE
perf: avoid an extra copy for otlp protobuf payload during unmarshaling

### DIFF
--- a/route/route.go
+++ b/route/route.go
@@ -643,7 +643,11 @@ func (router *Router) processOTLPRequestBatchMsgp(
 		totalEvents += len(batch.Events)
 		for _, ev := range batch.Events {
 			payload := types.NewPayload(router.Config, nil)
-			coreFieldsUnmarshaler.UnmarshalPayload(ev.Attributes, &payload)
+			err := coreFieldsUnmarshaler.UnmarshalPayloadComplete(ev.Attributes, &payload)
+			if err != nil {
+				router.Logger.Error().Logf("Error unmarshaling payload: " + err.Error())
+				continue
+			}
 
 			event := &types.Event{
 				Context:     ctx,


### PR DESCRIPTION
## Which problem is this PR solving?

Husky already returns a newly allocated message payload to Refinery after translating the OTLP request. We don't need to make another copy in `UnmarshalPayload`

## Short description of the changes

- Create `UnmarshalPayloadComplete` to allow unmarshal a single message without copying

## Benchmark Result
```
goos: darwin
goarch: arm64
pkg: github.com/honeycombio/refinery/route
cpu: Apple M2 Max
                       │   old.txt   │              new.txt               │
                       │   sec/op    │   sec/op     vs base               │
RouterBatch/msgpack-12   7.904µ ± 5%   7.624µ ± 7%  -3.54% (p=0.011 n=10)
RouterBatch/otlp-12      32.46µ ± 1%   31.14µ ± 1%  -4.06% (p=0.000 n=10)
geomean                  16.02µ        15.41µ       -3.80%

                       │   old.txt    │               new.txt                │
                       │     B/op     │     B/op      vs base                │
RouterBatch/msgpack-12   16.90Ki ± 1%   16.89Ki ± 1%        ~ (p=0.643 n=10)
RouterBatch/otlp-12      35.99Ki ± 0%   21.73Ki ± 0%  -39.63% (p=0.000 n=10)
geomean                  24.67Ki        19.16Ki       -22.33%

                       │  old.txt   │               new.txt               │
                       │ allocs/op  │ allocs/op   vs base                 │
RouterBatch/msgpack-12   33.00 ± 0%   33.00 ± 0%       ~ (p=1.000 n=10) ¹
RouterBatch/otlp-12      96.00 ± 0%   93.00 ± 0%  -3.12% (p=0.000 n=10)
geomean                  56.28        55.40       -1.57%
```
