### PR TITLE
maint: provide more actionable deprecation text for LegacyMetrics and BufferSizes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
     docker:
       - image: cimg/go:1.24
       - image: redis:6.2
-    resource_class: large
+    resource_class: xlarge
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,6 +67,7 @@ jobs:
     docker:
       - image: cimg/go:1.24
       - image: redis:6.2
+    resource_class: large
     steps:
       - checkout
       - restore_cache:

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -361,7 +361,7 @@ func newStartedApp(
 func post(t testing.TB, req *http.Request) {
 	req.Header.Set("User-Agent", "Test-Client")
 	resp, err := httpClient.Do(req)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	io.Copy(io.Discard, resp.Body)
 	resp.Body.Close()

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -87,12 +87,12 @@ Samplers:
 
 	// Test with version after deprecation should return an error
 	t.Run("shows deprecation warning for version newer than lastversion", func(t *testing.T) {
-		_, err := config.NewConfig(opts, "v2.10.0")
+		_, err := config.NewConfig(opts, "v3.1.0")
 		require.Error(t, err)
 
 		configErr, isConfigErr := err.(*config.FileConfigError)
 		require.True(t, isConfigErr, "Error should be a FileConfigError")
-		require.True(t, configErr.HasErrors(), "Error should be warning-only, not a fatal error")
+		require.True(t, configErr.HasErrors(), "Error should be a fatal error")
 		assert.Contains(t, err.Error(), "ERROR", "Expected warning message to contain ERROR")
 	})
 

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -1464,7 +1464,7 @@ groups:
         valuetype: nondefault
         firstversion: v2.9
         lastversion: v2.9.7
-        deprecationtext: MaxDropDecisionBatchSize was an experimental feature that has been removed.
+        deprecationtext: MaxDropDecisionBatchSize was part of TraceLocalityMode experimental feature that has been removed.
         unpublished: true
         default: 1000
         reload: false
@@ -1477,7 +1477,7 @@ groups:
         valuetype: nondefault
         firstversion: v2.9
         lastversion: v2.9.7
-        deprecationtext: DropDecisionSendInterval was an experimental feature that has been removed.
+        deprecationtext: DropDecisionSendInterval was part of TraceLocalityMode experimental feature that has been removed.
         unpublished: true
         default: 1s
         reload: true
@@ -1490,7 +1490,7 @@ groups:
         valuetype: nondefault
         firstversion: v2.9
         lastversion: v2.9.7
-        deprecationtext: MaxKeptDecisionBatchSize was an experimental feature that has been removed.
+        deprecationtext: MaxKeptDecisionBatchSize was part of TraceLocalityMode experimental feature that has been removed.
         unpublished: true
         default: 1000
         reload: false
@@ -1503,7 +1503,7 @@ groups:
         valuetype: nondefault
         firstversion: v2.9
         lastversion: v2.9.7
-        deprecationtext: KeptDecisionSendInterval was an experimental feature that has been removed.
+        deprecationtext: KeptDecisionSendInterval was part of TraceLocalityMode experimental feature that has been removed.
         unpublished: true
         default: 1s
         reload: true

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -732,7 +732,7 @@ groups:
   - name: LegacyMetrics
     title: "Legacy Metrics"
     lastversion: v2.9.7
-    deprecationtext: LegacyMetrics has been deprecated since v2.9.7. Please use OTelMetrics instead.
+    deprecationtext: LegacyMetrics was deprecated in v2.0.0. Replace with OTelMetrics. See documentation for more details.
     replacements:
       - field: OTelMetrics
     description: >
@@ -1260,7 +1260,7 @@ groups:
         type: int
         valuetype: nondefault
         lastversion: v2.9.7
-        deprecationtext: CacheCapacity is deprecated since version v2.9.7. Set PeerQueueSize and IncomingQueueSize to (3 x CacheCapacity) instead.
+        deprecationtext: CacheCapacity was deprecated in v2.9.7. Set PeerQueueSize and IncomingQueueSize to (3 x CacheCapacity) instead.
         replacements:
           - field: PeerQueueSize
             formula: "3 * value"
@@ -1370,6 +1370,7 @@ groups:
         valuetype: nondefault
         firstversion: v2.8
         lastversion: v2.9.7
+        deprecationtext: DisableRedistribution option was removed in v3.0.0. See release notes for more details.
         default: true
         reload: true
         summary: controls whether to transmit traces in cache to remaining peers during cluster scaling event.
@@ -1389,6 +1390,7 @@ groups:
         valuetype: nondefault
         firstversion: v2.9
         lastversion: v2.9.7
+        deprecationtext: RedistributionDelay option was removed in v3.0.0. See release notes for more details.
         default: 30s
         reload: false
         summary: controls the amount of time Refinery waits after each cluster scaling event before redistributing in-memory traces.
@@ -1420,7 +1422,7 @@ groups:
         valuetype: nondefault
         firstversion: v2.9
         lastversion: v2.9.7
-        deprecationtext: This feature was introduced as an experimental capability and is now deprecated.
+        deprecationtext: TraceLocalityMode was an experimental feature that has been removed.
         default: "concentrated"
         reload: false
         summary: controls how Refinery handles spans that belong to the same trace in a clustered environment.
@@ -1462,7 +1464,7 @@ groups:
         valuetype: nondefault
         firstversion: v2.9
         lastversion: v2.9.7
-        deprecationtext: This feature was introduced as an experimental capability and is now deprecated.
+        deprecationtext: MaxDropDecisionBatchSize was an experimental feature that has been removed.
         unpublished: true
         default: 1000
         reload: false
@@ -1475,7 +1477,7 @@ groups:
         valuetype: nondefault
         firstversion: v2.9
         lastversion: v2.9.7
-        deprecationtext: This feature was introduced as an experimental capability and is now deprecated.
+        deprecationtext: DropDecisionSendInterval was an experimental feature that has been removed.
         unpublished: true
         default: 1s
         reload: true
@@ -1488,7 +1490,7 @@ groups:
         valuetype: nondefault
         firstversion: v2.9
         lastversion: v2.9.7
-        deprecationtext: This feature was introduced as an experimental capability and is now deprecated.
+        deprecationtext: MaxKeptDecisionBatchSize was an experimental feature that has been removed.
         unpublished: true
         default: 1000
         reload: false
@@ -1501,7 +1503,7 @@ groups:
         valuetype: nondefault
         firstversion: v2.9
         lastversion: v2.9.7
-        deprecationtext: This feature was introduced as an experimental capability and is now deprecated.
+        deprecationtext: KeptDecisionSendInterval was an experimental feature that has been removed.
         unpublished: true
         default: 1s
         reload: true
@@ -1511,7 +1513,7 @@ groups:
 
   - name: BufferSizes
     title: "Buffer Sizes"
-    deprecationtext: BufferSizes group has been deprecation since v2.9.7. Please remove this section.
+    deprecationtext: BufferSizes was removed in v3.0.0. See release note for more details.
     lastversion: v2.9.7
     description: >
       contains the settings that are relevant to

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -732,6 +732,7 @@ groups:
   - name: LegacyMetrics
     title: "Legacy Metrics"
     lastversion: v2.9.7
+    deprecationtext: LegacyMetrics has been deprecated since v2.9.7. Please use OTelMetrics instead.
     replacements:
       - field: OTelMetrics
     description: >
@@ -1510,6 +1511,7 @@ groups:
 
   - name: BufferSizes
     title: "Buffer Sizes"
+    deprecationtext: BufferSizes group has been deprecation since v2.9.7. Please remove this section.
     lastversion: v2.9.7
     description: >
       contains the settings that are relevant to

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -731,7 +731,7 @@ groups:
 
   - name: LegacyMetrics
     title: "Legacy Metrics"
-    lastversion: v2.9.7
+    lastversion: v3.0.0
     deprecationtext: LegacyMetrics was deprecated in v2.0.0. Replace with OTelMetrics. See documentation for more details.
     replacements:
       - field: OTelMetrics
@@ -1259,7 +1259,7 @@ groups:
         v1name: CacheCapacity
         type: int
         valuetype: nondefault
-        lastversion: v2.9.7
+        lastversion: v3.0.0
         deprecationtext: CacheCapacity was deprecated in v2.9.7. Set PeerQueueSize and IncomingQueueSize to (3 x CacheCapacity) instead.
         replacements:
           - field: PeerQueueSize
@@ -1369,7 +1369,7 @@ groups:
         type: defaulttrue
         valuetype: nondefault
         firstversion: v2.8
-        lastversion: v2.9.7
+        lastversion: v3.0.0
         deprecationtext: DisableRedistribution option was removed in v3.0.0. See release notes for more details.
         default: true
         reload: true
@@ -1389,7 +1389,7 @@ groups:
         type: duration
         valuetype: nondefault
         firstversion: v2.9
-        lastversion: v2.9.7
+        lastversion: v3.0.0
         deprecationtext: RedistributionDelay option was removed in v3.0.0. See release notes for more details.
         default: 30s
         reload: false
@@ -1421,7 +1421,7 @@ groups:
         type: string
         valuetype: nondefault
         firstversion: v2.9
-        lastversion: v2.9.7
+        lastversion: v3.0.0
         deprecationtext: TraceLocalityMode was an experimental feature that has been removed.
         default: "concentrated"
         reload: false
@@ -1463,7 +1463,7 @@ groups:
         type: int
         valuetype: nondefault
         firstversion: v2.9
-        lastversion: v2.9.7
+        lastversion: v3.0.0
         deprecationtext: MaxDropDecisionBatchSize was part of TraceLocalityMode experimental feature that has been removed.
         unpublished: true
         default: 1000
@@ -1476,7 +1476,7 @@ groups:
         type: duration
         valuetype: nondefault
         firstversion: v2.9
-        lastversion: v2.9.7
+        lastversion: v3.0.0
         deprecationtext: DropDecisionSendInterval was part of TraceLocalityMode experimental feature that has been removed.
         unpublished: true
         default: 1s
@@ -1489,7 +1489,7 @@ groups:
         type: int
         valuetype: nondefault
         firstversion: v2.9
-        lastversion: v2.9.7
+        lastversion: v3.0.0
         deprecationtext: MaxKeptDecisionBatchSize was part of TraceLocalityMode experimental feature that has been removed.
         unpublished: true
         default: 1000
@@ -1502,7 +1502,7 @@ groups:
         type: duration
         valuetype: nondefault
         firstversion: v2.9
-        lastversion: v2.9.7
+        lastversion: v3.0.0
         deprecationtext: KeptDecisionSendInterval was part of TraceLocalityMode experimental feature that has been removed.
         unpublished: true
         default: 1s
@@ -1514,7 +1514,7 @@ groups:
   - name: BufferSizes
     title: "Buffer Sizes"
     deprecationtext: BufferSizes was removed in v3.0.0. See release note for more details.
-    lastversion: v2.9.7
+    lastversion: v3.0.0
     description: >
       contains the settings that are relevant to
       the sizes of communications buffers.

--- a/config/validate.go
+++ b/config/validate.go
@@ -563,14 +563,14 @@ func checkForDeprecation(path string, item deprecator, currentVersion ...string)
 		if isVersionDeprecated(currentVersion[0], item.GetLastVersion()) {
 			// Current version is before the last version - collect for grouped warning
 			if message == "" {
-				message = fmt.Sprintf("config %s is going to be deprecated starting at version %s", path, item.GetLastVersion())
+				message = fmt.Sprintf("config %s is deprecated and will be removed in version %s", path, item.GetLastVersion())
 			}
 		} else {
 			// Current version is equal to or after the last version - fail validation
 			comparison, err := compareVersions(currentVersion[0], item.GetLastVersion())
 			if err != nil || comparison >= 0 {
 				if message == "" {
-					message = fmt.Sprintf("config %s is deprecated since version %s", path, item.GetLastVersion())
+					message = fmt.Sprintf("config %s was deprecated and removed in version %s", path, item.GetLastVersion())
 				}
 				return ValidationResult{
 					Message:  message,

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -455,7 +455,7 @@ func TestValidateDeprecationWarnings(t *testing.T) {
 			currentVersion: "v2.6.0", // After v2.5.0 but before v2.9.7
 			expected: []string{
 				"CacheCapacity is deprecated since version v2.9.7. Set PeerQueueSize and IncomingQueueSize instead.",
-				"config Collection.OtherDeprecatedField is deprecated since version v2.5.0"},
+				"config Collection.OtherDeprecatedField was deprecated and removed in version v2.5.0"},
 		},
 		{
 			name: "old version shows all deprecated field warnings",
@@ -468,7 +468,7 @@ func TestValidateDeprecationWarnings(t *testing.T) {
 			currentVersion: "v2.4.0", // Before both deprecation versions
 			expected: []string{
 				"CacheCapacity is deprecated since version v2.9.7. Set PeerQueueSize and IncomingQueueSize instead.",
-				"config Collection.OtherDeprecatedField is going to be deprecated starting at version v2.5.0"},
+				"config Collection.OtherDeprecatedField is deprecated and will be removed in version v2.5.0"},
 		},
 	}
 


### PR DESCRIPTION
## Which problem is this PR solving?

Before:
```
│ ERROR: Validation failed for config [/etc/refinery/config.yaml]:                                                                                                                                                │
│   config BufferSizes is deprecated since version v2.9.7
│   config LegacyMetrics is deprecated since version v2.9.7                      
```

After:
```
                                                                                                                                   │
│ ERROR: Validation failed for config [/etc/refinery/config.yaml]:                                                                                                                                                │
│   LegacyMetrics was deprecated in v2.0.0. Replace with OTelMetrics. See documentation for more details.                                                                                                                               │
│   BufferSizes was removed in v3.0.0. See release note for more details.   
```
## Short description of the changes

- add specific deprecationtext in configMeta.yaml

