### PR TITLE
feat: allow file peers to be hot-reloaded

### DIFF
--- a/config.md
+++ b/config.md
@@ -3,7 +3,7 @@
 # Honeycomb Refinery Configuration Documentation
 
 This is the documentation for the configuration file for Honeycomb's Refinery.
-It was automatically generated on 2025-07-15 at 17:41:46 UTC.
+It was automatically generated on 2025-07-25 at 19:58:08 UTC.
 
 ## The Config file
 
@@ -866,7 +866,7 @@ Peers is the list of peers to use when Type is "file", excluding self.
 This list is ignored when Type is "redis".
 The format is a list of strings of the form "scheme://host:port".
 
-- Not eligible for live reload.
+- Eligible for live reload.
 - Type: `stringarray`
 - Example: `http://192.168.1.11:8081,http://192.168.1.12:8081`
 

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -658,8 +658,8 @@ groups:
         envvar: REFINERY_HONEYCOMB_LOGGER_ADDITIONAL_ATTRIBUTES
         commandline: logger-additional-attributes
         description: >
-           When supplying via a environment variable, the value should be a string of comma-separated key-value pairs. 
-           When supplying via the command line, the value should be a key value pair. 
+           When supplying via a environment variable, the value should be a string of comma-separated key-value pairs.
+           When supplying via the command line, the value should be a key value pair.
            If multiple key-value pairs are needed, each should be supplied via its own command line flag.
            The key-value pairs must use ':' as the separator.
 
@@ -1058,7 +1058,7 @@ groups:
         type: stringarray
         valuetype: stringarray
         example: "http://192.168.1.11:8081,http://192.168.1.12:8081"
-        reload: false
+        reload: true
         validations:
           - type: elementType
             arg: url

--- a/config_complete.yaml
+++ b/config_complete.yaml
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created on 2025-07-15 at 17:41:46 UTC from ../../config.yaml using a template generated on 2025-07-15 at 17:41:41 UTC
+# created on 2025-07-25 at 19:58:08 UTC from ../../config.yaml using a template generated on 2025-07-25 at 19:57:55 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of
@@ -566,8 +566,8 @@ HoneycombLogger:
     ## by the Honeycomb logger.
     ##
     ## When supplying via a environment variable, the value should be a
-    ## string of comma-separated key-value pairs.  When supplying via the
-    ## command line, the value should be a key value pair.  If multiple
+    ## string of comma-separated key-value pairs. When supplying via the
+    ## command line, the value should be a key value pair. If multiple
     ## key-value pairs are needed, each should be supplied via its own
     ## command line flag. The key-value pairs must use ':' as the separator.
     ##
@@ -904,7 +904,7 @@ PeerManagement:
     ## This list is ignored when Type is "redis". The format is a list of
     ## strings of the form "scheme://host:port".
     ##
-    ## Not eligible for live reload.
+    ## Eligible for live reload.
     # Peers:
       # - http://192.168.1.11:8081
       # - http://192.168.1.12:8081
@@ -1275,8 +1275,8 @@ Specialized:
     ##
     ## Eligible for live reload.
     # AdditionalAttributes:
-      #  ClusterName: MyCluster
       #  environment: production
+      #  ClusterName: MyCluster
 
 ###############
 ## ID Fields ##

--- a/internal/peer/file.go
+++ b/internal/peer/file.go
@@ -36,8 +36,8 @@ func (p *FilePeers) GetInstanceID() (string, error) {
 
 func (p *FilePeers) RegisterUpdatedPeersCallback(callback func()) {
 	// whenever registered, call the callback immediately
-	// otherwise do nothing since they never change
 	callback()
+	// and also add it to the list of callbacks
 	p.callbacks = append(p.callbacks, callback)
 }
 

--- a/internal/peer/pubsub_redis.go
+++ b/internal/peer/pubsub_redis.go
@@ -105,6 +105,7 @@ type RedisPubsubPeers struct {
 }
 
 // checkHash checks the hash of the current list of peers and calls any registered callbacks
+// in a separate goroutine if the hash has changed.
 func (p *RedisPubsubPeers) checkHash() {
 	peers := p.peers.SortedKeys()
 	newhash := hashList(peers)

--- a/refinery_config.md
+++ b/refinery_config.md
@@ -850,7 +850,7 @@ If this value is specified, then Refinery will use the first IPV6 unicast addres
 This list is ignored when Type is "redis".
 The format is a list of strings of the form "scheme://host:port".
 
-- Not eligible for live reload.
+- Eligible for live reload.
 - Type: `stringarray`
 - Example: `http://192.168.1.11:8081,http://192.168.1.12:8081`
 

--- a/tools/convert/templates/configV2.tmpl
+++ b/tools/convert/templates/configV2.tmpl
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created {{ now }} from {{ .Input }} using a template generated on 2025-07-15 at 17:41:41 UTC
+# created {{ now }} from {{ .Input }} using a template generated on 2025-07-25 at 19:57:55 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of
@@ -564,8 +564,8 @@ HoneycombLogger:
     ## by the Honeycomb logger.
     ##
     ## When supplying via a environment variable, the value should be a
-    ## string of comma-separated key-value pairs.  When supplying via the
-    ## command line, the value should be a key value pair.  If multiple
+    ## string of comma-separated key-value pairs. When supplying via the
+    ## command line, the value should be a key value pair. If multiple
     ## key-value pairs are needed, each should be supplied via its own
     ## command line flag. The key-value pairs must use ':' as the separator.
     ##
@@ -900,7 +900,7 @@ PeerManagement:
     ## This list is ignored when Type is "redis". The format is a list of
     ## strings of the form "scheme://host:port".
     ##
-    ## Not eligible for live reload.
+    ## Eligible for live reload.
     {{ renderStringarray .Data "Peers" "PeerManagement.Peers" "http://192.168.1.11:8081,http://192.168.1.12:8081" }}
 
 ###########################


### PR DESCRIPTION
## Which problem is this PR solving?

- In #1521, @wjordan proposed allowing file peers to be hot-reloaded. This is a good idea, but they stopped responding. This PR effectively replicates that one and fixes the documentation.

## Short description of the changes

- Add callbacks to FilePeers.
- Regenerate documentation.

Closes #1521.

