### PR TITLE
perf: optimized JSON batch handling

### DIFF
--- a/route/batched_event.go
+++ b/route/batched_event.go
@@ -195,14 +195,10 @@ func (b *batchedEvents) unmarshalBatchedEventFromFastJSON(event *batchedEvent, v
 	// Visit each field in the event object
 	var dataValue *fastjson.Value
 	obj.Visit(func(key []byte, v *fastjson.Value) {
-		if err != nil {
-			return
-		}
-
 		switch string(key) {
 		case "time":
 			if v.Type() == fastjson.TypeString {
-				s, _ := v.StringBytes()
+				s := v.GetStringBytes()
 				event.Timestamp = string(s)
 			}
 		case "samplerate":
@@ -225,7 +221,6 @@ func (b *batchedEvents) unmarshalBatchedEventFromFastJSON(event *batchedEvent, v
 			bytesPool.Put(buf)
 		}()
 
-		// Use AppendJSONValue directly to avoid expensive MarshalTo() call
 		*buf, err = types.AppendJSONValue(*buf, dataValue)
 		if err != nil {
 			return err

--- a/route/batched_event.go
+++ b/route/batched_event.go
@@ -3,12 +3,16 @@ package route
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/honeycombio/refinery/config"
 	"github.com/honeycombio/refinery/types"
 	"github.com/tinylib/msgp/msgp"
+	"github.com/valyala/fastjson"
 )
+
+var fastJsonParserPool fastjson.ParserPool
 
 type batchedEvent struct {
 	Timestamp           string        `json:"time"`
@@ -35,6 +39,8 @@ func (b *batchedEvent) getSampleRate() uint {
 }
 
 func (b *batchedEvent) UnmarshalJSON(data []byte) error {
+	// This method is now primarily used as a fallback for individual event unmarshaling
+	// Most of the time, events are unmarshaled via batchedEvents.UnmarshalJSON
 	type tempEvent struct {
 		Timestamp  string          `json:"time"`
 		SampleRate int64           `json:"samplerate"`
@@ -42,25 +48,23 @@ func (b *batchedEvent) UnmarshalJSON(data []byte) error {
 	}
 
 	var temp tempEvent
-	err := json.Unmarshal(data, &temp)
-	if err != nil {
+	if err := json.Unmarshal(data, &temp); err != nil {
 		return err
 	}
 
-	// Copy the simple fields
 	b.Timestamp = temp.Timestamp
 	b.SampleRate = temp.SampleRate
-
-	// Initialize Data with config
 	b.Data = types.NewPayload(b.cfg, nil)
 
-	// Convert JSON Data to MessagePack and use optimized unmarshaling
+	// Convert data field to MessagePack and use optimized unmarshaling
 	buf := httpBodyBufferPool.Get().(*bytes.Buffer)
 	defer recycleHTTPBodyBuffer(buf)
 
 	msgpackData, err := types.JSONToMessagePack(buf.Bytes()[:0], temp.Data)
+	if err != nil {
+		return err
+	}
 
-	// Use the same optimized unmarshaling logic as UnmarshalMsg
 	_, err = b.coreFieldsExtractor.UnmarshalPayload(msgpackData, &b.Data)
 	return err
 }
@@ -167,18 +171,30 @@ func (b *batchedEvents) MarshalJSON() ([]byte, error) {
 }
 
 func (b *batchedEvents) UnmarshalJSON(data []byte) error {
-	var rawEvents []json.RawMessage
-	err := json.Unmarshal(data, &rawEvents)
+	parser := fastJsonParserPool.Get()
+	defer fastJsonParserPool.Put(parser)
+
+	v, err := parser.ParseBytes(data)
 	if err != nil {
 		return err
 	}
 
-	b.events = make([]batchedEvent, len(rawEvents))
-	for i := range b.events {
+	if v.Type() != fastjson.TypeArray {
+		return fmt.Errorf("expected JSON array")
+	}
+
+	arr, err := v.Array()
+	if err != nil {
+		return err
+	}
+
+	b.events = make([]batchedEvent, len(arr))
+	for i, eventValue := range arr {
 		b.events[i].cfg = b.cfg
 		b.events[i].coreFieldsExtractor = b.coreFieldsExtractor
 
-		err = json.Unmarshal(rawEvents[i], &b.events[i])
+		// Parse each event directly using fastjson
+		err = b.unmarshalBatchedEventFromFastJSON(&b.events[i], eventValue)
 		if err != nil {
 			return err
 		}
@@ -186,3 +202,66 @@ func (b *batchedEvents) UnmarshalJSON(data []byte) error {
 
 	return nil
 }
+
+// unmarshalBatchedEventFromFastJSON populates a batchedEvent from a fastjson.Value
+func (b *batchedEvents) unmarshalBatchedEventFromFastJSON(event *batchedEvent, v *fastjson.Value) error {
+	if v.Type() != fastjson.TypeObject {
+		return fmt.Errorf("expected JSON object for event")
+	}
+
+	obj, err := v.Object()
+	if err != nil {
+		return err
+	}
+
+	// Initialize Data with config
+	event.Data = types.NewPayload(event.cfg, nil)
+
+	var dataValue *fastjson.Value
+
+	// Visit each field in the event object
+	obj.Visit(func(key []byte, v *fastjson.Value) {
+		if err != nil {
+			return
+		}
+
+		switch string(key) {
+		case "time":
+			if v.Type() == fastjson.TypeString {
+				s, _ := v.StringBytes()
+				event.Timestamp = string(s)
+			}
+		case "samplerate":
+			if v.Type() == fastjson.TypeNumber {
+				event.SampleRate = v.GetInt64()
+			}
+		case "data":
+			if v.Type() == fastjson.TypeObject {
+				dataValue = v
+			}
+		}
+	})
+
+	if err != nil {
+		return err
+	}
+
+	// Convert data field to MessagePack and use optimized unmarshaling
+	if dataValue != nil {
+		buf := httpBodyBufferPool.Get().(*bytes.Buffer)
+		defer recycleHTTPBodyBuffer(buf)
+
+		// Use AppendJSONValue directly to avoid expensive MarshalTo() call
+		msgpackData, err := types.AppendJSONValue(buf.Bytes()[:0], dataValue)
+		if err != nil {
+			return err
+		}
+
+		// Use the same optimized unmarshaling logic as UnmarshalMsg
+		_, err = event.coreFieldsExtractor.UnmarshalPayload(msgpackData, &event.Data)
+		return err
+	}
+
+	return nil
+}
+

--- a/route/route.go
+++ b/route/route.go
@@ -916,6 +916,12 @@ func unmarshal(r *http.Request, data []byte, v interface{}) error {
 		decoder.UseLooseInterfaceDecoding(true)
 		return decoder.Decode(v)
 	default:
+		// If UnmarshalJSON is available, call it directly, which is surprisingly
+		// much more efficient than allowing it to be called from the library.
+		if unmarshaler, ok := v.(json.Unmarshaler); ok {
+			err := unmarshaler.UnmarshalJSON(data)
+			return err
+		}
 		return jsoniter.Unmarshal(data, v)
 	}
 }

--- a/route/route_test.go
+++ b/route/route_test.go
@@ -230,11 +230,23 @@ func TestUnmarshal(t *testing.T) {
 
 					assert.Equal(t, now.UTC(), result.events[0].getEventTime())
 					assert.Equal(t, uint(2), result.events[0].getSampleRate())
-					assert.Equal(t, testData, maps.Collect(result.events[0].Data.All()))
+
+					// When using JSON->MessagePack conversion, integers are preserved as int64
+					expectedData := map[string]any{
+						"trace.trace_id": "test-trace-id",
+						"trace.span_id":  "test-span-id",
+						"service.name":   "test-service",
+						"operation.name": "test-operation",
+						"duration_ms":    150.5,        // float remains float64
+						"status_code":    int64(200),   // 200.0 -> 200 in JSON -> int64 in MessagePack
+						"user_id":        int64(12345), // 12345.0 -> 12345 in JSON -> int64 in MessagePack
+						"is_error":       false,
+					}
+					assert.Equal(t, expectedData, maps.Collect(result.events[0].Data.All()))
 
 					assert.Equal(t, now.Add(time.Second).UTC(), result.events[1].getEventTime())
 					assert.Equal(t, uint(4), result.events[1].getSampleRate())
-					assert.Equal(t, testData, maps.Collect(result.events[1].Data.All()))
+					assert.Equal(t, expectedData, maps.Collect(result.events[1].Data.All()))
 				})
 			}
 		})

--- a/route/route_test.go
+++ b/route/route_test.go
@@ -1332,7 +1332,7 @@ func BenchmarkRouterBatch(b *testing.B) {
 	batchEvents := createBatchEventsWithLargeAttributes(3, router.Config)
 	mockCollector := router.Collector.(*collect.MockCollector)
 
-	b.Run("msgpack", func(b *testing.B) {
+	b.Run("batch_msgpack", func(b *testing.B) {
 		batchMsgpack, err := msgpack.Marshal(batchEvents.events)
 		require.NoError(b, err)
 
@@ -1363,7 +1363,7 @@ func BenchmarkRouterBatch(b *testing.B) {
 		}
 	})
 
-	b.Run("json", func(b *testing.B) {
+	b.Run("batch_json", func(b *testing.B) {
 		batchMsgpack, err := json.Marshal(batchEvents.events)
 		require.NoError(b, err)
 

--- a/route/route_test.go
+++ b/route/route_test.go
@@ -230,23 +230,11 @@ func TestUnmarshal(t *testing.T) {
 
 					assert.Equal(t, now.UTC(), result.events[0].getEventTime())
 					assert.Equal(t, uint(2), result.events[0].getSampleRate())
-
-					// When using JSON->MessagePack conversion, integers are preserved as int64
-					expectedData := map[string]any{
-						"trace.trace_id": "test-trace-id",
-						"trace.span_id":  "test-span-id",
-						"service.name":   "test-service",
-						"operation.name": "test-operation",
-						"duration_ms":    150.5,        // float remains float64
-						"status_code":    int64(200),   // 200.0 -> 200 in JSON -> int64 in MessagePack
-						"user_id":        int64(12345), // 12345.0 -> 12345 in JSON -> int64 in MessagePack
-						"is_error":       false,
-					}
-					assert.Equal(t, expectedData, maps.Collect(result.events[0].Data.All()))
+					assert.Equal(t, testData, maps.Collect(result.events[0].Data.All()))
 
 					assert.Equal(t, now.Add(time.Second).UTC(), result.events[1].getEventTime())
 					assert.Equal(t, uint(4), result.events[1].getSampleRate())
-					assert.Equal(t, expectedData, maps.Collect(result.events[1].Data.All()))
+					assert.Equal(t, testData, maps.Collect(result.events[1].Data.All()))
 				})
 			}
 		})

--- a/types/json_to_msgp.go
+++ b/types/json_to_msgp.go
@@ -1,0 +1,94 @@
+package types
+
+import (
+	"github.com/tinylib/msgp/msgp"
+	"github.com/valyala/fastjson"
+)
+
+var parserPool fastjson.ParserPool
+
+// Oddly, while one of messagepack's selling points is its alleged interoperability
+// with JSON, none of the golang messagepack libaries actually provide a method to
+// do the translation in this direction. So here's a simple implementation which
+// is fast but doesn't go to any great lengths to re-create types which were lost
+// during JSON serialization; for example, dates that were encoded as strings stay
+// strings, where a direct msgp encoding would have used the time type. This is
+// fine for our field payload maps but doesn't work well with structs.
+func JSONToMessagePack(buf []byte, jsonData []byte) ([]byte, error) {
+	parser := parserPool.Get()
+	defer parserPool.Put(parser)
+
+	v, err := parser.ParseBytes(jsonData)
+	if err != nil {
+		return buf, err
+	}
+
+	buf, err = appendJSONValue(buf, v)
+	if err != nil {
+		return buf, err
+	}
+
+	return buf, nil
+}
+
+func appendJSONValue(buf []byte, v *fastjson.Value) ([]byte, error) {
+	switch v.Type() {
+	case fastjson.TypeObject:
+		return appendJSONObject(buf, v)
+	case fastjson.TypeArray:
+		return appendJSONArray(buf, v)
+	case fastjson.TypeString:
+		s, _ := v.StringBytes()
+		return msgp.AppendString(buf, string(s)), nil
+	case fastjson.TypeNumber:
+		if float64(v.GetInt64()) == v.GetFloat64() {
+			return msgp.AppendInt64(buf, v.GetInt64()), nil
+		}
+		return msgp.AppendFloat64(buf, v.GetFloat64()), nil
+	case fastjson.TypeTrue:
+		return msgp.AppendBool(buf, true), nil
+	case fastjson.TypeFalse:
+		return msgp.AppendBool(buf, false), nil
+	case fastjson.TypeNull:
+		return msgp.AppendNil(buf), nil
+	default:
+		return msgp.AppendIntf(buf, nil)
+	}
+}
+
+func appendJSONObject(buf []byte, v *fastjson.Value) ([]byte, error) {
+	obj, err := v.Object()
+	if err != nil {
+		return buf, err
+	}
+
+	buf = msgp.AppendMapHeader(buf, uint32(obj.Len()))
+
+	obj.Visit(func(key []byte, v *fastjson.Value) {
+		if err != nil {
+			return
+		}
+		buf = msgp.AppendStringFromBytes(buf, key)
+		buf, err = appendJSONValue(buf, v)
+	})
+
+	return buf, err
+}
+
+func appendJSONArray(buf []byte, v *fastjson.Value) ([]byte, error) {
+	arr, err := v.Array()
+	if err != nil {
+		return buf, err
+	}
+
+	buf = msgp.AppendArrayHeader(buf, uint32(len(arr)))
+
+	for _, item := range arr {
+		buf, err = appendJSONValue(buf, item)
+		if err != nil {
+			return buf, err
+		}
+	}
+
+	return buf, nil
+}

--- a/types/json_to_msgp.go
+++ b/types/json_to_msgp.go
@@ -43,9 +43,6 @@ func AppendJSONValue(buf []byte, v *fastjson.Value) ([]byte, error) {
 		s, _ := v.StringBytes()
 		return msgp.AppendStringFromBytes(buf, s), nil
 	case fastjson.TypeNumber:
-		if float64(v.GetInt64()) == v.GetFloat64() {
-			return msgp.AppendInt64(buf, v.GetInt64()), nil
-		}
 		return msgp.AppendFloat64(buf, v.GetFloat64()), nil
 	case fastjson.TypeTrue:
 		return msgp.AppendBool(buf, true), nil

--- a/types/json_to_msgp.go
+++ b/types/json_to_msgp.go
@@ -23,7 +23,7 @@ func JSONToMessagePack(buf []byte, jsonData []byte) ([]byte, error) {
 		return buf, err
 	}
 
-	buf, err = appendJSONValue(buf, v)
+	buf, err = AppendJSONValue(buf, v)
 	if err != nil {
 		return buf, err
 	}
@@ -31,7 +31,9 @@ func JSONToMessagePack(buf []byte, jsonData []byte) ([]byte, error) {
 	return buf, nil
 }
 
-func appendJSONValue(buf []byte, v *fastjson.Value) ([]byte, error) {
+// AppendJSONValue appends a fastjson.Value to a MessagePack buffer.
+// It recursively converts JSON types to their MessagePack equivalents.
+func AppendJSONValue(buf []byte, v *fastjson.Value) ([]byte, error) {
 	switch v.Type() {
 	case fastjson.TypeObject:
 		return appendJSONObject(buf, v)
@@ -39,7 +41,7 @@ func appendJSONValue(buf []byte, v *fastjson.Value) ([]byte, error) {
 		return appendJSONArray(buf, v)
 	case fastjson.TypeString:
 		s, _ := v.StringBytes()
-		return msgp.AppendString(buf, string(s)), nil
+		return msgp.AppendStringFromBytes(buf, s), nil
 	case fastjson.TypeNumber:
 		if float64(v.GetInt64()) == v.GetFloat64() {
 			return msgp.AppendInt64(buf, v.GetInt64()), nil
@@ -69,7 +71,7 @@ func appendJSONObject(buf []byte, v *fastjson.Value) ([]byte, error) {
 			return
 		}
 		buf = msgp.AppendStringFromBytes(buf, key)
-		buf, err = appendJSONValue(buf, v)
+		buf, err = AppendJSONValue(buf, v)
 	})
 
 	return buf, err
@@ -84,7 +86,7 @@ func appendJSONArray(buf []byte, v *fastjson.Value) ([]byte, error) {
 	buf = msgp.AppendArrayHeader(buf, uint32(len(arr)))
 
 	for _, item := range arr {
-		buf, err = appendJSONValue(buf, item)
+		buf, err = AppendJSONValue(buf, item)
 		if err != nil {
 			return buf, err
 		}

--- a/types/json_to_msgp_test.go
+++ b/types/json_to_msgp_test.go
@@ -19,7 +19,7 @@ func TestJSONToMessagePack(t *testing.T) {
 			input: `{"str": "hello", "num": 123, "flag": true, "empty": null}`,
 			expected: map[string]any{
 				"str":   "hello",
-				"num":   int64(123),
+				"num":   float64(123),
 				"flag":  true,
 				"empty": nil,
 			},
@@ -30,7 +30,7 @@ func TestJSONToMessagePack(t *testing.T) {
 			expected: map[string]any{
 				"nested": map[string]any{
 					"inner": "value",
-					"count": int64(5),
+					"count": float64(5),
 				},
 			},
 		},
@@ -45,14 +45,14 @@ func TestJSONToMessagePack(t *testing.T) {
 			name:  "array of numbers",
 			input: `{"numbers": [1, 2, 3]}`,
 			expected: map[string]any{
-				"numbers": []any{int64(1), int64(2), int64(3)},
+				"numbers": []any{float64(1), float64(2), float64(3)},
 			},
 		},
 		{
 			name:  "array of mixed types",
 			input: `{"mixed": ["string", 42, true, null]}`,
 			expected: map[string]any{
-				"mixed": []any{"string", int64(42), true, nil},
+				"mixed": []any{"string", float64(42), true, nil},
 			},
 		},
 		{
@@ -73,10 +73,10 @@ func TestJSONToMessagePack(t *testing.T) {
 			expected: map[string]any{
 				"data": map[string]any{
 					"users": []any{
-						map[string]any{"name": "Alice", "age": int64(30)},
-						map[string]any{"name": "Bob", "age": int64(25)},
+						map[string]any{"name": "Alice", "age": float64(30)},
+						map[string]any{"name": "Bob", "age": float64(25)},
 					},
-					"count": int64(2),
+					"count": float64(2),
 				},
 			},
 		},
@@ -115,8 +115,7 @@ func TestJSONToMessagePack(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expected, result)
 
-			// Note: We don't compare with json.Unmarshal because it converts all numbers to float64,
-			// while our converter correctly preserves integers as int64
+			// Note: Our converter now matches json.Unmarshal behavior by converting all numbers to float64
 
 			// Test idempotency - convert same input again
 			msgpackData2, err := JSONToMessagePack(nil, []byte(tt.input))

--- a/types/json_to_msgp_test.go
+++ b/types/json_to_msgp_test.go
@@ -1,0 +1,180 @@
+package types
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tinylib/msgp/msgp"
+)
+
+func TestJSONToMessagePack(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected map[string]any
+	}{
+		{
+			name:  "mixed types",
+			input: `{"str": "hello", "num": 123, "flag": true, "empty": null}`,
+			expected: map[string]any{
+				"str":   "hello",
+				"num":   int64(123),
+				"flag":  true,
+				"empty": nil,
+			},
+		},
+		{
+			name:  "nested object",
+			input: `{"nested": {"inner": "value", "count": 5}}`,
+			expected: map[string]any{
+				"nested": map[string]any{
+					"inner": "value",
+					"count": int64(5),
+				},
+			},
+		},
+		{
+			name:  "array of strings",
+			input: `{"items": ["a", "b", "c"]}`,
+			expected: map[string]any{
+				"items": []any{"a", "b", "c"},
+			},
+		},
+		{
+			name:  "array of numbers",
+			input: `{"numbers": [1, 2, 3]}`,
+			expected: map[string]any{
+				"numbers": []any{int64(1), int64(2), int64(3)},
+			},
+		},
+		{
+			name:  "array of mixed types",
+			input: `{"mixed": ["string", 42, true, null]}`,
+			expected: map[string]any{
+				"mixed": []any{"string", int64(42), true, nil},
+			},
+		},
+		{
+			name:     "empty object",
+			input:    `{}`,
+			expected: map[string]any{},
+		},
+		{
+			name:  "empty array",
+			input: `{"empty": []}`,
+			expected: map[string]any{
+				"empty": []any{},
+			},
+		},
+		{
+			name:  "complex nested structure",
+			input: `{"data": {"users": [{"name": "Alice", "age": 30}, {"name": "Bob", "age": 25}], "count": 2}}`,
+			expected: map[string]any{
+				"data": map[string]any{
+					"users": []any{
+						map[string]any{"name": "Alice", "age": int64(30)},
+						map[string]any{"name": "Bob", "age": int64(25)},
+					},
+					"count": int64(2),
+				},
+			},
+		},
+		{
+			name:  "unicode characters",
+			input: `{"message": "Hello 🌍 World! αβγδε"}`,
+			expected: map[string]any{
+				"message": "Hello 🌍 World! αβγδε",
+			},
+		},
+		{
+			name:  "escaped characters",
+			input: `{"message": "Line 1\nLine 2\tTabbed"}`,
+			expected: map[string]any{
+				"message": "Line 1\nLine 2\tTabbed",
+			},
+		},
+		{
+			name:  "quotes in string",
+			input: `{"message": "She said \"Hello\""}`,
+			expected: map[string]any{
+				"message": "She said \"Hello\"",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test conversion
+			msgpackData, err := JSONToMessagePack(nil, []byte(tt.input))
+			assert.NoError(t, err)
+
+			// Test unmarshaling
+			var result any
+			result, _, err = msgp.ReadIntfBytes(msgpackData)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+
+			// Note: We don't compare with json.Unmarshal because it converts all numbers to float64,
+			// while our converter correctly preserves integers as int64
+
+			// Test idempotency - convert same input again
+			msgpackData2, err := JSONToMessagePack(nil, []byte(tt.input))
+			assert.NoError(t, err)
+			assert.Equal(t, msgpackData, msgpackData2, "Conversion should be idempotent")
+		})
+	}
+}
+
+func TestJSONToMessagePackErrorCases(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "invalid JSON",
+			input: `{"key": }`,
+		},
+		{
+			name:  "empty input",
+			input: ``,
+		},
+		{
+			name:  "malformed JSON",
+			input: `{"key": "value"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := JSONToMessagePack(nil, []byte(tt.input))
+			assert.Error(t, err)
+		})
+	}
+}
+
+func BenchmarkJSONToMessagePack(b *testing.B) {
+	testData := `{"trace_id": "abc123", "span_id": "xyz789", "timestamp": 1641024000, "duration": 150.5, "service": "web-api", "operation": "GET /users", "status": "ok", "tags": {"user_id": 12345, "region": "us-west-2", "version": "1.2.3"}, "events": [{"timestamp": 1641024001, "name": "cache_miss"}, {"time": "2023-01-01T12:00:00.123456789Z", "name": "db_query", "duration": 25.2}]}`
+
+	b.Run("DirectConversion", func(b *testing.B) {
+		var buf []byte
+		for range b.N {
+			buf, _ = JSONToMessagePack(buf[:0], []byte(testData))
+		}
+	})
+
+	b.Run("StandardWay", func(b *testing.B) {
+		var buf []byte
+		for range b.N {
+			var data map[string]any
+			err := json.Unmarshal([]byte(testData), &data)
+			if err != nil {
+				b.Fatal(err)
+			}
+			buf, err = msgp.AppendIntf(buf[:0], data)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}


### PR DESCRIPTION
## Which problem is this PR solving?
JSON is still a thing, so we need to handle it efficiently.

## Short description of the changes
Short-circuits the batch JSON parsing pathway to directly pick out the fields we want using optimized code, and then turn the data blob directly into messagepack. That makes this slower than messagepack, but faster than OTLP, which isn't bad.

```
benchmark                              old ns/op     new ns/op     delta
BenchmarkRouterBatch/batch_json-12     346258        26287         -92.41%

benchmark                              old allocs     new allocs     delta
BenchmarkRouterBatch/batch_json-12     1935           30             -98.45%

benchmark                              old bytes     new bytes     delta
BenchmarkRouterBatch/batch_json-12     113436        17539         -84.54%
```
