### PR TITLE
perf: reduce the amount of time the write lock is held during drain()

### DIFF
--- a/collect/cache/cuckoo.go
+++ b/collect/cache/cuckoo.go
@@ -121,6 +121,7 @@ func (c *CuckooTraceChecker) drain() {
 		return
 	}
 	batch := batchPool.Get().([]string)
+	timeout := time.NewTimer(500 * time.Microsecond)
 queueLoop:
 	for i := 0; i < n; i++ {
 		select {
@@ -129,11 +130,10 @@ queueLoop:
 			if !ok {
 				break queueLoop
 			}
-			if len(batch) >= AddQueueDepth {
-				break queueLoop
-			}
 			// building up the queue
 			batch = append(batch, t)
+		case <-timeout.C:
+			break queueLoop
 		default:
 			// if the channel is empty, stop
 			break queueLoop


### PR DESCRIPTION
## Which problem is this PR solving?

Reading from a channel is concurrency-safe in Go, so there’s no need to hold a mutex while pulling work from it. Currently, holding the lock during this phase causes unnecessary contention, limiting throughput and slowing down channel draining.

This change reduces lock contention and gives more room for concurrent readers to operate efficiently.

## Short description of the changes

- Build the batch of trace decisions that need to be inserted into the cuckoo cache concurrently. 
- Only grab the mutex when actually doing the insertion.

