### PR TITLE
fix: unpublish OpAMP configs

### DIFF
--- a/config.md
+++ b/config.md
@@ -3,7 +3,7 @@
 # Honeycomb Refinery Configuration Documentation
 
 This is the documentation for the configuration file for Honeycomb's Refinery.
-It was automatically generated on 2025-10-01 at 18:54:38 UTC.
+It was automatically generated on 2025-10-02 at 19:03:23 UTC.
 
 ## The Config file
 
@@ -157,41 +157,6 @@ This setting is the destination to which Refinery sends all events that it decid
 OpAMP support is an experimental feature, subject to breaking changes at any time.
 Not intended or supported for customer use.
 **FOR INTERNAL USE ONLY**
-
-### `Enabled`
-
-Enabled controls whether to enable OpAMP support.
-
-OpAMP support is an experimental feature, subject to breaking changes at any time.
-Not intended or supported for customer use.
-**FOR INTERNAL USE ONLY**
-
-- Not eligible for live reload.
-- Type: `bool`
-
-### `RecordUsage`
-
-RecordUsage controls whether to record usage metrics.
-
-OpAMP support is an experimental feature, subject to breaking changes at any time.
-Not intended or supported for customer use.
-**FOR INTERNAL USE ONLY**
-
-- Eligible for live reload.
-- Type: `bool`
-- Default: `true`
-
-### `Endpoint`
-
-Endpoint is the URL of the OpAMP server for this client.
-
-OpAMP support is an experimental feature, subject to breaking changes at any time.
-Not intended or supported for customer use.
-**FOR INTERNAL USE ONLY**
-
-- Not eligible for live reload.
-- Type: `string`
-- Default: `wss://127.0.0.1:4320/v1/opamp`
 
 ## Access Key Configuration
 

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -154,6 +154,7 @@ groups:
         valuetype: nondefault
         default: false
         reload: false
+        unpublished: true
         firstversion: v2.9.4
         summary: controls whether to enable OpAMP support.
         description: >
@@ -163,6 +164,7 @@ groups:
         type: defaulttrue
         valuetype: nondefault
         default: true
+        unpublished: true
         reload: true
         firstversion: v2.9.4
         summary: controls whether to record usage metrics.
@@ -173,6 +175,7 @@ groups:
         type: string
         valuetype: assigndefault
         default: "wss://127.0.0.1:4320/v1/opamp"
+        unpublished: true
         reload: false
         firstversion: v2.9.4
         summary: is the URL of the OpAMP server for this client.

--- a/config_complete.yaml
+++ b/config_complete.yaml
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created on 2025-10-01 at 18:54:38 UTC from ../../config.yaml using a template generated on 2025-10-01 at 18:54:36 UTC
+# created on 2025-10-02 at 19:03:22 UTC from ../../config.yaml using a template generated on 2025-10-02 at 19:03:19 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of
@@ -136,35 +136,6 @@ OpAMP:
   ## intended or supported for customer use. **FOR INTERNAL USE ONLY**
   ##
   ####
-    ## Enabled controls whether to enable OpAMP support.
-    ##
-    ## OpAMP support is an experimental feature, subject to breaking changes
-    ## at any time. Not intended or supported for customer use. **FOR
-    ## INTERNAL USE ONLY**
-    ##
-    ## Not eligible for live reload.
-    # Enabled: false
-
-    ## RecordUsage controls whether to record usage metrics.
-    ##
-    ## OpAMP support is an experimental feature, subject to breaking changes
-    ## at any time. Not intended or supported for customer use. **FOR
-    ## INTERNAL USE ONLY**
-    ##
-    ## default: true
-    ## Eligible for live reload.
-    # RecordUsage: true
-
-    ## Endpoint is the URL of the OpAMP server for this client.
-    ##
-    ## OpAMP support is an experimental feature, subject to breaking changes
-    ## at any time. Not intended or supported for customer use. **FOR
-    ## INTERNAL USE ONLY**
-    ##
-    ## default: wss://127.0.0.1:4320/v1/opamp
-    ## Not eligible for live reload.
-    Endpoint: wss://127.0.0.1:4320/v1/opamp
-
 ##############################
 ## Access Key Configuration ##
 ##############################

--- a/refinery_config.md
+++ b/refinery_config.md
@@ -135,41 +135,6 @@ OpAMP support is an experimental feature, subject to breaking changes at any tim
 Not intended or supported for customer use.
 **FOR INTERNAL USE ONLY**
 
-### `Enabled`
-
-`Enabled` controls whether to enable OpAMP support.
-
-OpAMP support is an experimental feature, subject to breaking changes at any time.
-Not intended or supported for customer use.
-**FOR INTERNAL USE ONLY**
-
-- Not eligible for live reload.
-- Type: `bool`
-
-### `RecordUsage`
-
-`RecordUsage` controls whether to record usage metrics.
-
-OpAMP support is an experimental feature, subject to breaking changes at any time.
-Not intended or supported for customer use.
-**FOR INTERNAL USE ONLY**
-
-- Eligible for live reload.
-- Type: `defaulttrue`
-- Default: `true`
-
-### `Endpoint`
-
-`Endpoint` is the URL of the OpAMP server for this client.
-
-OpAMP support is an experimental feature, subject to breaking changes at any time.
-Not intended or supported for customer use.
-**FOR INTERNAL USE ONLY**
-
-- Not eligible for live reload.
-- Type: `string`
-- Default: `wss://127.0.0.1:4320/v1/opamp`
-
 ## Access Key Configuration
 
 `AccessKeys` contains access keys -- API keys that the proxy will treat specially, and other flags that control how the proxy handles API keys.

--- a/tools/convert/configDataNames.txt
+++ b/tools/convert/configDataNames.txt
@@ -1,5 +1,5 @@
 # Names of groups and fields in the new config file format.
-# Automatically generated on 2025-10-01 at 18:54:37 UTC.
+# Automatically generated on 2025-10-02 at 19:03:20 UTC.
 
 General:
   - ConfigurationVersion

--- a/tools/convert/minimal_config.yaml
+++ b/tools/convert/minimal_config.yaml
@@ -1,5 +1,5 @@
 # sample uncommented config file containing all possible fields
-# automatically generated on 2025-10-01 at 18:54:37 UTC
+# automatically generated on 2025-10-02 at 19:03:20 UTC
 General:
   ConfigurationVersion: 2
   MinRefineryVersion: "v2.0"
@@ -11,9 +11,6 @@ Network:
   HTTPIdleTimeout: 0s
   HoneycombAPI: "https://api.honeycomb.io"
 OpAMP:
-  Enabled: false
-  RecordUsage: true
-  Endpoint: "wss://127.0.0.1:4320/v1/opamp"
 AccessKeys:
   ReceiveKeys: 
     - "your-key-goes-here"

--- a/tools/convert/templates/configV2.tmpl
+++ b/tools/convert/templates/configV2.tmpl
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created {{ now }} from {{ .Input }} using a template generated on 2025-10-01 at 18:54:36 UTC
+# created {{ now }} from {{ .Input }} using a template generated on 2025-10-02 at 19:03:19 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of
@@ -136,35 +136,6 @@ OpAMP:
   ## intended or supported for customer use. **FOR INTERNAL USE ONLY**
   ##
   ####
-    ## Enabled controls whether to enable OpAMP support.
-    ##
-    ## OpAMP support is an experimental feature, subject to breaking changes
-    ## at any time. Not intended or supported for customer use. **FOR
-    ## INTERNAL USE ONLY**
-    ##
-    ## Not eligible for live reload.
-    {{ nonDefaultOnly .Data "Enabled" "Enabled" false }}
-
-    ## RecordUsage controls whether to record usage metrics.
-    ##
-    ## OpAMP support is an experimental feature, subject to breaking changes
-    ## at any time. Not intended or supported for customer use. **FOR
-    ## INTERNAL USE ONLY**
-    ##
-    ## default: true
-    ## Eligible for live reload.
-    {{ nonDefaultOnly .Data "RecordUsage" "RecordUsage" true }}
-
-    ## Endpoint is the URL of the OpAMP server for this client.
-    ##
-    ## OpAMP support is an experimental feature, subject to breaking changes
-    ## at any time. Not intended or supported for customer use. **FOR
-    ## INTERNAL USE ONLY**
-    ##
-    ## default: wss://127.0.0.1:4320/v1/opamp
-    ## Not eligible for live reload.
-    Endpoint: wss://127.0.0.1:4320/v1/opamp
-
 ##############################
 ## Access Key Configuration ##
 ##############################


### PR DESCRIPTION
## Which problem is this PR solving?

All opamp configs should not be published for public use since it's internal use only

## Short description of the changes

- marks opamp configs as `unpublished`
- re-generate docs

