### PR TITLE
test: improve efficiency of BenchmarkCollectorWithSamplers

### DIFF
--- a/types/payload.go
+++ b/types/payload.go
@@ -729,6 +729,10 @@ func (p *Payload) Set(key string, value any) {
 	p.memoizedFields[key] = value
 }
 
+func (p *Payload) UnsetForTest(key string) {
+	delete(p.memoizedFields, key)
+}
+
 func (p *Payload) IsEmpty() bool {
 	return len(p.memoizedFields) == 0 && len(p.msgpData) == 0
 }


### PR DESCRIPTION
## Which problem is this PR solving?
This benchmark was totally bogged down in creating test data points, making it slow to run and innaccurate.

## Short description of the changes
Changes the structure of the benchmark so that N is the number of spans, not the number of traces. Gives up on the 1M-span trace which I think is not really necessary to get the idea of the performance curve. Re-uses spans.

At some point the input will again become the bottleneck here, but multiple input goroutines really slowed things down so I stuck with just the one - for now anyway.
