### PR TITLE
feat: support multi-deployment using the same redis instance in Pubsub

### DIFF
--- a/config/file_config.go
+++ b/config/file_config.go
@@ -792,13 +792,6 @@ func (f *fileConfig) GetRedisUsername() string {
 	return f.mainConfig.RedisPeerManagement.Username
 }
 
-func (f *fileConfig) GetRedisPrefix() string {
-	f.mux.RLock()
-	defer f.mux.RUnlock()
-
-	return f.mainConfig.RedisPeerManagement.Prefix
-}
-
 func (f *fileConfig) GetRedisPassword() string {
 	f.mux.RLock()
 	defer f.mux.RUnlock()


### PR DESCRIPTION
## Which problem is this PR solving?

Add `RedisPeerManagementConfig.Prefix` support to Redis pubsub topics. This enables multiple Refinery deployments to share a single Redis instance without topic collisions.

To add prefix support safely without breaking rolling upgrades, the change is split into two phases. This PR implements phase 1: dual subscribing and dual publishing. Existing nodes only subscribe to and publish on the unprefixed topics. New nodes subscribe to and publish on both the unprefixed topics and the prefixed topics (when a prefix is configured). This ensures backward compatibility during mixed-version rollouts.

In a future release, after phase 1 has been released for a while, we can safely remove the dual publish/subscribe behavior.

Dual subscribing and publishing will increase pubsub network traffic. However, this should not have a significant impact on overall network usage, since pubsub traffic is relatively small compared to peer traffic.

fixes: #1463 
## Short description of the changes

- create a new topic with redis prefix if it's configured
- dual subscribe/publish to both the new and old topics

