### PR TITLE
feat: add RaaS support — ReceiveKeyIDs, AdditionalAttributes, and granular event metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Refinery Changelog
 
+## Unreleased
+
+### 💡 Enhancements
+
+- feat: add `OTelMetrics.AdditionalAttributes` config option to inject custom resource attributes into OTLP metrics
+
 ## 3.1.1 2026-02-25
 
 ### Features

--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,8 @@ wait_for_redis: dockerize
 # You can override this version from an environment variable.
 HOST_OS := $(shell uname -s | tr A-Z a-z)
 # You can override this version from an environment variable.
-KO_VERSION ?= 0.11.2
-KO_RELEASE_ASSET := ko_${KO_VERSION}_${HOST_OS}_x86_64.tar.gz
+KO_VERSION ?= 0.18.0
+KO_RELEASE_ASSET := ko_${KO_VERSION}_${HOST_OS}_arm64.tar.gz
 # ensure the ko command is available
 ko: ko_${KO_VERSION}.tar.gz
 	tar xzvmf $< ko
@@ -189,7 +189,3 @@ unsmoke:
 	@echo "+++ Spinning down the smokers."
 	@echo ""
 	cd smoke-test && docker-compose down --volumes
-
-
-
-

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ wait_for_redis: dockerize
 HOST_OS := $(shell uname -s | tr A-Z a-z)
 # You can override this version from an environment variable.
 KO_VERSION ?= 0.18.0
-KO_RELEASE_ASSET := ko_${KO_VERSION}_${HOST_OS}_arm64.tar.gz
+KO_RELEASE_ASSET := ko_${KO_VERSION}_${HOST_OS}_amd64.tar.gz
 # ensure the ko command is available
 ko: ko_${KO_VERSION}.tar.gz
 	tar xzvmf $< ko

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ wait_for_redis: dockerize
 HOST_OS := $(shell uname -s | tr A-Z a-z)
 # You can override this version from an environment variable.
 KO_VERSION ?= 0.18.0
-KO_RELEASE_ASSET := ko_${KO_VERSION}_${HOST_OS}_amd64.tar.gz
+KO_RELEASE_ASSET := ko_${KO_VERSION}_${HOST_OS}_x86_64.tar.gz
 # ensure the ko command is available
 ko: ko_${KO_VERSION}.tar.gz
 	tar xzvmf $< ko

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -228,6 +228,18 @@ func (agent *Agent) healthCheck() {
 
 				agent.usageTracker.Add(signal_traces, traceUsage)
 				agent.usageTracker.Add(signal_logs, logUsage)
+
+				eventsReceivedTraces, _ := agent.metrics.Get("events_received_traces")
+				agent.usageTracker.Add(signal_events_received_traces, eventsReceivedTraces)
+
+				eventsReceivedLogs, _ := agent.metrics.Get("events_received_logs")
+				agent.usageTracker.Add(signal_events_received_logs, eventsReceivedLogs)
+
+				eventsDroppedTraces, _ := agent.metrics.Get("events_dropped_traces")
+				agent.usageTracker.Add(signal_events_dropped_traces, eventsDroppedTraces)
+
+				eventsDroppedLogs, _ := agent.metrics.Get("events_dropped_logs")
+				agent.usageTracker.Add(signal_events_dropped_logs, eventsDroppedLogs)
 			}
 		}
 	}

--- a/agent/otlp_metrics.go
+++ b/agent/otlp_metrics.go
@@ -9,9 +9,24 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 )
 
+type metricMapping struct {
+	metricName string
+	signal     string
+}
+
+var signalToMetric = map[usageSignal]metricMapping{
+	signal_traces:                 {metricName: "bytes_received", signal: "traces"},
+	signal_logs:                   {metricName: "bytes_received", signal: "logs"},
+	signal_events_received_traces: {metricName: "events_received", signal: "traces"},
+	signal_events_received_logs:   {metricName: "events_received", signal: "logs"},
+	signal_events_dropped_traces:  {metricName: "events_dropped", signal: "traces"},
+	signal_events_dropped_logs:    {metricName: "events_dropped", signal: "logs"},
+}
+
 type otlpMetrics struct {
 	metrics pmetric.Metrics
-	ms      pmetric.Sum
+	sums    map[string]pmetric.Sum
+	sm      pmetric.ScopeMetrics
 }
 
 func newOTLPMetrics(serviceName, version, hostname string) *otlpMetrics {
@@ -22,25 +37,40 @@ func newOTLPMetrics(serviceName, version, hostname string) *otlpMetrics {
 	resourceAttrs.PutStr("service.version", version)
 	resourceAttrs.PutStr("host.name", hostname)
 	sm := rm.ScopeMetrics().AppendEmpty()
-	ms := sm.Metrics().AppendEmpty()
-	ms.SetName("bytes_received")
-	sum := ms.SetEmptySum()
-	sum.SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
 	return &otlpMetrics{
 		metrics: metrics,
-		ms:      sum,
+		sums:    make(map[string]pmetric.Sum),
+		sm:      sm,
 	}
 }
 
+func (om *otlpMetrics) getOrCreateSum(metricName string) pmetric.Sum {
+	if sum, ok := om.sums[metricName]; ok {
+		return sum
+	}
+	ms := om.sm.Metrics().AppendEmpty()
+	ms.SetName(metricName)
+	sum := ms.SetEmptySum()
+	sum.SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
+	om.sums[metricName] = sum
+	return sum
+}
+
 func (om *otlpMetrics) addOTLPSum(timestamp time.Time, value float64, signal usageSignal) error {
+	mapping, ok := signalToMetric[signal]
+	if !ok {
+		return fmt.Errorf("unknown usage signal: %s", signal)
+	}
+
 	intVal, err := convertFloat64ToInt64(value)
 	if err != nil {
 		return err
 	}
-	d := om.ms.DataPoints().AppendEmpty()
+	sum := om.getOrCreateSum(mapping.metricName)
+	d := sum.DataPoints().AppendEmpty()
 	d.SetTimestamp(pcommon.NewTimestampFromTime(timestamp))
 	d.SetIntValue(intVal)
-	d.Attributes().PutStr("signal", string(signal))
+	d.Attributes().PutStr("signal", mapping.signal)
 	return nil
 }
 

--- a/agent/usage_report.go
+++ b/agent/usage_report.go
@@ -89,6 +89,10 @@ func (ur *usageTracker) completeSend() {
 type usageSignal string
 
 var (
-	signal_traces usageSignal = "traces"
-	signal_logs   usageSignal = "logs"
+	signal_traces                 usageSignal = "traces"
+	signal_logs                   usageSignal = "logs"
+	signal_events_received_traces usageSignal = "events_received_traces"
+	signal_events_received_logs   usageSignal = "events_received_logs"
+	signal_events_dropped_traces  usageSignal = "events_dropped_traces"
+	signal_events_dropped_logs    usageSignal = "events_dropped_logs"
 )

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -382,10 +382,19 @@ func newStartedApp(
 	assert.NoError(t, err)
 
 	err = startstop.Start(g.Objects(), nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	// Racy: wait just a moment for ListenAndServe to start up.
-	time.Sleep(15 * time.Millisecond)
+	// Wait for the HTTP server to be ready by polling the listen address.
+	listenAddr := c.GetListenAddr()
+	require.Eventually(t, func() bool {
+		conn, err := net.DialTimeout("tcp", listenAddr, 50*time.Millisecond)
+		if err != nil {
+			return false
+		}
+		conn.Close()
+		return true
+	}, 2*time.Second, 10*time.Millisecond, "server failed to start listening on %s", listenAddr)
+
 	return &a, g
 }
 

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -72,7 +72,7 @@ echo "Building image locally with ko for multi-registry push..."
 IMAGE_REF=$(./ko publish \
   --tags "${TAGS}" \
   --base-import-paths \
-  --platform "linux/amd64,linux/arm64" \
+  --platform "linux/arm64,linux/amd64" \
   --image-label org.opencontainers.image.source=https://github.com/honeycombio/refinery \
   --image-label org.opencontainers.image.licenses=Apache-2.0 \
   --image-label org.opencontainers.image.revision=${GIT_COMMIT} \

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -72,7 +72,7 @@ echo "Building image locally with ko for multi-registry push..."
 IMAGE_REF=$(./ko publish \
   --tags "${TAGS}" \
   --base-import-paths \
-  --platform "linux/arm64" \
+  --platform "linux/amd64,linux/arm64" \
   --image-label org.opencontainers.image.source=https://github.com/honeycombio/refinery \
   --image-label org.opencontainers.image.licenses=Apache-2.0 \
   --image-label org.opencontainers.image.revision=${GIT_COMMIT} \

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -72,7 +72,7 @@ echo "Building image locally with ko for multi-registry push..."
 IMAGE_REF=$(./ko publish \
   --tags "${TAGS}" \
   --base-import-paths \
-  --platform "linux/arm64,linux/amd64" \
+  --platform "linux/arm64" \
   --image-label org.opencontainers.image.source=https://github.com/honeycombio/refinery \
   --image-label org.opencontainers.image.licenses=Apache-2.0 \
   --image-label org.opencontainers.image.revision=${GIT_COMMIT} \

--- a/collect/collect.go
+++ b/collect/collect.go
@@ -152,6 +152,8 @@ var inMemCollectorMetrics = []metrics.Metadata{
 
 	{Name: "dropped_from_stress", Type: metrics.Counter, Unit: metrics.Dimensionless, Description: "number of spans dropped due to stress relief"},
 	{Name: "kept_from_stress", Type: metrics.Counter, Unit: metrics.Dimensionless, Description: "number of spans kept due to stress relief"},
+	{Name: "events_dropped_traces", Type: metrics.Counter, Unit: metrics.Dimensionless, Description: "number of trace events dropped"},
+	{Name: "events_dropped_logs", Type: metrics.Counter, Unit: metrics.Dimensionless, Description: "number of log events dropped"},
 	{Name: "trace_kept_sample_rate", Type: metrics.Histogram, Unit: metrics.Dimensionless, Description: "sample rate of kept traces"},
 	{Name: "trace_aggregate_sample_rate", Type: metrics.Histogram, Unit: metrics.Dimensionless, Description: "aggregate sample rate of both kept and dropped traces"},
 	{Name: "collector_collect_loop_duration_ms", Type: metrics.Histogram, Unit: metrics.Milliseconds, Description: "duration of the collect loop, the primary event processing goroutine"},
@@ -460,6 +462,11 @@ func (i *InMemCollector) ProcessSpanImmediately(sp *types.Span) (processed bool,
 
 	if !keep {
 		i.Metrics.Increment("dropped_from_stress")
+		if sp.Data.MetaSignalType == "log" {
+			i.Metrics.Increment("events_dropped_logs")
+		} else {
+			i.Metrics.Increment("events_dropped_traces")
+		}
 		return true, false
 	}
 
@@ -600,6 +607,16 @@ func (i *InMemCollector) send(ctx context.Context, trace sendableTrace) {
 	// if we're supposed to drop this trace, and dry run mode is not enabled, then we're done.
 	if !trace.KeepSample && !i.Config.GetIsDryRun() {
 		i.Metrics.Increment("trace_send_dropped")
+		dropCount := int64(trace.DescendantCount())
+		signalType := "traces"
+		if trace.RootSpan != nil && trace.RootSpan.Data.MetaSignalType == "log" {
+			signalType = "logs"
+		}
+		if signalType == "logs" {
+			i.Metrics.Count("events_dropped_logs", dropCount)
+		} else {
+			i.Metrics.Count("events_dropped_traces", dropCount)
+		}
 		i.Logger.Debug().WithFields(logFields).Logf("Dropping trace because of sampling decision")
 		return
 	}

--- a/config.md
+++ b/config.md
@@ -3,7 +3,7 @@
 # Honeycomb Refinery Configuration Documentation
 
 This is the documentation for the configuration file for Honeycomb's Refinery.
-It was automatically generated on 2026-02-25 at 20:49:27 UTC.
+It was automatically generated on 2026-03-09 at 14:11:11 UTC.
 
 ## The Config file
 
@@ -181,16 +181,29 @@ ReceiveKeys is a set of Honeycomb API keys that the proxy will treat specially.
 
 This list only applies to span traffic - other Honeycomb API actions will be proxied through to the upstream API directly without modifying keys.
 
-- Not eligible for live reload.
+- Eligible for live reload.
 - Type: `stringarray`
 - Example: `your-key-goes-here`
+
+### `ReceiveKeyIDs`
+
+ReceiveKeyIDs is a set of Honeycomb Ingest Key IDs that the proxy will treat specially.
+
+When `AcceptOnlyListedKeys` is `true`, traffic using an API key whose Honeycomb ingest key ID matches an entry in this list will be accepted.
+The key ID is the `id` field returned by the Honeycomb `/1/auth` endpoint; it is distinct from the full API key value.
+This allows authorization based on key IDs rather than full key values, which avoids storing secret key material in the configuration file.
+Both `ReceiveKeys` and `ReceiveKeyIDs` may be used simultaneously.
+
+- Eligible for live reload.
+- Type: `stringarray`
+- Example: `your-key-id-goes-here`
 
 ### `AcceptOnlyListedKeys`
 
 AcceptOnlyListedKeys is a boolean flag that causes events arriving with API keys not in the `ReceiveKeys` list to be rejected.
 
-If `true`, then only traffic using the keys listed in `ReceiveKeys` is accepted.
-Events arriving with API keys not in the `ReceiveKeys` list will be rejected with an HTTP `401` error.
+If `true`, then only traffic using the keys listed in `ReceiveKeys` or whose key ID is listed in `ReceiveKeyIDs` is accepted.
+Events arriving with API keys not in either list will be rejected with an HTTP `401` error.
 If `false`, then all traffic is accepted and `ReceiveKeys` is ignored.
 This setting is applied **before** the `SendKey` and `SendKeyMode` settings.
 
@@ -528,7 +541,7 @@ The key-value pairs must use ':' as the separator.
 
 - Not eligible for live reload.
 - Type: `map`
-- Example: `pipeline.id:'12345',rollout.id:'67890'`
+- Example: `pipeline.id:12345,rollout.id:67890`
 - Environment variable: `REFINERY_HONEYCOMB_LOGGER_ADDITIONAL_ATTRIBUTES`
 
 ## Stdout Logger
@@ -665,12 +678,11 @@ In rare circumstances, compression costs may outweigh the benefits, in which cas
 AdditionalAttributes adds the provided attributes as resource attributes on all OpenTelemetry metrics emitted by Refinery.
 
 This is useful for injecting deployment-specific metadata (such as a cluster ID or environment name) into metrics so they can be filtered or grouped in the metrics backend.
-
 Both keys and values must be strings.
 
 - Not eligible for live reload.
-- Type: `map[string]string`
-- Default: `{}`
+- Type: `map`
+- Example: `pipeline.id:'12345',rollout.id:'67890'`
 
 ## OpenTelemetry Tracing
 

--- a/config.md
+++ b/config.md
@@ -660,6 +660,18 @@ In rare circumstances, compression costs may outweigh the benefits, in which cas
 - Default: `gzip`
 - Options: `none`, `gzip`
 
+### `AdditionalAttributes`
+
+AdditionalAttributes adds the provided attributes as resource attributes on all OpenTelemetry metrics emitted by Refinery.
+
+This is useful for injecting deployment-specific metadata (such as a cluster ID or environment name) into metrics so they can be filtered or grouped in the metrics backend.
+
+Both keys and values must be strings.
+
+- Not eligible for live reload.
+- Type: `map[string]string`
+- Default: `{}`
+
 ## OpenTelemetry Tracing
 
 `OTelTracing` contains configuration for Refinery's own tracing.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -909,6 +909,23 @@ func TestAdditionalAttributes(t *testing.T) {
 	assert.Equal(t, map[string]string{"name": "foo", "other": "bar", "another": "OneHundred"}, c.GetAdditionalAttributes())
 }
 
+func TestOTelMetricsAdditionalAttributes(t *testing.T) {
+	cm := makeYAML(
+		"General.ConfigurationVersion", 2,
+		"OTelMetrics.AdditionalAttributes", map[string]string{
+			"cluster.id":  "my-cluster",
+			"environment": "production",
+		},
+	)
+	rm := makeYAML("ConfigVersion", 2)
+	config, rules := createTempConfigs(t, cm, rm)
+	c, err := getConfig([]string{"--no-validate", "--config", config, "--rules_config", rules})
+	assert.NoError(t, err)
+
+	otelCfg := c.GetOTelMetricsConfig()
+	assert.Equal(t, map[string]string{"cluster.id": "my-cluster", "environment": "production"}, otelCfg.AdditionalAttributes)
+}
+
 func TestHoneycombIdFieldsConfig(t *testing.T) {
 	cm := makeYAML(
 		"General.ConfigurationVersion", 2,

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -278,12 +278,13 @@ type PrometheusMetricsConfig struct {
 }
 
 type OTelMetricsConfig struct {
-	Enabled           bool     `yaml:"Enabled" default:"false"`
-	APIHost           string   `yaml:"APIHost" default:"https://api.honeycomb.io" cmdenv:"TelemetryEndpoint"`
-	APIKey            string   `yaml:"APIKey" cmdenv:"OTelMetricsAPIKey,HoneycombAPIKey"`
-	Dataset           string   `yaml:"Dataset" default:"Refinery Metrics"`
-	Compression       string   `yaml:"Compression" default:"gzip"`
-	ReportingInterval Duration `yaml:"ReportingInterval" default:"30s"`
+	Enabled              bool              `yaml:"Enabled" default:"false"`
+	APIHost              string            `yaml:"APIHost" default:"https://api.honeycomb.io" cmdenv:"TelemetryEndpoint"`
+	APIKey               string            `yaml:"APIKey" cmdenv:"OTelMetricsAPIKey,HoneycombAPIKey"`
+	Dataset              string            `yaml:"Dataset" default:"Refinery Metrics"`
+	Compression          string            `yaml:"Compression" default:"gzip"`
+	ReportingInterval    Duration          `yaml:"ReportingInterval" default:"30s"`
+	AdditionalAttributes map[string]string `yaml:"AdditionalAttributes" default:"{}"`
 }
 
 type OTelTracingConfig struct {

--- a/config/file_config_test.go
+++ b/config/file_config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"errors"
+	"fmt"
 	"runtime"
 	"testing"
 
@@ -166,6 +167,104 @@ func TestAccessKeyConfig_IsAccepted(t *testing.T) {
 				return
 			}
 			assert.Equal(t, tt.want.Error(), err.Error())
+		})
+	}
+}
+
+func BenchmarkAccessKeyConfig_IsAccepted(b *testing.B) {
+	// Generate realistic key lists
+	makeKeys := func(n int) []string {
+		keys := make([]string, n)
+		for i := range keys {
+			keys[i] = fmt.Sprintf("key-%06d", i)
+		}
+		return keys
+	}
+
+	benchmarks := []struct {
+		name   string
+		config AccessKeyConfig
+		key    string
+		keyID  string
+	}{
+		{
+			name:   "no_filtering",
+			config: AccessKeyConfig{AcceptOnlyListedKeys: false},
+			key:    "anykey",
+			keyID:  "",
+		},
+		{
+			name: "ReceiveKeys_10_match_last",
+			config: AccessKeyConfig{
+				ReceiveKeys:          makeKeys(10),
+				AcceptOnlyListedKeys: true,
+			},
+			key:   "key-000009",
+			keyID: "",
+		},
+		{
+			name: "ReceiveKeys_100_match_last",
+			config: AccessKeyConfig{
+				ReceiveKeys:          makeKeys(100),
+				AcceptOnlyListedKeys: true,
+			},
+			key:   "key-000099",
+			keyID: "",
+		},
+		{
+			name: "ReceiveKeys_100_no_match",
+			config: AccessKeyConfig{
+				ReceiveKeys:          makeKeys(100),
+				AcceptOnlyListedKeys: true,
+			},
+			key:   "unknown-key",
+			keyID: "",
+		},
+		{
+			name: "ReceiveKeyIDs_10_match_last",
+			config: AccessKeyConfig{
+				ReceiveKeyIDs:        makeKeys(10),
+				AcceptOnlyListedKeys: true,
+			},
+			key:   "anykey",
+			keyID: "key-000009",
+		},
+		{
+			name: "ReceiveKeyIDs_100_match_last",
+			config: AccessKeyConfig{
+				ReceiveKeyIDs:        makeKeys(100),
+				AcceptOnlyListedKeys: true,
+			},
+			key:   "anykey",
+			keyID: "key-000099",
+		},
+		{
+			name: "ReceiveKeyIDs_100_no_match",
+			config: AccessKeyConfig{
+				ReceiveKeyIDs:        makeKeys(100),
+				AcceptOnlyListedKeys: true,
+			},
+			key:   "anykey",
+			keyID: "unknown-kid",
+		},
+		{
+			name: "both_100_match_by_keyID",
+			config: AccessKeyConfig{
+				ReceiveKeys:          makeKeys(100),
+				ReceiveKeyIDs:        makeKeys(100),
+				AcceptOnlyListedKeys: true,
+			},
+			key:   "unknown-key",
+			keyID: "key-000050",
+		},
+	}
+
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_ = bm.config.IsAccepted(bm.key, bm.keyID)
+			}
 		})
 	}
 }

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -223,20 +223,36 @@ groups:
           will be proxied through to the upstream API directly without modifying
           keys.
 
+      - name: ReceiveKeyIDs
+        type: stringarray
+        valuetype: stringarray
+        example: "your-key-id-goes-here"
+        reload: false
+        validations:
+          - type: elementType
+            arg: string
+        summary: is a set of Honeycomb Ingest Key IDs that the proxy will treat specially.
+        description: >
+          When `AcceptOnlyListedKeys` is `true`, traffic using an API key whose
+          Honeycomb ingest key ID matches an entry in this list will be accepted.
+          The key ID is the `id` field returned by the Honeycomb `/1/auth`
+          endpoint; it is distinct from the full API key value.
+
+          This allows authorization based on key IDs rather than full key values,
+          which avoids storing secret key material in the configuration file.
+          Both `ReceiveKeys` and `ReceiveKeyIDs` may be used simultaneously.
+
       - name: AcceptOnlyListedKeys
         type: bool
         valuetype: conditional
         extra: nostar APIKeys
         default: false
         reload: true
-        validation:
-          - type: requiredWith
-            arg: ReceiveKeys
         summary: is a boolean flag that causes events arriving with API keys not in the `ReceiveKeys` list to be rejected.
         description: >
-          If `true`, then only traffic using the keys listed in `ReceiveKeys` is
-          accepted. Events arriving with API keys not in the `ReceiveKeys` list
-          will be rejected with an HTTP `401` error.
+          If `true`, then only traffic using the keys listed in `ReceiveKeys` or
+          whose key ID is listed in `ReceiveKeyIDs` is accepted. Events arriving
+          with API keys not in either list will be rejected with an HTTP `401` error.
 
           If `false`, then all traffic is accepted and `ReceiveKeys` is ignored.
 

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -213,7 +213,7 @@ groups:
         valuetype: stringarray
         v1name: APIKeys
         example: "your-key-goes-here"
-        reload: false
+        reload: true
         validations:
           - type: elementType
             arg: string
@@ -227,7 +227,7 @@ groups:
         type: stringarray
         valuetype: stringarray
         example: "your-key-id-goes-here"
-        reload: false
+        reload: true
         validations:
           - type: elementType
             arg: string
@@ -687,19 +687,16 @@ groups:
       - name: AdditionalAttributes
         type: map
         valuetype: map
-        example: "pipeline.id:'12345',rollout.id:'67890'"
+        example: "pipeline.id:12345,rollout.id:67890"
         reload: false
-        validations:
-          - type: elementType
-            arg: string
         summary: adds the provided attributes to all logs written by the Honeycomb logger.
         envvar: REFINERY_HONEYCOMB_LOGGER_ADDITIONAL_ATTRIBUTES
         commandline: logger-additional-attributes
         description: >
-           When supplying via a environment variable, the value should be a string of comma-separated key-value pairs.
-           When supplying via the command line, the value should be a key value pair.
-           If multiple key-value pairs are needed, each should be supplied via its own command line flag.
-           The key-value pairs must use ':' as the separator.
+          When supplying via a environment variable, the value should be a string of comma-separated key-value pairs.
+          When supplying via the command line, the value should be a key value pair.
+          If multiple key-value pairs are needed, each should be supplied via its own command line flag.
+          The key-value pairs must use ':' as the separator.
 
   - name: StdoutLogger
     title: "Stdout Logger"
@@ -934,10 +931,13 @@ groups:
 
       - name: AdditionalAttributes
         type: map
-        valuetype: nondefault
-        default: "{}"
+        valuetype: map
+        example: "pipeline.id:'12345',rollout.id:'67890'"
         reload: false
         firstversion: v2.10
+        validations:
+          - type: elementType
+            arg: string
         summary: adds the provided attributes as resource attributes on all OpenTelemetry metrics emitted by Refinery.
         description: >
           This is useful for injecting deployment-specific metadata (such as

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -932,6 +932,19 @@ groups:
           compression costs may outweigh the benefits, in which case `none`
           may be used.
 
+      - name: AdditionalAttributes
+        type: map
+        valuetype: nondefault
+        default: "{}"
+        reload: false
+        firstversion: v2.10
+        summary: adds the provided attributes as resource attributes on all OpenTelemetry metrics emitted by Refinery.
+        description: >
+          This is useful for injecting deployment-specific metadata (such as
+          a cluster ID or environment name) into metrics so they can be
+          filtered or grouped in the metrics backend.
+          Both keys and values must be strings.
+
   - name: OTelTracing
     title: "OpenTelemetry Tracing"
     description: contains configuration for Refinery's own tracing.

--- a/config_complete.yaml
+++ b/config_complete.yaml
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created on 2026-02-25 at 20:49:27 UTC from ../../config.yaml using a template generated on 2026-02-25 at 20:49:24 UTC
+# created on 2026-03-09 at 14:11:11 UTC from ../../config.yaml using a template generated on 2026-03-09 at 14:11:08 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of
@@ -166,16 +166,33 @@ AccessKeys:
     ## will be proxied through to the upstream API directly without modifying
     ## keys.
     ##
-    ## Not eligible for live reload.
+    ## Eligible for live reload.
     # ReceiveKeys:
       # - your-key-goes-here
+
+    ## ReceiveKeyIDs is a set of Honeycomb Ingest Key IDs that the proxy will
+    ## treat specially.
+    ##
+    ## When `AcceptOnlyListedKeys` is `true`, traffic using an API key whose
+    ## Honeycomb ingest key ID matches an entry in this list will be
+    ## accepted. The key ID is the `id` field returned by the Honeycomb
+    ## `/1/auth` endpoint; it is distinct from the full API key value.
+    ## This allows authorization based on key IDs rather than full key
+    ## values, which avoids storing secret key material in the configuration
+    ## file. Both `ReceiveKeys` and `ReceiveKeyIDs` may be used
+    ## simultaneously.
+    ##
+    ## Eligible for live reload.
+    # ReceiveKeyIDs:
+      # - your-key-id-goes-here
 
     ## AcceptOnlyListedKeys is a boolean flag that causes events arriving
     ## with API keys not in the `ReceiveKeys` list to be rejected.
     ##
-    ## If `true`, then only traffic using the keys listed in `ReceiveKeys` is
-    ## accepted. Events arriving with API keys not in the `ReceiveKeys` list
-    ## will be rejected with an HTTP `401` error.
+    ## If `true`, then only traffic using the keys listed in `ReceiveKeys` or
+    ## whose key ID is listed in `ReceiveKeyIDs` is accepted. Events arriving
+    ## with API keys not in either list will be rejected with an HTTP `401`
+    ## error.
     ## If `false`, then all traffic is accepted and `ReceiveKeys` is ignored.
     ## This setting is applied **before** the `SendKey` and `SendKeyMode`
     ## settings.
@@ -558,8 +575,8 @@ HoneycombLogger:
     ##
     ## Not eligible for live reload.
     # AdditionalAttributes:
-      #  pipeline.id: '12345'
-      #  rollout.id: '67890'
+      #  pipeline.id: 12345
+      #  rollout.id: 67890
 
 ###################
 ## Stdout Logger ##
@@ -698,16 +715,15 @@ OTelMetrics:
     ## AdditionalAttributes adds the provided attributes as resource
     ## attributes on all OpenTelemetry metrics emitted by Refinery.
     ##
-    ## This is useful for injecting deployment-specific metadata (such as
-    ## a cluster ID or environment name) into metrics so they can be
-    ## filtered or grouped in the metrics backend.
-    ##
-    ## Both keys and values must be strings.
+    ## This is useful for injecting deployment-specific metadata (such as a
+    ## cluster ID or environment name) into metrics so they can be filtered
+    ## or grouped in the metrics backend. Both keys and values must be
+    ## strings.
     ##
     ## Not eligible for live reload.
     # AdditionalAttributes:
-    #   ClusterName: MyCluster
-    #   environment: production
+      #  pipeline.id: '12345'
+      #  rollout.id: '67890'
 
 ###########################
 ## OpenTelemetry Tracing ##

--- a/config_complete.yaml
+++ b/config_complete.yaml
@@ -695,6 +695,20 @@ OTelMetrics:
     ## Options: none gzip
     # Compression: gzip
 
+    ## AdditionalAttributes adds the provided attributes as resource
+    ## attributes on all OpenTelemetry metrics emitted by Refinery.
+    ##
+    ## This is useful for injecting deployment-specific metadata (such as
+    ## a cluster ID or environment name) into metrics so they can be
+    ## filtered or grouped in the metrics backend.
+    ##
+    ## Both keys and values must be strings.
+    ##
+    ## Not eligible for live reload.
+    # AdditionalAttributes:
+    #   ClusterName: MyCluster
+    #   environment: production
+
 ###########################
 ## OpenTelemetry Tracing ##
 ###########################

--- a/metrics.md
+++ b/metrics.md
@@ -3,7 +3,7 @@
 # Honeycomb Refinery Metrics Documentation
 
 This document contains the description of various metrics used in Refinery.
-It was automatically generated on 2026-02-25 at 20:49:27 UTC.
+It was automatically generated on 2026-03-09 at 14:11:11 UTC.
 
 Note: This document does not include metrics defined in the dynsampler-go dependency, as those metrics are generated dynamically at runtime. As a result, certain metrics may be missing or incomplete in this document, but they will still be available during execution with their full names.
 

--- a/metrics/otel_metrics.go
+++ b/metrics/otel_metrics.go
@@ -118,13 +118,19 @@ func (o *OTelMetrics) Start() error {
 		hostname = hn
 	}
 
-	res, err := resource.New(ctx,
+	// Build resource attributes: start with defaults, then add user-defined additional attributes
+	resourceOpts := []resource.Option{
 		resource.WithAttributes(resource.Default().Attributes()...),
 		resource.WithAttributes(attribute.KeyValue{Key: "service.name", Value: attribute.StringValue("refinery")}),
 		resource.WithAttributes(attribute.KeyValue{Key: "service.version", Value: attribute.StringValue(o.Version)}),
 		resource.WithAttributes(attribute.KeyValue{Key: "host.name", Value: attribute.StringValue(hostname)}),
 		resource.WithAttributes(attribute.KeyValue{Key: "hostname", Value: attribute.StringValue(hostname)}),
-	)
+	}
+	for k, v := range cfg.AdditionalAttributes {
+		resourceOpts = append(resourceOpts, resource.WithAttributes(attribute.KeyValue{Key: attribute.Key(k), Value: attribute.StringValue(v)}))
+	}
+
+	res, err := resource.New(ctx, resourceOpts...)
 
 	if err != nil {
 		return err

--- a/metrics/otel_metrics_test.go
+++ b/metrics/otel_metrics_test.go
@@ -124,6 +124,46 @@ func Test_OTelMetrics_Raciness(t *testing.T) {
 	metricdatatest.AssertEqual(t, want, got, metricdatatest.IgnoreTimestamp())
 }
 
+func Test_OTelMetrics_AdditionalAttributes(t *testing.T) {
+	rdr := sdkmetric.NewManualReader()
+
+	o := &OTelMetrics{
+		Logger: &logger.MockLogger{},
+		Config: &config.MockConfig{
+			GetOTelMetricsConfigVal: config.OTelMetricsConfig{
+				AdditionalAttributes: map[string]string{
+					"cluster.id":  "test-cluster-123",
+					"environment": "staging",
+				},
+			},
+		},
+		testReader: rdr,
+	}
+
+	err := o.Start()
+	defer o.Stop()
+	require.NoError(t, err)
+
+	// Emit a metric so we can collect resource data
+	o.Register(Metadata{Name: "test_attr", Type: Counter})
+	o.Increment("test_attr")
+
+	rm := metricdata.ResourceMetrics{}
+	err = rdr.Collect(t.Context(), &rm)
+	require.NoError(t, err)
+
+	// Check that the additional attributes are present as resource attributes
+	attrs := rm.Resource.Attributes()
+	attrMap := make(map[string]string)
+	for _, attr := range attrs {
+		attrMap[string(attr.Key)] = attr.Value.AsString()
+	}
+
+	assert.Equal(t, "test-cluster-123", attrMap["cluster.id"], "cluster.id resource attribute should be set")
+	assert.Equal(t, "staging", attrMap["environment"], "environment resource attribute should be set")
+	assert.Equal(t, "refinery", attrMap["service.name"], "service.name should still be present")
+}
+
 func Benchmark_OTelMetrics_ConcurrentAccess(b *testing.B) {
 	o := &OTelMetrics{
 		Logger: &logger.NullLogger{},

--- a/refinery_config.md
+++ b/refinery_config.md
@@ -158,16 +158,29 @@ Not intended or supported for customer use.
 
 This list only applies to span traffic - other Honeycomb API actions will be proxied through to the upstream API directly without modifying keys.
 
-- Not eligible for live reload.
+- Eligible for live reload.
 - Type: `stringarray`
 - Example: `your-key-goes-here`
+
+### `ReceiveKeyIDs`
+
+`ReceiveKeyIDs` is a set of Honeycomb Ingest Key IDs that the proxy will treat specially.
+
+When `AcceptOnlyListedKeys` is `true`, traffic using an API key whose Honeycomb ingest key ID matches an entry in this list will be accepted.
+The key ID is the `id` field returned by the Honeycomb `/1/auth` endpoint; it is distinct from the full API key value.
+This allows authorization based on key IDs rather than full key values, which avoids storing secret key material in the configuration file.
+Both `ReceiveKeys` and `ReceiveKeyIDs` may be used simultaneously.
+
+- Eligible for live reload.
+- Type: `stringarray`
+- Example: `your-key-id-goes-here`
 
 ### `AcceptOnlyListedKeys`
 
 `AcceptOnlyListedKeys` is a boolean flag that causes events arriving with API keys not in the `ReceiveKeys` list to be rejected.
 
-If `true`, then only traffic using the keys listed in `ReceiveKeys` is accepted.
-Events arriving with API keys not in the `ReceiveKeys` list will be rejected with an HTTP `401` error.
+If `true`, then only traffic using the keys listed in `ReceiveKeys` or whose key ID is listed in `ReceiveKeyIDs` is accepted.
+Events arriving with API keys not in either list will be rejected with an HTTP `401` error.
 If `false`, then all traffic is accepted and `ReceiveKeys` is ignored.
 This setting is applied **before** the `SendKey` and `SendKeyMode` settings.
 
@@ -510,7 +523,7 @@ The key-value pairs must use ':' as the separator.
 
 - Not eligible for live reload.
 - Type: `map`
-- Example: `pipeline.id:'12345',rollout.id:'67890'`
+- Example: `pipeline.id:12345,rollout.id:67890`
 - Environment variable: `REFINERY_HONEYCOMB_LOGGER_ADDITIONAL_ATTRIBUTES`
 
 ## Stdout Logger
@@ -649,12 +662,11 @@ In rare circumstances, compression costs may outweigh the benefits, in which cas
 `AdditionalAttributes` adds the provided attributes as resource attributes on all OpenTelemetry metrics emitted by Refinery.
 
 This is useful for injecting deployment-specific metadata (such as a cluster ID or environment name) into metrics so they can be filtered or grouped in the metrics backend.
-
 Both keys and values must be strings.
 
 - Not eligible for live reload.
-- Type: `map[string]string`
-- Default: `{}`
+- Type: `map`
+- Example: `pipeline.id:'12345',rollout.id:'67890'`
 
 ## OpenTelemetry Tracing
 

--- a/refinery_config.md
+++ b/refinery_config.md
@@ -644,6 +644,18 @@ In rare circumstances, compression costs may outweigh the benefits, in which cas
 - Default: `gzip`
 - Options: `none`, `gzip`
 
+### `AdditionalAttributes`
+
+`AdditionalAttributes` adds the provided attributes as resource attributes on all OpenTelemetry metrics emitted by Refinery.
+
+This is useful for injecting deployment-specific metadata (such as a cluster ID or environment name) into metrics so they can be filtered or grouped in the metrics backend.
+
+Both keys and values must be strings.
+
+- Not eligible for live reload.
+- Type: `map[string]string`
+- Default: `{}`
+
 ## OpenTelemetry Tracing
 
 `OTelTracing` contains configuration for Refinery's own tracing.

--- a/route/middleware.go
+++ b/route/middleware.go
@@ -45,7 +45,11 @@ func (r *Router) apiKeyProcessor(next http.Handler) http.Handler {
 		}
 
 		keycfg := r.Config.GetAccessKeyConfig()
-		if err := keycfg.IsAccepted(apiKey); err != nil {
+		keyID := ""
+		if keycfg.HasKeyIDs() {
+			keyID = r.getKeyID(apiKey)
+		}
+		if err := keycfg.IsAccepted(apiKey, keyID); err != nil {
 			r.handlerReturnWithError(w, ErrAuthInvalid, err)
 			return
 		}

--- a/route/otlp_logs_test.go
+++ b/route/otlp_logs_test.go
@@ -603,8 +603,8 @@ func TestLogsOTLPHandler(t *testing.T) {
 			},
 		} {
 			t.Run(fmt.Sprintf("ApiKey %s SendKeyMode %s SendKey %s", tt.apiKey, tt.mode, tt.sendKey), func(t *testing.T) {
-				router.environmentCache.addItem(tt.apiKey, "local", time.Minute)
-				router.environmentCache.addItem(tt.sendKey, "local", time.Minute)
+				router.environmentCache.addItem(tt.apiKey, authData{environment: "local"}, time.Minute)
+				router.environmentCache.addItem(tt.sendKey, authData{environment: "local"}, time.Minute)
 
 				// HTTP
 				request, _ := http.NewRequest("POST", "/v1/logs", bytes.NewReader(body))

--- a/route/otlp_trace.go
+++ b/route/otlp_trace.go
@@ -26,7 +26,11 @@ func (r *Router) postOTLPTrace(w http.ResponseWriter, req *http.Request) {
 
 	ri := huskyotlp.GetRequestInfoFromHttpHeaders(req.Header)
 	apicfg := r.Config.GetAccessKeyConfig()
-	if err := apicfg.IsAccepted(ri.ApiKey); err != nil {
+	keyID := ""
+	if apicfg.HasKeyIDs() {
+		keyID = r.getKeyID(ri.ApiKey)
+	}
+	if err := apicfg.IsAccepted(ri.ApiKey, keyID); err != nil {
 		r.handleOTLPFailureResponse(w, req, huskyotlp.OTLPError{Message: err.Error(), HTTPStatusCode: http.StatusUnauthorized})
 		return
 	}
@@ -137,7 +141,11 @@ func (t *TraceServer) ExportTraceData(
 
 	// Perform final authentication check (key processing already done in handler)
 	apicfg := t.router.Config.GetAccessKeyConfig()
-	if err := apicfg.IsAccepted(ri.ApiKey); err != nil {
+	keyID := ""
+	if apicfg.HasKeyIDs() {
+		keyID = t.router.getKeyID(ri.ApiKey)
+	}
+	if err := apicfg.IsAccepted(ri.ApiKey, keyID); err != nil {
 		return nil, status.Error(codes.Unauthenticated, err.Error())
 	}
 

--- a/route/otlp_trace_test.go
+++ b/route/otlp_trace_test.go
@@ -505,7 +505,7 @@ func TestOTLPHandler(t *testing.T) {
 		apiKey := "my-api-key"
 
 		// add cached environment lookup
-		router.environmentCache.addItem(apiKey, "local", time.Minute)
+		router.environmentCache.addItem(apiKey, authData{environment: "local"}, time.Minute)
 
 		req := &collectortrace.ExportTraceServiceRequest{
 			ResourceSpans: []*trace.ResourceSpans{{
@@ -920,8 +920,8 @@ func TestOTLPHandler(t *testing.T) {
 			},
 		} {
 			t.Run(fmt.Sprintf("ApiKey %s SendKeyMode %s SendKey %s", tt.apiKey, tt.mode, tt.sendKey), func(t *testing.T) {
-				router.environmentCache.addItem(tt.apiKey, "local", time.Minute)
-				router.environmentCache.addItem(tt.sendKey, "local", time.Minute)
+				router.environmentCache.addItem(tt.apiKey, authData{environment: "local"}, time.Minute)
+				router.environmentCache.addItem(tt.sendKey, authData{environment: "local"}, time.Minute)
 
 				// HTTP
 				request, _ := http.NewRequest("POST", "/v1/traces", bytes.NewReader(body))

--- a/route/route.go
+++ b/route/route.go
@@ -146,6 +146,8 @@ var routerMetrics = []metrics.Metadata{
 	{Name: "_router_otlp_trace_grpc", Type: metrics.Counter, Unit: metrics.Dimensionless, Description: "the number of otlp trace grpc requests received"},
 	{Name: "bytes_received_traces", Type: metrics.Counter, Unit: metrics.Bytes, Description: "the number of bytes received in trace events"},
 	{Name: "bytes_received_logs", Type: metrics.Counter, Unit: metrics.Bytes, Description: "the number of bytes received in log events"},
+	{Name: "events_received_traces", Type: metrics.Counter, Unit: metrics.Dimensionless, Description: "the number of trace events received"},
+	{Name: "events_received_logs", Type: metrics.Counter, Unit: metrics.Dimensionless, Description: "the number of log events received"},
 }
 
 func (r *Router) registerMetricNames() {
@@ -748,8 +750,10 @@ func (r *Router) processEvent(ev *types.Event, reqID interface{}) error {
 	if r.routerType.IsIncoming() && r.Config.GetOpAMPConfig().Enabled && r.Config.GetOpAMPConfig().RecordUsage.Get() {
 		if span.Data.MetaSignalType == "log" {
 			r.Metrics.Count("bytes_received_logs", int64(span.GetDataSize()))
+			r.Metrics.Increment("events_received_logs")
 		} else {
 			r.Metrics.Count("bytes_received_traces", int64(span.GetDataSize()))
+			r.Metrics.Increment("events_received_traces")
 		}
 	}
 

--- a/rules.md
+++ b/rules.md
@@ -3,7 +3,7 @@
 # Honeycomb Refinery Rules Documentation
 
 This is the documentation for the rules configuration for Honeycomb's Refinery.
-It was automatically generated on 2026-02-25 at 20:49:27 UTC.
+It was automatically generated on 2026-03-09 at 14:11:12 UTC.
 
 ## The Rules file
 

--- a/tools/convert/configDataNames.txt
+++ b/tools/convert/configDataNames.txt
@@ -1,5 +1,5 @@
 # Names of groups and fields in the new config file format.
-# Automatically generated on 2026-02-25 at 20:49:25 UTC.
+# Automatically generated on 2026-03-09 at 14:11:09 UTC.
 
 General:
   - ConfigurationVersion
@@ -33,6 +33,8 @@ OpAMP:
 
 AccessKeys:
   - ReceiveKeys (originally APIKeys)
+
+  - ReceiveKeyIDs
 
   - AcceptOnlyListedKeys
 

--- a/tools/convert/configDataNames.txt
+++ b/tools/convert/configDataNames.txt
@@ -136,6 +136,8 @@ OTelMetrics:
 
   - Compression
 
+  - AdditionalAttributes
+
 
 OTelTracing:
   - Enabled

--- a/tools/convert/minimal_config.yaml
+++ b/tools/convert/minimal_config.yaml
@@ -1,5 +1,5 @@
 # sample uncommented config file containing all possible fields
-# automatically generated on 2026-02-25 at 20:49:25 UTC
+# automatically generated on 2026-03-09 at 14:11:10 UTC
 General:
   ConfigurationVersion: 2
   MinRefineryVersion: "v2.0"
@@ -17,6 +17,9 @@ OpAMP:
 AccessKeys:
   ReceiveKeys: 
     - "your-key-goes-here"
+
+  ReceiveKeyIDs: 
+    - "your-key-id-goes-here"
 
   AcceptOnlyListedKeys: false
   SendKey: SetThisToAHoneycombKey
@@ -51,8 +54,8 @@ HoneycombLogger:
   SamplerEnabled: true
   SamplerThroughput: 10
   AdditionalAttributes: 
-    "pipeline.id": "'12345'"
-    "rollout.id": "'67890'"
+    "pipeline.id": 12345
+    "rollout.id": 67890
 
 StdoutLogger:
   Structured: false
@@ -68,7 +71,10 @@ OTelMetrics:
   Dataset: "Refinery Metrics"
   ReportingInterval: 30s
   Compression: gzip
-  AdditionalAttributes:
+  AdditionalAttributes: 
+    "pipeline.id": "'12345'"
+    "rollout.id": "'67890'"
+
 OTelTracing:
   Enabled: false
   APIHost: "https://api.honeycomb.io"

--- a/tools/convert/minimal_config.yaml
+++ b/tools/convert/minimal_config.yaml
@@ -68,6 +68,7 @@ OTelMetrics:
   Dataset: "Refinery Metrics"
   ReportingInterval: 30s
   Compression: gzip
+  AdditionalAttributes:
 OTelTracing:
   Enabled: false
   APIHost: "https://api.honeycomb.io"

--- a/tools/convert/templates/configV2.tmpl
+++ b/tools/convert/templates/configV2.tmpl
@@ -690,6 +690,18 @@ OTelMetrics:
     ## Options: none gzip
     {{ choice .Data "Compression" "Compression" (makeSlice "none" "gzip") "gzip" }}
 
+    ## AdditionalAttributes adds the provided attributes as resource
+    ## attributes on all OpenTelemetry metrics emitted by Refinery.
+    ##
+    ## This is useful for injecting deployment-specific metadata (such as
+    ## a cluster ID or environment name) into metrics so they can be
+    ## filtered or grouped in the metrics backend.
+    ##
+    ## Both keys and values must be strings.
+    ##
+    ## Not eligible for live reload.
+    {{ renderMap .Data "AdditionalAttributes" "AdditionalAttributes" "ClusterName:MyCluster,environment:production" }}
+
 ###########################
 ## OpenTelemetry Tracing ##
 ###########################

--- a/tools/convert/templates/configV2.tmpl
+++ b/tools/convert/templates/configV2.tmpl
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created {{ now }} from {{ .Input }} using a template generated on 2026-02-25 at 20:49:24 UTC
+# created {{ now }} from {{ .Input }} using a template generated on 2026-03-09 at 14:11:08 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of
@@ -165,15 +165,31 @@ AccessKeys:
     ## will be proxied through to the upstream API directly without modifying
     ## keys.
     ##
-    ## Not eligible for live reload.
+    ## Eligible for live reload.
     {{ renderStringarray .Data "ReceiveKeys" "APIKeys" "your-key-goes-here" }}
+
+    ## ReceiveKeyIDs is a set of Honeycomb Ingest Key IDs that the proxy will
+    ## treat specially.
+    ##
+    ## When `AcceptOnlyListedKeys` is `true`, traffic using an API key whose
+    ## Honeycomb ingest key ID matches an entry in this list will be
+    ## accepted. The key ID is the `id` field returned by the Honeycomb
+    ## `/1/auth` endpoint; it is distinct from the full API key value.
+    ## This allows authorization based on key IDs rather than full key
+    ## values, which avoids storing secret key material in the configuration
+    ## file. Both `ReceiveKeys` and `ReceiveKeyIDs` may be used
+    ## simultaneously.
+    ##
+    ## Eligible for live reload.
+    {{ renderStringarray .Data "ReceiveKeyIDs" "ReceiveKeyIDs" "your-key-id-goes-here" }}
 
     ## AcceptOnlyListedKeys is a boolean flag that causes events arriving
     ## with API keys not in the `ReceiveKeys` list to be rejected.
     ##
-    ## If `true`, then only traffic using the keys listed in `ReceiveKeys` is
-    ## accepted. Events arriving with API keys not in the `ReceiveKeys` list
-    ## will be rejected with an HTTP `401` error.
+    ## If `true`, then only traffic using the keys listed in `ReceiveKeys` or
+    ## whose key ID is listed in `ReceiveKeyIDs` is accepted. Events arriving
+    ## with API keys not in either list will be rejected with an HTTP `401`
+    ## error.
     ## If `false`, then all traffic is accepted and `ReceiveKeys` is ignored.
     ## This setting is applied **before** the `SendKey` and `SendKeyMode`
     ## settings.
@@ -554,7 +570,7 @@ HoneycombLogger:
     ## command line flag. The key-value pairs must use ':' as the separator.
     ##
     ## Not eligible for live reload.
-    {{ renderMap .Data "AdditionalAttributes" "AdditionalAttributes" "pipeline.id:'12345',rollout.id:'67890'" }}
+    {{ renderMap .Data "AdditionalAttributes" "AdditionalAttributes" "pipeline.id:12345,rollout.id:67890" }}
 
 ###################
 ## Stdout Logger ##
@@ -693,14 +709,13 @@ OTelMetrics:
     ## AdditionalAttributes adds the provided attributes as resource
     ## attributes on all OpenTelemetry metrics emitted by Refinery.
     ##
-    ## This is useful for injecting deployment-specific metadata (such as
-    ## a cluster ID or environment name) into metrics so they can be
-    ## filtered or grouped in the metrics backend.
-    ##
-    ## Both keys and values must be strings.
+    ## This is useful for injecting deployment-specific metadata (such as a
+    ## cluster ID or environment name) into metrics so they can be filtered
+    ## or grouped in the metrics backend. Both keys and values must be
+    ## strings.
     ##
     ## Not eligible for live reload.
-    {{ renderMap .Data "AdditionalAttributes" "AdditionalAttributes" "ClusterName:MyCluster,environment:production" }}
+    {{ renderMap .Data "AdditionalAttributes" "AdditionalAttributes" "pipeline.id:'12345',rollout.id:'67890'" }}
 
 ###########################
 ## OpenTelemetry Tracing ##


### PR DESCRIPTION
## Which problem is this PR solving?

Refinery needs new configuration capabilities to support **RaaS (Refinery as a Service)** — Honeycomb's managed Refinery sampling feature. Specifically, Refinery must be able to: (1) authorize ingest traffic by key ID rather than full key value, (2) attach deployment-identifying resource attributes to its OTLP metrics, and (3) report granular event metrics (received/dropped × traces/logs) for usage tracking.

Relates to [FRE-19](https://linear.app/honeycomb/issue/FRE-19)

## Short description of the changes

### Architecture Context

```mermaid
graph TD
    Admin[Honeycomb Admin] -->|Admin UI: CRUD deployments| Hound
    User[Team User] -->|User UI: manage rules| Hound
    Beekeeper -->|"GET /2/teams/{slug}/raas/{id}/configuration"| Hound
    Beekeeper -->|"POST /2/teams/{slug}/raas/{id}/health"| Hound
    Beekeeper -->|"OpAMP: push config_yaml + rules_yaml"| Refinery
    Refinery -->|"OpAMP: health + usage reports"| Beekeeper
```

This PR adds the Refinery-side changes for RaaS. Hound generates the Refinery config YAML and distributes it via Beekeeper/OpAMP. These changes enable Refinery to consume the new config fields.

### Changes

#### 1. `AccessKeys.ReceiveKeyIDs` — Key ID-based authorization

New config field `AccessKeys.ReceiveKeyIDs` (`[]string`) allows authorizing API keys by their Honeycomb key ID (not the full key value). This is more secure for RaaS because key IDs are not secret.

- **`IsAccepted(key, keyID string) error`** now checks three sources: `SendKey`, `ReceiveKeys`, and `ReceiveKeyIDs`
- **`HasKeyIDs() bool`** helper controls whether middleware performs the key ID lookup (avoids unnecessary auth API calls when not using RaaS)
- **Middleware integration** (`route/middleware.go`): Only calls `getKeyID()` when `ReceiveKeyIDs` is configured

#### 2. `OTelMetrics.AdditionalAttributes` — Deployment-identifying resource attributes

New config field `OTelMetrics.AdditionalAttributes` (`map[string]string`) adds OTLP resource attributes on every metric exported by Refinery. RaaS injects `raas_deployment_name` and `raas_deployment_id` so metrics can be attributed to specific managed deployments.

Mirrors the existing `HoneycombLogger.AdditionalAttributes` pattern.

#### 3. Granular event metrics and usage report enhancements

Enhanced the OpAMP usage reporting to include per-signal (traces/logs) event counts for received and dropped events, enabling Hound to track per-deployment usage and compute effective sample rates.

### Pre-existing test modifications

| File | Test / Helper | What Changed |
|------|--------------|--------------|
| `config/file_config_test.go` | `TestAccessKeyConfig_IsAccepted` | Updated `IsAccepted()` signature to accept `keyID` param; added 6 new `ReceiveKeyIDs` test cases |
| `config/file_config_test.go` | `BenchmarkAccessKeyConfig_IsAccepted` | New benchmark with 8 cases for `ReceiveKeys` and `ReceiveKeyIDs` at 10/100 entry scales |
| `route/route_test.go` | `TestEnvironmentCache`, `newBatchRouter`, `TestDependencyInjection` | Updated to use `authData{environment, keyID}` struct instead of plain string |
| `route/otlp_trace_test.go` | Test setup / helpers | Updated router initialization to use `newEnvironmentCache` with `authData` handling |
| `route/otlp_logs_test.go` | Test setup / helpers | Updated router initialization to use `newEnvironmentCache` with `authData` handling |
| `metrics/otel_metrics_test.go` | `Test_OTelMetrics_AdditionalAttributes` | New test verifying resource attribute injection |

### Configuration Reference

| Config Field | Type | Default | Description |
|-------------|------|---------|-------------|
| `AccessKeys.ReceiveKeyIDs` | `[]string` | `[]` | Ingest key IDs accepted by Refinery |
| `OTelMetrics.AdditionalAttributes` | `map[string]string` | `{}` | Resource attributes on OTLP metrics |
| `OpAMP.RecordUsage` | `bool` | `true` | Enable usage reporting (always true for RaaS) |