### PR TITLE
fix: repair bad rule example

### DIFF
--- a/rules_complete.yaml
+++ b/rules_complete.yaml
@@ -111,8 +111,7 @@ Samplers:
                       Operator: =
                       Value: users
                     - Field: trace.parent_id
-                      Operator: =
-                      Value: root
+                      Operator: does-not-exist
                 - Name: drop incomplete traces from the buggy service
                   Drop: true
                   Conditions:


### PR DESCRIPTION
## Which problem is this PR solving?

- A customer pointed out that we had a very bad example of checking for a root span in our rules_complete file. This fixes it.

## Short description of the changes

- Use the proper syntax

