### PR TITLE
maint: update husky to 0.39.1

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -414,7 +414,7 @@ func TestAppIntegration(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := http.DefaultTransport.RoundTrip(req)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	resp.Body.Close()
 

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/honeycombio/dynsampler-go v0.6.3
 	github.com/honeycombio/hpsf v0.14.0
-	github.com/honeycombio/husky v0.39.0
+	github.com/honeycombio/husky v0.39.1
 	github.com/honeycombio/libhoney-go v1.25.0
 	github.com/jessevdk/go-flags v1.6.1
 	github.com/jonboulle/clockwork v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -128,6 +128,8 @@ github.com/honeycombio/hpsf v0.14.0 h1:LeQbDuT+aVmiJnWp9Kqb9Qqz5OZcjDk85RMzzwKtC
 github.com/honeycombio/hpsf v0.14.0/go.mod h1:VyPjyn1GViOiCrpBbPZCkEJnuDuSTUpU8LV5CWVTQm4=
 github.com/honeycombio/husky v0.39.0 h1:EZKZoq9f7ibNcUwop4j7VXu0dVBiAuDwGZiN7J435mo=
 github.com/honeycombio/husky v0.39.0/go.mod h1:ateXiI7NXRLFbNiwyjl5Gio5KSbUodoRNUxgJ3PyMCE=
+github.com/honeycombio/husky v0.39.1 h1:2k7mjsnxVHdEPgxvEBeVXS1pua1QZKRiLacp+xDueA0=
+github.com/honeycombio/husky v0.39.1/go.mod h1:ateXiI7NXRLFbNiwyjl5Gio5KSbUodoRNUxgJ3PyMCE=
 github.com/honeycombio/libhoney-go v1.25.0 h1:r33tlX90HtafK0bgRcjfNnsrJ9ZMTKuI/1DYaOFCc1o=
 github.com/honeycombio/libhoney-go v1.25.0/go.mod h1:Fc0HjqlwYf5xy6H34EItpOverAGbCixnYOX3YTUQovg=
 github.com/honeycombio/opentelemetry-proto-go/otlp v1.3.1-compat h1:i9CAIguM5tMQC9xSRihqdFBoh40OBOhuhfR8OrXsZ9o=


### PR DESCRIPTION
## Which problem is this PR solving?

To bring in the fix for https://github.com/honeycombio/husky/commit/afd2a202573d9c972e555aad40d4eee1a829a43e that fixes a nil pointer panic for converting otel attributes to honeycomb event attributes

## Short description of the changes

- update husky in go.mod

