### PR TITLE
feat: initial concurrent collect loops

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -239,6 +239,7 @@ func defaultConfigWithGRPC(basePort int, redisDB int, apiURL string, enableGRPC 
 		GetHoneycombAPIVal:       apiURL,
 		GetCollectionConfigVal: config.CollectionConfig{
 			CacheCapacity:      10000,
+			NumCollectLoops:    8,
 			ShutdownDelay:      config.Duration(1 * time.Second),
 			HealthCheckTimeout: config.Duration(3 * time.Second),
 		},

--- a/collect/cache/cache.go
+++ b/collect/cache/cache.go
@@ -4,12 +4,13 @@ import (
 	"math"
 	"time"
 
+	"github.com/rdleal/go-priorityq/kpq"
+	"golang.org/x/exp/maps"
+
 	"github.com/honeycombio/refinery/generics"
 	"github.com/honeycombio/refinery/logger"
 	"github.com/honeycombio/refinery/metrics"
 	"github.com/honeycombio/refinery/types"
-	"github.com/rdleal/go-priorityq/kpq"
-	"golang.org/x/exp/maps"
 )
 
 // Cache is a non-threadsafe cache. It must not be used for concurrent access.

--- a/collect/cache/cache_test.go
+++ b/collect/cache/cache_test.go
@@ -6,11 +6,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/honeycombio/refinery/generics"
 	"github.com/honeycombio/refinery/logger"
 	"github.com/honeycombio/refinery/metrics"
 	"github.com/honeycombio/refinery/types"
-	"github.com/stretchr/testify/assert"
 )
 
 // TestCacheSetGet sets a value then fetches it back

--- a/collect/cache/cuckoo.go
+++ b/collect/cache/cuckoo.go
@@ -4,8 +4,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/honeycombio/refinery/metrics"
 	cuckoo "github.com/panmari/cuckoofilter"
+
+	"github.com/honeycombio/refinery/metrics"
 )
 
 // These are the names of metrics tracked for the cuckoo filter

--- a/collect/cache/cuckooSentCache.go
+++ b/collect/cache/cuckooSentCache.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	lru "github.com/hashicorp/golang-lru/v2"
+
 	"github.com/honeycombio/refinery/config"
 	"github.com/honeycombio/refinery/generics"
 	"github.com/honeycombio/refinery/metrics"

--- a/collect/cache/cuckoo_test.go
+++ b/collect/cache/cuckoo_test.go
@@ -6,8 +6,9 @@ import (
 	"time"
 
 	"github.com/dgryski/go-wyhash"
-	"github.com/honeycombio/refinery/metrics"
 	"github.com/sourcegraph/conc/pool"
+
+	"github.com/honeycombio/refinery/metrics"
 )
 
 // genID returns a random hex string of length numChars

--- a/collect/cache/kept_reason_cache_test.go
+++ b/collect/cache/kept_reason_cache_test.go
@@ -8,9 +8,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/honeycombio/refinery/collect/cache"
 	"github.com/honeycombio/refinery/metrics"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestKeptReasonCache(t *testing.T) {

--- a/collect/cache/kept_reasons_cache.go
+++ b/collect/cache/kept_reasons_cache.go
@@ -13,7 +13,6 @@ import (
 // It acts as a mapping between the string representation of send reason
 // and a uint.
 // This is used to reduce the memory footprint of the trace cache.
-// It is now concurrency-safe.
 
 type KeptReasonsCache struct {
 	Metrics metrics.Metrics

--- a/collect/collect.go
+++ b/collect/collect.go
@@ -6,16 +6,17 @@ import (
 	"fmt"
 	"os"
 	"runtime"
-	"sort"
 	"sync"
 	"time"
 
-	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
+
+	"github.com/dgryski/go-wyhash"
+	"github.com/jonboulle/clockwork"
+	"github.com/sirupsen/logrus"
 
 	"github.com/honeycombio/refinery/collect/cache"
 	"github.com/honeycombio/refinery/config"
-	"github.com/honeycombio/refinery/generics"
 	"github.com/honeycombio/refinery/internal/health"
 	"github.com/honeycombio/refinery/internal/otelutil"
 	"github.com/honeycombio/refinery/internal/peer"
@@ -26,8 +27,6 @@ import (
 	"github.com/honeycombio/refinery/sharder"
 	"github.com/honeycombio/refinery/transmit"
 	"github.com/honeycombio/refinery/types"
-	"github.com/jonboulle/clockwork"
-	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -76,7 +75,7 @@ type sendableTrace struct {
 	samplerSelector string
 }
 
-// InMemCollector is a single threaded collector.
+// InMemCollector is a collector that can use multiple concurrent collection loops.
 type InMemCollector struct {
 	Config  config.Config   `inject:""`
 	Logger  logger.Logger   `inject:""`
@@ -97,20 +96,20 @@ type InMemCollector struct {
 	TestMode       bool
 	BlockOnAddSpan bool
 
+	// Parallel collection support
+	collectLoops []*CollectLoop
+
 	// mutex must be held whenever non-channel internal fields are accessed.
-	// This exists to avoid data races in tests and startup/shutdown.
 	mutex sync.RWMutex
-	cache cache.Cache
 
 	datasetSamplers map[string]sample.Sampler
 
 	sampleTraceCache cache.TraceSentCache
 
 	shutdownWG     sync.WaitGroup
-	incoming       chan *types.Span
-	fromPeer       chan *types.Span
+	collectLoopsWG sync.WaitGroup // Separate WaitGroup for collect loops
+	reload         chan struct{}  // Channel for config reload signals
 	outgoingTraces chan sendableTrace
-	reload         chan struct{}
 	done           chan struct{}
 
 	hostname string
@@ -175,12 +174,18 @@ func (i *InMemCollector) Start() error {
 	i.Logger.Debug().Logf("Starting InMemCollector")
 	defer func() { i.Logger.Debug().Logf("Finished starting InMemCollector") }()
 	imcConfig := i.Config.GetCollectionConfig()
-	i.cache = cache.NewInMemCache(imcConfig.CacheCapacity, i.Metrics, i.Logger)
+
+	numLoops := imcConfig.GetNumCollectLoops()
+
+	i.Logger.Info().WithField("num_loops", numLoops).Logf("Starting InMemCollector with %d collection loops", numLoops)
+
 	i.StressRelief.UpdateFromConfig()
 
 	// listen for config reloads
 	i.Config.RegisterReloadCallback(i.sendReloadSignal)
 
+	// Find or create a test, make sure we signal health based (somehow)
+	// on all the collect loops running.
 	i.Health.Register(CollectorHealthKey, i.Config.GetHealthCheckTimeout())
 
 	for _, metric := range inMemCollectorMetrics {
@@ -194,15 +199,10 @@ func (i *InMemCollector) Start() error {
 		return err
 	}
 
-	i.incoming = make(chan *types.Span, imcConfig.GetIncomingQueueSize())
-	i.fromPeer = make(chan *types.Span, imcConfig.GetPeerQueueSize())
 	i.outgoingTraces = make(chan sendableTrace, 100_000)
-	i.Metrics.Store("INCOMING_CAP", float64(cap(i.incoming)))
-	i.Metrics.Store("PEER_CAP", float64(cap(i.fromPeer)))
+	i.done = make(chan struct{})
 	i.reload = make(chan struct{}, 1)
-	i.done = make(chan struct{})
-	i.datasetSamplers = make(map[string]sample.Sampler)
-	i.done = make(chan struct{})
+	i.datasetSamplers = make(map[string]sample.Sampler) // Initialize for makeDecision
 
 	if i.Config.GetAddHostMetadataToTrace() {
 		if hostname, err := os.Hostname(); err == nil && hostname != "" {
@@ -210,15 +210,32 @@ func (i *InMemCollector) Start() error {
 		}
 	}
 
-	// spin up one collector because this is a single threaded collector
-	i.shutdownWG.Add(1)
-	go i.collect()
+	i.collectLoops = make([]*CollectLoop, numLoops)
+
+	// Divide cache capacity among loops
+	cachePerLoop := imcConfig.CacheCapacity / numLoops
+	if cachePerLoop < 100 {
+		cachePerLoop = 100 // minimum cache size per loop
+	}
+
+	// Divide queue sizes among loops
+	incomingPerLoop := imcConfig.GetIncomingQueueSize() / numLoops
+	peerPerLoop := imcConfig.GetPeerQueueSize() / numLoops
+
+	for loopID := range i.collectLoops {
+		loop := NewCollectLoop(loopID, i, cachePerLoop, incomingPerLoop, peerPerLoop)
+		i.collectLoops[loopID] = loop
+
+		// Start the collect goroutine for this loop
+		i.collectLoopsWG.Add(1)
+		go loop.collect()
+	}
 
 	i.shutdownWG.Add(1)
 	go i.sendTraces()
 
 	i.shutdownWG.Add(1)
-	go i.recordQueueMetrics()
+	go i.houseKeeping()
 
 	return nil
 }
@@ -243,7 +260,9 @@ func (i *InMemCollector) reloadConfigs() {
 
 	// clear out any samplers that we have previously created
 	// so that the new configuration will be propagated
+	i.mutex.Lock()
 	i.datasetSamplers = make(map[string]sample.Sampler)
+	i.mutex.Unlock()
 	// TODO add resizing the LRU sent trace cache on config reload
 }
 
@@ -268,62 +287,29 @@ func (i *InMemCollector) checkAlloc(ctx context.Context) {
 	// Because our impact numbers are only the data size, reducing by enough to reach
 	// max alloc will actually do more than that.
 	totalToRemove := mem.Alloc - uint64(maxAlloc)
+	perLoopToRemove := int(totalToRemove) / len(i.collectLoops)
 
-	// The size of the cache exceeds the user's intended allocation, so we're going to
-	// remove the traces from the cache that have had the most impact on allocation.
-	// To do this, we sort the traces by their CacheImpact value and then remove traces
-	// until the total size is less than the amount to which we want to shrink.
-	allTraces := i.cache.GetAll()
-	span.SetAttributes(attribute.Int("cache_size", len(allTraces)))
-
-	timeout := i.Config.GetTracesConfig().GetTraceTimeout()
-	if timeout == 0 {
-		timeout = 60 * time.Second
-	} // Sort traces by CacheImpact, heaviest first
-	sort.Slice(allTraces, func(i, j int) bool {
-		return allTraces[i].CacheImpact(timeout) > allTraces[j].CacheImpact(timeout)
-	})
-
-	// Now start removing the biggest traces, by summing up DataSize for
-	// successive traces until we've crossed the totalToRemove threshold
-	// or just run out of traces to delete.
-
-	cacheSize := len(allTraces)
-	i.Metrics.Gauge("collector_cache_size", float64(cacheSize))
-
-	totalDataSizeSent := 0
-	tracesSent := generics.NewSet[string]()
-	// Send the traces we can't keep.
-	traceTimeout := i.Config.GetTracesConfig().GetTraceTimeout()
-	for _, trace := range allTraces {
-		// only eject traces that belong to this peer or the trace is an orphan
-		if _, ok := i.IsMyTrace(trace.ID()); !ok && !trace.IsOrphan(traceTimeout, i.Clock.Now()) {
-			i.Logger.Debug().WithFields(map[string]interface{}{
-				"trace_id": trace.ID(),
-			}).Logf("cannot eject trace that does not belong to this peer")
-
-			continue
-		}
-		t, err := i.makeDecision(ctx, trace, TraceSendEjectedMemsize)
-		if err != nil {
-			continue
-		}
-		tracesSent.Add(trace.TraceID)
-		totalDataSizeSent += trace.DataSize
-		i.send(ctx, t)
-		if totalDataSizeSent > int(totalToRemove) {
-			break
+	var wg sync.WaitGroup
+	var cacheSizeBefore, cacheSizeAfter int
+	wg.Add(len(i.collectLoops))
+	for _, loop := range i.collectLoops {
+		cacheSizeBefore += loop.GetCacheSize()
+		loop.sendEarly <- sendEarly{
+			wg:          &wg,
+			bytesToSend: perLoopToRemove,
 		}
 	}
-	i.cache.RemoveTraces(tracesSent)
+	wg.Wait()
+
+	for _, loop := range i.collectLoops {
+		cacheSizeAfter += loop.GetCacheSize()
+	}
 
 	// Treat any MaxAlloc overage as an error so we know it's happening
 	i.Logger.Warn().
-		WithField("cache_size", cacheSize).
 		WithField("alloc", mem.Alloc).
-		WithField("num_traces_sent", len(tracesSent)).
-		WithField("datasize_sent", totalDataSizeSent).
-		WithField("new_trace_count", i.cache.GetCacheEntryCount()).
+		WithField("old_trace_count", cacheSizeBefore).
+		WithField("new_trace_count", cacheSizeAfter).
 		Logf("Making some trace decisions early due to memory overrun.")
 
 	// Manually GC here - without this we can easily end up evicting more than we
@@ -332,14 +318,74 @@ func (i *InMemCollector) checkAlloc(ctx context.Context) {
 	return
 }
 
-// AddSpan accepts the incoming span to a queue and returns immediately
-func (i *InMemCollector) AddSpan(sp *types.Span) error {
-	return i.add(sp, i.incoming)
+// houseKeeping listens for reload signals and calls reloadConfigs
+func (i *InMemCollector) houseKeeping() {
+	defer i.shutdownWG.Done()
+
+	ctx := context.Background()
+
+	ticker := time.NewTicker(100 * time.Millisecond)
+	for {
+		select {
+		case <-ticker.C:
+			i.Health.Ready(CollectorHealthKey, true)
+
+			// Aggregate metrics
+			totalIncoming := 0
+			totalPeer := 0
+			totalCacheSize := 0
+
+			for _, loop := range i.collectLoops {
+				totalIncoming += len(loop.incoming)
+				totalPeer += len(loop.fromPeer)
+				totalCacheSize += loop.GetCacheSize()
+			}
+
+			i.Metrics.Histogram("collector_incoming_queue", float64(totalIncoming))
+			i.Metrics.Histogram("collector_peer_queue", float64(totalPeer))
+			i.Metrics.Gauge("collector_incoming_queue_length", float64(totalIncoming))
+			i.Metrics.Gauge("collector_peer_queue_length", float64(totalPeer))
+			i.Metrics.Gauge("collector_cache_size", float64(totalCacheSize))
+			i.Metrics.Gauge("collector_num_loops", float64(len(i.collectLoops)))
+
+			// Send traces early if we're over memory budget
+			i.checkAlloc(ctx)
+		case <-i.reload:
+			i.reloadConfigs()
+		case <-i.done:
+			ticker.Stop()
+			return
+		}
+	}
+}
+
+// getLoopForTrace determines which CollectLoop should handle a given trace ID
+// using consistent hashing to ensure all spans for a trace go to the same loop
+func (i *InMemCollector) getLoopForTrace(traceID string) int {
+	// Hash with a seed so that we don't align with any other hashes of this
+	// trace. We use a different algorithm to assign traces to nodes, but we
+	// still want to minimize the risk of any synchronization beteween that
+	// distribution and this one.
+	hash := wyhash.Hash([]byte(traceID), 7215963184435617557)
+
+	// Map to loop index
+	loopIndex := int(hash % uint64(len(i.collectLoops)))
+
+	return loopIndex
 }
 
 // AddSpan accepts the incoming span to a queue and returns immediately
+func (i *InMemCollector) AddSpan(sp *types.Span) error {
+	// Route to the appropriate loop
+	loopIndex := i.getLoopForTrace(sp.TraceID)
+	return i.collectLoops[loopIndex].addSpan(sp)
+}
+
+// AddSpanFromPeer accepts the incoming span from a peer to a queue and returns immediately
 func (i *InMemCollector) AddSpanFromPeer(sp *types.Span) error {
-	return i.add(sp, i.fromPeer)
+	// Route to the appropriate loop
+	loopIndex := i.getLoopForTrace(sp.TraceID)
+	return i.collectLoops[loopIndex].addSpanFromPeer(sp)
 }
 
 // Stressed returns true if the collector is undergoing significant stress
@@ -349,261 +395,6 @@ func (i *InMemCollector) Stressed() bool {
 
 func (i *InMemCollector) GetStressedSampleRate(traceID string) (rate uint, keep bool, reason string) {
 	return i.StressRelief.GetSampleRate(traceID)
-}
-
-func (i *InMemCollector) add(sp *types.Span, ch chan<- *types.Span) error {
-	if i.BlockOnAddSpan {
-		ch <- sp
-		i.Metrics.Increment("span_received")
-		i.Metrics.Up("spans_waiting")
-		return nil
-	}
-
-	select {
-	case ch <- sp:
-		i.Metrics.Increment("span_received")
-		i.Metrics.Up("spans_waiting")
-		return nil
-	default:
-		return ErrWouldBlock
-	}
-}
-
-// collect handles both accepting spans that have been handed to it and sending
-// the complete traces. These are done with channels in order to keep collecting
-// single threaded so we don't need any locks. Actions taken from this select
-// block is the only place we are allowed to modify any running data
-// structures.
-func (i *InMemCollector) collect() {
-	defer i.shutdownWG.Done()
-
-	tickerDuration := i.Config.GetTracesConfig().GetSendTickerValue()
-	ticker := time.NewTicker(tickerDuration)
-	defer ticker.Stop()
-
-	// mutex is normally held by this goroutine at all times.
-	// It is unlocked once per ticker cycle for tests.
-	i.mutex.Lock()
-	defer i.mutex.Unlock()
-
-	for {
-		ctx, span := otelutil.StartSpan(context.Background(), i.Tracer, "collect")
-		startTime := time.Now()
-
-		i.Health.Ready(CollectorHealthKey, true)
-		// Always drain peer channel before doing anything else. By processing peer
-		// traffic preferentially we avoid the situation where the cluster essentially
-		// deadlocks because peers are waiting to get their events handed off to each
-		// other.
-		select {
-		case <-i.done:
-			span.End()
-			return
-		case sp, ok := <-i.fromPeer:
-			if !ok {
-				// channel's been closed; we should shut down.
-				span.End()
-				return
-			}
-			i.processSpan(ctx, sp, types.RouterTypePeer)
-		default:
-			select {
-			case <-ticker.C:
-				i.sendExpiredTracesInCache(ctx, i.Clock.Now())
-				i.checkAlloc(ctx)
-
-				// Briefly unlock the cache, to allow test access.
-				if i.TestMode {
-					// This is a bit of a hack, but it allows us to test
-					// the collector without having to worry about the
-					// cache being locked.
-					_, goSchedSpan := otelutil.StartSpan(ctx, i.Tracer, "Gosched")
-					i.mutex.Unlock()
-					runtime.Gosched()
-					i.mutex.Lock()
-					goSchedSpan.End()
-				}
-			case sp, ok := <-i.incoming:
-				if !ok {
-					// channel's been closed; we should shut down.
-					span.End()
-					return
-				}
-				i.processSpan(ctx, sp, types.RouterTypeIncoming)
-			case sp, ok := <-i.fromPeer:
-				if !ok {
-					// channel's been closed; we should shut down.
-					span.End()
-					return
-				}
-				i.processSpan(ctx, sp, types.RouterTypePeer)
-			case <-i.reload:
-				i.reloadConfigs()
-			}
-		}
-
-		i.Metrics.Histogram("collector_collect_loop_duration_ms", float64(time.Now().Sub(startTime).Milliseconds()))
-		span.End()
-	}
-}
-
-func (i *InMemCollector) sendExpiredTracesInCache(ctx context.Context, now time.Time) {
-	ctx, span := otelutil.StartSpan(ctx, i.Tracer, "sendExpiredTracesInCache")
-	startTime := time.Now()
-	defer func() {
-		i.Metrics.Histogram("collector_send_expired_traces_in_cache_dur_ms", float64(time.Since(startTime).Milliseconds()))
-		span.End()
-	}()
-
-	traces := i.cache.TakeExpiredTraces(now, int(i.Config.GetTracesConfig().MaxExpiredTraces), nil)
-
-	dur := time.Now().Sub(startTime)
-
-	span.SetAttributes(attribute.Int("num_traces_to_expire", len(traces)), attribute.Int64("take_expired_traces_duration_ms", dur.Milliseconds()))
-
-	spanLimit := uint32(i.Config.GetTracesConfig().SpanLimit)
-
-	var totalSpansSent int64
-
-	for _, t := range traces {
-		ctx, sendExpiredTraceSpan := otelutil.StartSpan(ctx, i.Tracer, "sendExpiredTrace")
-		totalSpansSent += int64(t.DescendantCount())
-
-		if t.RootSpan != nil {
-			tr, err := i.makeDecision(ctx, t, TraceSendGotRoot)
-			if err != nil {
-				sendExpiredTraceSpan.End()
-				continue
-			}
-			i.send(ctx, tr)
-		} else {
-			if spanLimit > 0 && t.DescendantCount() > spanLimit {
-				tr, err := i.makeDecision(ctx, t, TraceSendSpanLimit)
-				if err != nil {
-					sendExpiredTraceSpan.End()
-					continue
-				}
-				i.send(ctx, tr)
-			} else {
-				tr, err := i.makeDecision(ctx, t, TraceSendExpired)
-				if err != nil {
-					sendExpiredTraceSpan.End()
-					continue
-				}
-				i.send(ctx, tr)
-			}
-		}
-		sendExpiredTraceSpan.End()
-	}
-
-	span.SetAttributes(attribute.Int64("total_spans_sent", totalSpansSent))
-}
-
-// processSpan does all the stuff necessary to take an incoming span and add it
-// to (or create a new placeholder for) a trace.
-func (i *InMemCollector) processSpan(ctx context.Context, sp *types.Span, source types.RouterType) {
-	ctx, span := otelutil.StartSpan(ctx, i.Tracer, "processSpan")
-	defer func() {
-		i.Metrics.Increment("span_processed")
-		i.Metrics.Down("spans_waiting")
-		span.End()
-	}()
-
-	var (
-		targetShard sharder.Shard
-	)
-
-	targetShard = i.Sharder.WhichShard(sp.TraceID)
-	if !targetShard.Equals(i.Sharder.MyShard()) {
-		sp.APIHost = targetShard.GetAddress()
-		i.PeerTransmission.EnqueueSpan(sp)
-		return
-	}
-
-	tcfg := i.Config.GetTracesConfig()
-
-	trace := i.cache.Get(sp.TraceID)
-	if trace == nil {
-		// if the trace has already been sent, just pass along the span
-		if sr, keptReason, found := i.sampleTraceCache.CheckSpan(sp); found {
-			i.Metrics.Increment("trace_sent_cache_hit")
-			// bump the count of records on this trace -- if the root span isn't
-			// the last late span, then it won't be perfect, but it will be better than
-			// having none at all
-			i.dealWithSentTrace(ctx, sr, keptReason, sp)
-			return
-		}
-
-		// trace hasn't already been sent (or this span is really old); let's
-		// create a new trace to hold it
-		i.Metrics.Increment("trace_accepted")
-
-		timeout := tcfg.GetTraceTimeout()
-		if timeout == 0 {
-			timeout = 60 * time.Second
-		}
-
-		now := i.Clock.Now()
-
-		trace = &types.Trace{
-			APIHost:          sp.APIHost,
-			APIKey:           sp.APIKey,
-			Dataset:          sp.Dataset,
-			Environment:      sp.Environment,
-			TraceID:          sp.TraceID,
-			ArrivalTime:      now,
-			DeciderShardAddr: targetShard.GetAddress(),
-			SendBy:           now.Add(timeout),
-		}
-		trace.SetSampleRate(sp.SampleRate) // if it had a sample rate, we want to keep it
-		// push this into the cache and if we eject an unsent trace, send it ASAP
-		i.cache.Set(trace)
-	}
-	// if the trace we got back from the cache has already been sent, deal with the
-	// span.
-	if trace.Sent {
-		if sr, reason, found := i.sampleTraceCache.CheckSpan(sp); found {
-			i.Metrics.Increment("trace_sent_cache_hit")
-			i.dealWithSentTrace(ctx, sr, reason, sp)
-			return
-		}
-		// trace has already been sent, but this is not in the sent cache.
-		// we will just use the default late span reason as the sent reason which is
-		// set inside the dealWithSentTrace function
-		i.dealWithSentTrace(ctx, cache.NewKeptTraceCacheEntry(trace), "", sp)
-		return
-	}
-
-	// great! trace is live. add the span.
-	trace.AddSpan(sp)
-
-	// we may override these values in conditions below
-	var markTraceForSending bool
-	timeout := tcfg.GetSendDelay()
-	if timeout == 0 {
-		timeout = 2 * time.Second // a sensible default
-	}
-
-	// if this is a root span, say so and send the trace
-	if sp.IsRoot {
-		markTraceForSending = true
-		trace.RootSpan = sp
-	}
-
-	// if the span count has exceeded our SpanLimit, send the trace immediately
-	if tcfg.SpanLimit > 0 && uint(trace.DescendantCount()) > tcfg.SpanLimit {
-		markTraceForSending = true
-		timeout = 0 // don't use a timeout in this case; this is an "act fast" situation
-	}
-
-	if markTraceForSending {
-		updatedSendBy := i.Clock.Now().Add(timeout)
-		// if the trace has already timed out, we should not update the send_by time
-		if trace.SendBy.After(updatedSendBy) {
-			trace.SendBy = updatedSendBy
-			i.cache.Set(trace)
-		}
-	}
 }
 
 // ProcessSpanImmediately is an escape hatch used under stressful conditions --
@@ -667,6 +458,7 @@ func (i *InMemCollector) ProcessSpanImmediately(sp *types.Span) (processed bool,
 // dealWithSentTrace handles a span that has arrived after the sampling decision
 // on the trace has already been made, and it obeys that decision by either
 // sending the span immediately or dropping it.
+// This method is made public so CollectLoop can access it.
 func (i *InMemCollector) dealWithSentTrace(ctx context.Context, tr cache.TraceSentRecord, keptReason string, sp *types.Span) {
 	_, span := otelutil.StartSpanMulti(ctx, i.Tracer, "dealWithSentTrace", map[string]interface{}{
 		"trace_id":    sp.TraceID,
@@ -819,33 +611,58 @@ func (i *InMemCollector) send(ctx context.Context, trace sendableTrace) {
 	} else {
 		i.Logger.Info().WithFields(logFields).Logf("Sending trace")
 	}
-	i.Logger.Info().WithFields(logFields).Logf("Sending trace")
-	i.outgoingTraces <- trace
+
+	// Check if we're shutting down before sending
+	select {
+	case <-i.done:
+		// We're shutting down, don't send
+		i.Logger.Debug().Logf("Not sending trace during shutdown")
+		return
+	case i.outgoingTraces <- trace:
+		// Successfully sent
+	}
 }
 
 func (i *InMemCollector) Stop() error {
-	close(i.done)
-	// signal the health system to not be ready and
-	// stop liveness check
-	// so that no new traces are accepted
-	i.Health.Unregister(CollectorHealthKey)
-	i.mutex.Lock()
+	i.Logger.Debug().Logf("Starting InMemCollector shutdown")
 
+	// Signal shutdown to all components
+	close(i.done)
+
+	// signal the health system to not be ready and
+	// stop liveness check so that no new traces are accepted
+	i.Health.Unregister(CollectorHealthKey)
+
+	// Close all loop input channels, which will cause the loops to stop.
+	for idx, loop := range i.collectLoops {
+		i.Logger.Debug().WithField("loop_id", idx).Logf("closing loop channels")
+		close(loop.incoming)
+		close(loop.fromPeer)
+	}
+	i.collectLoopsWG.Wait()
+
+	// Stop shared samplers
+	i.mutex.Lock()
 	for _, sampler := range i.datasetSamplers {
 		sampler.Stop()
 	}
-
-	// TODO:we probably still should have some logic to drain the in-flight traces on shutdown
-
-	i.sampleTraceCache.Stop()
 	i.mutex.Unlock()
 
-	close(i.incoming)
-	close(i.fromPeer)
+	// Stop the sample trace cache
+	if i.sampleTraceCache != nil {
+		i.sampleTraceCache.Stop()
+	}
+
+	// Now it's safe to close the outgoing traces channel
+	// No more traces will be sent to it
 	close(i.outgoingTraces)
+
+	// Wait for remaining goroutines (sendTraces, recordQueueMetrics) to finish
+	i.Logger.Debug().Logf("Waiting for all goroutines to finish")
 
 	i.shutdownWG.Wait()
 
+	i.Logger.Debug().Logf("InMemCollector shutdown complete")
 	return nil
 }
 
@@ -854,13 +671,6 @@ type sentRecord struct {
 	span   *types.Span
 	record cache.TraceSentRecord
 	reason string
-}
-
-// Convenience method for tests.
-func (i *InMemCollector) getFromCache(traceID string) *types.Trace {
-	i.mutex.Lock()
-	defer i.mutex.Unlock()
-	return i.cache.Get(traceID)
 }
 
 func (i *InMemCollector) addAdditionalAttributes(sp *types.Span) {
@@ -950,10 +760,13 @@ func (i *InMemCollector) makeDecision(ctx context.Context, trace *types.Trace, s
 	samplerSelector := i.Config.DetermineSamplerKey(trace.APIKey, trace.Environment, trace.Dataset)
 
 	// use sampler key to find sampler; create and cache if not found
+	// Need to lock when accessing/modifying the shared datasetSamplers map
+	i.mutex.Lock()
 	if sampler, found = i.datasetSamplers[samplerSelector]; !found {
 		sampler = i.SamplerFactory.GetSamplerImplementationForKey(samplerSelector)
 		i.datasetSamplers[samplerSelector] = sampler
 	}
+	i.mutex.Unlock()
 
 	// prepopulate spans with key fields
 	allFields, nonRootFields := sampler.GetKeyFields()
@@ -1015,22 +828,4 @@ func (i *InMemCollector) IsMyTrace(traceID string) (sharder.Shard, bool) {
 
 	return targeShard, i.Sharder.MyShard().Equals(targeShard)
 
-}
-
-func (i *InMemCollector) recordQueueMetrics() {
-	defer i.shutdownWG.Done()
-
-	ticker := time.NewTicker(100 * time.Millisecond)
-	for {
-		select {
-		case <-ticker.C:
-			i.Metrics.Histogram("collector_incoming_queue", float64(len(i.incoming)))
-			i.Metrics.Histogram("collector_peer_queue", float64(len(i.fromPeer)))
-			i.Metrics.Gauge("collector_incoming_queue_length", float64(len(i.incoming)))
-			i.Metrics.Gauge("collector_peer_queue_length", float64(len(i.fromPeer)))
-		case <-i.done:
-			ticker.Stop()
-			return
-		}
-	}
 }

--- a/collect/collect_loop.go
+++ b/collect/collect_loop.go
@@ -1,0 +1,375 @@
+package collect
+
+import (
+	"context"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/honeycombio/refinery/collect/cache"
+	"github.com/honeycombio/refinery/generics"
+	"github.com/honeycombio/refinery/internal/otelutil"
+	"github.com/honeycombio/refinery/types"
+)
+
+type sendEarly struct {
+	wg          *sync.WaitGroup
+	bytesToSend int
+}
+
+// CollectLoop represents a single concurrent collection loop that processes
+// a subset of the trace ID space. Each loop has its own cache and channels
+// but shares configuration and transmission resources with the parent collector.
+type CollectLoop struct {
+	// ID identifies this particular loop instance
+	ID int
+
+	// parent is a reference to the parent InMemCollector for accessing shared resources
+	parent *InMemCollector
+
+	// Input channels specific to this loop
+	incoming chan *types.Span
+	fromPeer chan *types.Span
+
+	// Control signal for memory overages
+	sendEarly chan sendEarly
+
+	// Optional pause signal to stop all work. Blocks on receiving a channel, then
+	// waits for the received channel to unblock, then resumes.
+	pause chan chan struct{}
+
+	// Our local trace cache. This deliberatly does not have a mutex around it;
+	// there is no way to safely access this directly from the outside.
+	cache cache.Cache
+
+	// For reporting cache size asynchronously.
+	lastCacheSize atomic.Int64
+}
+
+// NewCollectLoop creates a new CollectLoop instance
+func NewCollectLoop(
+	id int,
+	parent *InMemCollector,
+	cacheCapacity int,
+	incomingSize int,
+	peerSize int,
+) *CollectLoop {
+	return &CollectLoop{
+		ID:        id,
+		parent:    parent,
+		cache:     cache.NewInMemCache(cacheCapacity, parent.Metrics, parent.Logger),
+		incoming:  make(chan *types.Span, incomingSize),
+		fromPeer:  make(chan *types.Span, peerSize),
+		sendEarly: make(chan sendEarly, 1),
+
+		// Important that this be unbuffered, so the sender blocks until the
+		// signal has been received.
+		pause: make(chan chan struct{}),
+	}
+}
+
+// addSpan adds a span to this loop's incoming channel
+func (cl *CollectLoop) addSpan(sp *types.Span) error {
+	if cl.parent.BlockOnAddSpan {
+		cl.incoming <- sp
+		cl.parent.Metrics.Increment("span_received")
+		cl.parent.Metrics.Up("spans_waiting")
+		return nil
+	}
+
+	select {
+	case cl.incoming <- sp:
+		cl.parent.Metrics.Increment("span_received")
+		cl.parent.Metrics.Up("spans_waiting")
+		return nil
+	default:
+		return ErrWouldBlock
+	}
+}
+
+// addSpanFromPeer adds a span from a peer to this loop's peer channel
+func (cl *CollectLoop) addSpanFromPeer(sp *types.Span) error {
+	if cl.parent.BlockOnAddSpan {
+		cl.fromPeer <- sp
+		cl.parent.Metrics.Increment("span_received")
+		cl.parent.Metrics.Up("spans_waiting")
+		return nil
+	}
+
+	select {
+	case cl.fromPeer <- sp:
+		cl.parent.Metrics.Increment("span_received")
+		cl.parent.Metrics.Up("spans_waiting")
+		return nil
+	default:
+		return ErrWouldBlock
+	}
+}
+
+// collect is the main event processing loop for this CollectLoop
+func (cl *CollectLoop) collect() {
+	defer cl.parent.collectLoopsWG.Done()
+
+	tickerDuration := cl.parent.Config.GetTracesConfig().GetSendTickerValue()
+	ticker := cl.parent.Clock.NewTicker(tickerDuration)
+	defer ticker.Stop()
+
+	for {
+		ctx, span := otelutil.StartSpanWith(context.Background(), cl.parent.Tracer, "collect_loop", "loop_id", cl.ID)
+		startTime := cl.parent.Clock.Now()
+
+		// Always drain peer channel before doing anything else. By processing peer
+		// traffic preferentially we avoid the situation where the cluster essentially
+		// deadlocks because peers are waiting to get their events handed off to each
+		// other.
+		select {
+		case sp, ok := <-cl.fromPeer:
+			if !ok {
+				// channel's been closed; we should shut down.
+				span.End()
+				return
+			}
+			cl.processSpan(ctx, sp)
+		default:
+			select {
+			case <-ticker.Chan():
+				cl.sendExpiredTracesInCache(ctx, cl.parent.Clock.Now())
+
+				// Report per-loop metrics
+				cl.reportLoopMetrics()
+			case sp, ok := <-cl.incoming:
+				if !ok {
+					// channel's been closed; we should shut down.
+					span.End()
+					return
+				}
+				cl.processSpan(ctx, sp)
+			case sp, ok := <-cl.fromPeer:
+				if !ok {
+					// channel's been closed; we should shut down.
+					span.End()
+					return
+				}
+				cl.processSpan(ctx, sp)
+			case sendEarly := <-cl.sendEarly:
+				cl.sendTracesEarly(ctx, sendEarly.bytesToSend)
+				sendEarly.wg.Done()
+			case ch := <-cl.pause:
+				// We got a pause signal, wait until it unblocks.
+				<-ch
+			}
+		}
+
+		cl.parent.Metrics.Histogram("collector_collect_loop_duration_ms", float64(cl.parent.Clock.Since(startTime).Milliseconds()))
+		span.End()
+	}
+}
+
+// processSpan handles a single span, adding it to the cache or forwarding it
+func (cl *CollectLoop) processSpan(ctx context.Context, sp *types.Span) {
+	ctx, span := otelutil.StartSpanWith(ctx, cl.parent.Tracer, "processSpan", "loop_id", cl.ID)
+	defer func() {
+		cl.parent.Metrics.Increment("span_processed")
+		cl.parent.Metrics.Down("spans_waiting")
+		span.End()
+	}()
+
+	tcfg := cl.parent.Config.GetTracesConfig()
+
+	trace := cl.cache.Get(sp.TraceID)
+	if trace == nil {
+		// if the trace has already been sent, just pass along the span
+		if sr, keptReason, found := cl.parent.sampleTraceCache.CheckSpan(sp); found {
+			cl.parent.Metrics.Increment("trace_sent_cache_hit")
+			// bump the count of records on this trace -- if the root span isn't
+			// the last late span, then it won't be perfect, but it will be better than
+			// having none at all
+			cl.parent.dealWithSentTrace(ctx, sr, keptReason, sp)
+			return
+		}
+
+		// trace hasn't already been sent (or this span is really old); let's
+		// create a new trace to hold it
+		cl.parent.Metrics.Increment("trace_accepted")
+
+		timeout := tcfg.GetTraceTimeout()
+		if timeout == 0 {
+			timeout = 60 * time.Second
+		}
+
+		now := cl.parent.Clock.Now()
+
+		trace = &types.Trace{
+			APIHost:     sp.APIHost,
+			APIKey:      sp.APIKey,
+			Dataset:     sp.Dataset,
+			Environment: sp.Environment,
+			TraceID:     sp.TraceID,
+			ArrivalTime: now,
+			SendBy:      now.Add(timeout),
+		}
+		trace.SetSampleRate(sp.SampleRate) // if it had a sample rate, we want to keep it
+		// push this into the cache
+		cl.cache.Set(trace)
+	}
+	// if the trace we got back from the cache has already been sent, deal with the
+	// span.
+	if trace.Sent {
+		if sr, reason, found := cl.parent.sampleTraceCache.CheckSpan(sp); found {
+			cl.parent.Metrics.Increment("trace_sent_cache_hit")
+			cl.parent.dealWithSentTrace(ctx, sr, reason, sp)
+			return
+		}
+		// trace has already been sent, but this is not in the sent cache.
+		// we will just use the default late span reason as the sent reason which is
+		// set inside the dealWithSentTrace function
+		cl.parent.dealWithSentTrace(ctx, cache.NewKeptTraceCacheEntry(trace), "", sp)
+		return
+	}
+
+	// great! trace is live. add the span.
+	trace.AddSpan(sp)
+
+	// we may override these values in conditions below
+	var markTraceForSending bool
+	timeout := tcfg.GetSendDelay()
+	if timeout == 0 {
+		timeout = 2 * time.Second // a sensible default
+	}
+
+	// if this is a root span, say so and send the trace
+	if sp.IsRoot {
+		markTraceForSending = true
+		trace.RootSpan = sp
+	}
+
+	// if the span count has exceeded our SpanLimit, send the trace immediately
+	if tcfg.SpanLimit > 0 && uint(trace.DescendantCount()) > tcfg.SpanLimit {
+		markTraceForSending = true
+		timeout = 0 // don't use a timeout in this case; this is an "act fast" situation
+	}
+
+	if markTraceForSending {
+		updatedSendBy := cl.parent.Clock.Now().Add(timeout)
+		// if the trace has already timed out, we should not update the send_by time
+		if trace.SendBy.After(updatedSendBy) {
+			trace.SendBy = updatedSendBy
+			cl.cache.Set(trace)
+		}
+	}
+}
+
+// sendExpiredTracesInCache finds and sends traces that have exceeded their timeout
+func (cl *CollectLoop) sendExpiredTracesInCache(ctx context.Context, now time.Time) {
+	ctx, span := otelutil.StartSpanWith(ctx, cl.parent.Tracer, "sendExpiredTracesInCache", "loop_id", cl.ID)
+	startTime := cl.parent.Clock.Now()
+	defer func() {
+		cl.parent.Metrics.Histogram("collector_send_expired_traces_in_cache_dur_ms", float64(cl.parent.Clock.Since(startTime).Milliseconds()))
+		span.End()
+	}()
+
+	traces := cl.cache.TakeExpiredTraces(now, int(cl.parent.Config.GetTracesConfig().MaxExpiredTraces), nil)
+
+	dur := cl.parent.Clock.Since(startTime)
+
+	span.SetAttributes(
+		attribute.Int("num_traces_to_expire", len(traces)),
+		attribute.Int64("take_expired_traces_duration_ms", dur.Milliseconds()),
+	)
+
+	spanLimit := uint32(cl.parent.Config.GetTracesConfig().SpanLimit)
+
+	var totalSpansSent int64
+
+	for _, t := range traces {
+		ctx, sendExpiredTraceSpan := otelutil.StartSpan(ctx, cl.parent.Tracer, "sendExpiredTrace")
+		totalSpansSent += int64(t.DescendantCount())
+
+		if t.RootSpan != nil {
+			tr, err := cl.parent.makeDecision(ctx, t, TraceSendGotRoot)
+			if err != nil {
+				sendExpiredTraceSpan.End()
+				continue
+			}
+			cl.parent.send(ctx, tr)
+		} else {
+			if spanLimit > 0 && t.DescendantCount() > spanLimit {
+				tr, err := cl.parent.makeDecision(ctx, t, TraceSendSpanLimit)
+				if err != nil {
+					sendExpiredTraceSpan.End()
+					continue
+				}
+				cl.parent.send(ctx, tr)
+			} else {
+				tr, err := cl.parent.makeDecision(ctx, t, TraceSendExpired)
+				if err != nil {
+					sendExpiredTraceSpan.End()
+					continue
+				}
+				cl.parent.send(ctx, tr)
+			}
+		}
+		sendExpiredTraceSpan.End()
+	}
+
+	span.SetAttributes(attribute.Int64("total_spans_sent", totalSpansSent))
+}
+
+func (cl *CollectLoop) sendTracesEarly(ctx context.Context, sendEarlyBytes int) {
+	// The size of the cache exceeds the user's intended allocation, so we're going to
+	// remove the traces from the cache that have had the most impact on allocation.
+	// To do this, we sort the traces by their CacheImpact value and then remove traces
+	// until the total size is less than the amount to which we want to shrink.
+	allTraces := cl.cache.GetAll()
+
+	traceTimeout := cl.parent.Config.GetTracesConfig().GetTraceTimeout()
+	if traceTimeout == 0 {
+		traceTimeout = 60 * time.Second
+	}
+
+	// Sort traces by CacheImpact, heaviest first
+	sort.Slice(allTraces, func(i, j int) bool {
+		return allTraces[i].CacheImpact(traceTimeout) > allTraces[j].CacheImpact(traceTimeout)
+	})
+
+	totalDataSizeSent := 0
+	tracesSent := generics.NewSet[string]()
+	// Send the traces we can't keep.
+	for _, trace := range allTraces {
+		// only eject traces that belong to this peer or the trace is an orphan
+		if _, ok := cl.parent.IsMyTrace(trace.ID()); !ok && !trace.IsOrphan(traceTimeout, cl.parent.Clock.Now()) {
+			cl.parent.Logger.Debug().WithFields(map[string]interface{}{
+				"trace_id": trace.ID(),
+			}).Logf("cannot eject trace that does not belong to this peer")
+
+			continue
+		}
+
+		t, err := cl.parent.makeDecision(ctx, trace, TraceSendEjectedMemsize)
+		if err != nil {
+			continue
+		}
+		tracesSent.Add(trace.TraceID)
+		totalDataSizeSent += trace.DataSize
+		cl.parent.send(ctx, t)
+		if totalDataSizeSent > sendEarlyBytes {
+			break
+		}
+	}
+	cl.cache.RemoveTraces(tracesSent)
+
+	cl.lastCacheSize.Store(int64(cl.cache.GetCacheEntryCount()))
+}
+
+// GetCacheSize returns the most recently recorded count of traces in this loop's cache
+func (cl *CollectLoop) GetCacheSize() int {
+	return int(cl.lastCacheSize.Load())
+}
+
+func (cl *CollectLoop) reportLoopMetrics() {
+	cacheSize := cl.cache.GetCacheEntryCount()
+	cl.lastCacheSize.Store(int64(cacheSize))
+}

--- a/collect/collect_loop.go
+++ b/collect/collect_loop.go
@@ -138,8 +138,9 @@ func (cl *CollectLoop) collect() {
 			case <-ticker.Chan():
 				cl.sendExpiredTracesInCache(ctx, cl.parent.Clock.Now())
 
-				// Report per-loop metrics
-				cl.reportLoopMetrics()
+				// Note latest cache size for GetCacheSize()
+				cacheSize := cl.cache.GetCacheEntryCount()
+				cl.lastCacheSize.Store(int64(cacheSize))
 			case sp, ok := <-cl.incoming:
 				if !ok {
 					// channel's been closed; we should shut down.
@@ -367,9 +368,4 @@ func (cl *CollectLoop) sendTracesEarly(ctx context.Context, sendEarlyBytes int) 
 // GetCacheSize returns the most recently recorded count of traces in this loop's cache
 func (cl *CollectLoop) GetCacheSize() int {
 	return int(cl.lastCacheSize.Load())
-}
-
-func (cl *CollectLoop) reportLoopMetrics() {
-	cacheSize := cl.cache.GetCacheEntryCount()
-	cl.lastCacheSize.Store(int64(cacheSize))
 }

--- a/collect/multi_loop_test.go
+++ b/collect/multi_loop_test.go
@@ -1,0 +1,610 @@
+package collect
+
+import (
+	"fmt"
+	"math/rand"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/honeycombio/refinery/config"
+	"github.com/honeycombio/refinery/generics"
+	"github.com/honeycombio/refinery/metrics"
+	"github.com/honeycombio/refinery/transmit"
+	"github.com/honeycombio/refinery/types"
+)
+
+// getAllTracesFromLoops is a test helper that efficiently gets all traces from all loops.
+// It pauses each loop, then extracts all traces. Note the traces themselves aren't locked
+// so there is still a hypothetical race condition after this function returns.
+func getAllTracesFromLoops(collector *InMemCollector) map[string]*types.Trace {
+	ch := make(chan struct{})
+	defer close(ch)
+
+	allTraces := make(map[string]*types.Trace)
+	for _, loop := range collector.collectLoops {
+		loop.pause <- ch
+		traces := loop.cache.GetAll()
+
+		for _, trace := range traces {
+			allTraces[trace.TraceID] = trace
+		}
+	}
+	return allTraces
+}
+
+// TestMultiLoopProcessing tests that multiple collect loops can process spans concurrently
+func TestMultiLoopProcessing(t *testing.T) {
+	conf := &config.MockConfig{
+		GetTracesConfigVal: config.TracesConfig{
+			SendTicker:   config.Duration(100 * time.Millisecond),
+			SendDelay:    config.Duration(50 * time.Millisecond),
+			TraceTimeout: config.Duration(5 * time.Second), // Longer timeout for test
+			MaxBatchSize: 500,
+		},
+		GetCollectionConfigVal: config.CollectionConfig{
+			CacheCapacity: 10000,
+			MaxAlloc:      0,
+		},
+		GetSamplerTypeVal:  &config.DeterministicSamplerConfig{SampleRate: 1},
+		ParentIdFieldNames: []string{"trace.parent_id", "parentId"},
+		TraceIdFieldNames:  []string{"trace.trace_id", "traceId"},
+		SampleCache: config.SampleCacheConfig{
+			KeptSize:          1000,
+			DroppedSize:       1000,
+			SizeCheckInterval: config.Duration(1 * time.Second),
+		},
+	}
+
+	// Test with different numbers of loops
+	for _, numLoops := range []int{2, 4, 8} {
+		t.Run(fmt.Sprintf("%d_loops", numLoops), func(t *testing.T) {
+			conf.GetCollectionConfigVal.NumCollectLoops = numLoops
+
+			collector := newTestCollector(t, conf)
+
+			// Verify loops were created
+			assert.Equal(t, numLoops, len(collector.collectLoops))
+
+			// Send spans to different traces (should go to different loops)
+			numTraces := 100
+			spansPerTrace := 10
+			spansAdded := int32(0)
+
+			var wg sync.WaitGroup
+			for i := 0; i < numTraces; i++ {
+				wg.Add(1)
+				go func(traceNum int) {
+					defer wg.Done()
+					traceID := fmt.Sprintf("trace-%d", traceNum)
+
+					for j := 0; j < spansPerTrace; j++ {
+						span := &types.Span{
+							Event: types.Event{
+								APIHost:    "http://api.honeycomb.io",
+								APIKey:     legacyAPIKey,
+								Dataset:    "test.dataset",
+								SampleRate: 1,
+								Timestamp:  time.Now(),
+								Data:       types.Payload{},
+							},
+							TraceID:     traceID,
+							IsRoot:      false, // Don't send root spans so traces stay in cache
+							ArrivalTime: time.Now(),
+						}
+						span.Data.Set("span_id", fmt.Sprintf("span-%d", j))
+
+						err := collector.AddSpan(span)
+						if err == nil {
+							atomic.AddInt32(&spansAdded, 1)
+						}
+					}
+				}(i)
+			}
+
+			wg.Wait()
+
+			// Verify spans were added
+			assert.Equal(t, int32(numTraces*spansPerTrace), atomic.LoadInt32(&spansAdded))
+
+			// Verify traces are distributed across loops
+			loopUsage := make(map[int]int)
+			for i := 0; i < numTraces; i++ {
+				traceID := fmt.Sprintf("trace-%d", i)
+				loopIndex := collector.getLoopForTrace(traceID)
+				loopUsage[loopIndex]++
+			}
+
+			// All loops should have been used (with high probability)
+			assert.Equal(t, numLoops, len(loopUsage),
+				"All loops should be used with %d traces", numTraces)
+
+			// Wait for all spans to be processed into traces
+			assert.Eventually(t, func() bool {
+				// Get all traces at once to avoid multiple mutex acquisitions
+				allTraces := getAllTracesFromLoops(collector)
+
+				// Count how many of our test traces we found
+				foundCount := 0
+				for i := 0; i < numTraces; i++ {
+					traceID := fmt.Sprintf("trace-%d", i)
+					if _, exists := allTraces[traceID]; exists {
+						foundCount++
+					}
+				}
+
+				// We should find most traces (some may have expired)
+				return foundCount >= numTraces/2
+			}, 5*time.Second, 500*time.Millisecond) // Check less frequently since each check is now fast
+
+			met := collector.Metrics.(*metrics.MockMetrics)
+			count, ok := met.Get("span_received")
+			assert.True(t, ok)
+			assert.Equal(t, float64(1000), count)
+			count, ok = met.Get("span_processed")
+			assert.True(t, ok)
+			assert.Equal(t, float64(1000), count)
+			count, ok = met.Get("trace_accepted")
+			assert.True(t, ok)
+			assert.Equal(t, float64(100), count)
+
+			// These metrics are nondeterministic, but we can at least confirm they were reported
+			for _, name := range []string{
+				"spans_waiting",
+				"memory_heap_allocation",
+				"collector_incoming_queue_length",
+				"collector_peer_queue_length",
+				"collector_cache_size",
+				"collector_num_loops",
+			} {
+				_, ok = met.Get(name)
+				assert.True(t, ok)
+			}
+
+			assert.Greater(t, met.GetHistogramCount("collector_collect_loop_duration_ms"), 0)
+			assert.Greater(t, met.GetHistogramCount("collect_cache_entries"), 0)
+			assert.Greater(t, met.GetHistogramCount("collector_send_expired_traces_in_cache_dur_ms"), 0)
+			assert.Greater(t, met.GetHistogramCount("collector_incoming_queue"), 0)
+			assert.Greater(t, met.GetHistogramCount("collector_peer_queue"), 0)
+		})
+	}
+}
+
+// TestTraceIDSharding verifies that traces are consistently routed to the same loop.
+func TestTraceIDSharding(t *testing.T) {
+	// Test with different numbers of loops and their expected deterministic distributions
+	// These distributions were empirically discovered for trace-0 through trace-99
+	testCases := []struct {
+		name                 string
+		numLoops             int
+		expectedDistribution []int
+	}{
+		{"single_loop", 1, []int{100}},
+		{"two_loops", 2, []int{54, 46}},
+		{"four_loops", 4, []int{26, 20, 28, 26}},
+		{"eight_loops", 8, []int{12, 10, 15, 10, 14, 10, 13, 16}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			conf := &config.MockConfig{
+				GetTracesConfigVal: config.TracesConfig{
+					SendTicker:   config.Duration(100 * time.Millisecond),
+					SendDelay:    config.Duration(50 * time.Millisecond),
+					TraceTimeout: config.Duration(1 * time.Second),
+					MaxBatchSize: 500,
+				},
+				GetCollectionConfigVal: config.CollectionConfig{
+					CacheCapacity:   1000,
+					NumCollectLoops: tc.numLoops,
+				},
+				GetSamplerTypeVal:  &config.DeterministicSamplerConfig{SampleRate: 2},
+				ParentIdFieldNames: []string{"trace.parent_id", "parentId"},
+				TraceIdFieldNames:  []string{"trace.trace_id", "traceId"},
+				SampleCache: config.SampleCacheConfig{
+					KeptSize:          100,
+					DroppedSize:       100,
+					SizeCheckInterval: config.Duration(1 * time.Second),
+				},
+			}
+
+			collector := newTestCollector(t, conf)
+
+			// Track which loop each trace ID maps to
+			traceToLoop := make(map[string]int)
+
+			// Test multiple trace IDs
+			for i := 0; i < 100; i++ {
+				traceID := fmt.Sprintf("trace-%d", i)
+
+				// Get the loop for this trace multiple times
+				// It should always return the same loop
+				firstLoop := collector.getLoopForTrace(traceID)
+				traceToLoop[traceID] = firstLoop
+
+				// Verify consistency - call multiple times
+				for j := 0; j < 10; j++ {
+					loop := collector.getLoopForTrace(traceID)
+					assert.Equal(t, firstLoop, loop,
+						"Trace %s should always map to the same loop", traceID)
+				}
+
+				// Verify the loop index is within bounds
+				assert.GreaterOrEqual(t, firstLoop, 0)
+				assert.Less(t, firstLoop, tc.numLoops)
+			}
+
+			// Count traces per loop for distribution analysis
+			loopCounts := make([]int, tc.numLoops)
+			for _, loop := range traceToLoop {
+				loopCounts[loop]++
+			}
+
+			// Assert the deterministic expected distribution
+			assert.Equal(t, tc.expectedDistribution, loopCounts)
+
+			// Also verify all loops are used appropriately
+			assert.Equal(t, tc.numLoops, len(loopCounts), "Loop counts should match number of loops")
+			totalTraces := 0
+			for loop, count := range loopCounts {
+				assert.Greater(t, count, 0, "Loop %d should have at least some traces", loop)
+				totalTraces += count
+			}
+			assert.Equal(t, 100, totalTraces, "Total traces should equal 100")
+		})
+	}
+}
+
+// TestParallelCollectRaceConditions tests for race conditions when the collector
+// processes spans concurrently.
+func TestParallelCollectRaceConditions(t *testing.T) {
+	// This test is designed to be run with -race flag
+	const (
+		numTraces     = 100
+		spansPerTrace = 50
+		numGoroutines = 10
+	)
+
+	conf := &config.MockConfig{
+		GetTracesConfigVal: config.TracesConfig{
+			SendTicker:   config.Duration(100 * time.Millisecond),
+			SendDelay:    config.Duration(50 * time.Millisecond),
+			TraceTimeout: config.Duration(1 * time.Second),
+			MaxBatchSize: 500,
+		},
+		GetCollectionConfigVal: config.CollectionConfig{
+			CacheCapacity:   10000,
+			NumCollectLoops: 4,
+		},
+		GetSamplerTypeVal:  &config.DeterministicSamplerConfig{SampleRate: 2},
+		ParentIdFieldNames: []string{"trace.parent_id", "parentId"},
+		TraceIdFieldNames:  []string{"trace.trace_id", "traceId"},
+		AddSpanCountToRoot: true,
+		AddCountsToRoot:    false,
+		DryRun:             false,
+		SampleCache: config.SampleCacheConfig{
+			KeptSize:          100,
+			DroppedSize:       100,
+			SizeCheckInterval: config.Duration(1 * time.Second),
+		},
+	}
+
+	clock := clockwork.NewFakeClock()
+	collector := newTestCollector(t, conf, clock)
+	transmission := collector.Transmission.(*transmit.MockTransmission)
+
+	// Track all traces we send
+	sentTraces := generics.NewSet[string]()
+	var sentMutex sync.Mutex
+
+	// Generate test data
+	type testSpan struct {
+		traceID string
+		spanID  int
+		isRoot  bool
+	}
+
+	allSpans := make([]testSpan, 0, numTraces*spansPerTrace)
+	for i := 0; i < numTraces; i++ {
+		traceID := fmt.Sprintf("trace-%d", i)
+		sentMutex.Lock()
+		sentTraces.Add(traceID)
+		sentMutex.Unlock()
+
+		for j := 0; j < spansPerTrace; j++ {
+			allSpans = append(allSpans, testSpan{
+				traceID: traceID,
+				spanID:  j,
+				isRoot:  j == spansPerTrace-1, // Last span is root
+			})
+		}
+	}
+
+	// Shuffle spans to simulate random arrival
+	rand.Shuffle(len(allSpans), func(i, j int) {
+		allSpans[i], allSpans[j] = allSpans[j], allSpans[i]
+	})
+
+	// Start multiple goroutines to add spans concurrently
+	var wg sync.WaitGroup
+	for g := 0; g < numGoroutines; g++ {
+		wg.Add(1)
+		go func(goroutineID int) {
+			defer wg.Done()
+
+			// Each goroutine gets a slice of spans to add
+			startIdx := goroutineID * (len(allSpans) / numGoroutines)
+			endIdx := startIdx + (len(allSpans) / numGoroutines)
+			if goroutineID == numGoroutines-1 {
+				endIdx = len(allSpans) // Last goroutine handles remainder
+			}
+
+			for i := startIdx; i < endIdx; i++ {
+				span := &types.Span{
+					Event: types.Event{
+						APIHost:    "http://api.honeycomb.io",
+						APIKey:     legacyAPIKey,
+						Dataset:    "test.dataset",
+						SampleRate: 1,
+						Timestamp:  time.Now(),
+						Data:       types.Payload{},
+					},
+					TraceID:     allSpans[i].traceID,
+					IsRoot:      allSpans[i].isRoot,
+					ArrivalTime: time.Now(),
+				}
+
+				span.Data.Set("span_id", fmt.Sprintf("span-%d", allSpans[i].spanID))
+				span.Data.Set("goroutine", goroutineID)
+
+				// Alternate between AddSpan and AddSpanFromPeer
+				var err error
+				if i%2 == 0 {
+					err = collector.AddSpan(span)
+				} else {
+					err = collector.AddSpanFromPeer(span)
+				}
+				assert.NoError(t, err)
+			}
+		}(g)
+	}
+
+	// Recreational reload command, should be fine.
+	collector.sendReloadSignal("hash1", "hash2")
+
+	// Wait for all input goroutines to complete - note this will deadlock if
+	// we fill the input channels.
+	wg.Wait()
+
+	// Now that all the events have been enqueued, advance time to allow transmisison.
+	clock.Advance(time.Second)
+
+	// Wait for spans to be processed and sent
+	var totalSent int
+	assert.Eventually(t, func() bool {
+		clock.Advance(time.Second)
+		events := transmission.GetBlock(0)
+		totalSent += len(events)
+
+		// Sample rate of 2 in the confix means we expect roughly half of our
+		// events to actually be sent. Make sure we get at least 45%
+		return float64(totalSent) >= float64(len(allSpans))*0.45
+	}, 2*time.Second, transmission.WaitTime, "Should have sent some spans to transmission")
+}
+
+// TestMemoryPressureWithConcurrency tests the collector's behavior under memory pressure
+// with concurrent operations
+func TestMemoryPressureWithConcurrency(t *testing.T) {
+	const (
+		numTraces     = 500
+		spansPerTrace = 100
+		maxAlloc      = 10 * 1024 * 1024 // 10MB limit
+	)
+
+	conf := &config.MockConfig{
+		GetTracesConfigVal: config.TracesConfig{
+			SendTicker:   config.Duration(100 * time.Millisecond),
+			SendDelay:    config.Duration(50 * time.Millisecond),
+			TraceTimeout: config.Duration(2 * time.Second),
+			MaxBatchSize: 500,
+		},
+		GetCollectionConfigVal: config.CollectionConfig{
+			CacheCapacity: 5000,
+			MaxAlloc:      config.MemorySize(maxAlloc),
+		},
+		GetSamplerTypeVal:  &config.DeterministicSamplerConfig{SampleRate: 1},
+		ParentIdFieldNames: []string{"trace.parent_id", "parentId"},
+		TraceIdFieldNames:  []string{"trace.trace_id", "traceId"},
+		SampleCache: config.SampleCacheConfig{
+			KeptSize:          100,
+			DroppedSize:       100,
+			SizeCheckInterval: config.Duration(1 * time.Second),
+		},
+	}
+
+	clock := clockwork.NewFakeClock()
+	collector := newTestCollector(t, conf, clock)
+	transmission := collector.Transmission.(*transmit.MockTransmission)
+
+	var wg sync.WaitGroup
+	spansAdded := int32(0)
+	spansEvicted := int32(0)
+
+	// Monitor spans being sent (which indicates eviction) by advancing fake clock
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if fakeClock, ok := collector.Clock.(*clockwork.FakeClock); ok {
+			for i := 0; i < 50; i++ { // Check 50 times
+				fakeClock.Advance(100 * time.Millisecond) // Advance fake clock
+				count := len(transmission.Events)
+				if count > 0 {
+					atomic.StoreInt32(&spansEvicted, int32(count))
+				}
+			}
+		}
+	}()
+
+	// Add spans concurrently to trigger memory pressure
+	numGoroutines := 5
+	for g := 0; g < numGoroutines; g++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+
+			for i := 0; i < numTraces/numGoroutines; i++ {
+				traceID := fmt.Sprintf("trace-%d-%d", id, i)
+
+				for j := 0; j < spansPerTrace; j++ {
+					span := &types.Span{
+						Event: types.Event{
+							APIHost:    "http://api.honeycomb.io",
+							APIKey:     legacyAPIKey,
+							Dataset:    "test.dataset",
+							SampleRate: 1,
+							Timestamp:  time.Now(),
+							Data:       types.Payload{},
+						},
+						TraceID:     traceID,
+						IsRoot:      j == spansPerTrace-1,
+						ArrivalTime: time.Now(),
+					}
+
+					// Add large data to trigger memory pressure
+					span.Data.Set("large_field", make([]byte, 1024)) // 1KB per span
+
+					if err := collector.AddSpan(span); err == nil {
+						atomic.AddInt32(&spansAdded, 1)
+					}
+
+					// Removed microsecond sleep to speed up test
+				}
+			}
+		}(g)
+	}
+
+	wg.Wait()
+
+	// Verify the collector handled memory pressure
+	assert.Greater(t, atomic.LoadInt32(&spansAdded), int32(0), "Should have added spans")
+	// Note: Eviction might not always happen depending on actual memory usage
+}
+
+// TestCoordinatedReload verifies config reload coordination across loops
+func TestCoordinatedReload(t *testing.T) {
+	conf := &config.MockConfig{
+		GetTracesConfigVal: config.TracesConfig{
+			SendTicker:   config.Duration(100 * time.Millisecond),
+			SendDelay:    config.Duration(50 * time.Millisecond),
+			TraceTimeout: config.Duration(1 * time.Second),
+			MaxBatchSize: 500,
+		},
+		GetCollectionConfigVal: config.CollectionConfig{
+			CacheCapacity:   1000,
+			NumCollectLoops: 4,
+		},
+		GetSamplerTypeVal:  &config.DeterministicSamplerConfig{SampleRate: 1},
+		ParentIdFieldNames: []string{"trace.parent_id", "parentId"},
+		TraceIdFieldNames:  []string{"trace.trace_id", "traceId"},
+		SampleCache: config.SampleCacheConfig{
+			KeptSize:          100,
+			DroppedSize:       100,
+			SizeCheckInterval: config.Duration(1 * time.Second),
+		},
+	}
+
+	collector := newTestCollector(t, conf)
+
+	// Send some test spans to create dataset samplers
+	processedInitial := int32(0)
+	for i := 0; i < 10; i++ {
+		span := &types.Span{
+			Event: types.Event{
+				APIHost:    "http://api.honeycomb.io",
+				APIKey:     legacyAPIKey,
+				Dataset:    fmt.Sprintf("dataset-%d", i%3),
+				SampleRate: 1,
+				Timestamp:  time.Now(),
+				Data:       types.Payload{},
+			},
+			TraceID:     fmt.Sprintf("reload-trace-%d", i),
+			IsRoot:      true,
+			ArrivalTime: time.Now(),
+		}
+		if err := collector.AddSpan(span); err == nil {
+			atomic.AddInt32(&processedInitial, 1)
+		}
+	}
+
+	// Wait for initial spans to be processed
+	assert.Eventually(t, func() bool {
+		return atomic.LoadInt32(&processedInitial) >= 8
+	}, 2*time.Second, 10*time.Millisecond, "Initial spans should be processed")
+
+	// Trigger a reload - this should cause loops to recreate their samplers
+	collector.sendReloadSignal("hash1", "hash2")
+
+	// Give a moment for the reload signal to be processed (reload is async)
+	// We'll verify the reload worked by checking that spans still get processed
+	time.Sleep(50 * time.Millisecond)
+
+	// Check that samplers were recreated by sending more spans
+	processedAfterReload := int32(0)
+	for i := 0; i < 20; i++ {
+		span := &types.Span{
+			Event: types.Event{
+				APIHost:    "http://api.honeycomb.io",
+				APIKey:     legacyAPIKey,
+				Dataset:    "test.reload",
+				SampleRate: 1,
+				Timestamp:  time.Now(),
+				Data:       types.Payload{},
+			},
+			TraceID:     fmt.Sprintf("after-reload-%d", i),
+			IsRoot:      true,
+			ArrivalTime: time.Now(),
+		}
+		if err := collector.AddSpan(span); err == nil {
+			atomic.AddInt32(&processedAfterReload, 1)
+		}
+	}
+
+	// Verify spans were processed after reload
+	assert.Eventually(t, func() bool {
+		return atomic.LoadInt32(&processedAfterReload) >= 15
+	}, 2*time.Second, 100*time.Millisecond, "Spans should be processed after reload")
+
+	// Trigger another reload to verify multiple reloads work
+	collector.sendReloadSignal("hash2", "hash3")
+	time.Sleep(50 * time.Millisecond)
+
+	// Send more spans to verify system still works
+	processedAfterSecondReload := int32(0)
+	for i := 0; i < 20; i++ {
+		span := &types.Span{
+			Event: types.Event{
+				APIHost:    "http://api.honeycomb.io",
+				APIKey:     legacyAPIKey,
+				Dataset:    "test.reload2",
+				SampleRate: 1,
+				Timestamp:  time.Now(),
+				Data:       types.Payload{},
+			},
+			TraceID:     fmt.Sprintf("after-second-reload-%d", i),
+			IsRoot:      true,
+			ArrivalTime: time.Now(),
+		}
+		if err := collector.AddSpan(span); err == nil {
+			atomic.AddInt32(&processedAfterSecondReload, 1)
+		}
+	}
+
+	// Verify spans were processed after second reload
+	assert.Eventually(t, func() bool {
+		return atomic.LoadInt32(&processedAfterSecondReload) >= 15
+	}, 2*time.Second, 100*time.Millisecond, "Spans should be processed after second reload")
+}

--- a/collect/stressRelief.go
+++ b/collect/stressRelief.go
@@ -11,13 +11,14 @@ import (
 
 	"github.com/dgryski/go-wyhash"
 	"github.com/facebookgo/startstop"
+	"github.com/jonboulle/clockwork"
+
 	"github.com/honeycombio/refinery/config"
 	"github.com/honeycombio/refinery/internal/health"
 	"github.com/honeycombio/refinery/internal/peer"
 	"github.com/honeycombio/refinery/logger"
 	"github.com/honeycombio/refinery/metrics"
 	"github.com/honeycombio/refinery/pubsub"
-	"github.com/jonboulle/clockwork"
 )
 
 const stressReliefTopic = "refinery-stress-relief"

--- a/collect/stress_relief_test.go
+++ b/collect/stress_relief_test.go
@@ -6,15 +6,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/honeycombio/refinery/config"
 	"github.com/honeycombio/refinery/internal/health"
 	"github.com/honeycombio/refinery/internal/peer"
 	"github.com/honeycombio/refinery/logger"
 	"github.com/honeycombio/refinery/metrics"
 	"github.com/honeycombio/refinery/pubsub"
-	"github.com/jonboulle/clockwork"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // TestStressRelief_Monitor tests that the Stressed method returns the correct value
@@ -135,6 +136,7 @@ func TestStressRelief_Peer(t *testing.T) {
 	}, 2*time.Second, 100*time.Millisecond, "stress relief should be false")
 }
 
+// TestStressRelief_OverallStressLevel tests overall stress level calculation across multiple peers
 func TestStressRelief_OverallStressLevel(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 	sr, stop := newStressRelief(t, clock, nil)
@@ -224,7 +226,7 @@ func newStressRelief(t *testing.T, clock clockwork.Clock, channel pubsub.PubSub)
 	metric.Start()
 
 	if clock == nil {
-		clock = clockwork.NewRealClock()
+		clock = clockwork.NewFakeClock()
 	}
 
 	if channel == nil {

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -327,6 +327,11 @@ type CollectionConfig struct {
 	DropDecisionSendInterval Duration `yaml:"DropDecisionSendInterval" default:"1s"`
 	MaxKeptDecisionBatchSize int      `yaml:"MaxKeptDecisionBatchSize" default:"1000"`
 	KeptDecisionSendInterval Duration `yaml:"KeptDecisionSendInterval" default:"1s"`
+
+	// NumCollectLoops controls the number of parallel collection loops.
+	// Each loop processes a subset of traces independently.
+	// Higher values can improve throughput on multi-core systems.
+	NumCollectLoops int `yaml:"NumCollectLoops" default:"8"`
 }
 
 // GetMaxAlloc returns the maximum amount of memory to use for the cache.
@@ -356,6 +361,12 @@ func (c CollectionConfig) GetIncomingQueueSize() int {
 		return c.CacheCapacity * 3
 	}
 	return c.IncomingQueueSize
+}
+
+// GetNumCollectLoops returns the number of parallel collection loops.
+// Ensures the value is at least 1.
+func (c CollectionConfig) GetNumCollectLoops() int {
+	return max(c.NumCollectLoops, 1)
 }
 
 type BufferSizeConfig struct {

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -1454,6 +1454,21 @@ groups:
         description: >
           Sets the time interval for sending accumulated kept decisions in batches. This ensures that kept decisions are processed at regular intervals, improving efficiency by reducing the frequency of network transmissions. If the maximum batch size (MaxKeptDecisionBatchSize) is reached before this interval elapses, the batch will be sent immediately.
 
+      - name: NumCollectLoops
+        type: int
+        valuetype: nondefault
+        default: 8
+        reload: true
+        validations:
+          - type: minimum
+            arg: 1
+        summary: is the number of parallel collection loops to run for trace processing.
+        description: >
+          Controls the number of parallel collection loops used for processing traces.
+          Each loop processes a subset of traces independently using consistent hashing.
+          Values greater than 1 enable parallel processing which can improve throughput
+          on multi-core systems.
+
   - name: BufferSizes
     title: "Buffer Sizes"
     description: >

--- a/transmit/mock.go
+++ b/transmit/mock.go
@@ -28,6 +28,7 @@ func (m *MockTransmission) Stop() error {
 		select {
 		case <-m.Events:
 		default:
+			close(m.Events)
 			return nil
 		}
 	}

--- a/transmit/mock.go
+++ b/transmit/mock.go
@@ -36,16 +36,14 @@ func (m *MockTransmission) Stop() error {
 // GetBlock will return up to `expectedCount` events from the channel. If there are
 // fewer than `expectedCount` events in the channel, it will block until there
 // are enough events to return.
-// If `expectedCount` is 0, it will retry up to 3 times before returning the
-// events that are in the channel.
+// If `expectedCount` is 0, will wait WaitTime for events.
 func (m *MockTransmission) GetBlock(expectedCount int) []*types.Event {
 	events := make([]*types.Event, 0, len(m.Events))
-	var ticker *time.Ticker
+	var expiry <-chan time.Time
 
 	// Initialize ticker only if expectedCount is zero
 	if expectedCount == 0 {
-		ticker = time.NewTicker(m.WaitTime)
-		defer ticker.Stop()
+		expiry = time.After(m.WaitTime)
 	}
 
 	for {
@@ -57,22 +55,8 @@ func (m *MockTransmission) GetBlock(expectedCount int) []*types.Event {
 			if expectedCount > 0 && len(events) == expectedCount {
 				return events
 			}
-
-		default:
-			// Only check the ticker if it was initialized
-			if ticker != nil {
-				select {
-				case <-ticker.C:
-					return events
-				default:
-					// Continue to prevent blocking if ticker channel is not ready
-				}
-			}
-
-			// Return early if expectedCount is reached
-			if expectedCount > 0 && len(events) >= expectedCount {
-				return events
-			}
+		case <-expiry:
+			return events
 		}
 	}
 }


### PR DESCRIPTION
## Which problem is this PR solving?
The single collect loop is a giant bottleneck.

## Short description of the changes
First stab at concurrent collect loops, with mutexes all over the place to protect shared resources. This has a lot of bottlenecks; if most of the collect loop time is being spent in sampler decison-making, we'll probably want each loop to have its own set of sampler instances.

Includes a bunch of new testing and some light test cleanup.