### PR TITLE
maint: update streamlined data handling branch to the latest changes in main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Refinery Changelog
 
+## 2.9.7 2025-07-16
+
+### Features
+
+- feat: add support for REFINERY_HONEYCOMB_LOGGER_ADDITIONAL_FIELDS to honeycomb logger (#1600) | [Tyler Helmuth](https://github.com/TylerHelmuth)
+
+### Fixes
+
+- fix: use unique port number for integration test (#1621) | [Yingrong Zhao](https://github.com/vinozzZ)
+- fix: send http status code 400 for empty event payload (#1618) | [Yingrong Zhao](https://github.com/vinozzZ)
+- fix: make TestStableMaxAlloc less flaky (#1596) | [Yingrong Zhao](https://github.com/vinozzZ)
+- fix: wait for goroutines to finish before shutting down (#1593) | [Yingrong Zhao](https://github.com/vinozzZ)
+
+### Maintenance
+
+- maint: use collect.Start() in collector_test.go (#1591) | [Yingrong Zhao](https://github.com/vinozzZ)
+
 ## 2.9.6 2025-06-20
 
 This release aims to improve user experience by adding new metrics and making default values more sensible.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,10 @@
 
 While [CHANGELOG.md](./CHANGELOG.md) contains detailed documentation and links to all the source code changes in a given release, this document is intended to be aimed at a more comprehensible version of the contents of the release from the point of view of users of Refinery.
 
+## Version 2.9.7
+
+This release focuses on improving Refinery by fixing a bug with empty payloads. It also adds a new feature that allows you to add static fields to all internal refinery logs.
+
 ## Version 2.9.6
 
 This release focuses on improving observability and making Refinery easier to operate with better default values and new metrics. It also includes several important bug fixes for edge cases and configuration handling.

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -509,6 +509,60 @@ func TestAppIntegrationWithUnauthorizedKey(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestAppIntegrationEmptyEvent(t *testing.T) {
+	t.Parallel()
+	port := 19010
+	redisDB := 8
+
+	cfg := defaultConfig(port, redisDB, "")
+	_, graph := newStartedApp(t, nil, nil, cfg)
+
+	tt := []struct {
+		name                       string
+		data                       string
+		expectedResponseStatusCode int
+		expectedResponse           string
+	}{
+		{
+			name:                       "batch",
+			data:                       `[{"data":{}}]`, // Empty event data
+			expectedResponseStatusCode: http.StatusOK,
+			expectedResponse:           "status\":400,\"error\":\"empty event data\"",
+		},
+		{
+			name:                       "events",
+			data:                       `{}`,
+			expectedResponseStatusCode: http.StatusBadRequest,
+			expectedResponse:           "{\"source\":\"refinery\",\"error\":\"failed to parse event\"",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			// Send an empty event, it should return a 400 error but the batch request is processed with 200.
+			req := httptest.NewRequest(
+				"POST",
+				fmt.Sprintf("http://localhost:%d/1/%s/dataset", port, tc.name),
+				strings.NewReader(tc.data),
+			)
+			req.Header.Set("X-Honeycomb-Team", legacyAPIKey)
+			req.Header.Set("Content-Type", "application/json")
+
+			resp, err := http.DefaultTransport.RoundTrip(req)
+			assert.NoError(t, err)
+
+			assert.Equal(t, tc.expectedResponseStatusCode, resp.StatusCode)
+			data, err := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			assert.NoError(t, err)
+			assert.Contains(t, string(data), tc.expectedResponse)
+		})
+	}
+
+	err := startstop.Stop(graph.Objects(), nil)
+	assert.NoError(t, err)
+}
+
 func TestPeerRouting(t *testing.T) {
 	// Parallel integration tests need different ports!
 	t.Parallel()

--- a/config.md
+++ b/config.md
@@ -3,7 +3,7 @@
 # Honeycomb Refinery Configuration Documentation
 
 This is the documentation for the configuration file for Honeycomb's Refinery.
-It was automatically generated on 2025-06-04 at 22:30:00 UTC.
+It was automatically generated on 2025-07-25 at 19:58:08 UTC.
 
 ## The Config file
 
@@ -540,6 +540,20 @@ The sampling algorithm attempts to make sure that the average throughput approxi
 - Default: `10`
 - Example: `10`
 
+### `AdditionalAttributes`
+
+AdditionalAttributes adds the provided attributes to all logs written by the Honeycomb logger.
+
+When supplying via a environment variable, the value should be a string of comma-separated key-value pairs.
+When supplying via the command line, the value should be a key value pair.
+If multiple key-value pairs are needed, each should be supplied via its own command line flag.
+The key-value pairs must use ':' as the separator.
+
+- Not eligible for live reload.
+- Type: `map`
+- Example: `pipeline.id:'12345',rollout.id:'67890'`
+- Environment variable: `REFINERY_HONEYCOMB_LOGGER_ADDITIONAL_ATTRIBUTES`
+
 ## Stdout Logger
 
 `StdoutLogger` contains configuration for logging to `stdout`.
@@ -852,7 +866,7 @@ Peers is the list of peers to use when Type is "file", excluding self.
 This list is ignored when Type is "redis".
 The format is a list of strings of the form "scheme://host:port".
 
-- Not eligible for live reload.
+- Eligible for live reload.
 - Type: `stringarray`
 - Example: `http://192.168.1.11:8081,http://192.168.1.12:8081`
 

--- a/config/cmdenv.go
+++ b/config/cmdenv.go
@@ -26,34 +26,35 @@ import (
 // that this system uses reflection to establish the relationship between the
 // config struct and the command line options.
 type CmdEnv struct {
-	ConfigLocations       []string   `short:"c" long:"config" env:"REFINERY_CONFIG" env-delim:"," default:"/etc/refinery/refinery.yaml" description:"config file or URL to load; can be specified more than once"`
-	RulesLocations        []string   `short:"r" long:"rules_config" env:"REFINERY_RULES_CONFIG" env-delim:"," default:"/etc/refinery/rules.yaml" description:"config file or URL to load; can be specified more than once"`
-	HTTPListenAddr        string     `long:"http-listen-address" env:"REFINERY_HTTP_LISTEN_ADDRESS" description:"HTTP listen address for incoming event traffic"`
-	PeerListenAddr        string     `long:"peer-listen-address" env:"REFINERY_PEER_LISTEN_ADDRESS" description:"Peer listen address for communication between Refinery instances"`
-	GRPCListenAddr        string     `long:"grpc-listen-address" env:"REFINERY_GRPC_LISTEN_ADDRESS" description:"gRPC listen address for OTLP traffic"`
-	RedisHost             string     `long:"redis-host" env:"REFINERY_REDIS_HOST" description:"Redis host address"`
-	RedisClusterHosts     []string   `long:"redis-cluster-hosts" env:"REFINERY_REDIS_CLUSTER_HOSTS" env-delim:"," description:"Redis cluster host addresses"`
-	RedisUsername         string     `long:"redis-username" env:"REFINERY_REDIS_USERNAME" description:"Redis username. Setting this value via a flag may expose credentials - it is recommended to use the env var or a configuration file."`
-	RedisPassword         string     `long:"redis-password" env:"REFINERY_REDIS_PASSWORD" description:"Redis password. Setting this value via a flag may expose credentials - it is recommended to use the env var or a configuration file."`
-	RedisAuthCode         string     `long:"redis-auth-code" env:"REFINERY_REDIS_AUTH_CODE" description:"Redis AUTH code. Setting this value via a flag may expose credentials - it is recommended to use the env var or a configuration file."`
-	HoneycombAPI          string     `long:"honeycomb-api" env:"REFINERY_HONEYCOMB_API" description:"Honeycomb API URL"`
-	HoneycombAPIKey       string     `long:"honeycomb-api-key" env:"REFINERY_HONEYCOMB_API_KEY" description:"Honeycomb API key (for logger and metrics). Setting this value via a flag may expose credentials - it is recommended to use the env var or a configuration file."`
-	HoneycombLoggerAPIKey string     `long:"logger-api-key" env:"REFINERY_HONEYCOMB_LOGGER_API_KEY" description:"Honeycomb logger API key. Setting this value via a flag may expose credentials - it is recommended to use the env var or a configuration file."`
-	LegacyMetricsAPIKey   string     `long:"legacy-metrics-api-key" env:"REFINERY_HONEYCOMB_METRICS_API_KEY" description:"API key for legacy Honeycomb metrics. Setting this value via a flag may expose credentials - it is recommended to use the env var or a configuration file."`
-	OpAMPEndpoint         string     `long:"opamp-server-url" env:"REFINERY_OPAMP_ENDPOINT" description:"URL of the OpAMP server to use for remote management."`
-	TelemetryEndpoint     string     `long:"telemetry-endpoint" env:"REFINERY_TELEMETRY_ENDPOINT" description:"Endpoint to send Refinery's internal telemetry to. This is separate from the Honeycomb API endpoint and is used for sending metrics about Refinery's performance."`
-	OTelMetricsAPIKey     string     `long:"otel-metrics-api-key" env:"REFINERY_OTEL_METRICS_API_KEY" description:"API key for OTel metrics if being sent to Honeycomb. Setting this value via a flag may expose credentials - it is recommended to use the env var or a configuration file."`
-	OTelTracesAPIKey      string     `long:"otel-traces-api-key" env:"REFINERY_OTEL_TRACES_API_KEY" description:"API key for OTel traces if being sent to Honeycomb. Setting this value via a flag may expose credentials - it is recommended to use the env var or a configuration file."`
-	QueryAuthToken        string     `long:"query-auth-token" env:"REFINERY_QUERY_AUTH_TOKEN" description:"Token for debug/management queries. Setting this value via a flag may expose credentials - it is recommended to use the env var or a configuration file."`
-	AvailableMemory       MemorySize `long:"available-memory" env:"REFINERY_AVAILABLE_MEMORY" description:"The maximum memory available for Refinery to use (ex: 4GiB)."`
-	SendKey               string     `long:"send-key" env:"REFINERY_SEND_KEY" description:"The Honeycomb API key that Refinery can use to send data to Honeycomb."`
-	Debug                 bool       `short:"d" long:"debug" description:"Runs debug service (on the first open port between localhost:6060 and :6069 by default)"`
-	Version               bool       `short:"v" long:"version" description:"Print version number and exit"`
-	InterfaceNames        bool       `long:"interface-names" description:"Print system's network interface names and exit."`
-	Validate              bool       `short:"V" long:"validate" description:"Validate the configuration files, writing results to stdout, and exit with 0 if valid, 1 if invalid."`
-	NoValidate            bool       `long:"no-validate" description:"Do not attempt to validate the configuration files. Makes --validate meaningless."`
-	WriteConfig           string     `long:"write-config" description:"After applying defaults, environment variables, and command line values, write the loaded configuration to the specified file as YAML and exit."`
-	WriteRules            string     `long:"write-rules" description:"After applying defaults, write the loaded rules to the specified file as YAML and exit."`
+	ConfigLocations                     []string          `short:"c" long:"config" env:"REFINERY_CONFIG" env-delim:"," default:"/etc/refinery/refinery.yaml" description:"config file or URL to load; can be specified more than once"`
+	RulesLocations                      []string          `short:"r" long:"rules_config" env:"REFINERY_RULES_CONFIG" env-delim:"," default:"/etc/refinery/rules.yaml" description:"config file or URL to load; can be specified more than once"`
+	HTTPListenAddr                      string            `long:"http-listen-address" env:"REFINERY_HTTP_LISTEN_ADDRESS" description:"HTTP listen address for incoming event traffic"`
+	PeerListenAddr                      string            `long:"peer-listen-address" env:"REFINERY_PEER_LISTEN_ADDRESS" description:"Peer listen address for communication between Refinery instances"`
+	GRPCListenAddr                      string            `long:"grpc-listen-address" env:"REFINERY_GRPC_LISTEN_ADDRESS" description:"gRPC listen address for OTLP traffic"`
+	RedisHost                           string            `long:"redis-host" env:"REFINERY_REDIS_HOST" description:"Redis host address"`
+	RedisClusterHosts                   []string          `long:"redis-cluster-hosts" env:"REFINERY_REDIS_CLUSTER_HOSTS" env-delim:"," description:"Redis cluster host addresses"`
+	RedisUsername                       string            `long:"redis-username" env:"REFINERY_REDIS_USERNAME" description:"Redis username. Setting this value via a flag may expose credentials - it is recommended to use the env var or a configuration file."`
+	RedisPassword                       string            `long:"redis-password" env:"REFINERY_REDIS_PASSWORD" description:"Redis password. Setting this value via a flag may expose credentials - it is recommended to use the env var or a configuration file."`
+	RedisAuthCode                       string            `long:"redis-auth-code" env:"REFINERY_REDIS_AUTH_CODE" description:"Redis AUTH code. Setting this value via a flag may expose credentials - it is recommended to use the env var or a configuration file."`
+	HoneycombAPI                        string            `long:"honeycomb-api" env:"REFINERY_HONEYCOMB_API" description:"Honeycomb API URL"`
+	HoneycombAPIKey                     string            `long:"honeycomb-api-key" env:"REFINERY_HONEYCOMB_API_KEY" description:"Honeycomb API key (for logger and metrics). Setting this value via a flag may expose credentials - it is recommended to use the env var or a configuration file."`
+	HoneycombLoggerAPIKey               string            `long:"logger-api-key" env:"REFINERY_HONEYCOMB_LOGGER_API_KEY" description:"Honeycomb logger API key. Setting this value via a flag may expose credentials - it is recommended to use the env var or a configuration file."`
+	HoneycombLoggerAdditionalAttributes map[string]string `long:"logger-additional-attributes" env:"REFINERY_HONEYCOMB_LOGGER_ADDITIONAL_ATTRIBUTES" env-delim:"," description:"Additional attributes to add to all logs written by the Honeycomb logger. When supplying via a environment variable, the value should be a string of comma-separated key-value pairs. When supplying via the command line, the value should be a key value pair. If multiple key-value pairs are needed, each should be supplied via its own command line flag. The key-value pairs must use ':' as the separator."`
+	LegacyMetricsAPIKey                 string            `long:"legacy-metrics-api-key" env:"REFINERY_HONEYCOMB_METRICS_API_KEY" description:"API key for legacy Honeycomb metrics. Setting this value via a flag may expose credentials - it is recommended to use the env var or a configuration file."`
+	OpAMPEndpoint                       string            `long:"opamp-server-url" env:"REFINERY_OPAMP_ENDPOINT" description:"URL of the OpAMP server to use for remote management."`
+	TelemetryEndpoint                   string            `long:"telemetry-endpoint" env:"REFINERY_TELEMETRY_ENDPOINT" description:"Endpoint to send Refinery's internal telemetry to. This is separate from the Honeycomb API endpoint and is used for sending metrics about Refinery's performance."`
+	OTelMetricsAPIKey                   string            `long:"otel-metrics-api-key" env:"REFINERY_OTEL_METRICS_API_KEY" description:"API key for OTel metrics if being sent to Honeycomb. Setting this value via a flag may expose credentials - it is recommended to use the env var or a configuration file."`
+	OTelTracesAPIKey                    string            `long:"otel-traces-api-key" env:"REFINERY_OTEL_TRACES_API_KEY" description:"API key for OTel traces if being sent to Honeycomb. Setting this value via a flag may expose credentials - it is recommended to use the env var or a configuration file."`
+	QueryAuthToken                      string            `long:"query-auth-token" env:"REFINERY_QUERY_AUTH_TOKEN" description:"Token for debug/management queries. Setting this value via a flag may expose credentials - it is recommended to use the env var or a configuration file."`
+	AvailableMemory                     MemorySize        `long:"available-memory" env:"REFINERY_AVAILABLE_MEMORY" description:"The maximum memory available for Refinery to use (ex: 4GiB)."`
+	SendKey                             string            `long:"send-key" env:"REFINERY_SEND_KEY" description:"The Honeycomb API key that Refinery can use to send data to Honeycomb."`
+	Debug                               bool              `short:"d" long:"debug" description:"Runs debug service (on the first open port between localhost:6060 and :6069 by default)"`
+	Version                             bool              `short:"v" long:"version" description:"Print version number and exit"`
+	InterfaceNames                      bool              `long:"interface-names" description:"Print system's network interface names and exit."`
+	Validate                            bool              `short:"V" long:"validate" description:"Validate the configuration files, writing results to stdout, and exit with 0 if valid, 1 if invalid."`
+	NoValidate                          bool              `long:"no-validate" description:"Do not attempt to validate the configuration files. Makes --validate meaningless."`
+	WriteConfig                         string            `long:"write-config" description:"After applying defaults, environment variables, and command line values, write the loaded configuration to the specified file as YAML and exit."`
+	WriteRules                          string            `long:"write-rules" description:"After applying defaults, write the loaded rules to the specified file as YAML and exit."`
 }
 
 func NewCmdEnvOptions(args []string) (*CmdEnv, error) {
@@ -130,41 +131,43 @@ func applyCmdEnvTags(s reflect.Value, fielder getFielder) error {
 					}
 
 					// don't overwrite values that are already set
-					if !value.IsZero() {
-						// ensure that the types match
-						if fieldType.Type != value.Type() {
-							return fmt.Errorf("programming error -- types don't match for field: %s (%v and %v)",
-								fieldType.Name, fieldType.Type, value.Type())
+					if value.IsZero() || ((value.Kind() == reflect.Map || value.Kind() == reflect.Slice) && value.Len() == 0) {
+						continue
+					}
+
+					// ensure that the types match
+					if fieldType.Type != value.Type() {
+						return fmt.Errorf("programming error -- types don't match for field: %s (%v and %v)",
+							fieldType.Name, fieldType.Type, value.Type())
+					}
+
+					if value.Kind() == reflect.Slice {
+						delimiter := fielder.GetDelimiter(tag)
+						if delimiter == "" {
+							return fmt.Errorf("programming error -- missing delimiter for slice field: %s", fieldType.Name)
 						}
 
-						if value.Kind() == reflect.Slice {
-							delimiter := fielder.GetDelimiter(tag)
-							if delimiter == "" {
-								return fmt.Errorf("programming error -- missing delimiter for slice field: %s", fieldType.Name)
-							}
-
-							rawValue, ok := value.Index(0).Interface().(string)
-							if !ok {
-								return fmt.Errorf("programming error -- slice field must be a string: %s", fieldType.Name)
-							}
-
-							// split the value on the delimiter
-							values := strings.Split(rawValue, delimiter)
-							// create a new slice of the same type as the field
-							slice := reflect.MakeSlice(field.Type(), len(values), len(values))
-							// iterate over the values and set them
-							for i, v := range values {
-								slice.Index(i).SetString(v)
-							}
-							// set the field
-							field.Set(slice)
-							break
+						rawValue, ok := value.Index(0).Interface().(string)
+						if !ok {
+							return fmt.Errorf("programming error -- slice field must be a string: %s", fieldType.Name)
 						}
-						// now we can set it
-						field.Set(value)
-						// and we're done with this field
+
+						// split the value on the delimiter
+						values := strings.Split(rawValue, delimiter)
+						// create a new slice of the same type as the field
+						slice := reflect.MakeSlice(field.Type(), len(values), len(values))
+						// iterate over the values and set them
+						for i, v := range values {
+							slice.Index(i).SetString(v)
+						}
+						// set the field
+						field.Set(slice)
 						break
 					}
+					// now we can set it
+					field.Set(value)
+					// and we're done with this field
+					break
 				}
 			}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -642,6 +642,11 @@ func TestHoneycombLoggerConfig(t *testing.T) {
 		"HoneycombLogger.Dataset", "loggerDataset",
 		"HoneycombLogger.SamplerEnabled", true,
 		"HoneycombLogger.SamplerThroughput", 5,
+		"HoneycombLogger.AdditionalAttributes", map[string]string{
+			"name":    "foo",
+			"other":   "bar",
+			"another": "OneHundred",
+		},
 	)
 	rm := makeYAML("ConfigVersion", 2)
 	config, rules := createTempConfigs(t, cm, rm)
@@ -659,6 +664,7 @@ func TestHoneycombLoggerConfig(t *testing.T) {
 	assert.Equal(t, "loggerDataset", loggerConfig.Dataset)
 	assert.Equal(t, true, loggerConfig.GetSamplerEnabled())
 	assert.Equal(t, 5, loggerConfig.SamplerThroughput)
+	assert.Equal(t, map[string]string{"name": "foo", "other": "bar", "another": "OneHundred"}, loggerConfig.AdditionalAttributes)
 }
 
 func TestHoneycombLoggerConfigDefaults(t *testing.T) {
@@ -678,6 +684,7 @@ func TestHoneycombLoggerConfigDefaults(t *testing.T) {
 
 	assert.Equal(t, true, loggerConfig.GetSamplerEnabled())
 	assert.Equal(t, 10, loggerConfig.SamplerThroughput)
+	assert.Len(t, loggerConfig.AdditionalAttributes, 0)
 }
 
 func TestHoneycombGRPCConfigDefaults(t *testing.T) {

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -239,11 +239,12 @@ type LoggerConfig struct {
 }
 
 type HoneycombLoggerConfig struct {
-	APIHost           string       `yaml:"APIHost" default:"https://api.honeycomb.io" cmdenv:"TelemetryEndpoint"`
-	APIKey            string       `yaml:"APIKey" cmdenv:"HoneycombLoggerAPIKey,HoneycombAPIKey"`
-	Dataset           string       `yaml:"Dataset" default:"Refinery Logs"`
-	SamplerEnabled    *DefaultTrue `yaml:"SamplerEnabled" default:"true"` // Avoid pointer woe on access, use GetSamplerEnabled() instead.
-	SamplerThroughput int          `yaml:"SamplerThroughput" default:"10"`
+	APIHost              string            `yaml:"APIHost" default:"https://api.honeycomb.io" cmdenv:"TelemetryEndpoint"`
+	APIKey               string            `yaml:"APIKey" cmdenv:"HoneycombLoggerAPIKey,HoneycombAPIKey"`
+	Dataset              string            `yaml:"Dataset" default:"Refinery Logs"`
+	SamplerEnabled       *DefaultTrue      `yaml:"SamplerEnabled" default:"true"` // Avoid pointer woe on access, use GetSamplerEnabled() instead.
+	SamplerThroughput    int               `yaml:"SamplerThroughput" default:"10"`
+	AdditionalAttributes map[string]string `yaml:"AdditionalAttributes" default:"" cmdenv:"HoneycombLoggerAdditionalAttributes"`
 }
 
 // GetSamplerEnabled returns whether configuration has enabled sampling of

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -646,6 +646,23 @@ groups:
           unique logs arrive at Honeycomb at least once per sampling
           period.
 
+      - name: AdditionalAttributes
+        type: map
+        valuetype: map
+        example: "pipeline.id:'12345',rollout.id:'67890'"
+        reload: false
+        validations:
+          - type: elementType
+            arg: string
+        summary: adds the provided attributes to all logs written by the Honeycomb logger.
+        envvar: REFINERY_HONEYCOMB_LOGGER_ADDITIONAL_ATTRIBUTES
+        commandline: logger-additional-attributes
+        description: >
+           When supplying via a environment variable, the value should be a string of comma-separated key-value pairs.
+           When supplying via the command line, the value should be a key value pair.
+           If multiple key-value pairs are needed, each should be supplied via its own command line flag.
+           The key-value pairs must use ':' as the separator.
+
   - name: StdoutLogger
     title: "Stdout Logger"
     description: contains configuration for logging to `stdout`. Only used if `Logger.Type` is "stdout".
@@ -1041,7 +1058,7 @@ groups:
         type: stringarray
         valuetype: stringarray
         example: "http://192.168.1.11:8081,http://192.168.1.12:8081"
-        reload: false
+        reload: true
         validations:
           - type: elementType
             arg: url
@@ -1243,18 +1260,14 @@ groups:
         validations:
           - type: minimum
             arg: 1000
-        summary: is the number of traces to keep in the cache's circular buffer.
+        summary: Deprecated. Set PeerQueueSize and IncomingQueueSize instead.
         description: >
-          The collection cache is used to collect all active spans into traces.
-          It is organized as a circular buffer. When the buffer wraps around,
-          Refinery will try a few times to find an empty slot; if it fails, it
-          starts ejecting traces from the cache earlier than would otherwise be
-          necessary. Ideally, the size of the cache should be many
-          multiples (100x to 1000x) of the total number of concurrently active
-          traces (average trace throughput * average trace duration).
-
           NOTE: This setting is now deprecated and no longer controls the cache size.
-          Instead the maxmimum memory usage is controlled by `MaxMemoryPercentage` and `MaxAlloc`.
+          Instead the maximum memory usage is controlled by `MaxMemoryPercentage` and `MaxAlloc`.
+          
+          Setting this value does still set the default PeerQueueSize to (3 x CacheCapacity) and IncomingQueueSize
+          to (3 x CacheCapacity) if they are not set. This behavior will be removed in the future.
+          Instead, set PeerQueueSize and IncomingQueueSize to the exact values you want.
 
       - name: PeerQueueSize
         type: int

--- a/config_complete.yaml
+++ b/config_complete.yaml
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created on 2025-06-04 at 22:30:00 UTC from ../../config.yaml using a template generated on 2025-06-04 at 22:29:50 UTC
+# created on 2025-07-25 at 19:58:08 UTC from ../../config.yaml using a template generated on 2025-07-25 at 19:57:55 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of
@@ -562,6 +562,20 @@ HoneycombLogger:
     ## Not eligible for live reload.
     # SamplerThroughput: 10
 
+    ## AdditionalAttributes adds the provided attributes to all logs written
+    ## by the Honeycomb logger.
+    ##
+    ## When supplying via a environment variable, the value should be a
+    ## string of comma-separated key-value pairs. When supplying via the
+    ## command line, the value should be a key value pair. If multiple
+    ## key-value pairs are needed, each should be supplied via its own
+    ## command line flag. The key-value pairs must use ':' as the separator.
+    ##
+    ## Not eligible for live reload.
+    # AdditionalAttributes:
+      #  rollout.id: '67890'
+      #  pipeline.id: '12345'
+
 ###################
 ## Stdout Logger ##
 ###################
@@ -890,7 +904,7 @@ PeerManagement:
     ## This list is ignored when Type is "redis". The format is a list of
     ## strings of the form "scheme://host:port".
     ##
-    ## Not eligible for live reload.
+    ## Eligible for live reload.
     # Peers:
       # - http://192.168.1.11:8081
       # - http://192.168.1.12:8081
@@ -1261,8 +1275,8 @@ Specialized:
     ##
     ## Eligible for live reload.
     # AdditionalAttributes:
-      #  ClusterName: MyCluster
       #  environment: production
+      #  ClusterName: MyCluster
 
 ###############
 ## ID Fields ##

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/stretchr/testify v1.10.0
 	github.com/tidwall/gjson v1.18.0
 	github.com/tinylib/msgp v1.3.0
+	github.com/valyala/fastjson v1.6.4
 	github.com/vmihailenco/msgpack/v5 v5.4.1
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0
@@ -70,7 +71,6 @@ require (
 	github.com/spf13/cobra v1.7.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	github.com/valyala/fastjson v1.6.4 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	gopkg.in/alexcesaro/statsd.v2 v2.0.0 // indirect
@@ -81,7 +81,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/dgryski/go-metro v0.0.0-20200812162917-85c65e2d0165 // indirect
+	github.com/dgryski/go-metro v0.0.0-20250106013310-edb8663e5e33 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a // indirect
 	github.com/facebookgo/limitgroup v0.0.0-20150612190941-6abd8d71ec01 // indirect

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,9 @@ github.com/creasty/defaults v1.8.0/go.mod h1:iGzKe6pbEHnpMPtfDXZEr0NVxWnPTjb1bbD
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgryski/go-metro v0.0.0-20200812162917-85c65e2d0165 h1:BS21ZUJ/B5X2UVUbczfmdWH7GapPWAhxcMsDnjJTU1E=
 github.com/dgryski/go-metro v0.0.0-20200812162917-85c65e2d0165/go.mod h1:c9O8+fpSOX1DM8cPNSkX/qsBWdkD4yd2dpciOWQjpBw=
+github.com/dgryski/go-metro v0.0.0-20250106013310-edb8663e5e33 h1:ucRHb6/lvW/+mTEIGbvhcYU3S8+uSNkuMjx/qZFfhtM=
+github.com/dgryski/go-metro v0.0.0-20250106013310-edb8663e5e33/go.mod h1:c9O8+fpSOX1DM8cPNSkX/qsBWdkD4yd2dpciOWQjpBw=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/dgryski/go-wyhash v0.0.0-20191203203029-c4841ae36371 h1:bz5ApY1kzFBvw3yckuyRBCtqGvprWrKswYK468nm+Gs=

--- a/internal/peer/pubsub_redis.go
+++ b/internal/peer/pubsub_redis.go
@@ -105,6 +105,7 @@ type RedisPubsubPeers struct {
 }
 
 // checkHash checks the hash of the current list of peers and calls any registered callbacks
+// in a separate goroutine if the hash has changed.
 func (p *RedisPubsubPeers) checkHash() {
 	peers := p.peers.SortedKeys()
 	newhash := hashList(peers)

--- a/logger/honeycomb.go
+++ b/logger/honeycomb.go
@@ -9,7 +9,6 @@ import (
 	"github.com/honeycombio/dynsampler-go"
 	libhoney "github.com/honeycombio/libhoney-go"
 	"github.com/honeycombio/libhoney-go/transmission"
-
 	"github.com/honeycombio/refinery/config"
 )
 
@@ -81,6 +80,7 @@ func (h *HoneycombLogger) Start() error {
 	}
 	h.libhClient = libhClient
 
+	h.addResourceAttributes()
 	h.libhClient.AddField("refinery_version", h.Version)
 	if hostname, err := os.Hostname(); err == nil {
 		h.libhClient.AddField("hostname", hostname)
@@ -102,6 +102,17 @@ func (h *HoneycombLogger) Start() error {
 	fmt.Printf("Starting Honeycomb Logger - see Honeycomb %s dataset for service logs\n", h.loggerConfig.Dataset)
 
 	return nil
+}
+
+// Add support for the REFINERY_HONEYCOMB_LOGGER_ADDITIONAL_FIELDS env var which allows
+// specifying comma-separated key-value pairs to be added to outgoing logs as fields.
+// The key value pairs must be separated by `=`.
+// Credit to https://github.com/open-telemetry/opentelemetry-go/blob/553779c161e9bb7bbc1670b3a92a1bf3ceefb859/sdk/resource/env.go#L67-L95
+func (h *HoneycombLogger) addResourceAttributes() {
+	attrs := h.Config.GetHoneycombLoggerConfig().AdditionalAttributes
+	for k, v := range attrs {
+		h.libhClient.AddField(k, v)
+	}
 }
 
 func (h *HoneycombLogger) readResponses() {

--- a/metrics.md
+++ b/metrics.md
@@ -3,7 +3,7 @@
 # Honeycomb Refinery Metrics Documentation
 
 This document contains the description of various metrics used in Refinery.
-It was automatically generated on 2025-06-03 at 21:32:33 UTC.
+It was automatically generated on 2025-07-15 at 17:41:46 UTC.
 
 Note: This document does not include metrics defined in the dynsampler-go dependency, as those metrics are generated dynamically at runtime. As a result, certain metrics may be missing or incomplete in this document, but they will still be available during execution with their full names.
 

--- a/refinery_config.md
+++ b/refinery_config.md
@@ -520,6 +520,20 @@ The sampling algorithm attempts to make sure that the average throughput approxi
 - Default: `10`
 - Example: `10`
 
+### `AdditionalAttributes`
+
+`AdditionalAttributes` adds the provided attributes to all logs written by the Honeycomb logger.
+
+When supplying via a environment variable, the value should be a string of comma-separated key-value pairs.
+When supplying via the command line, the value should be a key value pair.
+If multiple key-value pairs are needed, each should be supplied via its own command line flag.
+The key-value pairs must use ':' as the separator.
+
+- Not eligible for live reload.
+- Type: `map`
+- Example: `pipeline.id:'12345',rollout.id:'67890'`
+- Environment variable: `REFINERY_HONEYCOMB_LOGGER_ADDITIONAL_ATTRIBUTES`
+
 ## Stdout Logger
 
 `StdoutLogger` contains configuration for logging to `stdout`.
@@ -836,7 +850,7 @@ If this value is specified, then Refinery will use the first IPV6 unicast addres
 This list is ignored when Type is "redis".
 The format is a list of strings of the form "scheme://host:port".
 
-- Not eligible for live reload.
+- Eligible for live reload.
 - Type: `stringarray`
 - Example: `http://192.168.1.11:8081,http://192.168.1.12:8081`
 

--- a/rules.md
+++ b/rules.md
@@ -3,7 +3,7 @@
 # Honeycomb Refinery Rules Documentation
 
 This is the documentation for the rules configuration for Honeycomb's Refinery.
-It was automatically generated on 2025-06-17 at 14:29:18 UTC.
+It was automatically generated on 2025-07-15 at 17:41:47 UTC.
 
 ## The Rules file
 

--- a/tools/convert/configDataNames.txt
+++ b/tools/convert/configDataNames.txt
@@ -1,5 +1,5 @@
 # Names of groups and fields in the new config file format.
-# Automatically generated on 2025-06-03 at 21:32:30 UTC.
+# Automatically generated on 2025-07-15 at 17:41:44 UTC.
 
 General:
   - ConfigurationVersion
@@ -91,6 +91,8 @@ HoneycombLogger:
   - SamplerEnabled (originally HoneycombLogger.LoggerSamplerEnabled)
 
   - SamplerThroughput
+
+  - AdditionalAttributes
 
 
 StdoutLogger:

--- a/tools/convert/minimal_config.yaml
+++ b/tools/convert/minimal_config.yaml
@@ -1,5 +1,5 @@
 # sample uncommented config file containing all possible fields
-# automatically generated on 2025-06-03 at 21:32:31 UTC
+# automatically generated on 2025-07-15 at 17:41:44 UTC
 General:
   ConfigurationVersion: 2
   MinRefineryVersion: "v2.0"
@@ -50,6 +50,10 @@ HoneycombLogger:
   Dataset: "Refinery Logs"
   SamplerEnabled: true
   SamplerThroughput: 10
+  AdditionalAttributes: 
+    "pipeline.id": "'12345'"
+    "rollout.id": "'67890'"
+
 StdoutLogger:
   Structured: false
   SamplerEnabled: false

--- a/tools/convert/templates/configV2.tmpl
+++ b/tools/convert/templates/configV2.tmpl
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created {{ now }} from {{ .Input }} using a template generated on 2025-06-04 at 22:29:50 UTC
+# created {{ now }} from {{ .Input }} using a template generated on 2025-07-25 at 19:57:55 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of
@@ -560,6 +560,18 @@ HoneycombLogger:
     ## Not eligible for live reload.
     # SamplerThroughput: 10
 
+    ## AdditionalAttributes adds the provided attributes to all logs written
+    ## by the Honeycomb logger.
+    ##
+    ## When supplying via a environment variable, the value should be a
+    ## string of comma-separated key-value pairs. When supplying via the
+    ## command line, the value should be a key value pair. If multiple
+    ## key-value pairs are needed, each should be supplied via its own
+    ## command line flag. The key-value pairs must use ':' as the separator.
+    ##
+    ## Not eligible for live reload.
+    {{ renderMap .Data "AdditionalAttributes" "AdditionalAttributes" "pipeline.id:'12345',rollout.id:'67890'" }}
+
 ###################
 ## Stdout Logger ##
 ###################
@@ -888,7 +900,7 @@ PeerManagement:
     ## This list is ignored when Type is "redis". The format is a list of
     ## strings of the form "scheme://host:port".
     ##
-    ## Not eligible for live reload.
+    ## Eligible for live reload.
     {{ renderStringarray .Data "Peers" "PeerManagement.Peers" "http://192.168.1.11:8081,http://192.168.1.12:8081" }}
 
 ###########################

--- a/types/payload.go
+++ b/types/payload.go
@@ -240,6 +240,7 @@ func (nb *nullableBool) Unset() {
 type Payload struct {
 	// A serialized messagepack map used to source fields.
 	msgpData []byte
+	isEmpty  bool
 
 	// Deserialized fields, either from the internal msgpMap, or set externally.
 	memoizedFields map[string]any
@@ -290,6 +291,10 @@ func (p *Payload) extractCriticalFieldsFromBytes(data []byte, traceIdFieldNames,
 	mapSize, remaining, err := msgp.ReadMapHeaderBytes(data)
 	if err != nil {
 		return len(data) - len(remaining), fmt.Errorf("failed to read msgpack map header: %w", err)
+	}
+
+	if mapSize == 0 {
+		p.isEmpty = true
 	}
 
 	// Process all map entries
@@ -730,7 +735,7 @@ func (p *Payload) Set(key string, value any) {
 }
 
 func (p *Payload) IsEmpty() bool {
-	return len(p.memoizedFields) == 0 && len(p.msgpData) == 0
+	return p.isEmpty
 }
 
 // All() allows easily iterating all values in the Payload, but this is very


### PR DESCRIPTION
## Which problem is this PR solving?

Before we can bring in all commits from the performance-work-branch into main, we need to update the perf branch to be update-to-date with main

## Short description of the changes

- stuff from 2.9.7
- a few changes after 2.9.7
- merge conflict fix: include recording that a payload is empty during field memoization instead of checking data lengths later

