### PR TITLE
fix: more Collect Loop -> Worker renaming

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -264,7 +264,7 @@ func defaultConfigWithGRPC(basePort int, redisDB int, apiURL string, enableGRPC 
 		GetPeerListenAddrVal: "127.0.0.1:" + strconv.Itoa(basePort+1),
 		GetHoneycombAPIVal:   apiURL,
 		GetCollectionConfigVal: config.CollectionConfig{
-			NumCollectLoops:    8,
+			WorkerCount:        8,
 			ShutdownDelay:      config.Duration(1 * time.Second),
 			HealthCheckTimeout: config.Duration(3 * time.Second),
 			IncomingQueueSize:  30000,

--- a/collect/collect.go
+++ b/collect/collect.go
@@ -179,7 +179,7 @@ func (i *InMemCollector) Start() error {
 	defer func() { i.Logger.Debug().Logf("Finished starting InMemCollector") }()
 	imcConfig := i.Config.GetCollectionConfig()
 
-	numWorkers := imcConfig.GetNumCollectLoops()
+	numWorkers := imcConfig.GetWorkerCount()
 
 	i.Logger.Info().WithField("num_workers", numWorkers).Logf("Starting InMemCollector with %d workers", numWorkers)
 
@@ -189,7 +189,7 @@ func (i *InMemCollector) Start() error {
 	i.Config.RegisterReloadCallback(i.sendReloadSignal)
 
 	// Find or create a test, make sure we signal health based (somehow)
-	// on all the collect loops running.
+	// on all the collect workers running.
 	i.Health.Register(collectorHealthKey, i.Config.GetHealthCheckTimeout())
 
 	for _, metric := range inMemCollectorMetrics {
@@ -219,9 +219,9 @@ func (i *InMemCollector) Start() error {
 
 	i.workers = make([]*CollectorWorker, numWorkers)
 
-	for loopID := range i.workers {
-		worker := NewCollectorWorker(loopID, i, imcConfig.GetIncomingQueueSizePerLoop(), imcConfig.GetPeerQueueSizePerLoop())
-		i.workers[loopID] = worker
+	for workerID := range i.workers {
+		worker := NewCollectorWorker(workerID, i, imcConfig.GetIncomingQueueSizePerWorker(), imcConfig.GetPeerQueueSizePerWorker())
+		i.workers[workerID] = worker
 
 		// Start the collect goroutine for this worker
 		i.workersWG.Add(1)

--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -160,7 +160,7 @@ func TestAddRootSpan(t *testing.T) {
 		TraceIdFieldNames:  []string{"trace.trace_id", "traceId"},
 		ParentIdFieldNames: []string{"trace.parent_id", "parentId"},
 		GetCollectionConfigVal: config.CollectionConfig{
-			NumCollectLoops:   2,
+			WorkerCount:       2,
 			ShutdownDelay:     config.Duration(1 * time.Millisecond),
 			IncomingQueueSize: 5,
 			PeerQueueSize:     5,
@@ -244,7 +244,7 @@ func TestOriginalSampleRateIsNotedInMetaField(t *testing.T) {
 		TraceIdFieldNames:  []string{"trace.trace_id", "traceId"},
 		ParentIdFieldNames: []string{"trace.parent_id", "parentId"},
 		GetCollectionConfigVal: config.CollectionConfig{
-			NumCollectLoops:   2,
+			WorkerCount:       2,
 			ShutdownDelay:     config.Duration(1 * time.Millisecond),
 			IncomingQueueSize: 5,
 			PeerQueueSize:     5,
@@ -330,7 +330,7 @@ func TestTransmittedSpansShouldHaveASampleRateOfAtLeastOne(t *testing.T) {
 		TraceIdFieldNames:  []string{"trace.trace_id", "traceId"},
 		ParentIdFieldNames: []string{"trace.parent_id", "parentId"},
 		GetCollectionConfigVal: config.CollectionConfig{
-			NumCollectLoops:   2,
+			WorkerCount:       2,
 			ShutdownDelay:     config.Duration(1 * time.Millisecond),
 			IncomingQueueSize: 5,
 			PeerQueueSize:     5,
@@ -376,7 +376,7 @@ func TestAddSpan(t *testing.T) {
 		TraceIdFieldNames:  []string{"trace.trace_id", "traceId"},
 		ParentIdFieldNames: []string{"trace.parent_id", "parentId"},
 		GetCollectionConfigVal: config.CollectionConfig{
-			NumCollectLoops:   2,
+			WorkerCount:       2,
 			ShutdownDelay:     config.Duration(1 * time.Millisecond),
 			IncomingQueueSize: 5,
 			PeerQueueSize:     5,
@@ -461,7 +461,7 @@ func TestDryRunMode(t *testing.T) {
 		TraceIdFieldNames:  []string{"trace.trace_id", "traceId"},
 		ParentIdFieldNames: []string{"trace.parent_id", "parentId"},
 		GetCollectionConfigVal: config.CollectionConfig{
-			NumCollectLoops:   2,
+			WorkerCount:       2,
 			ShutdownDelay:     config.Duration(1 * time.Millisecond),
 			IncomingQueueSize: 5,
 			PeerQueueSize:     5,
@@ -590,7 +590,7 @@ func TestSampleConfigReload(t *testing.T) {
 		TraceIdFieldNames:  []string{"trace.trace_id", "traceId"},
 		ParentIdFieldNames: []string{"trace.parent_id", "parentId"},
 		GetCollectionConfigVal: config.CollectionConfig{
-			NumCollectLoops:   1,
+			WorkerCount:       1,
 			IncomingQueueSize: 10,
 			ShutdownDelay:     config.Duration(1 * time.Millisecond),
 		},
@@ -721,7 +721,7 @@ func TestStableMaxAlloc(t *testing.T) {
 		TraceIdFieldNames:  []string{"trace.trace_id", "traceId"},
 		ParentIdFieldNames: []string{"trace.parent_id", "parentId"},
 		GetCollectionConfigVal: config.CollectionConfig{
-			NumCollectLoops:   2,
+			WorkerCount:       2,
 			ShutdownDelay:     config.Duration(1 * time.Millisecond),
 			IncomingQueueSize: 1000,
 			PeerQueueSize:     5,
@@ -779,8 +779,8 @@ func TestStableMaxAlloc(t *testing.T) {
 	var mem runtime.MemStats
 	runtime.ReadMemStats(&mem)
 
-	// With parallel loops, memory management is more aggressive as each loop
-	// gets 1/numLoops of the memory limit. Set a higher threshold to get
+	// With parallel workers, memory management is more aggressive as each worker
+	// gets 1/numWorkers of the memory limit. Set a higher threshold to get
 	// partial eviction rather than complete eviction.
 	conf.SetMaxAlloc(config.MemorySize(mem.Alloc * 98 / 100)) // More conservative than 99.5%
 	coll.reloadConfigs()
@@ -826,7 +826,7 @@ func TestAddSpanNoBlock(t *testing.T) {
 		TraceIdFieldNames:  []string{"trace.trace_id", "traceId"},
 		ParentIdFieldNames: []string{"trace.parent_id", "parentId"},
 		GetCollectionConfigVal: config.CollectionConfig{
-			NumCollectLoops:   2,
+			WorkerCount:       2,
 			ShutdownDelay:     config.Duration(1 * time.Millisecond),
 			IncomingQueueSize: 10,
 			PeerQueueSize:     10,
@@ -917,7 +917,7 @@ func TestAddCountsToRoot(t *testing.T) {
 		TraceIdFieldNames:  []string{"trace.trace_id", "traceId"},
 		ParentIdFieldNames: []string{"trace.parent_id", "parentId"},
 		GetCollectionConfigVal: config.CollectionConfig{
-			NumCollectLoops:   2,
+			WorkerCount:       2,
 			ShutdownDelay:     config.Duration(1 * time.Millisecond),
 			IncomingQueueSize: 9,
 			PeerQueueSize:     9,
@@ -1016,7 +1016,7 @@ func TestLateRootGetsCounts(t *testing.T) {
 		ParentIdFieldNames:   []string{"trace.parent_id", "parentId"},
 		AddRuleReasonToTrace: true,
 		GetCollectionConfigVal: config.CollectionConfig{
-			NumCollectLoops:   2,
+			WorkerCount:       2,
 			ShutdownDelay:     config.Duration(1 * time.Millisecond),
 			IncomingQueueSize: 10,
 			PeerQueueSize:     10,
@@ -1101,7 +1101,7 @@ func TestAddSpanCount(t *testing.T) {
 		TraceIdFieldNames:  []string{"trace.trace_id", "traceId"},
 		ParentIdFieldNames: []string{"trace.parent_id", "parentId"},
 		GetCollectionConfigVal: config.CollectionConfig{
-			NumCollectLoops:   2,
+			WorkerCount:       2,
 			ShutdownDelay:     config.Duration(1 * time.Millisecond),
 			IncomingQueueSize: 5,
 			PeerQueueSize:     5,
@@ -1179,7 +1179,7 @@ func TestLateRootGetsSpanCount(t *testing.T) {
 		TraceIdFieldNames:    []string{"trace.trace_id", "traceId"},
 		AddRuleReasonToTrace: true,
 		GetCollectionConfigVal: config.CollectionConfig{
-			NumCollectLoops:   2,
+			WorkerCount:       2,
 			ShutdownDelay:     config.Duration(1 * time.Millisecond),
 			IncomingQueueSize: 5,
 			PeerQueueSize:     5,
@@ -1245,7 +1245,7 @@ func TestLateSpanNotDecorated(t *testing.T) {
 		ParentIdFieldNames: []string{"trace.parent_id", "parentId"},
 		TraceIdFieldNames:  []string{"trace.trace_id", "traceId"},
 		GetCollectionConfigVal: config.CollectionConfig{
-			NumCollectLoops:   2,
+			WorkerCount:       2,
 			ShutdownDelay:     config.Duration(1 * time.Millisecond),
 			IncomingQueueSize: 5,
 			PeerQueueSize:     5,
@@ -1309,7 +1309,7 @@ func TestAddAdditionalAttributes(t *testing.T) {
 			"other": "bar",
 		},
 		GetCollectionConfigVal: config.CollectionConfig{
-			NumCollectLoops:   2,
+			WorkerCount:       2,
 			ShutdownDelay:     config.Duration(1 * time.Millisecond),
 			IncomingQueueSize: 5,
 			PeerQueueSize:     5,
@@ -1368,8 +1368,8 @@ func TestStressReliefSampleRate(t *testing.T) {
 		TraceIdFieldNames:  []string{"trace.trace_id", "traceId"},
 		ParentIdFieldNames: []string{"trace.parent_id", "parentId"},
 		GetCollectionConfigVal: config.CollectionConfig{
-			NumCollectLoops: 2,
-			ShutdownDelay:   config.Duration(1 * time.Millisecond),
+			WorkerCount:   2,
+			ShutdownDelay: config.Duration(1 * time.Millisecond),
 		},
 	}
 
@@ -1460,7 +1460,7 @@ func TestStressReliefDecorateHostname(t *testing.T) {
 			SamplingRate:      100,
 		},
 		GetCollectionConfigVal: config.CollectionConfig{
-			NumCollectLoops:   2,
+			WorkerCount:       2,
 			ShutdownDelay:     config.Duration(1 * time.Millisecond),
 			IncomingQueueSize: 5,
 			PeerQueueSize:     5,
@@ -1559,7 +1559,7 @@ func TestSpanWithRuleReasons(t *testing.T) {
 		ParentIdFieldNames:   []string{"trace.parent_id", "parentId"},
 		AddRuleReasonToTrace: true,
 		GetCollectionConfigVal: config.CollectionConfig{
-			NumCollectLoops:   2,
+			WorkerCount:       2,
 			ShutdownDelay:     config.Duration(1 * time.Millisecond),
 			IncomingQueueSize: 10,
 			PeerQueueSize:     10,
@@ -1663,7 +1663,7 @@ func TestBigTracesGoEarly(t *testing.T) {
 		TraceIdFieldNames:    []string{"trace.trace_id", "traceId"},
 		AddRuleReasonToTrace: true,
 		GetCollectionConfigVal: config.CollectionConfig{
-			NumCollectLoops:   2,
+			WorkerCount:       2,
 			IncomingQueueSize: 500,
 			PeerQueueSize:     500,
 		},
@@ -1740,8 +1740,8 @@ func TestSpanLimitSendByPreservation(t *testing.T) {
 		TraceIdFieldNames:  []string{"trace.trace_id", "traceId"},
 		ParentIdFieldNames: []string{"trace.parent_id", "parentId"},
 		GetCollectionConfigVal: config.CollectionConfig{
-			NumCollectLoops: 2,
-			ShutdownDelay:   config.Duration(1 * time.Millisecond),
+			WorkerCount:   2,
+			ShutdownDelay: config.Duration(1 * time.Millisecond),
 		},
 	}
 
@@ -1823,7 +1823,7 @@ func TestWorkerHealthReporting(t *testing.T) {
 		TraceIdFieldNames:  []string{"trace.trace_id", "traceId"},
 		ParentIdFieldNames: []string{"trace.parent_id", "parentId"},
 		GetCollectionConfigVal: config.CollectionConfig{
-			NumCollectLoops:    4, // Use multiple workers to test aggregation
+			WorkerCount:        4, // Use multiple workers to test aggregation
 			ShutdownDelay:      config.Duration(1 * time.Millisecond),
 			IncomingQueueSize:  5,
 			PeerQueueSize:      5,
@@ -2124,7 +2124,7 @@ func setupBenchmarkCollector(b *testing.B, samplerConfig any) *InMemCollector {
 			HealthCheckTimeout: config.Duration(100 * time.Millisecond),
 			IncomingQueueSize:  100000,
 			PeerQueueSize:      100000,
-			NumCollectLoops:    16,
+			WorkerCount:        16,
 		},
 		AddCountsToRoot:        true,
 		AddSpanCountToRoot:     true,

--- a/collect/collector_worker.go
+++ b/collect/collector_worker.go
@@ -34,7 +34,7 @@ type CollectorWorker struct {
 	// parent is a reference to the parent InMemCollector manager for accessing shared resources
 	parent *InMemCollector
 
-	// Input channels specific to this loop
+	// Input channels specific to this worker
 	incoming chan *types.Span
 	fromPeer chan *types.Span
 
@@ -144,7 +144,7 @@ func (cl *CollectorWorker) collect() {
 	// Initialize health timestamp
 	cl.healthCheckInAt.Store(cl.parent.Clock.Now().UnixNano())
 	for {
-		ctx, span := otelutil.StartSpanWith(context.Background(), cl.parent.Tracer, "collect_loop", "loop_id", cl.ID)
+		ctx, span := otelutil.StartSpanWith(context.Background(), cl.parent.Tracer, "collect_worker", "worker_id", cl.ID)
 		startTime := cl.parent.Clock.Now()
 
 		// Always drain peer channel before doing anything else. By processing peer
@@ -204,7 +204,7 @@ func (cl *CollectorWorker) collect() {
 
 // processSpan handles a single span, adding it to the cache or forwarding it
 func (cl *CollectorWorker) processSpan(ctx context.Context, sp *types.Span) {
-	ctx, span := otelutil.StartSpanWith(ctx, cl.parent.Tracer, "processSpan", "loop_id", cl.ID)
+	ctx, span := otelutil.StartSpanWith(ctx, cl.parent.Tracer, "processSpan", "worker_id", cl.ID)
 	defer func() {
 		cl.localSpanProcessed++
 		cl.localSpansWaiting.Add(-1)
@@ -298,7 +298,7 @@ func (cl *CollectorWorker) processSpan(ctx context.Context, sp *types.Span) {
 
 // sendExpiredTracesInCache finds and sends traces that have exceeded their timeout
 func (cl *CollectorWorker) sendExpiredTracesInCache(ctx context.Context, now time.Time) {
-	ctx, span := otelutil.StartSpanWith(ctx, cl.parent.Tracer, "sendExpiredTracesInCache", "loop_id", cl.ID)
+	ctx, span := otelutil.StartSpanWith(ctx, cl.parent.Tracer, "sendExpiredTracesInCache", "worker_id", cl.ID)
 	startTime := cl.parent.Clock.Now()
 	defer func() {
 		cl.parent.Metrics.Histogram("collector_send_expired_traces_in_cache_dur_ms", float64(cl.parent.Clock.Since(startTime).Milliseconds()))

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -317,10 +317,10 @@ type CollectionConfig struct {
 	MaxKeptDecisionBatchSize int      `yaml:"-"`
 	KeptDecisionSendInterval Duration `yaml:"-"`
 
-	// NumCollectLoops controls the number of parallel collection loops.
-	// Each loop processes a subset of traces independently.
+	// WorkerCount controls the number of parallel collection workers.
+	// Each worker processes a subset of traces independently.
 	// Higher values can improve throughput on multi-core systems.
-	NumCollectLoops int `yaml:"NumCollectLoops"` // default: GOMAXPROCS
+	WorkerCount int `yaml:"WorkerCount"` // default: GOMAXPROCS
 }
 
 // GetMaxAlloc returns the maximum amount of memory to use for the cache.
@@ -332,24 +332,24 @@ func (c CollectionConfig) GetMaxAlloc() MemorySize {
 	return c.AvailableMemory * MemorySize(c.MaxMemoryPercentage) / 100
 }
 
-// GetPeerQueueSizePerLoop returns the capacity per collect loop worker of the in-memory channel for peer traces.
-// It divides queue sizes among loops, rounding up to make sure total queue size across loops is equal to or greater than configured.
-func (c CollectionConfig) GetPeerQueueSizePerLoop() int {
-	numLoops := c.GetNumCollectLoops()
-	return (c.PeerQueueSize + numLoops - 1) / numLoops
+// GetPeerQueueSizePerWorker returns the capacity per collect worker of the in-memory channel for peer traces.
+// It divides queue sizes among workers, rounding up to make sure total queue size across workers is equal to or greater than configured.
+func (c CollectionConfig) GetPeerQueueSizePerWorker() int {
+	numWorkers := c.GetWorkerCount()
+	return (c.PeerQueueSize + numWorkers - 1) / numWorkers
 }
 
-// GetIncomingQueueSizePerLoop returns the capacity per collect loop worker of the in-memory channel for incoming traces.
-// It divides queue sizes among loops, rounding up to make sure total queue size across loops is equal to or greater than configured.
-func (c CollectionConfig) GetIncomingQueueSizePerLoop() int {
-	numLoops := c.GetNumCollectLoops()
-	return (c.IncomingQueueSize + numLoops - 1) / numLoops
+// GetIncomingQueueSizePerWorker returns the capacity per collect worker of the in-memory channel for incoming traces.
+// It divides queue sizes among workers, rounding up to make sure total queue size across workers is equal to or greater than configured.
+func (c CollectionConfig) GetIncomingQueueSizePerWorker() int {
+	numWorkers := c.GetWorkerCount()
+	return (c.IncomingQueueSize + numWorkers - 1) / numWorkers
 }
 
-// GetNumCollectLoops returns the number of parallel collection loops.
+// GetWorkerCount returns how many parallel collection workers to run.
 // Ensures the value is at least 1.
-func (c CollectionConfig) GetNumCollectLoops() int {
-	num := c.NumCollectLoops
+func (c CollectionConfig) GetWorkerCount() int {
+	num := c.WorkerCount
 	if num == 0 {
 		num = runtime.GOMAXPROCS(0)
 	}

--- a/config/file_config_test.go
+++ b/config/file_config_test.go
@@ -9,46 +9,46 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_GetNumCollectLoops(t *testing.T) {
+func Test_GetWorkerCount(t *testing.T) {
 	for _, tC := range []struct {
-		name     string
-		numLoops int
-		want     int
+		name       string
+		numWorkers int
+		want       int
 	}{
 		{"default", 0, runtime.GOMAXPROCS(0)},
 		{"configured/one worker", 1, 1},       // minimum allowed
 		{"configured/multiple workers", 4, 4}, // custom value
 	} {
 		t.Run(tC.name, func(t *testing.T) {
-			c := &CollectionConfig{NumCollectLoops: tC.numLoops}
-			assert.Equal(t, tC.want, c.GetNumCollectLoops())
+			c := &CollectionConfig{WorkerCount: tC.numWorkers}
+			assert.Equal(t, tC.want, c.GetWorkerCount())
 		})
 	}
 }
 
-func Test_GetQueueSizesPerLoop(t *testing.T) {
+func Test_GetQueueSizesPerWorker(t *testing.T) {
 	for _, tC := range []struct {
-		name                string
-		incomingQueueSize   int
-		peerQueueSize       int
-		numCollectLoops     int
-		wantIncomingPerLoop int
-		wantPeerPerLoop     int
+		name                  string
+		incomingQueueSize     int
+		peerQueueSize         int
+		numWorkers            int
+		wantIncomingPerWorker int
+		wantPeerPerWorker     int
 	}{
-		{"single loop/default", 30000, 30000, 1, 30000, 30000},
-		{"multiple loops/default", 30000, 30000, 8, 3750, 3750},
-		{"multiple loops/even division", 100, 50, 5, 20, 10},
-		{"multiple loops/uneven division", 5, 5, 2, 3, 3},            // rounds up
-		{"multiple loops/more loops than queue size", 3, 2, 5, 1, 1}, // minimum 1 per loop
+		{"single worker/default", 30000, 30000, 1, 30000, 30000},
+		{"multiple workers/default", 30000, 30000, 8, 3750, 3750},
+		{"multiple workers/even division", 100, 50, 5, 20, 10},
+		{"multiple workers/uneven division", 5, 5, 2, 3, 3},              // rounds up
+		{"multiple workers/more workers than queue size", 3, 2, 5, 1, 1}, // minimum 1 per worker
 	} {
 		t.Run(tC.name, func(t *testing.T) {
 			c := &CollectionConfig{
 				IncomingQueueSize: tC.incomingQueueSize,
 				PeerQueueSize:     tC.peerQueueSize,
-				NumCollectLoops:   tC.numCollectLoops,
+				WorkerCount:       tC.numWorkers,
 			}
-			assert.Equal(t, tC.wantIncomingPerLoop, c.GetIncomingQueueSizePerLoop())
-			assert.Equal(t, tC.wantPeerPerLoop, c.GetPeerQueueSizePerLoop())
+			assert.Equal(t, tC.wantIncomingPerWorker, c.GetIncomingQueueSizePerWorker())
+			assert.Equal(t, tC.wantPeerPerWorker, c.GetPeerQueueSizePerWorker())
 		})
 	}
 }

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -1278,7 +1278,7 @@ groups:
         description: >
           NOTE: This setting is now deprecated and no longer controls the cache size.
           Instead the maximum memory usage is controlled by `MaxMemoryPercentage` and `MaxAlloc`.
-          
+
           Setting this value does still set the default PeerQueueSize to (3 x CacheCapacity) and IncomingQueueSize
           to (3 x CacheCapacity) if they are not set. This behavior will be removed in the future.
           Instead, set PeerQueueSize and IncomingQueueSize to the exact values you want.
@@ -1514,7 +1514,7 @@ groups:
         description: >
           Sets the time interval for sending accumulated kept decisions in batches. This ensures that kept decisions are processed at regular intervals, improving efficiency by reducing the frequency of network transmissions. If the maximum batch size (MaxKeptDecisionBatchSize) is reached before this interval elapses, the batch will be sent immediately.
 
-      - name: NumCollectLoops
+      - name: WorkerCount
         type: int
         valuetype: nondefault
         default: 0
@@ -1522,10 +1522,10 @@ groups:
         validations:
           - type: minimum
             arg: 0
-        summary: is the number of parallel collection loops to run for trace processing.
+        summary: is the number of parallel collection workers to run for trace processing.
         description: >
-          Controls the number of parallel collection loops used for processing traces.
-          Each loop processes a subset of traces independently using consistent hashing.
+          Controls the number of parallel collection workers used for processing traces.
+          Each worker processes a subset of traces independently using consistent hashing.
           Values greater than 1 enable parallel processing which can improve throughput
           on multi-core systems.
           The default of 0 means Refinery will automatically set this value to the number of logical CPUs available at startup.


### PR DESCRIPTION
## Which problem is this PR solving?

Friendlier config option for how many Workers to run in Collection.

Then we updated many code comments and test code to refer to collect workers instead of collect loops. Some references remain:

* the loop inside a CollectWorker's collect() function
* metrics - partly because a metric is timing for the loop inside the collect() function but mostly to avoid breaking existing boards
