### PR TITLE
fix: race condition in DirectTransmit for metrics registration

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -314,7 +314,7 @@ func newStartedApp(
 	if mockTransmission != nil {
 		upstreamTransmission = mockTransmission
 	} else {
-		upstreamTransmission = transmit.NewDirectTransmission(metricsr, types.TransmitTypeUpstream, http.DefaultTransport.(*http.Transport), 500, 100*time.Millisecond, true)
+		upstreamTransmission = transmit.NewDirectTransmission(types.TransmitTypeUpstream, http.DefaultTransport.(*http.Transport), 500, 100*time.Millisecond, true)
 	}
 
 	// Always create real peer transmission using DirectTransmission
@@ -324,7 +324,7 @@ func newStartedApp(
 			Timeout: 3 * time.Second,
 		}).Dial,
 	}
-	peerTransmissionWrapper := transmit.NewDirectTransmission(metricsr, types.TransmitTypePeer, peerTransport, int(cfg.GetTracesConfigVal.MaxBatchSize), 100*time.Millisecond, false)
+	peerTransmissionWrapper := transmit.NewDirectTransmission(types.TransmitTypePeer, peerTransport, int(cfg.GetTracesConfigVal.MaxBatchSize), 100*time.Millisecond, false)
 
 	var g inject.Graph
 	err = g.Provide(

--- a/cmd/refinery/main.go
+++ b/cmd/refinery/main.go
@@ -167,7 +167,6 @@ func main() {
 
 	stressRelief := &collect.StressRelief{Done: done}
 	upstreamTransmission := transmit.NewDirectTransmission(
-		metricsSingleton,
 		types.TransmitTypeUpstream,
 		upstreamTransport,
 		int(c.GetTracesConfig().GetMaxBatchSize()),
@@ -175,7 +174,6 @@ func main() {
 		true,
 	)
 	peerTransmission := transmit.NewDirectTransmission(
-		metricsSingleton,
 		types.TransmitTypePeer,
 		peerTransport,
 		int(c.GetTracesConfig().GetMaxBatchSize()),
@@ -296,10 +294,6 @@ func main() {
 		fmt.Printf("failed to start peer management: %v\n", err)
 		os.Exit(1)
 	}
-
-	// Register metrics after the metrics object has been created
-	peerTransmission.RegisterMetrics()
-	upstreamTransmission.RegisterMetrics()
 
 	metricsSingleton.Store("UPSTREAM_BUFFER_SIZE", float64(c.GetUpstreamBufferSize()))
 	metricsSingleton.Store("PEER_BUFFER_SIZE", float64(c.GetPeerBufferSize()))

--- a/transmit/transmit.go
+++ b/transmit/transmit.go
@@ -18,8 +18,6 @@ type Transmission interface {
 	// Enqueue accepts a single event and schedules it for transmission to Honeycomb
 	EnqueueEvent(ev *types.Event)
 	EnqueueSpan(ev *types.Span)
-
-	RegisterMetrics()
 }
 
 type DefaultTransmission struct {


### PR DESCRIPTION
## Which problem is this PR solving?

We are referencing `Metrics` object in `Start` method in `DirectTransmit`. It has a race condition between writes in `RegisterMetrics` and accessing metrics in `Start` method.

## Short description of the changes

- Make `metrics` as a dependency for `DirectTransmit` using the injection library. 

