### PR TITLE
maint: clean up unused code

### DIFF
--- a/collect/cache/cache.go
+++ b/collect/cache/cache.go
@@ -58,7 +58,6 @@ var collectCacheMetrics = []metrics.Metadata{
 }
 
 func NewInMemCache(
-	capacity int,
 	met metrics.Metrics,
 	logger logger.Logger,
 ) *DefaultInMemCache {

--- a/collect/cache/cache_test.go
+++ b/collect/cache/cache_test.go
@@ -18,7 +18,7 @@ import (
 func TestCacheSetGet(t *testing.T) {
 	s := &metrics.MockMetrics{}
 	s.Start()
-	c := NewInMemCache(10, s, &logger.NullLogger{})
+	c := NewInMemCache(s, &logger.NullLogger{})
 
 	trace := &types.Trace{
 		TraceID: "abc123",
@@ -31,7 +31,7 @@ func TestCacheSetGet(t *testing.T) {
 func TestTakeExpiredTraces(t *testing.T) {
 	s := &metrics.MockMetrics{}
 	s.Start()
-	c := NewInMemCache(10, s, &logger.NullLogger{})
+	c := NewInMemCache(s, &logger.NullLogger{})
 
 	now := time.Now()
 	traces := []*types.Trace{
@@ -63,7 +63,7 @@ func TestTakeExpiredTraces(t *testing.T) {
 func TestRemoveSentTraces(t *testing.T) {
 	s := &metrics.MockMetrics{}
 	s.Start()
-	c := NewInMemCache(10, s, &logger.NullLogger{})
+	c := NewInMemCache(s, &logger.NullLogger{})
 
 	now := time.Now()
 	traces := []*types.Trace{
@@ -90,7 +90,7 @@ func BenchmarkCache_Set(b *testing.B) {
 	metrics.Start()
 	_, traces := generateTraces(b.N)
 
-	c := NewInMemCache(b.N, metrics, &logger.NullLogger{})
+	c := NewInMemCache(metrics, &logger.NullLogger{})
 
 	// setup is expensive, so reset timer and report allocations
 	b.ReportAllocs()
@@ -105,7 +105,7 @@ func BenchmarkCache_Get(b *testing.B) {
 	metrics.Start()
 	_, traces := generateTraces(b.N)
 
-	c := NewInMemCache(b.N, metrics, &logger.NullLogger{})
+	c := NewInMemCache(metrics, &logger.NullLogger{})
 	populateCache(c, traces)
 
 	// setup is expensive, so reset timer and report allocations
@@ -123,7 +123,7 @@ func BenchmarkCache_TakeExpiredTracesWithoutFilter(b *testing.B) {
 	metrics.Start()
 	now, traces := generateTraces(b.N)
 
-	c := NewInMemCache(b.N, metrics, &logger.NullLogger{})
+	c := NewInMemCache(metrics, &logger.NullLogger{})
 	populateCache(c, traces)
 
 	// setup is expensive, so reset timer and report allocations
@@ -140,7 +140,7 @@ func BenchmarkCache_TakeExpiredTracesWithFilter(b *testing.B) {
 	metrics.Start()
 	now, traces := generateTraces(b.N)
 
-	c := NewInMemCache(b.N, metrics, &logger.NullLogger{})
+	c := NewInMemCache(metrics, &logger.NullLogger{})
 	populateCache(c, traces)
 
 	// setup is expensive, so reset timer and report allocations
@@ -166,7 +166,7 @@ func BenchmarkCache_RemoveTraces(b *testing.B) {
 		deletes.Add("trace" + fmt.Sprint(i))
 	}
 
-	c := NewInMemCache(b.N, metrics, &logger.NullLogger{})
+	c := NewInMemCache(metrics, &logger.NullLogger{})
 	populateCache(c, traces)
 
 	// setup is expensive, so reset timer and report allocations

--- a/collect/cache/cuckooSentCache.go
+++ b/collect/cache/cuckooSentCache.go
@@ -227,6 +227,7 @@ func (c *cuckooSentCache) monitor() {
 func (c *cuckooSentCache) Stop() {
 	close(c.done)
 	c.dropped.Stop()
+	c.shutdownWG.Wait()
 }
 
 func (c *cuckooSentCache) Record(trace KeptTrace, keep bool, reason string) {

--- a/collect/collect.go
+++ b/collect/collect.go
@@ -213,18 +213,12 @@ func (i *InMemCollector) Start() error {
 
 	i.collectLoops = make([]*CollectLoop, numLoops)
 
-	// Divide cache capacity among loops
-	cachePerLoop := imcConfig.CacheCapacity / numLoops
-	if cachePerLoop < 100 {
-		cachePerLoop = 100 // minimum cache size per loop
-	}
-
 	// Divide queue sizes among loops
 	incomingPerLoop := imcConfig.GetIncomingQueueSize() / numLoops
 	peerPerLoop := imcConfig.GetPeerQueueSize() / numLoops
 
 	for loopID := range i.collectLoops {
-		loop := NewCollectLoop(loopID, i, cachePerLoop, incomingPerLoop, peerPerLoop)
+		loop := NewCollectLoop(loopID, i, incomingPerLoop, peerPerLoop)
 		i.collectLoops[loopID] = loop
 
 		// Start the collect goroutine for this loop

--- a/types/event.go
+++ b/types/event.go
@@ -200,11 +200,6 @@ func (t *Trace) SpanEventCount() uint32 {
 	return t.spanEventCount
 }
 
-// IsOrphan returns true if the trace is older than 4 times the traceTimeout
-func (t *Trace) IsOrphan(traceTimeout time.Duration, now time.Time) bool {
-	return now.Sub(t.SendBy) >= traceTimeout*4
-}
-
 // Span is an event that shows up with a trace ID, so will be part of a Trace
 // This is not thread-safe; only one goroutine should be working with a span object at a time.
 type Span struct {


### PR DESCRIPTION
## Which problem is this PR solving?

`CacheCapacity` has been deprecated. We should remove the reference to it from the collect loop.
With the `TraceLocalityMode` being removed, we no longer have orphan traces in trace cache

## Short description of the changes

- Remove `IsOrphan()`
- Remove `CacheCapacity` from trace cache

