### PR TITLE
fix: make sure all transmit metrics have correct libhoney prefix

### DIFF
--- a/transmit/direct_transmit.go
+++ b/transmit/direct_transmit.go
@@ -247,7 +247,7 @@ func (d *DirectTransmission) EnqueueSpan(sp *types.Span) {
 // it should be called after the metrics object has been created.
 func (d *DirectTransmission) RegisterMetrics() {
 	for _, m := range transmissionMetrics {
-		fullName := d.transmitType.String() + m.Name
+		fullName := "libhoney_" + d.transmitType.String() + m.Name
 		switch m.Name {
 		case updownQueuedItems:
 			d.metricKeys.updownQueuedItems = fullName
@@ -259,25 +259,17 @@ func (d *DirectTransmission) RegisterMetrics() {
 			d.metricKeys.counterResponse20x = fullName
 		case counterResponseErrors:
 			d.metricKeys.counterResponseErrors = fullName
-		// Below are metrics previously associated with the libhoney transmission used to send data upstream or to peers.
-		// Even though libhoney isn't used, include the prefix in these metric names to avoid breaking existing Refinery operations boards & queries.
 		case gaugeQueueLength:
-			fullName = "libhoney_" + fullName
 			d.metricKeys.gaugeQueueLength = fullName
 		case counterSendErrors:
-			fullName = "libhoney_" + fullName
 			d.metricKeys.counterSendErrors = fullName
 		case counterSendRetries:
-			fullName = "libhoney_" + fullName
 			d.metricKeys.counterSendRetries = fullName
 		case counterBatchesSent:
-			fullName = "libhoney_" + fullName
 			d.metricKeys.counterBatchesSent = fullName
 		case counterMessagesSent:
-			fullName = "libhoney_" + fullName
 			d.metricKeys.counterMessagesSent = fullName
 		case counterResponseDecodeErrors:
-			fullName = "libhoney_" + fullName
 			d.metricKeys.counterResponseDecodeErrors = fullName
 		}
 		m.Name = fullName // Update the metric name to include the transmit type

--- a/transmit/direct_transmit_test.go
+++ b/transmit/direct_transmit_test.go
@@ -509,11 +509,11 @@ func TestDirectTransmission(t *testing.T) {
 	require.NoError(t, err)
 	defer dt.Stop()
 	dt.RegisterMetrics()
-	assert.Equal(t, "upstream_queued_items", dt.metricKeys.updownQueuedItems)
-	assert.Equal(t, "upstream_response_20x", dt.metricKeys.counterResponse20x)
-	assert.Equal(t, "upstream_response_errors", dt.metricKeys.counterResponseErrors)
-	assert.Equal(t, "upstream_enqueue_errors", dt.metricKeys.counterEnqueueErrors)
-	assert.Equal(t, "upstream_queue_time", dt.metricKeys.histogramQueueTime)
+	assert.Equal(t, "libhoney_upstream_queued_items", dt.metricKeys.updownQueuedItems)
+	assert.Equal(t, "libhoney_upstream_response_20x", dt.metricKeys.counterResponse20x)
+	assert.Equal(t, "libhoney_upstream_response_errors", dt.metricKeys.counterResponseErrors)
+	assert.Equal(t, "libhoney_upstream_enqueue_errors", dt.metricKeys.counterEnqueueErrors)
+	assert.Equal(t, "libhoney_upstream_queue_time", dt.metricKeys.histogramQueueTime)
 
 	assert.Equal(t, "libhoney_upstream_send_errors", dt.metricKeys.counterSendErrors)
 	assert.Equal(t, "libhoney_upstream_send_retries", dt.metricKeys.counterSendRetries)
@@ -1126,9 +1126,9 @@ func TestDirectTransmissionRetryLogic(t *testing.T) {
 			requestMutex.Unlock()
 
 			if tt.expectSuccess {
-				assert.Contains(t, mockMetrics.CounterIncrements, "upstream_response_20x")
+				assert.Contains(t, mockMetrics.CounterIncrements, "libhoney_upstream_response_20x")
 			} else {
-				assert.Contains(t, mockMetrics.CounterIncrements, "upstream_response_errors")
+				assert.Contains(t, mockMetrics.CounterIncrements, "libhoney_upstream_response_errors")
 			}
 		})
 	}


### PR DESCRIPTION
## Which problem is this PR solving?

We would like to preserve all existing `libhoney` metric names so that users can compare the performance between version upgrades easily.

## Short description of the changes

- add `libhoney_` prefix to all transmit metrics 

