### PR TITLE
fix: set default sizes for queues

### DIFF
--- a/config/file_config.go
+++ b/config/file_config.go
@@ -312,8 +312,8 @@ type RedisPeerManagementConfig struct {
 }
 
 type CollectionConfig struct {
-	PeerQueueSize       int        `yaml:"PeerQueueSize"`
-	IncomingQueueSize   int        `yaml:"IncomingQueueSize"`
+	PeerQueueSize       int        `yaml:"PeerQueueSize" default:"30000"`
+	IncomingQueueSize   int        `yaml:"IncomingQueueSize" default:"30000"`
 	AvailableMemory     MemorySize `yaml:"AvailableMemory" cmdenv:"AvailableMemory"`
 	HealthCheckTimeout  Duration   `yaml:"HealthCheckTimeout" default:"15s"`
 	MaxMemoryPercentage int        `yaml:"MaxMemoryPercentage" default:"75"`


### PR DESCRIPTION
## Which problem is this PR solving?

- Starting up Refinery 3.0-beta without IncomingQueueSize or PeerQueueSize configured results in queue sizes set to `0`.

## Short description of the changes

- The sizes of these queues [used to be computed from the CacheCapacity config option that has been removed](https://github.com/honeycombio/refinery/pull/1666). With that math gone, we need to declare defaults or these will be size 0 and then you're going to have a bad time.

