### PR TITLE
perf: reduce MultiMetrics lock contention using sync.map

### DIFF
--- a/metrics/multi_metrics.go
+++ b/metrics/multi_metrics.go
@@ -20,14 +20,14 @@ var _ Metrics = (*MultiMetrics)(nil)
 //
 // To minimize lock contention, this implementation uses sync.Map for lock-free
 // concurrent access to metric values. atomic.Uint64 and atomic.Int64 types are used
-// for lock-free concurrent updates.
+// for reduced lock contention.
 type MultiMetrics struct {
 	Config      config.Config  `inject:""`
 	PromMetrics MetricsBackend `inject:"promMetrics"`
 	OTelMetrics MetricsBackend `inject:"otelMetrics"`
 	children    []MetricsBackend
 
-	// Use sync.Map with atomic types for lock-free concurrent access
+	// Use sync.Map with atomic types for reduced lock contention across metric types
 	counters sync.Map // map[string]*atomic.Uint64
 	gauges   sync.Map // map[string]*atomic.Uint64 (stores float64 bits)
 	updowns  sync.Map // map[string]*atomic.Int64 (can be negative)


### PR DESCRIPTION
## Which problem is this PR solving?

`MultiMetrics` shares one lock among all metric values. This creates lock contention in hot paths like per event operations.
This PR changes from using a shared lock to `sync.map` with atomic values. This reduces lock contention by around 18% in benchmark. I'm hopeful it should have a greater impact in hot paths.

## Benchmark Result
```
goos: darwin
goarch: arm64
pkg: github.com/honeycombio/refinery/metrics
cpu: Apple M2 Max
                                         │   old.txt   │               new.txt               │
                                         │   sec/op    │   sec/op     vs base                │
ConcurrentAccess/ConcurrentCounters-12     312.4n ± 0%   254.4n ± 1%  -18.57% (p=0.000 n=10)
ConcurrentAccess/ConcurrentGauges-12       305.2n ± 1%   246.4n ± 1%  -19.24% (p=0.000 n=10)
ConcurrentAccess/ConcurrentHistograms-12   254.2n ± 0%   255.3n ± 1%   +0.45% (p=0.007 n=10)
ConcurrentAccess/ConcurrentMixed-12        280.0n ± 1%   220.1n ± 3%  -21.41% (p=0.000 n=10)
geomean                                    287.0n        243.6n       -15.11%

                                         │   old.txt    │               new.txt               │
                                         │     B/op     │    B/op     vs base                 │
ConcurrentAccess/ConcurrentCounters-12     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
ConcurrentAccess/ConcurrentGauges-12       0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
ConcurrentAccess/ConcurrentHistograms-12   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
ConcurrentAccess/ConcurrentMixed-12        0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                               ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                                         │   old.txt    │               new.txt               │
                                         │  allocs/op   │ allocs/op   vs base                 │
ConcurrentAccess/ConcurrentCounters-12     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
ConcurrentAccess/ConcurrentGauges-12       0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
ConcurrentAccess/ConcurrentHistograms-12   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
ConcurrentAccess/ConcurrentMixed-12        0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                               ²               +0.00%        
```

