### PR TITLE
fix: set shutdown wait time to be 2x of BatchTimeout

### DIFF
--- a/cmd/refinery/main.go
+++ b/cmd/refinery/main.go
@@ -346,7 +346,8 @@ func main() {
 	sig := <-exitWait
 	// unregister ourselves before we go
 	close(done)
-	time.Sleep(100 * time.Millisecond)
+	// wait for at least 2x the batch timeout to allow in-flight requests from peers to complete
+	time.Sleep(c.GetTracesConfig().GetBatchTimeout() * 2)
 	a.Logger.Error().WithField("signal", sig).Logf("Caught OS signal")
 
 	// these are the subsystems that might not shut down properly, so we're


### PR DESCRIPTION
## Which problem is this PR solving?

When Peer A shuts down, it sends a pub/sub message to the rest of the cluster so they remove it from their peer lists. However, any spans already in Peer B’s transmit queue at that moment will not be redirected to another host. To avoid losing those spans, Peer A should remain available long enough to finish receiving and processing in-flight requests from other peers before completing its shutdown.

## Short description of the changes

- set the shutdown wait time to be longer than `BatchTimeout`

