### PR TITLE
feat: add public ECR upload for tagged releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -285,6 +285,34 @@ jobs:
             echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
             ./build-docker.sh
 
+  publish_docker_to_public_ecr:
+    docker:
+      - image: cimg/go:1.24
+    steps:
+      - checkout
+      - setup_remote_docker
+      - restore_cache:
+          keys:
+            - v2-googleko-{{ checksum "Makefile" }}
+      - restore_cache:
+          keys:
+            - go_build_cache-{{ .Environment.CIRCLE_SHA1 }}
+      - aws-cli/setup:
+          role-arn: "arn:aws:iam::702835727665:role/circleci-public-repos"
+          role-session-name: "refinery"
+          aws-region: AWS_REGION
+      - run:
+          name: publish docker image to aws public ecr
+          command: |
+            set -x
+
+            export ECR_HOST=public.ecr.aws
+            export KO_DOCKER_REPO=${ECR_HOST}/honeycombio
+
+            aws ecr-public get-login-password --region us-east-1 \
+              | docker login --username AWS --password-stdin "${ECR_HOST}"
+            ./build-docker.sh
+
 workflows:
   build:
     jobs:
@@ -351,6 +379,17 @@ workflows:
             branches:
               ignore: /.*/
       - publish_docker_to_dockerhub:
+          context: Honeycomb Secrets for Public Repos
+          requires:
+            - build_binaries
+            - build_docker
+            - smoke-test
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
+      - publish_docker_to_public_ecr:
           context: Honeycomb Secrets for Public Repos
           requires:
             - build_binaries


### PR DESCRIPTION
## Summary
- Add new `publish_docker_to_public_ecr` job to CircleCI configuration
- Configure job to upload Docker images to AWS Public ECR with repository name `refinery` and registry alias `honeycombio`
- Job runs only for tagged releases (v*) using existing CircleCI role permissions

## Changes
- Added `publish_docker_to_public_ecr` job that uses `aws ecr-public` commands to authenticate and push to public ECR
- Added job to workflow with same filters as other publishing jobs (tagged releases only)
- Uses existing IAM role `arn:aws:iam::702835727665:role/circleci-public-repos` with appropriate permissions

## Test plan
- [ ] Verify CircleCI configuration syntax is valid
- [ ] Test with a tagged release to confirm images are pushed to public ECR repository
- [ ] Confirm images are accessible at `public.ecr.aws/honeycombio/refinery`

🤖 Generated with [Claude Code](https://claude.ai/code)