### PR TITLE
feat(convert): support updating deprecated field using convert tool

### DIFF
--- a/config.md
+++ b/config.md
@@ -3,7 +3,7 @@
 # Honeycomb Refinery Configuration Documentation
 
 This is the documentation for the configuration file for Honeycomb's Refinery.
-It was automatically generated on 2025-07-25 at 19:58:08 UTC.
+It was automatically generated on 2025-08-26 at 15:28:23 UTC.
 
 ## The Config file
 
@@ -962,21 +962,6 @@ It is rarely necessary to adjust this value.
 If none of the memory settings are used, then Refinery will not attempt to limit its memory usage.
 This is not recommended for production use since a burst of traffic could cause Refinery to run out of memory and crash.
 
-### `CacheCapacity`
-
-CacheCapacity is the number of traces to keep in the cache's circular buffer.
-
-The collection cache is used to collect all active spans into traces.
-It is organized as a circular buffer.
-When the buffer wraps around, Refinery will try a few times to find an empty slot; if it fails, it starts ejecting traces from the cache earlier than would otherwise be necessary.
-Ideally, the size of the cache should be many multiples (100x to 1000x) of the total number of concurrently active traces (average trace throughput * average trace duration).
-NOTE: This setting is now deprecated and no longer controls the cache size.
-Instead the maxmimum memory usage is controlled by `MaxMemoryPercentage` and `MaxAlloc`.
-
-- Eligible for live reload.
-- Type: `int`
-- Default: `10000`
-
 ### `PeerQueueSize`
 
 PeerQueueSize is the maximum number of in-flight spans redirected from other peers stored in the peer span queue.
@@ -1064,6 +1049,7 @@ However, disabling redistribution may also cause partial data loss of traces tha
 
 - Eligible for live reload.
 - Type: `bool`
+- Default: `true`
 
 ### `RedistributionDelay`
 
@@ -1126,30 +1112,6 @@ Refinery will adjust the timeout based on the configured `MaxExpiredTraces`, so 
 ## Buffer Sizes
 
 `BufferSizes` contains the settings that are relevant to the sizes of communications buffers.
-
-### `UpstreamBufferSize`
-
-UpstreamBufferSize is the size of the queue used to buffer spans to send to the upstream Collector.
-
-The size of the buffer is measured in spans.
-If the buffer fills up, then performance will degrade because Refinery will block while waiting for space to become available.
-If this happens, then you should increase the buffer size.
-
-- Eligible for live reload.
-- Type: `int`
-- Default: `10000`
-
-### `PeerBufferSize`
-
-PeerBufferSize is the size of the queue used to buffer spans to send to peer nodes.
-
-The size of the buffer is measured in spans.
-If the buffer fills up, then performance will degrade because Refinery will block while waiting for space to become available.
-If this happens, then you should increase this buffer size.
-
-- Eligible for live reload.
-- Type: `int`
-- Default: `100000`
 
 ## Specialized Configuration
 

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -1257,6 +1257,11 @@ groups:
         valuetype: nondefault
         lastversion: v2.9.7
         deprecationtext: CacheCapacity is deprecated since version v2.9.7. Set PeerQueueSize and IncomingQueueSize instead.
+        replacements:
+          - field: PeerQueueSize
+            formula: "3 * value"
+          - field: IncomingQueueSize
+            formula: "3 * value"
         default: 10_000
         reload: true
         validations:

--- a/config_complete.yaml
+++ b/config_complete.yaml
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created on 2025-07-25 at 19:58:08 UTC from ../../config.yaml using a template generated on 2025-07-25 at 19:57:55 UTC
+# created on 2025-08-26 at 15:28:23 UTC from ../../config.yaml using a template generated on 2025-08-26 at 15:28:20 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of
@@ -573,8 +573,8 @@ HoneycombLogger:
     ##
     ## Not eligible for live reload.
     # AdditionalAttributes:
-      #  rollout.id: '67890'
       #  pipeline.id: '12345'
+      #  rollout.id: '67890'
 
 ###################
 ## Stdout Logger ##
@@ -1007,24 +1007,6 @@ Collection:
   ## Refinery to run out of memory and crash.
   ##
   ####
-    ## CacheCapacity is the number of traces to keep in the cache's circular
-    ## buffer.
-    ##
-    ## The collection cache is used to collect all active spans into traces.
-    ## It is organized as a circular buffer. When the buffer wraps around,
-    ## Refinery will try a few times to find an empty slot; if it fails, it
-    ## starts ejecting traces from the cache earlier than would otherwise be
-    ## necessary. Ideally, the size of the cache should be many multiples
-    ## (100x to 1000x) of the total number of concurrently active traces
-    ## (average trace throughput * average trace duration).
-    ## NOTE: This setting is now deprecated and no longer controls the cache
-    ## size. Instead the maxmimum memory usage is controlled by
-    ## `MaxMemoryPercentage` and `MaxAlloc`.
-    ##
-    ## default: 10000
-    ## Eligible for live reload.
-    # CacheCapacity: 10_000
-
     ## PeerQueueSize is the maximum number of in-flight spans redirected from
     ## other peers stored in the peer span queue.
     ##
@@ -1117,8 +1099,9 @@ Collection:
     ## However, disabling redistribution may also cause partial data loss of
     ## traces that were in flight when scaling occurred.
     ##
+    ## default: true
     ## Eligible for live reload.
-    # DisableRedistribution: false
+    # DisableRedistribution: true
 
     ## RedistributionDelay controls the amount of time Refinery waits after
     ## each cluster scaling event before redistributing in-memory traces.
@@ -1209,30 +1192,6 @@ BufferSizes:
   ## communications buffers.
   ##
   ####
-    ## UpstreamBufferSize is the size of the queue used to buffer spans to
-    ## send to the upstream Collector.
-    ##
-    ## The size of the buffer is measured in spans. If the buffer fills up,
-    ## then performance will degrade because Refinery will block while
-    ## waiting for space to become available. If this happens, then you
-    ## should increase the buffer size.
-    ##
-    ## default: 10000
-    ## Eligible for live reload.
-    # UpstreamBufferSize: 10_000
-
-    ## PeerBufferSize is the size of the queue used to buffer spans to send
-    ## to peer nodes.
-    ##
-    ## The size of the buffer is measured in spans. If the buffer fills up,
-    ## then performance will degrade because Refinery will block while
-    ## waiting for space to become available. If this happens, then you
-    ## should increase this buffer size.
-    ##
-    ## default: 100000
-    ## Eligible for live reload.
-    # PeerBufferSize: 100_000
-
 ###############################
 ## Specialized Configuration ##
 ###############################
@@ -1275,8 +1234,8 @@ Specialized:
     ##
     ## Eligible for live reload.
     # AdditionalAttributes:
-      #  environment: production
       #  ClusterName: MyCluster
+      #  environment: production
 
 ###############
 ## ID Fields ##
@@ -1568,6 +1527,10 @@ StressRelief:
     ## - PeerManagement.Prefix
     ## - PeerManagement.Database
     ## - PeerManagement.Strategy
+    ## - InMemCollector.CacheCapacity
+    ## - BufferSizes.UpstreamBufferSize
+    ## - BufferSizes.PeerBufferSize
+    ## - BufferSizes
     ## - Collector
     ## - InMemCollector.CacheOverrunStrategy
     ## - SampleCacheConfig/SampleCache.Type

--- a/refinery_config.md
+++ b/refinery_config.md
@@ -946,21 +946,6 @@ It is rarely necessary to adjust this value.
 If none of the memory settings are used, then Refinery will not attempt to limit its memory usage.
 This is not recommended for production use since a burst of traffic could cause Refinery to run out of memory and crash.
 
-### `CacheCapacity`
-
-`CacheCapacity` is the number of traces to keep in the cache's circular buffer.
-
-The collection cache is used to collect all active spans into traces.
-It is organized as a circular buffer.
-When the buffer wraps around, Refinery will try a few times to find an empty slot; if it fails, it starts ejecting traces from the cache earlier than would otherwise be necessary.
-Ideally, the size of the cache should be many multiples (100x to 1000x) of the total number of concurrently active traces (average trace throughput * average trace duration).
-NOTE: This setting is now deprecated and no longer controls the cache size.
-Instead the maxmimum memory usage is controlled by `MaxMemoryPercentage` and `MaxAlloc`.
-
-- Eligible for live reload.
-- Type: `int`
-- Default: `10000`
-
 ### `PeerQueueSize`
 
 `PeerQueueSize` is the maximum number of in-flight spans redirected from other peers stored in the peer span queue.
@@ -1047,7 +1032,8 @@ Disabling redistribution can help to prevent disruptive bursts of network traffi
 However, disabling redistribution may also cause partial data loss of traces that were in flight when scaling occurred.
 
 - Eligible for live reload.
-- Type: `bool`
+- Type: `defaulttrue`
+- Default: `true`
 
 ### `RedistributionDelay`
 
@@ -1110,30 +1096,6 @@ Refinery will adjust the timeout based on the configured `MaxExpiredTraces`, so 
 ## Buffer Sizes
 
 `BufferSizes` contains the settings that are relevant to the sizes of communications buffers.
-
-### `UpstreamBufferSize`
-
-`UpstreamBufferSize` is the size of the queue used to buffer spans to send to the upstream Collector.
-
-The size of the buffer is measured in spans.
-If the buffer fills up, then performance will degrade because Refinery will block while waiting for space to become available.
-If this happens, then you should increase the buffer size.
-
-- Eligible for live reload.
-- Type: `int`
-- Default: `10000`
-
-### `PeerBufferSize`
-
-`PeerBufferSize` is the size of the queue used to buffer spans to send to peer nodes.
-
-The size of the buffer is measured in spans.
-If the buffer fills up, then performance will degrade because Refinery will block while waiting for space to become available.
-If this happens, then you should increase this buffer size.
-
-- Eligible for live reload.
-- Type: `int`
-- Default: `100000`
 
 ## Specialized Configuration
 

--- a/tools/convert/configDataNames.txt
+++ b/tools/convert/configDataNames.txt
@@ -1,5 +1,5 @@
 # Names of groups and fields in the new config file format.
-# Automatically generated on 2025-07-15 at 17:41:44 UTC.
+# Automatically generated on 2025-08-26 at 15:28:21 UTC.
 
 General:
   - ConfigurationVersion

--- a/tools/convert/helpers_test.go
+++ b/tools/convert/helpers_test.go
@@ -1,7 +1,12 @@
 package main
 
 import (
+	"reflect"
 	"testing"
+
+	"github.com/honeycombio/refinery/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_conditional(t *testing.T) {
@@ -25,6 +30,235 @@ func Test_conditional(t *testing.T) {
 			if got := conditional(tt.data, tt.key, tt.extra); got != tt.want {
 				t.Errorf("conditional() = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func Test_evaluateFormula(t *testing.T) {
+	tests := []struct {
+		name    string
+		formula string
+		value   any
+		want    int64
+		wantErr bool
+	}{
+		{"simple value", "value", int(10), 10, false},
+		{"simple value int64", "value", int64(20), 20, false},
+		{"multiply left", "3 * value", int(10), 30, false},
+		{"multiply right", "value * 5", int(10), 50, false},
+		{"multiply with spaces", " 3  *  value ", int(10), 30, false},
+		{"unsupported type", "value", "string", 0, true},
+		{"invalid formula", "value + 5", int(10), 0, true},
+		{"invalid multiplier", "abc * value", int(10), 0, true},
+		{"missing operand", "3 *", int(10), 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := evaluateFormula(tt.formula, tt.value)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_setFieldValue(t *testing.T) {
+	tests := []struct {
+		name      string
+		data      map[string]any
+		groupName string
+		fieldName string
+		value     any
+		expected  map[string]any
+	}{
+		{
+			name:      "create new group and field",
+			data:      map[string]any{},
+			groupName: "TestGroup",
+			fieldName: "TestField",
+			value:     42,
+			expected: map[string]any{
+				"TestGroup": map[string]any{
+					"TestField": 42,
+				},
+			},
+		},
+		{
+			name: "add field to existing group",
+			data: map[string]any{
+				"TestGroup": map[string]any{
+					"ExistingField": "existing",
+				},
+			},
+			groupName: "TestGroup",
+			fieldName: "NewField",
+			value:     "new",
+			expected: map[string]any{
+				"TestGroup": map[string]any{
+					"ExistingField": "existing",
+					"NewField":      "new",
+				},
+			},
+		},
+		{
+			name: "overwrite existing field",
+			data: map[string]any{
+				"TestGroup": map[string]any{
+					"TestField": "old",
+				},
+			},
+			groupName: "TestGroup",
+			fieldName: "TestField",
+			value:     "new",
+			expected: map[string]any{
+				"TestGroup": map[string]any{
+					"TestField": "new",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setFieldValue(tt.data, tt.groupName, tt.fieldName, tt.value)
+			assert.True(t, reflect.DeepEqual(tt.data, tt.expected))
+		})
+	}
+}
+
+func Test_applyReplacement(t *testing.T) {
+	tests := []struct {
+		name            string
+		replacement     config.Replacement
+		groupName       string
+		deprecatedValue any
+		data            map[string]any
+		dryRun          bool
+		wantMessage     string
+		wantApplied     bool
+		expectedData    map[string]any
+	}{
+		{
+			name: "apply replacement when field doesn't exist",
+			replacement: config.Replacement{
+				Field:   "NewField",
+				Formula: "3 * value",
+			},
+			groupName:       "TestGroup",
+			deprecatedValue: int(10),
+			data:            map[string]any{},
+			dryRun:          false,
+			wantMessage:     "NewField set to 30 (using formula: 3 * value)",
+			wantApplied:     true,
+			expectedData: map[string]any{
+				"TestGroup": map[string]any{
+					"NewField": int64(30),
+				},
+			},
+		},
+		{
+			name: "skip when field already exists",
+			replacement: config.Replacement{
+				Field:   "ExistingField",
+				Formula: "value",
+			},
+			groupName:       "TestGroup",
+			deprecatedValue: int(10),
+			data: map[string]any{
+				"TestGroup": map[string]any{
+					"ExistingField": "already here",
+				},
+			},
+			dryRun:      false,
+			wantMessage: "",
+			wantApplied: false,
+			expectedData: map[string]any{
+				"TestGroup": map[string]any{
+					"ExistingField": "already here",
+				},
+			},
+		},
+		{
+			name: "apply when field doesn't exist in populated data",
+			replacement: config.Replacement{
+				Field:   "NewField",
+				Formula: "2 * value",
+			},
+			groupName:       "TestGroup",
+			deprecatedValue: int(5),
+			data: map[string]any{
+				"TestGroup": map[string]any{
+					"OtherField": "other",
+				},
+			},
+			dryRun:      false,
+			wantMessage: "NewField set to 10 (using formula: 2 * value)",
+			wantApplied: true,
+			expectedData: map[string]any{
+				"TestGroup": map[string]any{
+					"OtherField": "other",
+					"NewField":   int64(10),
+				},
+			},
+		},
+		{
+			name: "dry run mode doesn't modify data",
+			replacement: config.Replacement{
+				Field:   "NewField",
+				Formula: "value",
+			},
+			groupName:       "TestGroup",
+			deprecatedValue: int(10),
+			data:            map[string]any{},
+			dryRun:          true,
+			wantMessage:     "NewField set to 10 (using formula: value)",
+			wantApplied:     true,
+			expectedData:    map[string]any{}, // Should remain unchanged
+		},
+		{
+			name: "skip replacement when target field exists (overwrite protection)",
+			replacement: config.Replacement{
+				Field:   "ExistingField",
+				Formula: "5 * value",
+			},
+			groupName:       "TestGroup",
+			deprecatedValue: int(20),
+			data: map[string]any{
+				"TestGroup": map[string]any{
+					"ExistingField": "original_value",
+				},
+			},
+			dryRun:      false,
+			wantMessage: "",
+			wantApplied: false,
+			expectedData: map[string]any{
+				"TestGroup": map[string]any{
+					"ExistingField": "original_value", // Should remain unchanged
+				},
+			},
+		},
+		{
+			name: "invalid formula returns not applied",
+			replacement: config.Replacement{
+				Field:   "NewField",
+				Formula: "invalid formula",
+			},
+			groupName:       "TestGroup",
+			deprecatedValue: int(10),
+			data:            map[string]any{},
+			dryRun:          false,
+			wantMessage:     "",
+			wantApplied:     false,
+			expectedData:    map[string]any{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			message, applied := applyReplacement(tt.replacement, tt.groupName, tt.deprecatedValue, tt.data, tt.dryRun)
+			assert.Equal(t, tt.wantMessage, message)
+			assert.Equal(t, tt.wantApplied, applied)
+			assert.True(t, reflect.DeepEqual(tt.data, tt.expectedData))
 		})
 	}
 }

--- a/tools/convert/minimal_config.yaml
+++ b/tools/convert/minimal_config.yaml
@@ -1,5 +1,5 @@
 # sample uncommented config file containing all possible fields
-# automatically generated on 2025-07-15 at 17:41:44 UTC
+# automatically generated on 2025-08-26 at 15:28:22 UTC
 General:
   ConfigurationVersion: 2
   MinRefineryVersion: "v2.0"
@@ -102,20 +102,17 @@ RedisPeerManagement:
   UseTLSInsecure: false
   Timeout: 5s
 Collection:
-  CacheCapacity: 10_000
   PeerQueueSize: 30_000
   IncomingQueueSize: 30_000
   AvailableMemory: "4.5Gb"
   MaxMemoryPercentage: 75
   MaxAlloc: 0
-  DisableRedistribution: false
+  DisableRedistribution: true
   RedistributionDelay: 30s
   ShutdownDelay: 15s
   TraceLocalityMode: concentrated
   HealthCheckTimeout: 15s
 BufferSizes:
-  UpstreamBufferSize: 10_000
-  PeerBufferSize: 100_000
 Specialized:
   EnvironmentCacheTTL: 1h
   CompressPeerCommunication: true

--- a/tools/convert/templates/configV2.tmpl
+++ b/tools/convert/templates/configV2.tmpl
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created {{ now }} from {{ .Input }} using a template generated on 2025-07-25 at 19:57:55 UTC
+# created {{ now }} from {{ .Input }} using a template generated on 2025-08-26 at 15:28:20 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of
@@ -1000,24 +1000,6 @@ Collection:
   ## Refinery to run out of memory and crash.
   ##
   ####
-    ## CacheCapacity is the number of traces to keep in the cache's circular
-    ## buffer.
-    ##
-    ## The collection cache is used to collect all active spans into traces.
-    ## It is organized as a circular buffer. When the buffer wraps around,
-    ## Refinery will try a few times to find an empty slot; if it fails, it
-    ## starts ejecting traces from the cache earlier than would otherwise be
-    ## necessary. Ideally, the size of the cache should be many multiples
-    ## (100x to 1000x) of the total number of concurrently active traces
-    ## (average trace throughput * average trace duration).
-    ## NOTE: This setting is now deprecated and no longer controls the cache
-    ## size. Instead the maxmimum memory usage is controlled by
-    ## `MaxMemoryPercentage` and `MaxAlloc`.
-    ##
-    ## default: 10000
-    ## Eligible for live reload.
-    {{ nonDefaultOnly .Data "CacheCapacity" "InMemCollector.CacheCapacity" 10000 }}
-
     ## PeerQueueSize is the maximum number of in-flight spans redirected from
     ## other peers stored in the peer span queue.
     ##
@@ -1031,7 +1013,7 @@ Collection:
     ##
     ## default: 30000
     ## Not eligible for live reload.
-    {{ nonDefaultOnly .Data "PeerQueueSize" "PeerQueueSize" 30000 }}
+    {{ nonDefaultOnly .Data "PeerQueueSize" "Collection.PeerQueueSize" 30000 }}
 
     ## IncomingQueueSize is the number of in-flight spans to keep in the
     ## incoming span queue.
@@ -1043,7 +1025,7 @@ Collection:
     ##
     ## default: 30000
     ## Not eligible for live reload.
-    {{ nonDefaultOnly .Data "IncomingQueueSize" "IncomingQueueSize" 30000 }}
+    {{ nonDefaultOnly .Data "IncomingQueueSize" "Collection.IncomingQueueSize" 30000 }}
 
     ## AvailableMemory is the amount of system memory available to the
     ## Refinery process.
@@ -1110,8 +1092,9 @@ Collection:
     ## However, disabling redistribution may also cause partial data loss of
     ## traces that were in flight when scaling occurred.
     ##
+    ## default: true
     ## Eligible for live reload.
-    {{ nonDefaultOnly .Data "DisableRedistribution" "DisableRedistribution" false }}
+    {{ nonDefaultOnly .Data "DisableRedistribution" "DisableRedistribution" true }}
 
     ## RedistributionDelay controls the amount of time Refinery waits after
     ## each cluster scaling event before redistributing in-memory traces.
@@ -1202,30 +1185,6 @@ BufferSizes:
   ## communications buffers.
   ##
   ####
-    ## UpstreamBufferSize is the size of the queue used to buffer spans to
-    ## send to the upstream Collector.
-    ##
-    ## The size of the buffer is measured in spans. If the buffer fills up,
-    ## then performance will degrade because Refinery will block while
-    ## waiting for space to become available. If this happens, then you
-    ## should increase the buffer size.
-    ##
-    ## default: 10000
-    ## Eligible for live reload.
-    {{ nonDefaultOnly .Data "UpstreamBufferSize" "UpstreamBufferSize" 10000 }}
-
-    ## PeerBufferSize is the size of the queue used to buffer spans to send
-    ## to peer nodes.
-    ##
-    ## The size of the buffer is measured in spans. If the buffer fills up,
-    ## then performance will degrade because Refinery will block while
-    ## waiting for space to become available. If this happens, then you
-    ## should increase this buffer size.
-    ##
-    ## default: 100000
-    ## Eligible for live reload.
-    {{ nonDefaultOnly .Data "PeerBufferSize" "PeerBufferSize" 100000 }}
-
 ###############################
 ## Specialized Configuration ##
 ###############################
@@ -1555,6 +1514,10 @@ StressRelief:
     ## - PeerManagement.Prefix
     ## - PeerManagement.Database
     ## - PeerManagement.Strategy
+    ## - InMemCollector.CacheCapacity
+    ## - BufferSizes.UpstreamBufferSize
+    ## - BufferSizes.PeerBufferSize
+    ## - BufferSizes
     ## - Collector
     ## - InMemCollector.CacheOverrunStrategy
     ## - SampleCacheConfig/SampleCache.Type

--- a/tools/convert/templates/genremoved.tmpl
+++ b/tools/convert/templates/genremoved.tmpl
@@ -1,7 +1,8 @@
 {{- $group := . }}
+{{- /* Show deprecated fields */ -}}
 {{- range $group.Fields -}}
 {{- $field := . -}}
-{{- $oldname := $field.Name -}}
+{{- $oldname := (print $group.Name "." $field.Name) -}}
 {{- if $field.V1Name -}}
   {{- if $field.V1Group -}}
     {{- $oldname = (print $field.V1Group "." $field.V1Name) -}}
@@ -13,5 +14,10 @@
   {{- printf "- %s" $oldname | comment | indent 4  -}}
   {{- println -}}
 {{- end -}}
+{{- end -}}
+{{- /* Show deprecated group if all its fields are deprecated */ -}}
+{{- if $group.IsDeprecated -}}
+  {{- printf "- %s" $group.Name | comment | indent 4  -}}
+  {{- println -}}
 {{- end -}}
 


### PR DESCRIPTION
## Which problem is this PR solving?

This PR adds a new feature to the `convert` tool so that users can easily updating their existing config when there's deprecated fields in them.

## Short description of the changes

A new `--remove-deprecated` flag is added to support removing/replacing deprecated fields. Deprecated fields are marked with`lastversion` in configMeta.yaml. Each deprecated field can define `replacements` with `formula` to calculate new values. The `convert` tool uses this metadata to know what to remove and what to replace it with. 

## Example output
```
## INPUT
General:
  ConfigurationVersion: 2

Collection:
  CacheCapacity: 5000       # Deprecated
  PeerQueueSize: 25000      # Not deprecated
  MaxAlloc: 2147483648      # Not deprecated

## OUTPUT
# The following deprecated config options were removed:
# - Collection.CacheCapacity (deprecated in v2.9.7)
# -   → IncomingQueueSize set to 15000 (using formula: 3 * value)
#
Collection:
    IncomingQueueSize: 15000
    MaxAlloc: 2147483648
    PeerQueueSize: 25000
General:
    ConfigurationVersion: 2

```



