### PR TITLE
ci: fix flaky tests

### DIFF
--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -1201,9 +1201,12 @@ func TestAddSpanCount(t *testing.T) {
 	coll.AddSpanFromPeer(span)
 	coll.AddSpanFromPeer(decisionSpan)
 
-	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-		assert.Equal(collect, traceID, coll.getFromCache(traceID).TraceID, "after adding the span, we should have a trace in the cache with the right trace ID")
-	}, conf.GetTracesConfig().GetSendTickerValue()*6, conf.GetTracesConfig().GetSendTickerValue()*2)
+	assert.EventuallyWithT(t,
+		func(collect *assert.CollectT) { assert.Equal(collect, traceID, coll.getFromCache(traceID).TraceID) },
+		conf.GetTracesConfig().GetSendTickerValue()*60, // waitFor
+		conf.GetTracesConfig().GetSendTickerValue()*2,  // tick
+		"within a reasonable time, cache should contain a traceID matching the one from the span we added",
+	)
 	assert.Equal(t, 0, len(transmission.GetBlock(0)), "adding a non-root span should not yet send the span")
 
 	// ok now let's add the root span and verify that both got sent


### PR DESCRIPTION
## Which problem is this PR solving?

- Flaky tests!

## Short description of the changes

Expanding on what was found in #1623:

* use the `*assert.CollectT` instance instead of `testing.T` inside of the `EventuallyWithT()` assertion function, otherwise the first failed assertion in the Eventually loop fails the entire test
* base the `waitFor` and `tick` durations on the `SendTickerValue`
* replace a `time.Sleep()` with an `EventuallyWithT()`

