### PR TITLE
feat: enable  GOEXPERIMENT=greenteagc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,7 +201,7 @@ jobs:
 
   smoke-test:
     machine:
-      image: ubuntu-2204:2024.01.1
+      image: ubuntu-2204:2025.09.1
     steps:
       - checkout
       - restore_cache:

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -63,6 +63,7 @@ unset GOARCH
 export GOFLAGS="-ldflags=-X=main.BuildID=$VERSION"
 export SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH:-$(make latest_modification_time)}
 export GOEXPERIMENT=greenteagc
+go version
 
 # If KO_DOCKER_REPOS is set (comma-separated list), build once and push to multiple registries
 if [[ -n "${KO_DOCKER_REPOS:-}" ]]; then


### PR DESCRIPTION
## Which problem is this PR solving?

Per https://tip.golang.org/doc/go1.25#new-experimental-garbage-collector we can expect 10-40% improvements in GC overhead. I would like to see if this will shrink GC overhead for Refinery as well

## Short description of the changes

- enalbe  GOEXPERIMENT=greenteagc

