### PR TITLE
feat: use husky's optimized direct translation for GRPC calls

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -119,4 +119,4 @@ tool github.com/google/go-licenses/v2
 
 replace go.opentelemetry.io/proto/otlp => github.com/honeycombio/opentelemetry-proto-go/otlp v1.3.1-compat
 
-replace github.com/honeycombio/husky => github.com/honeycombio/husky v0.37.1-0.20250729164345-ed6a8be4045a
+replace github.com/honeycombio/husky => github.com/honeycombio/husky v0.37.1-0.20250729215257-eb95c950c0e9

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/honeycombio/dynsampler-go v0.6.3
 	github.com/honeycombio/hpsf v0.5.1-0.20250605195630-9b072f9dbd61
-	github.com/honeycombio/husky v0.36.0
+	github.com/honeycombio/husky v0.37.1-0.20250730154742-ddf9db5b5fe7
 	github.com/honeycombio/libhoney-go v1.25.0
 	github.com/jessevdk/go-flags v1.6.1
 	github.com/jonboulle/clockwork v0.5.0
@@ -118,5 +118,3 @@ require (
 tool github.com/google/go-licenses/v2
 
 replace go.opentelemetry.io/proto/otlp => github.com/honeycombio/opentelemetry-proto-go/otlp v1.3.1-compat
-
-replace github.com/honeycombio/husky => github.com/honeycombio/husky v0.37.1-0.20250729215257-eb95c950c0e9

--- a/go.sum
+++ b/go.sum
@@ -123,8 +123,8 @@ github.com/honeycombio/dynsampler-go v0.6.3 h1:myYNnqVbcJWac/dFfACWjobQFQcZXwkGL
 github.com/honeycombio/dynsampler-go v0.6.3/go.mod h1:mqCYD3JbAEgRvxu52Q0doTO3wKEUvEott8H8VMEpnQ0=
 github.com/honeycombio/hpsf v0.5.1-0.20250605195630-9b072f9dbd61 h1:cll8fstVhA805sKS5xjIVw/hKOz40qHpVvgAkg/h4hw=
 github.com/honeycombio/hpsf v0.5.1-0.20250605195630-9b072f9dbd61/go.mod h1:29/tpyeKw7tbT7mw1WCjMR6lqul7tmtNpuO0RICwzXk=
-github.com/honeycombio/husky v0.37.1-0.20250729215257-eb95c950c0e9 h1:89VwjLrv0JoxiQKqU0k1AvdMu03ks5zQujdyqVfwjbw=
-github.com/honeycombio/husky v0.37.1-0.20250729215257-eb95c950c0e9/go.mod h1:vNbOf54DrmrVkHsB759LMIOHdJC+xZhB0zRq2sVolAo=
+github.com/honeycombio/husky v0.37.1-0.20250730154742-ddf9db5b5fe7 h1:KRqxHheX+nN15lUhQwKNW1xBBpcgEEDvZWZ/MX1m1AI=
+github.com/honeycombio/husky v0.37.1-0.20250730154742-ddf9db5b5fe7/go.mod h1:gtbXLiN6nSDVHUPjIYHO5y47eJbtECe5u32dQNqvzfQ=
 github.com/honeycombio/libhoney-go v1.25.0 h1:r33tlX90HtafK0bgRcjfNnsrJ9ZMTKuI/1DYaOFCc1o=
 github.com/honeycombio/libhoney-go v1.25.0/go.mod h1:Fc0HjqlwYf5xy6H34EItpOverAGbCixnYOX3YTUQovg=
 github.com/honeycombio/opentelemetry-proto-go/otlp v1.3.1-compat h1:i9CAIguM5tMQC9xSRihqdFBoh40OBOhuhfR8OrXsZ9o=

--- a/go.sum
+++ b/go.sum
@@ -123,8 +123,8 @@ github.com/honeycombio/dynsampler-go v0.6.3 h1:myYNnqVbcJWac/dFfACWjobQFQcZXwkGL
 github.com/honeycombio/dynsampler-go v0.6.3/go.mod h1:mqCYD3JbAEgRvxu52Q0doTO3wKEUvEott8H8VMEpnQ0=
 github.com/honeycombio/hpsf v0.5.1-0.20250605195630-9b072f9dbd61 h1:cll8fstVhA805sKS5xjIVw/hKOz40qHpVvgAkg/h4hw=
 github.com/honeycombio/hpsf v0.5.1-0.20250605195630-9b072f9dbd61/go.mod h1:29/tpyeKw7tbT7mw1WCjMR6lqul7tmtNpuO0RICwzXk=
-github.com/honeycombio/husky v0.37.1-0.20250729164345-ed6a8be4045a h1:pU7E8fD57sEH3eawhLAqanLOY3RdJ17NQfAmr57tRjc=
-github.com/honeycombio/husky v0.37.1-0.20250729164345-ed6a8be4045a/go.mod h1:gtbXLiN6nSDVHUPjIYHO5y47eJbtECe5u32dQNqvzfQ=
+github.com/honeycombio/husky v0.37.1-0.20250729215257-eb95c950c0e9 h1:89VwjLrv0JoxiQKqU0k1AvdMu03ks5zQujdyqVfwjbw=
+github.com/honeycombio/husky v0.37.1-0.20250729215257-eb95c950c0e9/go.mod h1:vNbOf54DrmrVkHsB759LMIOHdJC+xZhB0zRq2sVolAo=
 github.com/honeycombio/libhoney-go v1.25.0 h1:r33tlX90HtafK0bgRcjfNnsrJ9ZMTKuI/1DYaOFCc1o=
 github.com/honeycombio/libhoney-go v1.25.0/go.mod h1:Fc0HjqlwYf5xy6H34EItpOverAGbCixnYOX3YTUQovg=
 github.com/honeycombio/opentelemetry-proto-go/otlp v1.3.1-compat h1:i9CAIguM5tMQC9xSRihqdFBoh40OBOhuhfR8OrXsZ9o=

--- a/route/otlp_trace.go
+++ b/route/otlp_trace.go
@@ -6,6 +6,7 @@ import (
 
 	huskyotlp "github.com/honeycombio/husky/otlp"
 	"github.com/honeycombio/refinery/internal/otelutil"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -77,9 +78,15 @@ func (r *Router) processOTLPRequestWithMsgp(ctx context.Context, w http.Response
 	}
 }
 
+// CustomTraceServiceServer defines our custom interface for the trace service.
+// It processes pre-translated trace data using msgpack optimization rather than
+// accepting raw OTLP protobuf requests.
+type CustomTraceServiceServer interface {
+	ExportTraceData(context.Context, *huskyotlp.TranslateOTLPRequestResultMsgp, huskyotlp.RequestInfo) (*collectortrace.ExportTraceServiceResponse, error)
+}
+
 type TraceServer struct {
 	router *Router
-	collectortrace.UnimplementedTraceServiceServer
 }
 
 func NewTraceServer(router *Router) *TraceServer {
@@ -87,32 +94,99 @@ func NewTraceServer(router *Router) *TraceServer {
 	return &traceServer
 }
 
-func (t *TraceServer) Export(ctx context.Context, req *collectortrace.ExportTraceServiceRequest) (*collectortrace.ExportTraceServiceResponse, error) {
+// ExportTraceData processes translated trace data using msgpack optimization
+func (t *TraceServer) ExportTraceData(ctx context.Context, result *huskyotlp.TranslateOTLPRequestResultMsgp, ri huskyotlp.RequestInfo) (*collectortrace.ExportTraceServiceResponse, error) {
 	ctx, span := otelutil.StartSpan(ctx, t.router.Tracer, "ExportOTLPTrace")
 	defer span.End()
 
-	ri := huskyotlp.GetRequestInfoFromGrpcMetadata(ctx)
+	// Perform final authentication check (key processing already done in handler)
 	apicfg := t.router.Config.GetAccessKeyConfig()
 	if err := apicfg.IsAccepted(ri.ApiKey); err != nil {
 		return nil, status.Error(codes.Unauthenticated, err.Error())
 	}
 
-	keyToUse, _ := apicfg.GetReplaceKey(ri.ApiKey)
-
-	if err := ri.ValidateTracesHeaders(); err != nil && err != huskyotlp.ErrMissingAPIKeyHeader {
-		return nil, huskyotlp.AsGRPCError(err)
-	}
-
-	ri.ApiKey = keyToUse
-
-	result, err := huskyotlp.TranslateTraceRequest(ctx, req, ri)
-	if err != nil {
-		return nil, huskyotlp.AsGRPCError(err)
-	}
-
-	if err := t.router.processOTLPRequest(ctx, result.Batches, keyToUse, ri.UserAgent); err != nil {
+	// Use optimized msgpack processing path with already translated data
+	if err := t.router.processOTLPRequestBatchMsgp(ctx, result.Batches, ri.ApiKey, ri.UserAgent); err != nil {
 		return nil, huskyotlp.AsGRPCError(err)
 	}
 
 	return &collectortrace.ExportTraceServiceResponse{}, nil
+}
+
+// translatedTraceServiceRequest is a wrapper that implements proto.Message but
+// actually produces a translated TranslateOTLPRequestResultMsgp instead of a
+// real unserialized protobuf struct.
+type translatedTraceServiceRequest struct {
+	requestInfo huskyotlp.RequestInfo
+	result      *huskyotlp.TranslateOTLPRequestResultMsgp
+	ctx         context.Context
+}
+
+// Implement proto.Message interface.
+func (r *translatedTraceServiceRequest) Reset() {
+	r.result = nil
+}
+
+func (r *translatedTraceServiceRequest) String() string {
+	return "translatedTraceServiceRequest"
+}
+
+func (r *translatedTraceServiceRequest) ProtoMessage() {}
+
+// Unmarshal implements a custom unmarshaling method that performs translation
+// during the unmarshaling step using husky's msgpack optimization.
+func (r *translatedTraceServiceRequest) Unmarshal(data []byte) error {
+	result, err := huskyotlp.UnmarshalTraceRequestDirectMsgp(r.ctx, data, r.requestInfo)
+	if err != nil {
+		return err
+	}
+	r.result = result
+	return nil
+}
+
+// customTraceExportHandler is a custom GRPC handler that uses husky's optimized
+// translation codepath.
+func customTraceExportHandler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
+	traceServer := srv.(*TraceServer)
+
+	// Get request info from GRPC metadata and prepare our custom wrapper.
+	ri := huskyotlp.GetRequestInfoFromGrpcMetadata(ctx)
+
+	// Handle SendKeyMode logic before validation, similar to HTTP handler
+	apicfg := traceServer.router.Config.GetAccessKeyConfig()
+	keyToUse, err := apicfg.GetReplaceKey(ri.ApiKey)
+	if err != nil {
+		return nil, status.Error(codes.Unauthenticated, err.Error())
+	}
+
+	// Update the RequestInfo with the processed key for the unmarshal step
+	ri.ApiKey = keyToUse
+
+	in := &translatedTraceServiceRequest{
+		requestInfo: ri,
+		ctx:         ctx,
+	}
+
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+
+	// Translation already happened during unmarshaling - just get the result
+	result := in.result
+	if result == nil {
+		return nil, status.Error(codes.Internal, "no processed result available")
+	}
+
+	if interceptor == nil {
+		return traceServer.ExportTraceData(ctx, result, ri)
+	}
+
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/opentelemetry.proto.collector.trace.v1.TraceService/Export",
+	}
+	handler := func(ctx context.Context, req any) (any, error) {
+		return traceServer.ExportTraceData(ctx, result, ri)
+	}
+	return interceptor(ctx, in, info, handler)
 }

--- a/route/otlp_trace_test.go
+++ b/route/otlp_trace_test.go
@@ -83,17 +83,6 @@ func createGRPCContext(headers map[string]string) context.Context {
 	return metadata.NewOutgoingContext(context.Background(), md)
 }
 
-// makeGRPCCall executes a trace export request via GRPC and returns any error.
-func makeGRPCCall(
-	t testing.TB,
-	client collectortrace.TraceServiceClient,
-	ctx context.Context,
-	req *collectortrace.ExportTraceServiceRequest,
-) error {
-	_, err := client.Export(ctx, req)
-	return err
-}
-
 func TestOTLPHandler(t *testing.T) {
 	mockMetrics := metrics.MockMetrics{}
 	mockMetrics.Start()
@@ -150,7 +139,7 @@ func TestOTLPHandler(t *testing.T) {
 			"x-honeycomb-team":    legacyAPIKey,
 			"x-honeycomb-dataset": "ds",
 		})
-		err := makeGRPCCall(t, grpcClient, ctx, req)
+		_, err := grpcClient.Export(ctx, req)
 		if err != nil {
 			t.Errorf(`Unexpected error: %s`, err)
 		}
@@ -171,7 +160,7 @@ func TestOTLPHandler(t *testing.T) {
 			"x-honeycomb-team":    legacyAPIKey,
 			"x-honeycomb-dataset": "ds",
 		})
-		err := makeGRPCCall(t, grpcClient, ctx, req)
+		_, err := grpcClient.Export(ctx, req)
 		if err != nil {
 			t.Errorf(`Unexpected error: %s`, err)
 		}
@@ -208,7 +197,7 @@ func TestOTLPHandler(t *testing.T) {
 			"x-honeycomb-team":    legacyAPIKey,
 			"x-honeycomb-dataset": "ds",
 		})
-		err := makeGRPCCall(t, grpcClient, ctx, req)
+		_, err := grpcClient.Export(ctx, req)
 		if err != nil {
 			t.Errorf(`Unexpected error: %s`, err)
 		}
@@ -257,7 +246,7 @@ func TestOTLPHandler(t *testing.T) {
 			"x-honeycomb-team":    legacyAPIKey,
 			"x-honeycomb-dataset": "ds",
 		})
-		err := makeGRPCCall(t, grpcClient, ctx, req)
+		_, err := grpcClient.Export(ctx, req)
 		if err != nil {
 			t.Errorf(`Unexpected error: %s`, err)
 		}
@@ -499,7 +488,7 @@ func TestOTLPHandler(t *testing.T) {
 			"x-honeycomb-team":    legacyAPIKey,
 			"x-honeycomb-dataset": "my-dataset",
 		})
-		err := makeGRPCCall(t, grpcClient, ctx, req)
+		_, err := grpcClient.Export(ctx, req)
 		if err != nil {
 			t.Errorf(`Unexpected error: %s`, err)
 		}
@@ -535,7 +524,7 @@ func TestOTLPHandler(t *testing.T) {
 		ctx := createGRPCContext(map[string]string{
 			"x-honeycomb-team": apiKey,
 		})
-		err := makeGRPCCall(t, grpcClient, ctx, req)
+		_, err := grpcClient.Export(ctx, req)
 		if err != nil {
 			t.Errorf(`Unexpected error: %s`, err)
 		}
@@ -612,7 +601,7 @@ func TestOTLPHandler(t *testing.T) {
 			"x-honeycomb-team":    legacyAPIKey,
 			"x-honeycomb-dataset": "ds",
 		})
-		err := makeGRPCCall(t, grpcClient, ctx, req)
+		_, err := grpcClient.Export(ctx, req)
 		assert.Equal(t, codes.Unauthenticated, status.Code(err))
 		assert.Contains(t, err.Error(), "not found in list of authorized keys")
 
@@ -633,7 +622,7 @@ func TestOTLPHandler(t *testing.T) {
 			"x-honeycomb-dataset": "ds",
 			"user-agent":          "my-user-agent",
 		})
-		err := makeGRPCCall(t, grpcClient, ctx, req)
+		_, err := grpcClient.Export(ctx, req)
 		if err != nil {
 			t.Errorf(`Unexpected error: %s`, err)
 		}
@@ -844,7 +833,7 @@ func TestOTLPHandler(t *testing.T) {
 					opts["x-honeycomb-team"] = tt.apiKey
 				}
 				ctx := createGRPCContext(opts)
-				err := makeGRPCCall(t, grpcClient, ctx, req)
+				_, err := grpcClient.Export(ctx, req)
 				if tt.wantStatus == http.StatusOK {
 					require.NoError(t, err)
 				} else {


### PR DESCRIPTION
## Which problem is this PR solving?
GRPC wants to do all unmarshaling itself based on stock generated code, which doesn't play nicely with our custom, optimized data path.

## Short description of the changes
Replaces the stock generated OTLP trace server with a new one which conforms to GRPC's, shall we say, idiosyncratic interface, but which uses husky's optimized translation instead of unmarshaling. This is a little awkward since (in some cases) we depend on the request info to extract the dataset, so request validation is now happening during Unmarshal, before any grpc interceptors get a look at the request. Fortunately we're not using any interceptors at the moment. The advantage of doing it this early is that we never need to make a copy of the input buffer.

Also moves some testing to work with the full GRPC stack, to remove dependencies on the details of our implementation. Also adds a GRPC concurrency test, which can help expose race conditions.

Benchmark results are promising, note this looks slower than HTTP mainly because of overhead in the benchmark itself, where the GRPC client is re-serializing the request on every iteration:
```
benchmark                         old ns/op     new ns/op     delta
BenchmarkTracesOTLP/grpc          564784        329547        -41.65%
benchmark                         old allocs    new allocs    delta
BenchmarkTracesOTLP/grpc          5070          909           -82.07%
benchmark                         old bytes     new bytes     delta
BenchmarkTracesOTLP/grpc          322256        119653        -62.87%
```
