### PR TITLE
perf: use []string for missingFields instead of a map

### DIFF
--- a/types/payload.go
+++ b/types/payload.go
@@ -232,9 +232,11 @@ type Payload struct {
 
 	// Deserialized fields, either from the internal msgpMap, or set externally.
 	memoizedFields map[string]any
-	// missingFields is a set of fields that were not found in the payload.
+	// missingFields is a list of fields that were not found in the payload.
 	// this is used to avoid repeatedly deserializing fields that are not present.
-	missingFields map[string]struct{}
+	// Using a slice instead of a map because the number of missing fields is typically small (0-10),
+	// and a slice has much lower memory overhead
+	missingFields []string
 
 	hasExtractedMetadata bool
 
@@ -370,11 +372,11 @@ func (p *Payload) extractCriticalFieldsFromBytes(data []byte, traceIdFieldNames,
 	if keysFound < len(samplingKeyFields) {
 		// If we didn't find all key fields, add them to missingFields
 		if p.missingFields == nil {
-			p.missingFields = make(map[string]struct{}, len(samplingKeyFields)-keysFound)
+			p.missingFields = make([]string, 0, len(samplingKeyFields)-keysFound)
 		}
 		for _, field := range samplingKeyFields {
 			if _, found := p.memoizedFields[field]; !found {
-				p.missingFields[field] = struct{}{}
+				p.missingFields = append(p.missingFields, field)
 			}
 		}
 	}
@@ -586,9 +588,6 @@ func (p *Payload) MemoizeFields(keys ...string) {
 	if p.memoizedFields == nil {
 		p.memoizedFields = make(map[string]any, len(keys))
 	}
-	if p.missingFields == nil {
-		p.missingFields = make(map[string]struct{}, len(keys))
-	}
 
 	// It is rare for a key field to not be memoized.
 	// Intentionally not allocating memory for keysToFind because it is rarely needed.
@@ -599,7 +598,7 @@ func (p *Payload) MemoizeFields(keys ...string) {
 	// we should reevaluate this optimization
 	keysToFind := make(map[string]struct{})
 	for _, key := range keys {
-		if _, ok := p.missingFields[key]; ok {
+		if slices.Contains(p.missingFields, key) {
 			continue
 		}
 		if _, ok := p.memoizedFields[key]; !ok {
@@ -641,7 +640,7 @@ func (p *Payload) MemoizeFields(keys ...string) {
 
 	for key := range keysToFind {
 		if _, ok := p.memoizedFields[key]; !ok {
-			p.missingFields[key] = struct{}{}
+			p.missingFields = append(p.missingFields, key)
 		}
 	}
 }
@@ -660,10 +659,8 @@ func (p *Payload) Exists(key string) bool {
 		}
 	}
 
-	if p.missingFields != nil {
-		if _, ok := p.missingFields[key]; ok {
-			return false
-		}
+	if slices.Contains(p.missingFields, key) {
+		return false
 	}
 
 	iter, err := newMsgpPayloadMapIter(p.msgpData)
@@ -703,10 +700,8 @@ func (p *Payload) Get(key string) any {
 		}
 	}
 
-	if p.missingFields != nil {
-		if _, ok := p.missingFields[key]; ok {
-			return nil
-		}
+	if slices.Contains(p.missingFields, key) {
+		return nil
 	}
 
 	iter, err := newMsgpPayloadMapIter(p.msgpData)

--- a/types/payload_test.go
+++ b/types/payload_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"slices"
 	"strings"
 	"testing"
 
@@ -392,15 +393,11 @@ func TestCoreFieldsUnmarshaler(t *testing.T) {
 			assert.True(t, v)
 
 			// Verify missing field is tracked
-			_, ok = payload.missingFields["missing_field"]
-			assert.True(t, ok)
-			_, ok = payload.missingFields["dynamic_missing_field"]
-			assert.True(t, ok)
-			_, ok = payload.missingFields["test"]
-			assert.True(t, ok)
+			assert.True(t, slices.Contains(payload.missingFields, "missing_field"))
+			assert.True(t, slices.Contains(payload.missingFields, "dynamic_missing_field"))
+			assert.True(t, slices.Contains(payload.missingFields, "test"))
 			// Verify computed field is not extracted
-			_, ok = payload.missingFields["?.NUMBER_DESCENDANTS"]
-			assert.False(t, ok)
+			assert.False(t, slices.Contains(payload.missingFields, "?.NUMBER_DESCENDANTS"))
 
 			// Verify field not in sampling config is NOT extracted
 			assert.Nil(t, payload.memoizedFields["missing_in_config"])


### PR DESCRIPTION
## Which problem is this PR solving?

The Payload type currently stores missingFields as a map[string]struct{}. This cache tracks which payload fields have already been checked and found to be absent, preventing repeated attempts to deserialize fields that do not exist. However, because missingFields is created for every event, using a map introduces unnecessary memory overhead—especially given that the number of missing fields is typically very small.

Since the common case involves only a few missing fields, we don’t need the lookup performance provided by a map. Replacing it with a simple []string reduces per-event memory usage without negatively impacting performance for realistic workloads.

## Short description of the changes

- change `missingFields` from a map to a slice

## Benchmark Result
```
goos: darwin
goarch: arm64
pkg: github.com/honeycombio/refinery/types
cpu: Apple M2 Max
                                             │   existing.txt   │              new.txt               │
                                             │   sec/op    │   sec/op     vs base               │
UnmarshalPayload/UnmarshalPayload-12           8.508µ ± 1%   7.790µ ± 1%  -8.44% (p=0.000 n=10)
UnmarshalPayload/UnmarshalPayloadComplete-12   7.987µ ± 1%   7.329µ ± 2%  -8.23% (p=0.000 n=10)
geomean                                        8.243µ        7.556µ       -8.34%

                                             │   old.txt    │               new.txt                │
                                             │     B/op     │     B/op      vs base                │
UnmarshalPayload/UnmarshalPayload-12           6.911Ki ± 0%   6.703Ki ± 0%   -3.01% (p=0.000 n=10)
UnmarshalPayload/UnmarshalPayloadComplete-12     933.0 ± 0%     720.0 ± 0%  -22.83% (p=0.000 n=10)
geomean                                        2.509Ki        2.171Ki       -13.49%

                                             │  old.txt   │              new.txt              │
                                             │ allocs/op  │ allocs/op   vs base               │
UnmarshalPayload/UnmarshalPayload-12           13.00 ± 0%   12.00 ± 0%  -7.69% (p=0.000 n=10)
UnmarshalPayload/UnmarshalPayloadComplete-12   12.00 ± 0%   11.00 ± 0%  -8.33% (p=0.000 n=10)
geomean                                        12.49        11.49       -8.01%
```

