### PR TITLE
perf: reduce lock contention for health check system

### DIFF
--- a/collect/collect.go
+++ b/collect/collect.go
@@ -332,20 +332,8 @@ func (i *InMemCollector) isReady() bool {
 	timeout := i.Config.GetHealthCheckTimeout()
 
 	for _, worker := range i.workers {
-		lastUpdate := worker.lastHealthUpdate.Load()
-		if lastUpdate == 0 {
-			// Worker hasn't initialized yet, consider it not healthy
-			ready = false
-		}
-
-		lastUpdateTime := time.Unix(0, lastUpdate)
-		if now.Sub(lastUpdateTime) > timeout {
-			// Worker hasn't reported in within timeout period
-			i.Logger.Warn().
-				WithField("worker_id", worker.ID).
-				WithField("last_update", lastUpdateTime).
-				WithField("timeout", timeout).
-				Logf("Worker is unhealthy - hasn't reported within timeout")
+		healthy := worker.IsHealthy(now, timeout)
+		if !healthy {
 			ready = false
 		}
 	}

--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -1839,7 +1839,7 @@ func TestWorkerHealthReporting(t *testing.T) {
 	}, 2*time.Second, 50*time.Millisecond, "InMemCollector should initially be healthy")
 
 	for i, worker := range coll.workers {
-		lastUpdate := worker.lastHealthUpdate.Load()
+		lastUpdate := worker.healthCheckInAt.Load()
 		assert.NotZero(t, lastUpdate, "Worker %d should have initialized health timestamp", i)
 	}
 


### PR DESCRIPTION
## Which problem is this PR solving?

Refinery’s health check system relies on a global state protected by a mutex. 

### Before:

Each worker registers and reports its readiness by writing to the global Health state. When Refinery runs with many workers, these concurrent updates lead to high lock contention, negatively impacting performance.

### After:

The Collector registers with the Health system. The Collector's readiness check is whether all its workers are healthy. Workers keep track of their own health check-in times to reduce updates to global Health state.

## Short description of the changes

This change introduces a collector-level health aggregation model:
- Each worker reports its health only to its collector (local state).
- The collector is solely responsible for reporting health to the global health system.
- If all workers are healthy, the collector reports healthy.
- If any worker is unhealthy, the collector reports unhealthy.

