### PR TITLE
maint: remove unused messagepack iterator code

### DIFF
--- a/types/payload_test.go
+++ b/types/payload_test.go
@@ -226,9 +226,7 @@ func TestPayloadExtractMetadataError(t *testing.T) {
 	t.Run("invalid msgpack data", func(t *testing.T) {
 		// Create a payload with invalid msgpack data
 		p := Payload{
-			msgpMap: MsgpPayloadMap{
-				rawData: []byte{0xFF, 0xFF, 0xFF}, // Invalid msgpack
-			},
+			msgpData: []byte{0xFF, 0xFF, 0xFF}, // Invalid msgpack
 			config: &config.MockConfig{
 				TraceIdFieldNames:  []string{"trace.trace_id"},
 				ParentIdFieldNames: []string{"trace.parent_id", "parentId"},


### PR DESCRIPTION
## Which problem is this PR solving?
Much of the original messagepack iterator code I wrote originally has been superseded by specialized code in payload.go.

## Short description of the changes
I created the initial iterator mainly as a reference point and proof of concept, but it's turn out we don't use the type-specific value fetchers (instead Payload parses the messagepack directly), so I'm removing them.

Also un-exports nextKey() and valueAny() since this stuff isn't used outside the package.