### PR TITLE
fix: set DisableRedistribution default to true

### DIFF
--- a/collect/collect.go
+++ b/collect/collect.go
@@ -218,7 +218,7 @@ func (i *InMemCollector) Start() error {
 		}
 	}
 
-	if !i.Config.GetCollectionConfig().DisableRedistribution {
+	if !i.Config.GetDisableRedistribution() {
 		i.Peers.RegisterUpdatedPeersCallback(i.redistributeTimer.Reset)
 	}
 
@@ -1109,7 +1109,7 @@ func (i *InMemCollector) Stop() error {
 		sampler.Stop()
 	}
 
-	if !i.Config.GetCollectionConfig().DisableRedistribution {
+	if !i.Config.GetDisableRedistribution() {
 		peers, err := i.Peers.GetPeers()
 		if err != nil {
 			i.Logger.Error().Logf("unable to get peer list with error %s", err.Error())

--- a/config/config.go
+++ b/config/config.go
@@ -88,6 +88,9 @@ type Config interface {
 	// GetCollectionConfig returns the config specific to the InMemCollector
 	GetCollectionConfig() CollectionConfig
 
+	// GetDisableRedistribution returns whether redistribution is disabled.
+	GetDisableRedistribution() bool
+
 	// GetHealthCheckTimeout returns the timeout for Refinery's internal health checks used in the collector
 	GetHealthCheckTimeout() time.Duration
 

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -321,8 +321,8 @@ type CollectionConfig struct {
 	MaxMemoryPercentage int        `yaml:"MaxMemoryPercentage" default:"75"`
 	MaxAlloc            MemorySize `yaml:"MaxAlloc"`
 
-	DisableRedistribution bool     `yaml:"DisableRedistribution"`
-	RedistributionDelay   Duration `yaml:"RedistributionDelay" default:"30s"`
+	DisableRedistribution *DefaultTrue `yaml:"DisableRedistribution" default:"true"` // Avoid pointer woe on access, use GetDisableRedistribution() instead.
+	RedistributionDelay   Duration     `yaml:"RedistributionDelay" default:"30s"`
 
 	ShutdownDelay     Duration `yaml:"ShutdownDelay" default:"15s"`
 	TraceLocalityMode string   `yaml:"TraceLocalityMode" default:"concentrated"`
@@ -924,6 +924,13 @@ func (f *fileConfig) GetCollectionConfig() CollectionConfig {
 	defer f.mux.RUnlock()
 
 	return f.mainConfig.Collection
+}
+
+func (f *fileConfig) GetDisableRedistribution() bool {
+	f.mux.RLock()
+	defer f.mux.RUnlock()
+
+	return f.mainConfig.Collection.DisableRedistribution.Get()
 }
 
 func (f *fileConfig) GetLegacyMetricsConfig() LegacyMetricsConfig {

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -1355,10 +1355,10 @@ groups:
           `Collections.AvailableMemory` must not be defined.
 
       - name: DisableRedistribution
-        type: bool
+        type: defaulttrue
         valuetype: nondefault
         firstversion: v2.8
-        default: false
+        default: true
         reload: true
         summary: controls whether to transmit traces in cache to remaining peers during cluster scaling event.
         description: >

--- a/config/mock.go
+++ b/config/mock.go
@@ -116,6 +116,13 @@ func (m *MockConfig) GetCollectionConfig() CollectionConfig {
 	return m.GetCollectionConfigVal
 }
 
+func (m *MockConfig) GetDisableRedistribution() bool {
+	m.Mux.RLock()
+	defer m.Mux.RUnlock()
+
+	return m.GetCollectionConfigVal.DisableRedistribution.Get()
+}
+
 func (m *MockConfig) GetHealthCheckTimeout() time.Duration {
 	m.Mux.RLock()
 	defer m.Mux.RUnlock()


### PR DESCRIPTION
## Which problem is this PR solving?

Refinery, like Redis, is an in-memory system where resilience via durable storage is not the primary goal. Refinery is optimized for availability and low-latency processing rather than guaranteed persistence of state.

In pursuing dynamic scaling, we attempted to make this transient state durable by synchronizing it across peers during cluster membership changes. This added complexity and instability: whenever nodes joined or left, internal state had to be redistributed, which introduced processing stalls, additional network traffic, and instability of the cluster.

We’ve concluded that emulating a durable, distributed store is not aligned with Refinery’s role or strengths. This PR begins rolling back the logic for maintaining and sharing in-memory state during cluster changes, returning to a simpler, more stable design.

## Short description of the changes

- set `DisableRedistribution` to true

