### PR TITLE
fix: dataset name should only be url encoded once

### DIFF
--- a/transmit/direct_transmit.go
+++ b/transmit/direct_transmit.go
@@ -723,11 +723,7 @@ type httpError interface {
 }
 
 func buildRequestURL(apiHost, dataset string) (string, error) {
-	// validate the apiHost is a valid URL
-	apiURL, err := url.Parse(apiHost)
-	if err != nil {
-		return "", err
-	}
+	escapedDataset := url.PathEscape(dataset)
 
-	return url.JoinPath(apiURL.String(), "/1/batch", url.PathEscape(dataset))
+	return url.JoinPath(apiHost, "/1/batch", escapedDataset)
 }

--- a/transmit/direct_transmit.go
+++ b/transmit/direct_transmit.go
@@ -724,10 +724,10 @@ type httpError interface {
 
 func buildRequestURL(apiHost, dataset string) (string, error) {
 	// validate the apiHost is a valid URL
-	_, err := url.Parse(apiHost)
+	apiURL, err := url.Parse(apiHost)
 	if err != nil {
 		return "", err
 	}
 
-	return url.JoinPath(apiHost, "/1/batch", url.PathEscape(dataset))
+	return url.JoinPath(apiURL.String(), "/1/batch", url.PathEscape(dataset))
 }

--- a/transmit/direct_transmit.go
+++ b/transmit/direct_transmit.go
@@ -430,13 +430,7 @@ func (d *DirectTransmission) sendBatch(wholeBatch []*types.Event) {
 		packed = packed[5-len(header):]
 		copy(packed, header)
 
-		apiURL, err := url.Parse(apiHost)
-		if err != nil {
-			d.Logger.Error().WithField("err", err.Error()).WithString("api_host", apiHost).Logf("failed to parse API host")
-			d.handleBatchFailure(subBatch)
-			continue
-		}
-		apiURL.Path, err = url.JoinPath("/1/batch", url.PathEscape(dataset))
+		apiURL, err := buildRequestURL(apiHost, dataset)
 		if err != nil {
 			d.Logger.Error().WithField("err", err.Error()).Logf("failed to create request URL")
 			d.handleBatchFailure(subBatch)
@@ -467,7 +461,7 @@ func (d *DirectTransmission) sendBatch(wholeBatch []*types.Event) {
 				readerPtr.Reset(packed)
 			}
 
-			req, err = http.NewRequest("POST", apiURL.String(), readerPtr)
+			req, err = http.NewRequest("POST", apiURL, readerPtr)
 			if err != nil {
 				d.Logger.Error().WithField("err", err.Error()).Logf("failed to create request")
 				d.handleBatchFailure(subBatch)
@@ -726,4 +720,8 @@ func (z *batchedEvent) MarshalMsg(b []byte) (o []byte, err error) {
 
 type httpError interface {
 	Timeout() bool
+}
+
+func buildRequestURL(apiHost, dataset string) (string, error) {
+	return url.JoinPath(apiHost, "/1/batch", url.PathEscape(dataset))
 }

--- a/transmit/direct_transmit.go
+++ b/transmit/direct_transmit.go
@@ -723,5 +723,11 @@ type httpError interface {
 }
 
 func buildRequestURL(apiHost, dataset string) (string, error) {
+	// validate the apiHost is a valid URL
+	_, err := url.Parse(apiHost)
+	if err != nil {
+		return "", err
+	}
+
 	return url.JoinPath(apiHost, "/1/batch", url.PathEscape(dataset))
 }

--- a/transmit/direct_transmit_test.go
+++ b/transmit/direct_transmit_test.go
@@ -1463,3 +1463,37 @@ func BenchmarkTransmissionComparison(b *testing.B) {
 		})
 	}
 }
+
+func TestBuildRequestURL(t *testing.T) {
+	const apiHost = "https://test-api"
+	const apiHostResult = apiHost + "/1/batch/"
+	testcases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "url encoded string",
+			input:    "foo%20bar",
+			expected: apiHostResult + "foo%2520bar",
+		},
+		{
+			name:     "with a space",
+			input:    "foo bar",
+			expected: apiHostResult + "foo%20bar",
+		},
+		{
+			name:     "with a slash",
+			input:    "foo/bar",
+			expected: apiHostResult + "foo%2Fbar",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run("all at once/"+tc.name, func(t *testing.T) {
+			result, err := buildRequestURL(apiHost, tc.input)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
## Which problem is this PR solving?

Customer has reported that their `service.name` with a space in the value is showing up as `foo%20bar`

## Short description of the changes

Turns out there was a [fix](https://github.com/honeycombio/libhoney-go/commit/9f4f37c3759e781e74a3c901417e80b50796a63e) added for this issue in libhoney. Our new `DirectTransmit` didn't include this fix. This PR introduce the fix into `DirectTransmit`.
TLDR is `url.Path` is expected to be unescaped. `url.String()` does the escape by default. If you set url.Path to be foo%20bar, url.String() will return foo%2520bar
