### PR TITLE
perf: optimize sampling key field extraction in payload processing

### DIFF
--- a/types/payload.go
+++ b/types/payload.go
@@ -332,10 +332,11 @@ func (p *Payload) extractCriticalFieldsFromBytes(data []byte, traceIdFieldNames,
 
 		// Handle special trace ID and parent ID fields
 		if !handled && valueType == msgp.StrType {
-			if p.MetaTraceID == "" && sliceContains(traceIdFieldNames, keyBytes) {
+			_, ok := sliceContains(traceIdFieldNames, keyBytes)
+			if p.MetaTraceID == "" && ok {
 				p.MetaTraceID, remaining, err = msgp.ReadStringBytes(remaining)
 				handled = true
-			} else if sliceContains(parentIdFieldNames, keyBytes) {
+			} else if _, ok := sliceContains(parentIdFieldNames, keyBytes); ok {
 				var parentId string
 				parentId, remaining, err = msgp.ReadStringBytes(remaining)
 				if err == nil && parentId != "" {
@@ -354,8 +355,8 @@ func (p *Payload) extractCriticalFieldsFromBytes(data []byte, traceIdFieldNames,
 		if !handled && keysFound < len(samplingKeyFields) {
 			// Check if the key matches any of the key fields
 			var val any
-			if sliceContains(samplingKeyFields, keyBytes) {
-				if p.memoizedFields[string(keyBytes)] != nil {
+			if idx, ok := sliceContains(samplingKeyFields, keyBytes); ok {
+				if p.memoizedFields[samplingKeyFields[idx]] != nil {
 					// If we already have this key, skip it
 					continue
 				}
@@ -366,7 +367,7 @@ func (p *Payload) extractCriticalFieldsFromBytes(data []byte, traceIdFieldNames,
 					return len(data) - len(remaining), fmt.Errorf("failed to read value for key %s: %w", string(keyBytes), err)
 				}
 
-				p.Set(string(keyBytes), val)
+				p.Set(samplingKeyFields[idx], val)
 				handled = true
 			}
 		}
@@ -967,11 +968,12 @@ func (p Payload) GetMemoizedFields() map[string]any {
 // When trying to find a particular []byte in a slice of strings, we could use
 // slices.Contains, but this involves casting the []byte to a string which does
 // a heap allocation. This is cheaper.
-func sliceContains(in []string, find []byte) bool {
+// Returns the index of the first matching string, or -1 if not found.
+func sliceContains(in []string, find []byte) (int, bool) {
 	for i := range in {
 		if bytes.Equal([]byte(in[i]), find) {
-			return true
+			return i, true
 		}
 	}
-	return false
+	return -1, false
 }


### PR DESCRIPTION
## Which problem is this PR solving?

The original logic checks whether a field has been “found” before verifying if it’s actually defined as a sampling key. This leads to unnecessary map lookups in cases where the field isn’t even relevant for sampling decisions. Since map access in Go carries non-trivial cost—especially in hot paths like trace processing—this approach adds avoidable overhead
<img width="643" height="874" alt="Screenshot 2025-07-31 at 11 52 21 AM" src="https://github.com/user-attachments/assets/602356fb-5feb-42b3-a793-5a7c4b13a4b4" />

## Short description of the changes

This change improves efficiency by reversing the order of checks when identifying sampling key fields. Instead of first checking whether a field has been found and then verifying if it is a sampling key field, we now first check whether the field is a sampling key. This avoids unnecessary map lookups and reduces overhead during field evaluation.

## Benchmark Result
```
goos: darwin
goarch: arm64
pkg: github.com/honeycombio/refinery/types
cpu: Apple M2 Max
                                             │ existing.txt │            improved.txt             │
                                             │    sec/op    │   sec/op     vs base                │
UnmarshalPayload/UnmarshalPayload-12           22.002µ ± 0%   8.958µ ± 8%  -59.28% (p=0.000 n=10)
UnmarshalPayload/UnmarshalPayloadComplete-12   21.151µ ± 0%   8.011µ ± 2%  -62.13% (p=0.000 n=10)
geomean                                         21.57µ        8.471µ       -60.73%

                                             │ existing.txt │            improved.txt             │
                                             │     B/op     │     B/op      vs base               │
UnmarshalPayload/UnmarshalPayload-12           6.984Ki ± 0%   6.969Ki ± 0%  -0.22% (p=0.000 n=10)
UnmarshalPayload/UnmarshalPayloadComplete-12    1008.0 ± 0%     992.0 ± 0%  -1.59% (p=0.000 n=10)
geomean                                        2.622Ki        2.598Ki       -0.91%

                                             │ existing.txt │           improved.txt            │
                                             │  allocs/op   │ allocs/op   vs base               │
UnmarshalPayload/UnmarshalPayload-12             14.00 ± 0%   13.00 ± 0%  -7.14% (p=0.000 n=10)
UnmarshalPayload/UnmarshalPayloadComplete-12     13.00 ± 0%   12.00 ± 0%  -7.69% (p=0.000 n=10)
geomean                                          13.49        12.49       -7.42%
```
