### PR TITLE
maint: make CacheCapacity deprecation text more actionable

### DIFF
--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -1256,7 +1256,7 @@ groups:
         type: int
         valuetype: nondefault
         lastversion: v2.9.7
-        deprecationtext: CacheCapacity is deprecated since version v2.9.7. Set PeerQueueSize and IncomingQueueSize instead.
+        deprecationtext: CacheCapacity is deprecated since version v2.9.7. Set PeerQueueSize and IncomingQueueSize to (3 x CacheCapacity) instead.
         replacements:
           - field: PeerQueueSize
             formula: "3 * value"


### PR DESCRIPTION
## Which problem is this PR solving?

Users may mistakenly set PeerQueueSize and IncomingQueueSize to be the same as CacheCapacity. That's not what we want.

## Short description of the changes

- Clarify PeerQueueSize and IncomingQueueSize should be 3x CacheCapacity in warning message

