### PR TITLE
maint: generate config for 3.0

### DIFF
--- a/config.md
+++ b/config.md
@@ -3,7 +3,7 @@
 # Honeycomb Refinery Configuration Documentation
 
 This is the documentation for the configuration file for Honeycomb's Refinery.
-It was automatically generated on 2025-08-26 at 15:28:23 UTC.
+It was automatically generated on 2025-10-01 at 18:54:38 UTC.
 
 ## The Config file
 
@@ -38,13 +38,11 @@ The remainder of this document describes the sections within the file and the fi
 - [Honeycomb Logger](#honeycomb-logger)
 - [Stdout Logger](#stdout-logger)
 - [Prometheus Metrics](#prometheus-metrics)
-- [Legacy Metrics](#legacy-metrics)
 - [OpenTelemetry Metrics](#opentelemetry-metrics)
 - [OpenTelemetry Tracing](#opentelemetry-tracing)
 - [Peer Management](#peer-management)
 - [Redis Peer Management](#redis-peer-management)
 - [Collection Settings](#collection-settings)
-- [Buffer Sizes](#buffer-sizes)
 - [Specialized Configuration](#specialized-configuration)
 - [ID Fields](#id-fields)
 - [gRPC Server Parameters](#grpc-server-parameters)
@@ -613,64 +611,6 @@ Only used if `Enabled` is `true` in `PrometheusMetrics`.
 - Type: `hostport`
 - Default: `localhost:2112`
 
-## Legacy Metrics
-
-`LegacyMetrics` contains configuration for Refinery's legacy metrics.
-Version 1.x of Refinery used this format for sending Metrics to Honeycomb.
-The metrics generated that way are nonstandard and will be deprecated in a future release.
-New installations should prefer `OTelMetrics`.
-
-### `Enabled`
-
-Enabled controls whether to send legacy-formatted metrics to Honeycomb.
-
-Each of the metrics providers can be enabled or disabled independently.
-Metrics can be sent to multiple destinations.
-
-- Not eligible for live reload.
-- Type: `bool`
-
-### `APIHost`
-
-APIHost is the URL of the Honeycomb API where legacy metrics are sent.
-
-Refinery's internal metrics will be sent to this host using the standard Honeycomb Events API.
-
-- Not eligible for live reload.
-- Type: `url`
-- Default: `https://api.honeycomb.io`
-
-### `APIKey`
-
-APIKey is the API key used by Refinery to send its metrics to Honeycomb. Setting this value via a command line flag may expose credentials - it is recommended to use the environment variable or a configuration file.
-
-It is recommended that you create a separate team and key for Refinery metrics.
-
-- Not eligible for live reload.
-- Type: `string`
-- Example: `SetThisToAHoneycombKey`
-- Environment variable: `REFINERY_HONEYCOMB_METRICS_API_KEY, REFINERY_HONEYCOMB_API_KEY`
-
-### `Dataset`
-
-Dataset is the Honeycomb dataset where Refinery sends its metrics.
-
-Only used if `APIKey` is specified.
-
-- Not eligible for live reload.
-- Type: `string`
-- Default: `Refinery Metrics`
-
-### `ReportingInterval`
-
-ReportingInterval is the interval between sending legacy metrics to Honeycomb.
-
-Between 1 and 60 seconds is typical.
-
-- Not eligible for live reload.
-- Type: `duration`
-- Default: `30s`
-
 ## OpenTelemetry Metrics
 
 `OTelMetrics` contains configuration for Refinery's OpenTelemetry (OTel) metrics.
@@ -1034,35 +974,6 @@ If set, `Collections.AvailableMemory` must not be defined.
 - Eligible for live reload.
 - Type: `memorysize`
 
-### `DisableRedistribution`
-
-DisableRedistribution controls whether to transmit traces in cache to remaining peers during cluster scaling event.
-
-Redistribution is intended to help prevent data loss by reconsolidating traces onto the appropriate node after a scaling event.
-During scale down events, all stored spans are forwarded to the new owning Refinery peer instance, so it can shut down without dropping spans.
-During scale up events, only stored spans that belong to another Refinery peer instance are forwarded, so that instance can make whole trace decisions.
-Refinery uses additional system resources during scale up/down events.
-If the cluster does not have enough resource capacity headroom, a redistribution event can cause the cluster to go into stress relief (if enabled).
-If `true`, Refinery will NOT forward live traces in its cache to the rest of the peers when peers join or leave the cluster.
-Disabling redistribution can help to prevent disruptive bursts of network traffic when large traces with long `TraceTimeout` are redistributed.
-However, disabling redistribution may also cause partial data loss of traces that were in flight when scaling occurred.
-
-- Eligible for live reload.
-- Type: `bool`
-- Default: `true`
-
-### `RedistributionDelay`
-
-RedistributionDelay controls the amount of time Refinery waits after each cluster scaling event before redistributing in-memory traces.
-
-This value should be longer than the amount of time between individual pod changes in a bulk scaling operation (changing the cluster size by more than one pod).
-Each redistribution generates additional traffic between peers.
-If this value is too short, multiple consecutive redistributions will occur and the resulting traffic may overwhelm the cluster.
-
-- Not eligible for live reload.
-- Type: `duration`
-- Default: `30s`
-
 ### `ShutdownDelay`
 
 ShutdownDelay controls the maximum time Refinery can use while draining traces at shutdown.
@@ -1074,26 +985,6 @@ This value should be set to a bit less than the normal timeout period for shutti
 - Eligible for live reload.
 - Type: `duration`
 - Default: `15s`
-
-### `TraceLocalityMode`
-
-TraceLocalityMode controls how Refinery handles spans that belong to the same trace in a clustered environment.
-
-This feature is experimental, in active development, and not intended for broad customer use at this time.
-**Distributed mode is UNSUPPORTED without prior coordination with the Honeycomb product engineering team.**
-When `concentrated`, Refinery will route all spans that belong to the same trace to a single peer.
-This is the default behavior ("Trace Locality") and the way Refinery has worked in the past.
-When `distributed`, Refinery will instead keep spans on the node where they were received, and forward proxy spans that contain only the key information needed to make a trace decision.
-This can reduce the amount of traffic between peers, and can help avoid a situation where a single large trace can cause a memory overrun on a single node.
-If `distributed`, the amount of traffic between peers will be reduced, but the amount of traffic between Refinery and Redis will significantly increase, because Refinery uses Redis to distribute the trace decisions to all nodes in the cluster.
-It is important to adjust the size of the Redis cluster in this case.
-The total volume of network traffic in `distributed` mode should be expected to decrease unless the cluster size is very large (hundreds of nodes).
-NOTE: This setting is not compatible with `DryRun` when set to `distributed`.
-See `DryRun` for more information.
-
-- Not eligible for live reload.
-- Type: `string`
-- Default: `concentrated`
 
 ### `HealthCheckTimeout`
 
@@ -1108,10 +999,6 @@ Refinery will adjust the timeout based on the configured `MaxExpiredTraces`, so 
 - Not eligible for live reload.
 - Type: `duration`
 - Default: `15s`
-
-## Buffer Sizes
-
-`BufferSizes` contains the settings that are relevant to the sizes of communications buffers.
 
 ## Specialized Configuration
 

--- a/config_complete.yaml
+++ b/config_complete.yaml
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created on 2025-08-26 at 15:28:23 UTC from ../../config.yaml using a template generated on 2025-08-26 at 15:28:20 UTC
+# created on 2025-10-01 at 18:54:38 UTC from ../../config.yaml using a template generated on 2025-10-01 at 18:54:36 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of
@@ -10,7 +10,6 @@
 # informational only. Text preceded by a single comment character (#) indicates
 # a value that is commented out and not used; it should be uncommented to enable
 # it.
-
 
 ###########################
 ## General Configuration ##
@@ -638,64 +637,6 @@ PrometheusMetrics:
     ## Not eligible for live reload.
     # ListenAddr: "localhost:2112"
 
-####################
-## Legacy Metrics ##
-####################
-LegacyMetrics:
-  ## LegacyMetrics contains configuration for Refinery's legacy metrics.
-  ## Version 1.x of Refinery used this format for sending Metrics to
-  ## Honeycomb. The metrics generated that way are nonstandard and will be
-  ## deprecated in a future release. New installations should prefer
-  ## `OTelMetrics`.
-  ##
-  ####
-    ## Enabled controls whether to send legacy-formatted metrics to
-    ## Honeycomb.
-    ##
-    ## Each of the metrics providers can be enabled or disabled
-    ## independently. Metrics can be sent to multiple destinations.
-    ##
-    ## Not eligible for live reload.
-    # Enabled: false
-
-    ## APIHost is the URL of the Honeycomb API where legacy metrics are sent.
-    ##
-    ## Refinery's internal metrics will be sent to this host using the
-    ## standard Honeycomb Events API.
-    ##
-    ## default: https://api.honeycomb.io
-    ## Not eligible for live reload.
-    # APIHost: "https://api.honeycomb.io"
-
-    ## APIKey is the API key used by Refinery to send its metrics to
-    ## Honeycomb. Setting this value via a command line flag may expose
-    ## credentials - it is recommended to use the environment variable or a
-    ## configuration file.
-    ##
-    ## It is recommended that you create a separate team and key for Refinery
-    ## metrics.
-    ##
-    ## Not eligible for live reload.
-    # APIKey: ""
-
-    ## Dataset is the Honeycomb dataset where Refinery sends its metrics.
-    ##
-    ## Only used if `APIKey` is specified.
-    ##
-    ## default: Refinery Metrics
-    ## Not eligible for live reload.
-    # Dataset: "Refinery Metrics"
-
-    ## ReportingInterval is the interval between sending legacy metrics to
-    ## Honeycomb.
-    ##
-    ## Between 1 and 60 seconds is typical.
-    ##
-    ## Accepts a duration string with units, like "30s".
-    ## default: 30s
-    ## Not eligible for live reload.
-    # ReportingInterval: ""
-
 ###########################
 ## OpenTelemetry Metrics ##
 ###########################
@@ -1079,45 +1020,6 @@ Collection:
     ## Eligible for live reload.
     # MaxAlloc: ""
 
-    ## DisableRedistribution controls whether to transmit traces in cache to
-    ## remaining peers during cluster scaling event.
-    ##
-    ## Redistribution is intended to help prevent data loss by
-    ## reconsolidating traces onto the appropriate node after a scaling
-    ## event. During scale down events, all stored spans are forwarded to the
-    ## new owning Refinery peer instance, so it can shut down without
-    ## dropping spans. During scale up events, only stored spans that belong
-    ## to another Refinery peer instance are forwarded, so that instance can
-    ## make whole trace decisions. Refinery uses additional system resources
-    ## during scale up/down events. If the cluster does not have enough
-    ## resource capacity headroom, a redistribution event can cause the
-    ## cluster to go into stress relief (if enabled).
-    ## If `true`, Refinery will NOT forward live traces in its cache to the
-    ## rest of the peers when peers join or leave the cluster. Disabling
-    ## redistribution can help to prevent disruptive bursts of network
-    ## traffic when large traces with long `TraceTimeout` are redistributed.
-    ## However, disabling redistribution may also cause partial data loss of
-    ## traces that were in flight when scaling occurred.
-    ##
-    ## default: true
-    ## Eligible for live reload.
-    # DisableRedistribution: true
-
-    ## RedistributionDelay controls the amount of time Refinery waits after
-    ## each cluster scaling event before redistributing in-memory traces.
-    ##
-    ## This value should be longer than the amount of time between individual
-    ## pod changes in a bulk scaling operation (changing the cluster size by
-    ## more than one pod). Each redistribution generates additional traffic
-    ## between peers. If this value is too short, multiple consecutive
-    ## redistributions will occur and the resulting traffic may overwhelm the
-    ## cluster.
-    ##
-    ## Accepts a duration string with units, like "30s".
-    ## default: 30s
-    ## Not eligible for live reload.
-    # RedistributionDelay: 30s
-
     ## ShutdownDelay controls the maximum time Refinery can use while
     ## draining traces at shutdown.
     ##
@@ -1133,35 +1035,6 @@ Collection:
     ## default: 15s
     ## Eligible for live reload.
     # ShutdownDelay: 15s
-
-    ## TraceLocalityMode controls how Refinery handles spans that belong to
-    ## the same trace in a clustered environment.
-    ##
-    ## This feature is experimental, in active development, and not intended
-    ## for broad customer use at this time. **Distributed mode is UNSUPPORTED
-    ## without prior coordination with the Honeycomb product engineering
-    ## team.**
-    ## When `concentrated`, Refinery will route all spans that belong to the
-    ## same trace to a single peer. This is the default behavior ("Trace
-    ## Locality") and the way Refinery has worked in the past. When
-    ## `distributed`, Refinery will instead keep spans on the node where they
-    ## were received, and forward proxy spans that contain only the key
-    ## information needed to make a trace decision. This can reduce the
-    ## amount of traffic between peers, and can help avoid a situation where
-    ## a single large trace can cause a memory overrun on a single node.
-    ## If `distributed`, the amount of traffic between peers will be reduced,
-    ## but the amount of traffic between Refinery and Redis will
-    ## significantly increase, because Refinery uses Redis to distribute the
-    ## trace decisions to all nodes in the cluster. It is important to adjust
-    ## the size of the Redis cluster in this case.
-    ## The total volume of network traffic in `distributed` mode should be
-    ## expected to decrease unless the cluster size is very large (hundreds
-    ## of nodes). NOTE: This setting is not compatible with `DryRun` when set
-    ## to `distributed`. See `DryRun` for more information.
-    ##
-    ## default: concentrated
-    ## Not eligible for live reload.
-    # TraceLocalityMode: concentrated
 
     ## HealthCheckTimeout controls the maximum duration allowed for
     ## collection health checks to complete.
@@ -1184,14 +1057,6 @@ Collection:
     ## Not eligible for live reload.
     # HealthCheckTimeout: 15s
 
-##################
-## Buffer Sizes ##
-##################
-BufferSizes:
-  ## BufferSizes contains the settings that are relevant to the sizes of
-  ## communications buffers.
-  ##
-  ####
 ###############################
 ## Specialized Configuration ##
 ###############################
@@ -1518,18 +1383,25 @@ StressRelief:
     ## Eligible for live reload.
     # MinimumActivationDuration: 10s
 
+
 ###################################################
 ## Config values removed by the config converter ##
 ###################################################
   ## The following configuration options are obsolete and are not included
   ## in the new configuration:
   ##
+    ## - LegacyMetrics
     ## - PeerManagement.Prefix
     ## - PeerManagement.Database
     ## - PeerManagement.Strategy
     ## - InMemCollector.CacheCapacity
-    ## - BufferSizes.UpstreamBufferSize
-    ## - BufferSizes.PeerBufferSize
+    ## - Collection.DisableRedistribution
+    ## - Collection.RedistributionDelay
+    ## - Collection.TraceLocalityMode
+    ## - Collection.MaxDropDecisionBatchSize
+    ## - Collection.DropDecisionSendInterval
+    ## - Collection.MaxKeptDecisionBatchSize
+    ## - Collection.KeptDecisionSendInterval
     ## - BufferSizes
     ## - Collector
     ## - InMemCollector.CacheOverrunStrategy

--- a/metrics.md
+++ b/metrics.md
@@ -3,7 +3,7 @@
 # Honeycomb Refinery Metrics Documentation
 
 This document contains the description of various metrics used in Refinery.
-It was automatically generated on 2025-08-07 at 21:56:06 UTC.
+It was automatically generated on 2025-10-01 at 18:54:38 UTC.
 
 Note: This document does not include metrics defined in the dynsampler-go dependency, as those metrics are generated dynamically at runtime. As a result, certain metrics may be missing or incomplete in this document, but they will still be available during execution with their full names.
 
@@ -105,6 +105,7 @@ Metrics in this table don't contain their expected prefixes. This is because the
 | _batches_sent | Counter | Dimensionless | number of batches of events sent to destination |
 | _messages_sent | Counter | Dimensionless | number of messages sent to destination |
 | _response_decode_errors | Counter | Dimensionless | number of errors encountered while decoding responses from destination |
+| _stale_dispatch_time | Histogram | Microseconds | The time spent per iteration of the stale batch dispatch loop |
 | _router_proxied | Counter | Dimensionless | the number of events proxied to another refinery |
 | _router_event | Counter | Dimensionless | the number of events received |
 | _router_event_bytes | Histogram | Bytes | the number of bytes per event received |

--- a/refinery_config.md
+++ b/refinery_config.md
@@ -595,64 +595,6 @@ Only used if `Enabled` is `true` in `PrometheusMetrics`.
 - Type: `hostport`
 - Default: `localhost:2112`
 
-## Legacy Metrics
-
-`LegacyMetrics` contains configuration for Refinery's legacy metrics.
-Version 1.x of Refinery used this format for sending Metrics to Honeycomb.
-The metrics generated that way are nonstandard and will be deprecated in a future release.
-New installations should prefer `OTelMetrics`.
-
-### `Enabled`
-
-`Enabled` controls whether to send legacy-formatted metrics to Honeycomb.
-
-Each of the metrics providers can be enabled or disabled independently.
-Metrics can be sent to multiple destinations.
-
-- Not eligible for live reload.
-- Type: `bool`
-
-### `APIHost`
-
-`APIHost` is the URL of the Honeycomb API where legacy metrics are sent.
-
-Refinery's internal metrics will be sent to this host using the standard Honeycomb Events API.
-
-- Not eligible for live reload.
-- Type: `url`
-- Default: `https://api.honeycomb.io`
-
-### `APIKey`
-
-`APIKey` is the API key used by Refinery to send its metrics to Honeycomb. Setting this value via a command line flag may expose credentials - it is recommended to use the environment variable or a configuration file.
-
-It is recommended that you create a separate team and key for Refinery metrics.
-
-- Not eligible for live reload.
-- Type: `string`
-- Example: `SetThisToAHoneycombKey`
-- Environment variable: `REFINERY_HONEYCOMB_METRICS_API_KEY, REFINERY_HONEYCOMB_API_KEY`
-
-### `Dataset`
-
-`Dataset` is the Honeycomb dataset where Refinery sends its metrics.
-
-Only used if `APIKey` is specified.
-
-- Not eligible for live reload.
-- Type: `string`
-- Default: `Refinery Metrics`
-
-### `ReportingInterval`
-
-`ReportingInterval` is the interval between sending legacy metrics to Honeycomb.
-
-Between 1 and 60 seconds is typical.
-
-- Not eligible for live reload.
-- Type: `duration`
-- Default: `30s`
-
 ## OpenTelemetry Metrics
 
 `OTelMetrics` contains configuration for Refinery's OpenTelemetry (OTel) metrics.
@@ -1018,35 +960,6 @@ If set, `Collections.AvailableMemory` must not be defined.
 - Eligible for live reload.
 - Type: `memorysize`
 
-### `DisableRedistribution`
-
-`DisableRedistribution` controls whether to transmit traces in cache to remaining peers during cluster scaling event.
-
-Redistribution is intended to help prevent data loss by reconsolidating traces onto the appropriate node after a scaling event.
-During scale down events, all stored spans are forwarded to the new owning Refinery peer instance, so it can shut down without dropping spans.
-During scale up events, only stored spans that belong to another Refinery peer instance are forwarded, so that instance can make whole trace decisions.
-Refinery uses additional system resources during scale up/down events.
-If the cluster does not have enough resource capacity headroom, a redistribution event can cause the cluster to go into stress relief (if enabled).
-If `true`, Refinery will NOT forward live traces in its cache to the rest of the peers when peers join or leave the cluster.
-Disabling redistribution can help to prevent disruptive bursts of network traffic when large traces with long `TraceTimeout` are redistributed.
-However, disabling redistribution may also cause partial data loss of traces that were in flight when scaling occurred.
-
-- Eligible for live reload.
-- Type: `defaulttrue`
-- Default: `true`
-
-### `RedistributionDelay`
-
-`RedistributionDelay` controls the amount of time Refinery waits after each cluster scaling event before redistributing in-memory traces.
-
-This value should be longer than the amount of time between individual pod changes in a bulk scaling operation (changing the cluster size by more than one pod).
-Each redistribution generates additional traffic between peers.
-If this value is too short, multiple consecutive redistributions will occur and the resulting traffic may overwhelm the cluster.
-
-- Not eligible for live reload.
-- Type: `duration`
-- Default: `30s`
-
 ### `ShutdownDelay`
 
 `ShutdownDelay` controls the maximum time Refinery can use while draining traces at shutdown.
@@ -1058,26 +971,6 @@ This value should be set to a bit less than the normal timeout period for shutti
 - Eligible for live reload.
 - Type: `duration`
 - Default: `15s`
-
-### `TraceLocalityMode`
-
-`TraceLocalityMode` controls how Refinery handles spans that belong to the same trace in a clustered environment.
-
-This feature is experimental, in active development, and not intended for broad customer use at this time.
-**Distributed mode is UNSUPPORTED without prior coordination with the Honeycomb product engineering team.**
-When `concentrated`, Refinery will route all spans that belong to the same trace to a single peer.
-This is the default behavior ("Trace Locality") and the way Refinery has worked in the past.
-When `distributed`, Refinery will instead keep spans on the node where they were received, and forward proxy spans that contain only the key information needed to make a trace decision.
-This can reduce the amount of traffic between peers, and can help avoid a situation where a single large trace can cause a memory overrun on a single node.
-If `distributed`, the amount of traffic between peers will be reduced, but the amount of traffic between Refinery and Redis will significantly increase, because Refinery uses Redis to distribute the trace decisions to all nodes in the cluster.
-It is important to adjust the size of the Redis cluster in this case.
-The total volume of network traffic in `distributed` mode should be expected to decrease unless the cluster size is very large (hundreds of nodes).
-NOTE: This setting is not compatible with `DryRun` when set to `distributed`.
-See `DryRun` for more information.
-
-- Not eligible for live reload.
-- Type: `string`
-- Default: `concentrated`
 
 ### `HealthCheckTimeout`
 
@@ -1092,10 +985,6 @@ Refinery will adjust the timeout based on the configured `MaxExpiredTraces`, so 
 - Not eligible for live reload.
 - Type: `duration`
 - Default: `15s`
-
-## Buffer Sizes
-
-`BufferSizes` contains the settings that are relevant to the sizes of communications buffers.
 
 ## Specialized Configuration
 

--- a/rules.md
+++ b/rules.md
@@ -3,7 +3,7 @@
 # Honeycomb Refinery Rules Documentation
 
 This is the documentation for the rules configuration for Honeycomb's Refinery.
-It was automatically generated on 2025-07-15 at 17:41:47 UTC.
+It was automatically generated on 2025-10-01 at 18:54:39 UTC.
 
 ## The Rules file
 

--- a/tools/convert/configDataNames.txt
+++ b/tools/convert/configDataNames.txt
@@ -1,5 +1,5 @@
 # Names of groups and fields in the new config file format.
-# Automatically generated on 2025-08-26 at 15:28:21 UTC.
+# Automatically generated on 2025-10-01 at 18:54:37 UTC.
 
 General:
   - ConfigurationVersion

--- a/tools/convert/metricsMeta.yaml
+++ b/tools/convert/metricsMeta.yaml
@@ -340,6 +340,10 @@ hasprefix:
       type: Counter
       unit: Dimensionless
       description: number of errors encountered while decoding responses from destination
+    - name: _stale_dispatch_time
+      type: Histogram
+      unit: Microseconds
+      description: The time spent per iteration of the stale batch dispatch loop
     - name: _router_proxied
       type: Counter
       unit: Dimensionless

--- a/tools/convert/minimal_config.yaml
+++ b/tools/convert/minimal_config.yaml
@@ -1,5 +1,5 @@
 # sample uncommented config file containing all possible fields
-# automatically generated on 2025-08-26 at 15:28:22 UTC
+# automatically generated on 2025-10-01 at 18:54:37 UTC
 General:
   ConfigurationVersion: 2
   MinRefineryVersion: "v2.0"
@@ -61,12 +61,6 @@ StdoutLogger:
 PrometheusMetrics:
   Enabled: false
   ListenAddr: "localhost:2112"
-LegacyMetrics:
-  Enabled: false
-  APIHost: "https://api.honeycomb.io"
-  APIKey: SetThisToAHoneycombKey
-  Dataset: "Refinery Metrics"
-  ReportingInterval: 30s
 OTelMetrics:
   Enabled: false
   APIHost: "https://api.honeycomb.io"
@@ -107,12 +101,8 @@ Collection:
   AvailableMemory: "4.5Gb"
   MaxMemoryPercentage: 75
   MaxAlloc: 0
-  DisableRedistribution: true
-  RedistributionDelay: 30s
   ShutdownDelay: 15s
-  TraceLocalityMode: concentrated
   HealthCheckTimeout: 15s
-BufferSizes:
 Specialized:
   EnvironmentCacheTTL: 1h
   CompressPeerCommunication: true

--- a/tools/convert/templates/cfg_docrepo.tmpl
+++ b/tools/convert/templates/cfg_docrepo.tmpl
@@ -29,11 +29,17 @@ The remainder of this document describes the sections within the file and the fi
 
 ## Table of Contents
 {{ range $file.Groups -}}
+{{- if .LastVersion -}}
+  {{- continue -}}
+{{- end -}}
 - [{{.Title}}](#{{ anchorize .Title }})
 {{- println -}}
 {{- end -}}
 
 {{ range $file.Groups -}}
+{{- if .LastVersion -}}
+  {{- continue -}}
+{{- end -}}
 {{- template "docsite_group" . -}}
 {{- end -}}
 {{- println -}}

--- a/tools/convert/templates/cfg_docsite.tmpl
+++ b/tools/convert/templates/cfg_docsite.tmpl
@@ -25,6 +25,9 @@ OTelMetrics:
 The remainder of this page describes the sections within the file and the fields in each.
 
 {{ range $file.Groups -}}
+{{- if .LastVersion -}}
+  {{- continue -}}
+{{- end -}}
 {{- template "docsite_group" . -}}
 {{- end -}}
 {{- println -}}

--- a/tools/convert/templates/configV2.tmpl
+++ b/tools/convert/templates/configV2.tmpl
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created {{ now }} from {{ .Input }} using a template generated on 2025-08-26 at 15:28:20 UTC
+# created {{ now }} from {{ .Input }} using a template generated on 2025-10-01 at 18:54:36 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of
@@ -10,7 +10,6 @@
 # informational only. Text preceded by a single comment character (#) indicates
 # a value that is commented out and not used; it should be uncommented to enable
 # it.
-
 
 ###########################
 ## General Configuration ##
@@ -634,64 +633,6 @@ PrometheusMetrics:
     ## Not eligible for live reload.
     {{ nonDefaultOnly .Data "ListenAddr" "PrometheusMetrics.MetricsListenAddr" "localhost:2112" }}
 
-####################
-## Legacy Metrics ##
-####################
-LegacyMetrics:
-  ## LegacyMetrics contains configuration for Refinery's legacy metrics.
-  ## Version 1.x of Refinery used this format for sending Metrics to
-  ## Honeycomb. The metrics generated that way are nonstandard and will be
-  ## deprecated in a future release. New installations should prefer
-  ## `OTelMetrics`.
-  ##
-  ####
-    ## Enabled controls whether to send legacy-formatted metrics to
-    ## Honeycomb.
-    ##
-    ## Each of the metrics providers can be enabled or disabled
-    ## independently. Metrics can be sent to multiple destinations.
-    ##
-    ## Not eligible for live reload.
-    {{ conditional .Data "Enabled" "eq Metrics honeycomb" }}
-
-    ## APIHost is the URL of the Honeycomb API where legacy metrics are sent.
-    ##
-    ## Refinery's internal metrics will be sent to this host using the
-    ## standard Honeycomb Events API.
-    ##
-    ## default: https://api.honeycomb.io
-    ## Not eligible for live reload.
-    {{ nonDefaultOnly .Data "APIHost" "HoneycombMetrics.MetricsHoneycombAPI" "https://api.honeycomb.io" }}
-
-    ## APIKey is the API key used by Refinery to send its metrics to
-    ## Honeycomb. Setting this value via a command line flag may expose
-    ## credentials - it is recommended to use the environment variable or a
-    ## configuration file.
-    ##
-    ## It is recommended that you create a separate team and key for Refinery
-    ## metrics.
-    ##
-    ## Not eligible for live reload.
-    {{ nonDefaultOnly .Data "APIKey" "HoneycombMetrics.MetricsAPIKey" "" }}
-
-    ## Dataset is the Honeycomb dataset where Refinery sends its metrics.
-    ##
-    ## Only used if `APIKey` is specified.
-    ##
-    ## default: Refinery Metrics
-    ## Not eligible for live reload.
-    {{ nonDefaultOnly .Data "Dataset" "HoneycombMetrics.MetricsDataset" "Refinery Metrics" }}
-
-    ## ReportingInterval is the interval between sending legacy metrics to
-    ## Honeycomb.
-    ##
-    ## Between 1 and 60 seconds is typical.
-    ##
-    ## Accepts a duration string with units, like "30s".
-    ## default: 30s
-    ## Not eligible for live reload.
-    {{ secondsToDuration .Data "ReportingInterval" "HoneycombMetrics.MetricsReportingInterval" "" }}
-
 ###########################
 ## OpenTelemetry Metrics ##
 ###########################
@@ -1013,7 +954,7 @@ Collection:
     ##
     ## default: 30000
     ## Not eligible for live reload.
-    {{ nonDefaultOnly .Data "PeerQueueSize" "Collection.PeerQueueSize" 30000 }}
+    {{ nonDefaultOnly .Data "PeerQueueSize" "PeerQueueSize" 30000 }}
 
     ## IncomingQueueSize is the number of in-flight spans to keep in the
     ## incoming span queue.
@@ -1025,7 +966,7 @@ Collection:
     ##
     ## default: 30000
     ## Not eligible for live reload.
-    {{ nonDefaultOnly .Data "IncomingQueueSize" "Collection.IncomingQueueSize" 30000 }}
+    {{ nonDefaultOnly .Data "IncomingQueueSize" "IncomingQueueSize" 30000 }}
 
     ## AvailableMemory is the amount of system memory available to the
     ## Refinery process.
@@ -1072,45 +1013,6 @@ Collection:
     ## Eligible for live reload.
     {{ memorysize .Data "MaxAlloc" "InMemCollector.MaxAlloc" "" }}
 
-    ## DisableRedistribution controls whether to transmit traces in cache to
-    ## remaining peers during cluster scaling event.
-    ##
-    ## Redistribution is intended to help prevent data loss by
-    ## reconsolidating traces onto the appropriate node after a scaling
-    ## event. During scale down events, all stored spans are forwarded to the
-    ## new owning Refinery peer instance, so it can shut down without
-    ## dropping spans. During scale up events, only stored spans that belong
-    ## to another Refinery peer instance are forwarded, so that instance can
-    ## make whole trace decisions. Refinery uses additional system resources
-    ## during scale up/down events. If the cluster does not have enough
-    ## resource capacity headroom, a redistribution event can cause the
-    ## cluster to go into stress relief (if enabled).
-    ## If `true`, Refinery will NOT forward live traces in its cache to the
-    ## rest of the peers when peers join or leave the cluster. Disabling
-    ## redistribution can help to prevent disruptive bursts of network
-    ## traffic when large traces with long `TraceTimeout` are redistributed.
-    ## However, disabling redistribution may also cause partial data loss of
-    ## traces that were in flight when scaling occurred.
-    ##
-    ## default: true
-    ## Eligible for live reload.
-    {{ nonDefaultOnly .Data "DisableRedistribution" "DisableRedistribution" true }}
-
-    ## RedistributionDelay controls the amount of time Refinery waits after
-    ## each cluster scaling event before redistributing in-memory traces.
-    ##
-    ## This value should be longer than the amount of time between individual
-    ## pod changes in a bulk scaling operation (changing the cluster size by
-    ## more than one pod). Each redistribution generates additional traffic
-    ## between peers. If this value is too short, multiple consecutive
-    ## redistributions will occur and the resulting traffic may overwhelm the
-    ## cluster.
-    ##
-    ## Accepts a duration string with units, like "30s".
-    ## default: 30s
-    ## Not eligible for live reload.
-    {{ nonDefaultOnly .Data "RedistributionDelay" "RedistributionDelay" "30s" }}
-
     ## ShutdownDelay controls the maximum time Refinery can use while
     ## draining traces at shutdown.
     ##
@@ -1126,35 +1028,6 @@ Collection:
     ## default: 15s
     ## Eligible for live reload.
     {{ nonDefaultOnly .Data "ShutdownDelay" "ShutdownDelay" "15s" }}
-
-    ## TraceLocalityMode controls how Refinery handles spans that belong to
-    ## the same trace in a clustered environment.
-    ##
-    ## This feature is experimental, in active development, and not intended
-    ## for broad customer use at this time. **Distributed mode is UNSUPPORTED
-    ## without prior coordination with the Honeycomb product engineering
-    ## team.**
-    ## When `concentrated`, Refinery will route all spans that belong to the
-    ## same trace to a single peer. This is the default behavior ("Trace
-    ## Locality") and the way Refinery has worked in the past. When
-    ## `distributed`, Refinery will instead keep spans on the node where they
-    ## were received, and forward proxy spans that contain only the key
-    ## information needed to make a trace decision. This can reduce the
-    ## amount of traffic between peers, and can help avoid a situation where
-    ## a single large trace can cause a memory overrun on a single node.
-    ## If `distributed`, the amount of traffic between peers will be reduced,
-    ## but the amount of traffic between Refinery and Redis will
-    ## significantly increase, because Refinery uses Redis to distribute the
-    ## trace decisions to all nodes in the cluster. It is important to adjust
-    ## the size of the Redis cluster in this case.
-    ## The total volume of network traffic in `distributed` mode should be
-    ## expected to decrease unless the cluster size is very large (hundreds
-    ## of nodes). NOTE: This setting is not compatible with `DryRun` when set
-    ## to `distributed`. See `DryRun` for more information.
-    ##
-    ## default: concentrated
-    ## Not eligible for live reload.
-    {{ nonDefaultOnly .Data "TraceLocalityMode" "TraceLocalityMode" "concentrated" }}
 
     ## HealthCheckTimeout controls the maximum duration allowed for
     ## collection health checks to complete.
@@ -1177,14 +1050,6 @@ Collection:
     ## Not eligible for live reload.
     {{ nonDefaultOnly .Data "HealthCheckTimeout" "HealthCheckTimeout" "15s" }}
 
-##################
-## Buffer Sizes ##
-##################
-BufferSizes:
-  ## BufferSizes contains the settings that are relevant to the sizes of
-  ## communications buffers.
-  ##
-  ####
 ###############################
 ## Specialized Configuration ##
 ###############################
@@ -1505,18 +1370,25 @@ StressRelief:
     ## Eligible for live reload.
     {{ nonDefaultOnly .Data "MinimumActivationDuration" "StressRelief.MinimumActivationDuration" "10s" }}
 
+
 ###################################################
 ## Config values removed by the config converter ##
 ###################################################
   ## The following configuration options are obsolete and are not included
   ## in the new configuration:
   ##
+    ## - LegacyMetrics
     ## - PeerManagement.Prefix
     ## - PeerManagement.Database
     ## - PeerManagement.Strategy
     ## - InMemCollector.CacheCapacity
-    ## - BufferSizes.UpstreamBufferSize
-    ## - BufferSizes.PeerBufferSize
+    ## - Collection.DisableRedistribution
+    ## - Collection.RedistributionDelay
+    ## - Collection.TraceLocalityMode
+    ## - Collection.MaxDropDecisionBatchSize
+    ## - Collection.DropDecisionSendInterval
+    ## - Collection.MaxKeptDecisionBatchSize
+    ## - Collection.KeptDecisionSendInterval
     ## - BufferSizes
     ## - Collector
     ## - InMemCollector.CacheOverrunStrategy

--- a/tools/convert/templates/gengroup.tmpl
+++ b/tools/convert/templates/gengroup.tmpl
@@ -1,4 +1,6 @@
 {{- $group := . }}
+{{- if .LastVersion -}}
+{{- else -}}
 {{ box $group.Title }}
 {{ $group.Name }}:
 {{ printf "%s %s" $group.Name $group.Description | wordwrap | comment | indent 2 }}
@@ -12,4 +14,5 @@
 {{- end -}}
 {{ template "genfield.tmpl" . }}
 {{- end -}}
-
+{{- println -}}
+{{- end -}}

--- a/tools/convert/templates/sample.tmpl
+++ b/tools/convert/templates/sample.tmpl
@@ -3,6 +3,9 @@
 {{- $file := . -}}
 {{ range $file.Groups -}}
     {{- $group := . }}
+    {{- if .LastVersion -}}
+        {{- continue -}}
+    {{- end -}}
     {{- println -}}
     {{- $group.Name | indent 0 }}:
     {{- range $group.Fields -}}


### PR DESCRIPTION
## Which problem is this PR solving?

This PR generates docs and configs using the internal `convert` tool.

When we added the feature to allow deprecating a config group, we didn't update all go template used for the convert tool to honor the feature. This PR adds the support in convert template as well.

## Short description of the changes

- generate all docs
- update template used for generating docs to honor group deprecation

