### PR TITLE
fix(ci): publish to ghcr.io/honeycombio/refinery not /honeycombio

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -279,7 +279,7 @@ jobs:
       - run:
           name: build once and publish to all public registries
           command: |
-            export KO_DOCKER_REPOS="${AWS_ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com,honeycombio,public.ecr.aws/honeycombio,ghcr.io/honeycombio"
+            export KO_DOCKER_REPOS="${AWS_ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com,honeycombio,public.ecr.aws/honeycombio,ghcr.io/honeycombio/refinery"
             echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
             echo "${GITHUB_TOKEN}" | docker login ghcr.io -u "${GITHUB_USERNAME}" --password-stdin
             ./build-docker.sh


### PR DESCRIPTION
## Which problem is this PR solving?

- github artifacts are different than the other artifacts, see https://github.com/orgs/honeycombio/packages

## Short description of the changes

- Associate published refinery images with this github repo.

