### PR TITLE
maint: set service.name for honeycomb logger

### DIFF
--- a/logger/honeycomb.go
+++ b/logger/honeycomb.go
@@ -82,6 +82,7 @@ func (h *HoneycombLogger) Start() error {
 
 	h.addResourceAttributes()
 	h.libhClient.AddField("refinery_version", h.Version)
+	h.libhClient.AddField("service.name", "refinery")
 	if hostname, err := os.Hostname(); err == nil {
 		h.libhClient.AddField("hostname", hostname)
 	}


### PR DESCRIPTION
## Which problem is this PR solving?

To be able to properly identify refinery logs sent either by OTel logger or honeycomb logger, we need a common field from both logger. I propose we add the `service.name` field on the honeycomb logs.

## Short description of the changes

- add `service.name` attribute on honeycomb logger

