### PR TITLE
perf: do not extract sampling fields for OTLP endpoint

### DIFF
--- a/route/batched_event.go
+++ b/route/batched_event.go
@@ -83,7 +83,7 @@ func (b *batchedEvent) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 		case bytes.Equal(field, []byte("data")):
 			b.Data = types.NewPayload(b.cfg, nil) // Initialize with config
-			bts, err = b.coreFieldsExtractor.UnmarshalPayload(bts, &b.Data)
+			bts, err = b.coreFieldsExtractor.UnmarshalMsgpFirstEvent(bts, &b.Data)
 			if err != nil {
 				err = msgp.WrapError(err, "Data")
 				return
@@ -227,7 +227,7 @@ func (b *batchedEvents) unmarshalBatchedEventFromFastJSON(event *batchedEvent, v
 		}
 
 		// Use the same optimized unmarshaling logic as UnmarshalMsg
-		_, err = event.coreFieldsExtractor.UnmarshalPayload(*buf, &event.Data)
+		_, err = event.coreFieldsExtractor.UnmarshalMsgpFirstEvent(*buf, &event.Data)
 		return err
 	}
 

--- a/route/route.go
+++ b/route/route.go
@@ -672,7 +672,15 @@ func (router *Router) processOTLPRequestBatchMsgp(
 		totalEvents += len(batch.Events)
 		for _, ev := range batch.Events {
 			payload := types.NewPayload(router.Config, nil)
-			err := coreFieldsUnmarshaler.UnmarshalPayloadCompleteMetadataOnly(ev.Attributes, &payload)
+			// In large Refinery deployments, most incoming spans are forwarded to peers for sampling,
+			// so the ingesting node doesn't need to extract or memoize sampling key fields. Skipping
+			// this work reduces allocations and improves memory efficiency.
+			//
+			// This optimization currently applies only to OTLP data because OTLP is accepted only from
+			// external sources, not from peers.
+			//
+			// TODO: Apply this optimization to all incoming data instead of relying on OTLP-specific behavior.
+			err := coreFieldsUnmarshaler.UnmarshalMsgpEventMetadataOnly(ev.Attributes, &payload)
 			if err != nil {
 				router.Logger.Error().Logf("Error unmarshaling payload: " + err.Error())
 				continue

--- a/types/payload.go
+++ b/types/payload.go
@@ -500,26 +500,26 @@ func NewCoreFieldsUnmarshaler(opt CoreFieldsUnmarshalerOptions) CoreFieldsUnmars
 	}
 }
 
-// UnmarshalPayloadCompleteMetadataOnly is similar to UnmarshalPayload, but it does not return
+// UnmarshalMsgpEventMetadataOnly is similar to UnmarshalPayload, but it does not return
 // the remaining bytes. It's expected to be used on a single message
 // where the entire byte slice is consumed.
 // It memoizes metadata fields only. If you need sampling key fields to be memoized, please use
 // UnmarshalPayloadComplete.
 // CAUTION: This should only be used when the entire byte slice is safe for the payload to keep.
-func (cu CoreFieldsUnmarshaler) UnmarshalPayloadCompleteMetadataOnly(bts []byte, payload *Payload) error {
-	return cu.unmarshalPayloadComplete(bts, payload, nil)
+func (cu CoreFieldsUnmarshaler) UnmarshalMsgpEventMetadataOnly(bts []byte, payload *Payload) error {
+	return cu.unmarshalMsgpEvent(bts, payload, nil)
 }
 
-// UnmarshalPayloadComplete is similar to UnmarshalPayload, but it does not return
+// UnmarshalMsgpEvent is similar to UnmarshalPayload, but it does not return
 // the remaining bytes. It's expected to be used on a single message
 // where the entire byte slice is consumed.
 // CAUTION: This should only be used when the entire byte slice is safe for the payload to keep.
-func (cu CoreFieldsUnmarshaler) UnmarshalPayloadComplete(bts []byte, payload *Payload) error {
-	return cu.unmarshalPayloadComplete(bts, payload, cu.samplingKeyFields)
+func (cu CoreFieldsUnmarshaler) UnmarshalMsgpEvent(bts []byte, payload *Payload) error {
+	return cu.unmarshalMsgpEvent(bts, payload, cu.samplingKeyFields)
 }
 
-// unmarshalPayloadComplete is the common implementation for unmarshaling a complete payload.
-func (cu CoreFieldsUnmarshaler) unmarshalPayloadComplete(bts []byte, payload *Payload, samplingKeyFields []string) error {
+// unmarshalMsgpEvent is the common implementation for unmarshaling a complete payload.
+func (cu CoreFieldsUnmarshaler) unmarshalMsgpEvent(bts []byte, payload *Payload, samplingKeyFields []string) error {
 	_, err := payload.extractCriticalFieldsFromBytes(bts,
 		cu.traceIdFieldNames, cu.parentIdFieldNames, samplingKeyFields)
 	if err != nil {
@@ -530,11 +530,11 @@ func (cu CoreFieldsUnmarshaler) unmarshalPayloadComplete(bts []byte, payload *Pa
 	return nil
 }
 
-// UnmarshalPayload creates and unmarshals a new Payload. It supports operating on a partial message
+// UnmarshalMsgpFirstEvent creates and unmarshals a new Payload. It supports operating on a partial message
 // and will extract the critical fields from the byte slice, leaving the rest of the data in the Payload's
 // msgpMap. This is useful for cases where the Payload is part of a larger message and we want to avoid
 // unnecessary allocations.
-func (cu CoreFieldsUnmarshaler) UnmarshalPayload(bts []byte, payload *Payload) ([]byte, error) {
+func (cu CoreFieldsUnmarshaler) UnmarshalMsgpFirstEvent(bts []byte, payload *Payload) ([]byte, error) {
 	consumed, err := payload.extractCriticalFieldsFromBytes(bts,
 		cu.traceIdFieldNames, cu.parentIdFieldNames, cu.samplingKeyFields)
 	if err != nil {

--- a/types/payload_test.go
+++ b/types/payload_test.go
@@ -412,13 +412,13 @@ func TestCoreFieldsUnmarshaler(t *testing.T) {
 			assert.Equal(t, int64(42), payload.Get("another_field"))
 		}
 
-		remainder, err := unmarshaler.UnmarshalPayload(msgpData, payload)
+		remainder, err := unmarshaler.UnmarshalMsgpFirstEvent(msgpData, payload)
 		require.NoError(t, err)
 		assert.Empty(t, remainder)
 		t.Run("UnmarshalPayload", doTest)
 
 		payload = &Payload{config: mockConfig}
-		require.NoError(t, unmarshaler.UnmarshalPayloadComplete(msgpData, payload))
+		require.NoError(t, unmarshaler.UnmarshalMsgpEvent(msgpData, payload))
 		t.Run("UnmarshalPayloadComplete", doTest)
 
 	})
@@ -454,7 +454,7 @@ func TestCoreFieldsUnmarshaler(t *testing.T) {
 
 		// Unmarshal first payload
 		payload1 := &Payload{config: mockConfig}
-		remainder, err := unmarshaler.UnmarshalPayload(combined, payload1)
+		remainder, err := unmarshaler.UnmarshalMsgpFirstEvent(combined, payload1)
 		require.NoError(t, err)
 		assert.Equal(t, "trace1", payload1.MetaTraceID)
 		assert.Equal(t, "value1", payload1.memoizedFields["sampling_field"])
@@ -462,7 +462,7 @@ func TestCoreFieldsUnmarshaler(t *testing.T) {
 
 		// Verify we can unmarshal the remainder
 		payload2 := &Payload{config: mockConfig}
-		remainder2, err := unmarshaler.UnmarshalPayload(remainder, payload2)
+		remainder2, err := unmarshaler.UnmarshalMsgpFirstEvent(remainder, payload2)
 		require.NoError(t, err)
 		assert.Equal(t, "trace2", payload2.MetaTraceID)
 		assert.Equal(t, "value2", payload2.memoizedFields["sampling_field"])
@@ -506,12 +506,12 @@ func TestCoreFieldsUnmarshaler(t *testing.T) {
 			assert.Equal(t, "should-not-be-extracted", payload.Get("regular_field"))
 		}
 
-		_, err = unmarshaler.UnmarshalPayload(msgpData, payload)
+		_, err = unmarshaler.UnmarshalMsgpFirstEvent(msgpData, payload)
 		require.NoError(t, err)
 		t.Run("UnmarshalPayload", doTest)
 
 		payload = &Payload{config: mockConfig}
-		require.NoError(t, unmarshaler.UnmarshalPayloadComplete(msgpData, payload))
+		require.NoError(t, unmarshaler.UnmarshalMsgpEvent(msgpData, payload))
 		t.Run("UnmarshalPayloadComplete", doTest)
 
 	})
@@ -773,14 +773,14 @@ func BenchmarkUnmarshalPayload(b *testing.B) {
 	b.Run("UnmarshalPayload", func(b *testing.B) {
 		for b.Loop() {
 			payload := &Payload{config: mockConfig}
-			_, _ = unmarshaler.UnmarshalPayload(msgpData, payload)
+			_, _ = unmarshaler.UnmarshalMsgpFirstEvent(msgpData, payload)
 		}
 	})
 
 	b.Run("UnmarshalPayloadComplete", func(b *testing.B) {
 		for b.Loop() {
 			payload := &Payload{config: mockConfig}
-			_ = unmarshaler.UnmarshalPayloadComplete(msgpData, payload)
+			_ = unmarshaler.UnmarshalMsgpEvent(msgpData, payload)
 		}
 	})
 }


### PR DESCRIPTION
## Which problem is this PR solving?

In large Refinery deployments, the majority of incoming spans are forwarded to peer nodes for their final sampling decision. This means the ingesting node does not need to extract or memoize the sampling key fields during initial unmarshaling. However, the current implementation still performs this work for every span, even when the local node will not use the sampling key. This results in unnecessary allocations and higher memory usage. By skipping sampling key memoization on ingest, we can significantly reduce allocation overhead and improve memory efficiency.

This optimization currently applies only to OTLP data, because OTLP is accepted exclusively from external sources and not from peers. While we ultimately want to extend this optimization to all incoming data, achieving that will require substantial additional work. We plan to address this more comprehensive implementation in the future.

## Short description of the changes

- create a `UnmarshalMsgpEventMetadataOnly` method
- use the new method in OTLP path

