### PR TITLE
fix: increase upstream tranmission timeout to 30s

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -313,7 +313,7 @@ func newStartedApp(
 	if mockTransmission != nil {
 		upstreamTransmission = mockTransmission
 	} else {
-		upstreamTransmission = transmit.NewDirectTransmission(types.TransmitTypeUpstream, http.DefaultTransport.(*http.Transport), 500, 100*time.Millisecond, true)
+		upstreamTransmission = transmit.NewDirectTransmission(types.TransmitTypeUpstream, http.DefaultTransport.(*http.Transport), 500, 100*time.Millisecond, 100*time.Millisecond, true)
 	}
 
 	// Always create real peer transmission using DirectTransmission
@@ -323,7 +323,7 @@ func newStartedApp(
 			Timeout: 3 * time.Second,
 		}).Dial,
 	}
-	peerTransmissionWrapper := transmit.NewDirectTransmission(types.TransmitTypePeer, peerTransport, int(cfg.GetTracesConfigVal.MaxBatchSize), 100*time.Millisecond, false)
+	peerTransmissionWrapper := transmit.NewDirectTransmission(types.TransmitTypePeer, peerTransport, int(cfg.GetTracesConfigVal.MaxBatchSize), 100*time.Millisecond, 100*time.Millisecond, false)
 
 	var g inject.Graph
 	err = g.Provide(

--- a/cmd/refinery/main.go
+++ b/cmd/refinery/main.go
@@ -175,7 +175,7 @@ func main() {
 		upstreamTransport,
 		int(c.GetTracesConfig().GetMaxBatchSize()),
 		time.Duration(c.GetTracesConfig().GetBatchTimeout()),
-		60*time.Second,
+		30*time.Second,
 		true,
 	)
 	peerTransmission := transmit.NewDirectTransmission(

--- a/cmd/refinery/main.go
+++ b/cmd/refinery/main.go
@@ -175,6 +175,7 @@ func main() {
 		upstreamTransport,
 		int(c.GetTracesConfig().GetMaxBatchSize()),
 		time.Duration(c.GetTracesConfig().GetBatchTimeout()),
+		60*time.Second,
 		true,
 	)
 	peerTransmission := transmit.NewDirectTransmission(
@@ -182,6 +183,7 @@ func main() {
 		peerTransport,
 		int(c.GetTracesConfig().GetMaxBatchSize()),
 		time.Duration(c.GetTracesConfig().GetBatchTimeout()),
+		10*time.Second,
 		c.GetCompressPeerCommunication(),
 	)
 

--- a/collect/collect.go
+++ b/collect/collect.go
@@ -207,7 +207,6 @@ func (i *InMemCollector) Start() error {
 	i.Metrics.Store("INCOMING_CAP", float64(cap(i.incoming)))
 	i.Metrics.Store("PEER_CAP", float64(cap(i.fromPeer)))
 	i.reload = make(chan struct{}, 1)
-	i.done = make(chan struct{})
 	i.datasetSamplers = make(map[string]sample.Sampler)
 	i.done = make(chan struct{})
 	i.redistributeTimer = newRedistributeNotifier(i.Logger, i.Metrics, i.Clock, time.Duration(i.Config.GetCollectionConfig().RedistributionDelay))

--- a/transmit/direct_transmit.go
+++ b/transmit/direct_transmit.go
@@ -135,8 +135,9 @@ type DirectTransmission struct {
 	enableCompression bool
 
 	// Batching configuration
-	maxBatchSize int
-	batchTimeout time.Duration
+	maxBatchSize     int
+	batchTimeout     time.Duration
+	batchSendTimeout time.Duration
 
 	eventBatches map[transmitKey]*eventBatch
 	batchMutex   sync.RWMutex
@@ -154,6 +155,7 @@ func NewDirectTransmission(
 	transport *http.Transport,
 	maxBatchSize int,
 	batchTimeout time.Duration,
+	batchSendTimeout time.Duration,
 	enableCompression bool,
 ) *DirectTransmission {
 	return &DirectTransmission{
@@ -163,6 +165,7 @@ func NewDirectTransmission(
 		enableCompression: enableCompression,
 		maxBatchSize:      maxBatchSize,
 		batchTimeout:      batchTimeout,
+		batchSendTimeout:  batchSendTimeout,
 		eventBatches:      make(map[transmitKey]*eventBatch),
 		stop:              make(chan struct{}),
 	}
@@ -173,7 +176,7 @@ func (d *DirectTransmission) Start() error {
 	d.userAgent = fmt.Sprintf("refinery/%s %s (%s/%s)", d.Version, strings.Replace(runtime.Version(), "go", "go/", 1), runtime.GOOS, runtime.GOARCH)
 	d.httpClient = &http.Client{
 		Transport: d.Transport,
-		Timeout:   10 * time.Second,
+		Timeout:   d.batchSendTimeout,
 	}
 
 	d.registerMetrics() // Ensure metrics are registered

--- a/transmit/direct_transmit_test.go
+++ b/transmit/direct_transmit_test.go
@@ -143,7 +143,7 @@ func setupDirectTransmissionTestWithBatchSize(t *testing.T, batchSize int, batch
 
 	mockLogger := &logger.MockLogger{}
 
-	dt := NewDirectTransmission(types.TransmitTypeUpstream, http.DefaultTransport.(*http.Transport), 10, 100*time.Millisecond, true)
+	dt := NewDirectTransmission(types.TransmitTypeUpstream, http.DefaultTransport.(*http.Transport), 10, 100*time.Millisecond, 10*time.Second, true)
 	dt.Logger = mockLogger
 	dt.Version = "test-version"
 	dt.Metrics = mockMetrics
@@ -499,7 +499,7 @@ func TestDirectTransmission(t *testing.T) {
 
 	// Use max batch size of 3 for testing
 	testServer := newTestDirectAPIServer(t, 3)
-	dt := NewDirectTransmission(types.TransmitTypeUpstream, http.DefaultTransport.(*http.Transport), 3, 50*time.Millisecond, true)
+	dt := NewDirectTransmission(types.TransmitTypeUpstream, http.DefaultTransport.(*http.Transport), 3, 50*time.Millisecond, 10*time.Second, true)
 	dt.Logger = mockLogger
 	dt.Version = "test-version"
 	dt.Metrics = mockMetrics
@@ -760,7 +760,7 @@ func TestDirectTransmissionBatchSizeLimit(t *testing.T) {
 	mockLogger := &logger.MockLogger{}
 
 	testServer := newTestDirectAPIServer(t, 50)
-	dt := NewDirectTransmission(types.TransmitTypeUpstream, http.DefaultTransport.(*http.Transport), 50, 50*time.Millisecond, true)
+	dt := NewDirectTransmission(types.TransmitTypeUpstream, http.DefaultTransport.(*http.Transport), 50, 50*time.Millisecond, 10*time.Second, true)
 	dt.Logger = mockLogger
 	dt.Version = "test-version"
 	dt.Metrics = mockMetrics
@@ -841,7 +841,7 @@ func TestDirectTransmissionBatchTiming(t *testing.T) {
 	fakeClock := clockwork.NewFakeClock()
 
 	// Use a 400ms batch timeout for testing
-	dt := NewDirectTransmission(types.TransmitTypeUpstream, http.DefaultTransport.(*http.Transport), 100, 400*time.Millisecond, true)
+	dt := NewDirectTransmission(types.TransmitTypeUpstream, http.DefaultTransport.(*http.Transport), 100, 400*time.Millisecond, 10*time.Second, true)
 	dt.Config = &config.MockConfig{}
 	dt.Logger = &logger.NullLogger{}
 	dt.Version = "test-version"
@@ -960,6 +960,7 @@ func TestDirectTransmissionQueueLengthGauge(t *testing.T) {
 		http.DefaultTransport.(*http.Transport),
 		10,
 		batchTimeout,
+		10*time.Second,
 		true,
 	)
 	dt.Config = &config.MockConfig{}
@@ -1359,6 +1360,7 @@ func BenchmarkTransmissionComparison(b *testing.B) {
 					httpTransport,
 					libhoney.DefaultMaxBatchSize,
 					libhoney.DefaultBatchTimeout,
+					60*time.Second, // this is the default batch send timeout in libhoney
 					false,
 				)
 				dt.Logger = &logger.NullLogger{}


### PR DESCRIPTION
## Which problem is this PR solving?

If Honeycomb API is taking longer than expected when receiving a batch, we want to try our best to send that data instead of bailing fast

## Short description of the changes

- Allow upstreamTransmission and peerTransmission to have different timeout value for their http client
- set client timeout to be 30s for upstreamTransmission

