### PR TITLE
Fix: Ignore computed fields during sampling key extraction

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -242,6 +242,7 @@ const RootPrefix = "root."
 // GetKeyFields returns the fields that should be used as keys for the sampler.
 // It returns two slices: the first contains all fields, including those with the root prefix,
 // and the second contains fields that do not have the root prefix.
+// Fields that start with "computed." are ignored since they should not exist as a field in a trace.
 func GetKeyFields(fields []string) (allFields []string, nonRootFields []string) {
 	if len(fields) == 0 {
 		return nil, nil
@@ -251,11 +252,26 @@ func GetKeyFields(fields []string) (allFields []string, nonRootFields []string) 
 	nonRootFields = make([]string, 0, len(fields))
 
 	for _, field := range fields {
-		if strings.HasPrefix(field, RootPrefix) {
-			rootFields = append(rootFields, field[len(RootPrefix):])
-		} else {
+		values := strings.SplitAfterN(field, ".", 2)
+		if len(values) < 2 {
+			nonRootFields = append(nonRootFields, field)
+			continue
+		}
+
+		switch values[0] {
+		case RootPrefix:
+			// If the field starts with "root.", add it to rootFields
+			rootFields = append(rootFields, values[1])
+		case ComputedFieldPrefix:
+			// If the field starts with "computed.", skip it
+		default:
+			// Otherwise, add it to nonRootFields
 			nonRootFields = append(nonRootFields, field)
 		}
+	}
+
+	if len(rootFields) == 0 && len(nonRootFields) == 0 {
+		return nil, nil
 	}
 
 	if len(rootFields) == 0 {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1318,6 +1318,12 @@ func TestGetKeyFields(t *testing.T) {
 			expectedAll:           []string{"test"},
 			expectedNonRootFields: []string{},
 		},
+		{
+			name:                  "computed fields",
+			input:                 []string{"root.test.field", "?.NUMBER_DESCENDANTS", "test.?.field"},
+			expectedAll:           []string{"test.field", "test.?.field"},
+			expectedNonRootFields: []string{"test.?.field"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/config/sampler_config.go
+++ b/config/sampler_config.go
@@ -300,7 +300,12 @@ func (r *RulesBasedSamplerConfig) GetSamplingFields() []string {
 		}
 	}
 
-	return fields.Members()
+	v := fields.Members()
+	if len(v) == 0 {
+		return nil
+	}
+
+	return v
 }
 
 var _ GetSamplingFielder = (*RulesBasedDownstreamSampler)(nil)

--- a/sample/rules_test.go
+++ b/sample/rules_test.go
@@ -18,10 +18,11 @@ type TestRulesData struct {
 	Spans []*types.Span
 	// Set to the matching rule's sample rate if the rule matches.
 	// Set to the default rate (1) if you expect no rule to match.
-	ExpectedRate      uint
-	ExpectedKeep      bool
-	ExpectedName      string
-	ExpectedKeyFields []string
+	ExpectedRate           uint
+	ExpectedKeep           bool
+	ExpectedName           string
+	ExpectedKeyFields      []string
+	ExpectedSamplingFields []string
 }
 
 func TestRules(t *testing.T) {
@@ -52,9 +53,10 @@ func TestRules(t *testing.T) {
 					},
 				},
 			},
-			ExpectedKeep:      true,
-			ExpectedRate:      10,
-			ExpectedKeyFields: []string{"test"},
+			ExpectedKeep:           true,
+			ExpectedRate:           10,
+			ExpectedKeyFields:      []string{"test"},
+			ExpectedSamplingFields: []string{"test"},
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -81,9 +83,10 @@ func TestRules(t *testing.T) {
 					},
 				},
 			},
-			ExpectedKeep:      true,
-			ExpectedRate:      10,
-			ExpectedKeyFields: []string{"test"},
+			ExpectedKeep:           true,
+			ExpectedRate:           10,
+			ExpectedKeyFields:      []string{"test"},
+			ExpectedSamplingFields: []string{"test"},
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -110,9 +113,10 @@ func TestRules(t *testing.T) {
 					},
 				},
 			},
-			ExpectedKeep:      true,
-			ExpectedRate:      10,
-			ExpectedKeyFields: []string{"test"},
+			ExpectedKeep:           true,
+			ExpectedRate:           10,
+			ExpectedKeyFields:      []string{"test"},
+			ExpectedSamplingFields: []string{"test"},
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -139,9 +143,10 @@ func TestRules(t *testing.T) {
 					},
 				},
 			},
-			ExpectedKeep:      true,
-			ExpectedRate:      10,
-			ExpectedKeyFields: []string{"test"},
+			ExpectedKeep:           true,
+			ExpectedRate:           10,
+			ExpectedKeyFields:      []string{"test"},
+			ExpectedSamplingFields: []string{"test"},
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -172,10 +177,11 @@ func TestRules(t *testing.T) {
 					},
 				},
 			},
-			ExpectedKeep:      true,
-			ExpectedRate:      10,
-			ExpectedName:      "fallback",
-			ExpectedKeyFields: []string{"test"},
+			ExpectedKeep:           true,
+			ExpectedRate:           10,
+			ExpectedName:           "fallback",
+			ExpectedKeyFields:      []string{"test"},
+			ExpectedSamplingFields: []string{"test"},
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -220,9 +226,10 @@ func TestRules(t *testing.T) {
 					},
 				},
 			},
-			ExpectedKeep:      true,
-			ExpectedRate:      10,
-			ExpectedKeyFields: []string{"test", "test_two"},
+			ExpectedKeep:           true,
+			ExpectedRate:           10,
+			ExpectedKeyFields:      []string{"test", "test_two"},
+			ExpectedSamplingFields: []string{"test", "test_two"},
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -249,9 +256,10 @@ func TestRules(t *testing.T) {
 					},
 				},
 			},
-			ExpectedKeep:      false,
-			ExpectedRate:      0,
-			ExpectedKeyFields: []string{"test"},
+			ExpectedKeep:           false,
+			ExpectedRate:           0,
+			ExpectedKeyFields:      []string{"test"},
+			ExpectedSamplingFields: []string{"test"},
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -271,9 +279,10 @@ func TestRules(t *testing.T) {
 					},
 				},
 			},
-			ExpectedKeep:      false,
-			ExpectedRate:      0,
-			ExpectedKeyFields: nil,
+			ExpectedKeep:           false,
+			ExpectedRate:           0,
+			ExpectedKeyFields:      nil,
+			ExpectedSamplingFields: nil,
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -314,9 +323,10 @@ func TestRules(t *testing.T) {
 			},
 			ExpectedKeep: true,
 			// the trace does not match all the rules so we expect the default sample rate
-			ExpectedRate:      1,
-			ExpectedName:      "no rule matched",
-			ExpectedKeyFields: []string{"first", "second"},
+			ExpectedRate:           1,
+			ExpectedName:           "no rule matched",
+			ExpectedKeyFields:      []string{"first", "second"},
+			ExpectedSamplingFields: []string{"first", "second"},
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -343,9 +353,10 @@ func TestRules(t *testing.T) {
 					},
 				},
 			},
-			ExpectedKeep:      true,
-			ExpectedRate:      4,
-			ExpectedKeyFields: []string{"first"},
+			ExpectedKeep:           true,
+			ExpectedRate:           4,
+			ExpectedKeyFields:      []string{"first"},
+			ExpectedSamplingFields: []string{"first"},
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -371,9 +382,10 @@ func TestRules(t *testing.T) {
 					},
 				},
 			},
-			ExpectedKeep:      true,
-			ExpectedRate:      4,
-			ExpectedKeyFields: []string{"first"},
+			ExpectedKeep:           true,
+			ExpectedRate:           4,
+			ExpectedKeyFields:      []string{"first"},
+			ExpectedSamplingFields: []string{"first"},
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -399,9 +411,10 @@ func TestRules(t *testing.T) {
 					},
 				},
 			},
-			ExpectedKeep:      true,
-			ExpectedRate:      4,
-			ExpectedKeyFields: []string{"first"},
+			ExpectedKeep:           true,
+			ExpectedRate:           4,
+			ExpectedKeyFields:      []string{"first"},
+			ExpectedSamplingFields: []string{"first"},
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -428,9 +441,10 @@ func TestRules(t *testing.T) {
 					},
 				},
 			},
-			ExpectedKeep:      true,
-			ExpectedRate:      4,
-			ExpectedKeyFields: []string{"first"},
+			ExpectedKeep:           true,
+			ExpectedRate:           4,
+			ExpectedKeyFields:      []string{"first"},
+			ExpectedSamplingFields: []string{"first"},
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -457,9 +471,10 @@ func TestRules(t *testing.T) {
 					},
 				},
 			},
-			ExpectedKeep:      true,
-			ExpectedRate:      4,
-			ExpectedKeyFields: []string{"first"},
+			ExpectedKeep:           true,
+			ExpectedRate:           4,
+			ExpectedKeyFields:      []string{"first"},
+			ExpectedSamplingFields: []string{"first"},
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -486,9 +501,10 @@ func TestRules(t *testing.T) {
 					},
 				},
 			},
-			ExpectedKeep:      true,
-			ExpectedRate:      4,
-			ExpectedKeyFields: []string{"first"},
+			ExpectedKeep:           true,
+			ExpectedRate:           4,
+			ExpectedKeyFields:      []string{"first"},
+			ExpectedSamplingFields: []string{"first"},
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -515,9 +531,10 @@ func TestRules(t *testing.T) {
 					},
 				},
 			},
-			ExpectedKeep:      true,
-			ExpectedRate:      10,
-			ExpectedKeyFields: []string{"test"},
+			ExpectedKeep:           true,
+			ExpectedRate:           10,
+			ExpectedKeyFields:      []string{"test"},
+			ExpectedSamplingFields: []string{"test"},
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -557,10 +574,11 @@ func TestRules(t *testing.T) {
 					},
 				},
 			},
-			ExpectedName:      "Check that root span is missing",
-			ExpectedKeep:      false,
-			ExpectedRate:      0,
-			ExpectedKeyFields: nil,
+			ExpectedName:           "Check that root span is missing",
+			ExpectedKeep:           false,
+			ExpectedRate:           0,
+			ExpectedKeyFields:      nil,
+			ExpectedSamplingFields: nil,
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -609,10 +627,11 @@ func TestRules(t *testing.T) {
 					},
 				},
 			},
-			ExpectedName:      "Check that root span is present",
-			ExpectedKeep:      true,
-			ExpectedRate:      99,
-			ExpectedKeyFields: nil,
+			ExpectedName:           "Check that root span is present",
+			ExpectedKeep:           true,
+			ExpectedRate:           99,
+			ExpectedKeyFields:      nil,
+			ExpectedSamplingFields: nil,
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -639,9 +658,10 @@ func TestRules(t *testing.T) {
 					},
 				},
 			},
-			ExpectedKeep:      true,
-			ExpectedRate:      10,
-			ExpectedKeyFields: []string{"test", "test2"},
+			ExpectedKeep:           true,
+			ExpectedRate:           10,
+			ExpectedKeyFields:      []string{"test", "test2"},
+			ExpectedSamplingFields: []string{"test", "test2"},
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -668,10 +688,11 @@ func TestRules(t *testing.T) {
 					},
 				},
 			},
-			ExpectedKeep:      true,
-			ExpectedName:      "no rule matched",
-			ExpectedRate:      1,
-			ExpectedKeyFields: []string{"test", "test2"},
+			ExpectedKeep:           true,
+			ExpectedName:           "no rule matched",
+			ExpectedRate:           1,
+			ExpectedKeyFields:      []string{"test", "test2"},
+			ExpectedSamplingFields: []string{"test", "test2"},
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -699,10 +720,11 @@ func TestRules(t *testing.T) {
 					},
 				},
 			},
-			ExpectedKeep:      true,
-			ExpectedName:      "no rule matched",
-			ExpectedRate:      1,
-			ExpectedKeyFields: []string{"test", "test2"},
+			ExpectedKeep:           true,
+			ExpectedName:           "no rule matched",
+			ExpectedRate:           1,
+			ExpectedKeyFields:      []string{"test", "test2"},
+			ExpectedSamplingFields: []string{"test", "test2"},
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -761,10 +783,11 @@ func TestRules(t *testing.T) {
 					},
 				},
 			},
-			ExpectedName:      "Check that the number of descendants is greater than 3",
-			ExpectedKeep:      false,
-			ExpectedRate:      1,
-			ExpectedKeyFields: []string{string(config.NUM_DESCENDANTS)},
+			ExpectedName:           "Check that the number of descendants is greater than 3",
+			ExpectedKeep:           false,
+			ExpectedRate:           1,
+			ExpectedKeyFields:      nil,
+			ExpectedSamplingFields: []string{"?.NUM_DESCENDANTS"},
 		},
 		{
 			Rules: &config.RulesBasedSamplerConfig{
@@ -821,10 +844,11 @@ func TestRules(t *testing.T) {
 					},
 				},
 			},
-			ExpectedName:      "no rule matched",
-			ExpectedKeep:      true,
-			ExpectedRate:      1,
-			ExpectedKeyFields: []string{string(config.NUM_DESCENDANTS)},
+			ExpectedName:           "no rule matched",
+			ExpectedKeep:           true,
+			ExpectedRate:           1,
+			ExpectedKeyFields:      nil,
+			ExpectedSamplingFields: []string{"?.NUM_DESCENDANTS"},
 		},
 	}
 
@@ -861,6 +885,9 @@ func TestRules(t *testing.T) {
 		assert.Contains(t, reason, name)
 		assert.Equal(t, "", key)
 
+		samplingFields := sampler.Config.GetSamplingFields()
+		slices.Sort(samplingFields)
+		assert.Equal(t, d.ExpectedSamplingFields, samplingFields)
 		allFields, nonRootFields := sampler.GetKeyFields()
 		slices.Sort(allFields)
 		assert.Equal(t, d.ExpectedKeyFields, allFields)

--- a/types/payload_test.go
+++ b/types/payload_test.go
@@ -353,6 +353,9 @@ func TestCoreFieldsUnmarshaler(t *testing.T) {
 								Field: "sampling_key_field",
 							},
 							{
+								Field: "?.NUMBER_DESCENDANTS",
+							},
+							{
 								Field: "root.test",
 							},
 							{
@@ -423,9 +426,14 @@ func TestCoreFieldsUnmarshaler(t *testing.T) {
 			assert.True(t, ok)
 			_, ok = payload.missingFields["test"]
 			assert.True(t, ok)
+			// Verify computed field is not extracted
+			_, ok = payload.missingFields["?.NUMBER_DESCENDANTS"]
+			assert.False(t, ok)
 
 			// Verify field not in sampling config is NOT extracted
 			assert.Nil(t, payload.memoizedFields["missing_in_config"])
+			// Verify computed field is not extracted
+			assert.Nil(t, payload.memoizedFields["?.NUMBER_DESCENDANTS"])
 
 			// Verify regular fields are still accessible through Get
 			assert.Equal(t, "value1", payload.Get("regular_field"))


### PR DESCRIPTION
## Which problem is this PR solving?

Refinery was attempting to extract computed fields (prefixed with `?.`) like `?.NUMBER_DESCENDANTS` as if they were regular trace fields during the unmarshaling process. This caused unnecessary performance overhead since computed fields are virtual fields calculated during rule evaluation and don't exist as actual fields in trace data.

## Short description of the changes

- Ignore computed fields in `GetKeyFields` function

