### PR TITLE
maint: (BREAKING) remove CacheCapacity functionality

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -240,6 +240,8 @@ func defaultConfigWithGRPC(basePort int, redisDB int, apiURL string, enableGRPC 
 		GetCollectionConfigVal: config.CollectionConfig{
 			ShutdownDelay:      config.Duration(1 * time.Second),
 			HealthCheckTimeout: config.Duration(3 * time.Second),
+			IncomingQueueSize:  30000,
+			PeerQueueSize:      30000,
 		},
 		TraceIdFieldNames:  []string{"trace.trace_id"},
 		ParentIdFieldNames: []string{"trace.parent_id"},

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -238,7 +238,6 @@ func defaultConfigWithGRPC(basePort int, redisDB int, apiURL string, enableGRPC 
 		GetPeerListenAddrVal:     "127.0.0.1:" + strconv.Itoa(basePort+1),
 		GetHoneycombAPIVal:       apiURL,
 		GetCollectionConfigVal: config.CollectionConfig{
-			CacheCapacity:      10000,
 			ShutdownDelay:      config.Duration(1 * time.Second),
 			HealthCheckTimeout: config.Duration(3 * time.Second),
 		},

--- a/collect/cache/cache.go
+++ b/collect/cache/cache.go
@@ -57,7 +57,6 @@ var collectCacheMetrics = []metrics.Metadata{
 }
 
 func NewInMemCache(
-	capacity int,
 	met metrics.Metrics,
 	logger logger.Logger,
 ) *DefaultInMemCache {

--- a/collect/cache/cache_test.go
+++ b/collect/cache/cache_test.go
@@ -17,7 +17,7 @@ import (
 func TestCacheSetGet(t *testing.T) {
 	s := &metrics.MockMetrics{}
 	s.Start()
-	c := NewInMemCache(10, s, &logger.NullLogger{})
+	c := NewInMemCache(s, &logger.NullLogger{})
 
 	trace := &types.Trace{
 		TraceID: "abc123",
@@ -30,7 +30,7 @@ func TestCacheSetGet(t *testing.T) {
 func TestTakeExpiredTraces(t *testing.T) {
 	s := &metrics.MockMetrics{}
 	s.Start()
-	c := NewInMemCache(10, s, &logger.NullLogger{})
+	c := NewInMemCache(s, &logger.NullLogger{})
 
 	now := time.Now()
 	traces := []*types.Trace{
@@ -62,7 +62,7 @@ func TestTakeExpiredTraces(t *testing.T) {
 func TestRemoveSentTraces(t *testing.T) {
 	s := &metrics.MockMetrics{}
 	s.Start()
-	c := NewInMemCache(10, s, &logger.NullLogger{})
+	c := NewInMemCache(s, &logger.NullLogger{})
 
 	now := time.Now()
 	traces := []*types.Trace{
@@ -89,7 +89,7 @@ func BenchmarkCache_Set(b *testing.B) {
 	metrics.Start()
 	_, traces := generateTraces(b.N)
 
-	c := NewInMemCache(b.N, metrics, &logger.NullLogger{})
+	c := NewInMemCache(metrics, &logger.NullLogger{})
 
 	// setup is expensive, so reset timer and report allocations
 	b.ReportAllocs()
@@ -104,7 +104,7 @@ func BenchmarkCache_Get(b *testing.B) {
 	metrics.Start()
 	_, traces := generateTraces(b.N)
 
-	c := NewInMemCache(b.N, metrics, &logger.NullLogger{})
+	c := NewInMemCache(metrics, &logger.NullLogger{})
 	populateCache(c, traces)
 
 	// setup is expensive, so reset timer and report allocations
@@ -122,7 +122,7 @@ func BenchmarkCache_TakeExpiredTracesWithoutFilter(b *testing.B) {
 	metrics.Start()
 	now, traces := generateTraces(b.N)
 
-	c := NewInMemCache(b.N, metrics, &logger.NullLogger{})
+	c := NewInMemCache(metrics, &logger.NullLogger{})
 	populateCache(c, traces)
 
 	// setup is expensive, so reset timer and report allocations
@@ -139,7 +139,7 @@ func BenchmarkCache_TakeExpiredTracesWithFilter(b *testing.B) {
 	metrics.Start()
 	now, traces := generateTraces(b.N)
 
-	c := NewInMemCache(b.N, metrics, &logger.NullLogger{})
+	c := NewInMemCache(metrics, &logger.NullLogger{})
 	populateCache(c, traces)
 
 	// setup is expensive, so reset timer and report allocations
@@ -165,7 +165,7 @@ func BenchmarkCache_RemoveTraces(b *testing.B) {
 		deletes.Add("trace" + fmt.Sprint(i))
 	}
 
-	c := NewInMemCache(b.N, metrics, &logger.NullLogger{})
+	c := NewInMemCache(metrics, &logger.NullLogger{})
 	populateCache(c, traces)
 
 	// setup is expensive, so reset timer and report allocations

--- a/collect/collect.go
+++ b/collect/collect.go
@@ -182,7 +182,7 @@ func (i *InMemCollector) Start() error {
 	i.Logger.Debug().Logf("Starting InMemCollector")
 	defer func() { i.Logger.Debug().Logf("Finished starting InMemCollector") }()
 	imcConfig := i.Config.GetCollectionConfig()
-	i.cache = cache.NewInMemCache(imcConfig.CacheCapacity, i.Metrics, i.Logger)
+	i.cache = cache.NewInMemCache(i.Metrics, i.Logger)
 	i.StressRelief.UpdateFromConfig()
 
 	// listen for config reloads

--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -970,8 +970,8 @@ func TestAddCountsToRoot(t *testing.T) {
 		ParentIdFieldNames: []string{"trace.parent_id", "parentId"},
 		GetCollectionConfigVal: config.CollectionConfig{
 			ShutdownDelay:     config.Duration(1 * time.Millisecond),
-			IncomingQueueSize: 3,
-			PeerQueueSize:     3,
+			IncomingQueueSize: 9,
+			PeerQueueSize:     9,
 		},
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -484,51 +484,6 @@ func TestMaxAlloc(t *testing.T) {
 	assert.Equal(t, expected, inMemConfig.MaxAlloc)
 }
 
-func TestPeerAndIncomingQueueSize(t *testing.T) {
-	testcases := []struct {
-		name                string
-		configYAML          string
-		expectedForPeer     int
-		expectedForIncoming int
-	}{
-		{
-			name:                "default",
-			configYAML:          makeYAML("General.ConfigurationVersion", 2, "Collection.CacheCapacity", 1000),
-			expectedForPeer:     3000,
-			expectedForIncoming: 3000,
-		},
-		{
-			name:                "PeerInMemoryCapacity is set",
-			configYAML:          makeYAML("General.ConfigurationVersion", 2, "Collection.CacheCapacity", 1000, "Collection.PeerQueueSize", 4000),
-			expectedForPeer:     4000,
-			expectedForIncoming: 3000,
-		},
-		{
-			name:                "IncomingInMemoryCapacity is set",
-			configYAML:          makeYAML("General.ConfigurationVersion", 2, "Collection.CacheCapacity", 1000, "Collection.IncomingQueueSize", 4000),
-			expectedForPeer:     3000,
-			expectedForIncoming: 4000,
-		},
-		{
-			name:                "below the minimum",
-			configYAML:          makeYAML("General.ConfigurationVersion", 2, "Collection.CacheCapacity", 1000, "Collection.PeerQueueSize", 2000, "Collection.IncomingQueueSize", 2000),
-			expectedForPeer:     3000,
-			expectedForIncoming: 3000,
-		},
-	}
-
-	for _, tc := range testcases {
-		rm := makeYAML("ConfigVersion", 2)
-		config, rules := createTempConfigs(t, tc.configYAML, rm)
-		c, err := getConfig([]string{"--no-validate", "--config", config, "--rules_config", rules})
-		assert.NoError(t, err)
-
-		inMemConfig := c.GetCollectionConfig()
-		assert.Equal(t, tc.expectedForPeer, inMemConfig.GetPeerQueueSize())
-		assert.Equal(t, tc.expectedForIncoming, inMemConfig.GetIncomingQueueSize())
-	}
-}
-
 func TestAvailableMemoryCmdLine(t *testing.T) {
 	cm := makeYAML("General.ConfigurationVersion", 2, "Collection.CacheCapacity", 1000, "Collection.AvailableMemory", 2_000_000_000)
 	rm := makeYAML("ConfigVersion", 2)

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -346,9 +346,6 @@ func (c CollectionConfig) GetMaxAlloc() MemorySize {
 // If PeerBufferCapacity is not set, it uses 3x the cache capacity.
 // The minimum value is 3x the cache capacity.
 func (c CollectionConfig) GetPeerQueueSize() int {
-	if c.PeerQueueSize == 0 || c.PeerQueueSize < c.CacheCapacity*3 {
-		return c.CacheCapacity * 3
-	}
 	return c.PeerQueueSize
 }
 
@@ -356,9 +353,6 @@ func (c CollectionConfig) GetPeerQueueSize() int {
 // If IncomingBufferCapacity is not set, it uses 3x the cache capacity.
 // The minimum value is 3x the cache capacity.
 func (c CollectionConfig) GetIncomingQueueSize() int {
-	if c.IncomingQueueSize == 0 || c.IncomingQueueSize < c.CacheCapacity*3 {
-		return c.CacheCapacity * 3
-	}
 	return c.IncomingQueueSize
 }
 

--- a/route/otlp_trace_test.go
+++ b/route/otlp_trace_test.go
@@ -103,8 +103,9 @@ func TestOTLPHandler(t *testing.T) {
 		},
 		GetSamplerTypeVal: &config.DeterministicSamplerConfig{SampleRate: 1},
 		GetCollectionConfigVal: config.CollectionConfig{
-			CacheCapacity: 100,
-			MaxAlloc:      100,
+			PeerQueueSize:     100,
+			IncomingQueueSize: 100,
+			MaxAlloc:          100,
 		},
 	}
 


### PR DESCRIPTION
## Which problem is this PR solving?

CacheCapacity is no longer in use. This PR is to remove it from automatically setting PeerQueueSize and IncomingQueueSize

## Short description of the changes

- Remove CacheCapacity from setting other configs

