### PR TITLE
fix: update CacheCapacity description

### DIFF
--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -1260,18 +1260,14 @@ groups:
         validations:
           - type: minimum
             arg: 1000
-        summary: is the number of traces to keep in the cache's circular buffer.
+        summary: Deprecated. Set PeerQueueSize and IncomingQueueSize instead.
         description: >
-          The collection cache is used to collect all active spans into traces.
-          It is organized as a circular buffer. When the buffer wraps around,
-          Refinery will try a few times to find an empty slot; if it fails, it
-          starts ejecting traces from the cache earlier than would otherwise be
-          necessary. Ideally, the size of the cache should be many
-          multiples (100x to 1000x) of the total number of concurrently active
-          traces (average trace throughput * average trace duration).
-
           NOTE: This setting is now deprecated and no longer controls the cache size.
-          Instead the maxmimum memory usage is controlled by `MaxMemoryPercentage` and `MaxAlloc`.
+          Instead the maximum memory usage is controlled by `MaxMemoryPercentage` and `MaxAlloc`.
+          
+          Setting this value does still set the default PeerQueueSize to (3 x CacheCapacity) and IncomingQueueSize
+          to (3 x CacheCapacity) if they are not set. This behavior will be removed in the future.
+          Instead, set PeerQueueSize and IncomingQueueSize to the exact values you want.
 
       - name: PeerQueueSize
         type: int


### PR DESCRIPTION
## Which problem is this PR solving?

- updates the CacheCapacity docs to be more explicit about the deprecation.

Related to https://github.com/honeycombio/refinery/issues/1642