### PR TITLE
feat: add ReceiveKeyIDs config option for key ID-based authorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Refinery Changelog
 
-## Unreleased
-
-### Features
-
-- feat: add `ReceiveKeyIDs` config option for API key ID-based authorization
-
 ## 3.1.2 2026-03-25
 
 This release addresses security vulnerabilities CVE-2026-27139, CVE-2026-27142, and CVE-2026-25679.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Refinery Changelog
 
+## Unreleased
+
+### Features
+
+- feat: add `ReceiveKeyIDs` config option for API key ID-based authorization
+
 ## 3.1.2 2026-03-25
 
 This release addresses security vulnerabilities CVE-2026-27139, CVE-2026-27142, and CVE-2026-25679.

--- a/config.md
+++ b/config.md
@@ -3,7 +3,7 @@
 # Honeycomb Refinery Configuration Documentation
 
 This is the documentation for the configuration file for Honeycomb's Refinery.
-It was automatically generated on 2026-02-25 at 20:49:27 UTC.
+It was automatically generated on 2026-04-07 at 20:01:27 UTC.
 
 ## The Config file
 
@@ -181,16 +181,29 @@ ReceiveKeys is a set of Honeycomb API keys that the proxy will treat specially.
 
 This list only applies to span traffic - other Honeycomb API actions will be proxied through to the upstream API directly without modifying keys.
 
-- Not eligible for live reload.
+- Eligible for live reload.
 - Type: `stringarray`
 - Example: `your-key-goes-here`
+
+### `ReceiveKeyIDs`
+
+ReceiveKeyIDs is a set of Honeycomb Ingest Key IDs that the proxy will treat specially.
+
+When `AcceptOnlyListedKeys` is `true`, traffic using an API key whose Honeycomb ingest key ID matches an entry in this list will be accepted.
+The key ID is the `id` field returned by the Honeycomb `/1/auth` endpoint; it is distinct from the full API key value.
+This allows authorization based on key IDs rather than full key values, which avoids storing secret key material in the configuration file.
+Both `ReceiveKeys` and `ReceiveKeyIDs` may be used simultaneously.
+
+- Eligible for live reload.
+- Type: `stringarray`
+- Example: `your-key-id-goes-here`
 
 ### `AcceptOnlyListedKeys`
 
 AcceptOnlyListedKeys is a boolean flag that causes events arriving with API keys not in the `ReceiveKeys` list to be rejected.
 
-If `true`, then only traffic using the keys listed in `ReceiveKeys` is accepted.
-Events arriving with API keys not in the `ReceiveKeys` list will be rejected with an HTTP `401` error.
+If `true`, then only traffic using the keys listed in `ReceiveKeys` or whose key ID is listed in `ReceiveKeyIDs` is accepted.
+Events arriving with API keys not in either list will be rejected with an HTTP `401` error.
 If `false`, then all traffic is accepted and `ReceiveKeys` is ignored.
 This setting is applied **before** the `SendKey` and `SendKeyMode` settings.
 

--- a/config.md
+++ b/config.md
@@ -3,7 +3,7 @@
 # Honeycomb Refinery Configuration Documentation
 
 This is the documentation for the configuration file for Honeycomb's Refinery.
-It was automatically generated on 2026-04-08 at 18:28:49 UTC.
+It was automatically generated on 2026-04-08 at 21:59:38 UTC.
 
 ## The Config file
 

--- a/config.md
+++ b/config.md
@@ -3,7 +3,7 @@
 # Honeycomb Refinery Configuration Documentation
 
 This is the documentation for the configuration file for Honeycomb's Refinery.
-It was automatically generated on 2026-04-07 at 20:01:27 UTC.
+It was automatically generated on 2026-04-08 at 18:28:49 UTC.
 
 ## The Config file
 
@@ -193,6 +193,8 @@ When `AcceptOnlyListedKeys` is `true`, traffic using an API key whose Honeycomb 
 The key ID is the `id` field returned by the Honeycomb `/1/auth` endpoint; it is distinct from the full API key value.
 This allows authorization based on key IDs rather than full key values, which avoids storing secret key material in the configuration file.
 Both `ReceiveKeys` and `ReceiveKeyIDs` may be used simultaneously.
+Note: This feature does not support legacy API keys.
+Only Honeycomb Ingest Keys (which have a key ID) are compatible with this setting.
 
 - Eligible for live reload.
 - Type: `stringarray`

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -123,7 +123,7 @@ func (a *AccessKeyConfig) HasKeyIDs() bool {
 // GetReplaceKey checks the given API key against the configuration
 // and possibly replaces it with the configured SendKey, if the settings so indicate.
 // It returns the key to use, or an error if the key is invalid given the settings.
-func (a *AccessKeyConfig) GetReplaceKey(apiKey string) (string, error) {
+func (a *AccessKeyConfig) GetReplaceKey(apiKey, keyID string) (string, error) {
 	if a.SendKey != "" {
 		overwriteWith := ""
 		switch a.SendKeyMode {
@@ -139,10 +139,10 @@ func (a *AccessKeyConfig) GetReplaceKey(apiKey string) (string, error) {
 				overwriteWith = a.SendKey
 			}
 		case "listedonly":
-			// only replace keys that are listed in the `ReceiveKeys` list,
+			// only replace keys that are listed in the `ReceiveKeys` or `ReceiveKeyIDs` list,
 			// otherwise use original key
 			overwriteWith = apiKey
-			if slices.Contains(a.ReceiveKeys, apiKey) {
+			if slices.Contains(a.ReceiveKeys, apiKey) || (keyID != "" && slices.Contains(a.ReceiveKeyIDs, keyID)) {
 				overwriteWith = a.SendKey
 			}
 		case "missingonly":
@@ -153,11 +153,11 @@ func (a *AccessKeyConfig) GetReplaceKey(apiKey string) (string, error) {
 				overwriteWith = a.SendKey
 			}
 		case "unlisted":
-			// only replace nonblank keys that are NOT listed in the `ReceiveKeys` list
+			// only replace nonblank keys that are NOT listed in the `ReceiveKeys` or `ReceiveKeyIDs` list
 			// otherwise use original key
 			if apiKey != "" {
 				overwriteWith = apiKey
-				if !slices.Contains(a.ReceiveKeys, apiKey) {
+				if !slices.Contains(a.ReceiveKeys, apiKey) && !(keyID != "" && slices.Contains(a.ReceiveKeyIDs, keyID)) {
 					overwriteWith = a.SendKey
 				}
 			}

--- a/config/file_config_test.go
+++ b/config/file_config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"errors"
+	"fmt"
 	"runtime"
 	"testing"
 
@@ -166,6 +167,104 @@ func TestAccessKeyConfig_IsAccepted(t *testing.T) {
 				return
 			}
 			assert.Equal(t, tt.want.Error(), err.Error())
+		})
+	}
+}
+
+func BenchmarkAccessKeyConfig_IsAccepted(b *testing.B) {
+	// Generate realistic key lists
+	makeKeys := func(n int) []string {
+		keys := make([]string, n)
+		for i := range keys {
+			keys[i] = fmt.Sprintf("key-%06d", i)
+		}
+		return keys
+	}
+
+	benchmarks := []struct {
+		name   string
+		config AccessKeyConfig
+		key    string
+		keyID  string
+	}{
+		{
+			name:   "no_filtering",
+			config: AccessKeyConfig{AcceptOnlyListedKeys: false},
+			key:    "anykey",
+			keyID:  "",
+		},
+		{
+			name: "ReceiveKeys_10_match_last",
+			config: AccessKeyConfig{
+				ReceiveKeys:          makeKeys(10),
+				AcceptOnlyListedKeys: true,
+			},
+			key:   "key-000009",
+			keyID: "",
+		},
+		{
+			name: "ReceiveKeys_100_match_last",
+			config: AccessKeyConfig{
+				ReceiveKeys:          makeKeys(100),
+				AcceptOnlyListedKeys: true,
+			},
+			key:   "key-000099",
+			keyID: "",
+		},
+		{
+			name: "ReceiveKeys_100_no_match",
+			config: AccessKeyConfig{
+				ReceiveKeys:          makeKeys(100),
+				AcceptOnlyListedKeys: true,
+			},
+			key:   "unknown-key",
+			keyID: "",
+		},
+		{
+			name: "ReceiveKeyIDs_10_match_last",
+			config: AccessKeyConfig{
+				ReceiveKeyIDs:        makeKeys(10),
+				AcceptOnlyListedKeys: true,
+			},
+			key:   "anykey",
+			keyID: "key-000009",
+		},
+		{
+			name: "ReceiveKeyIDs_100_match_last",
+			config: AccessKeyConfig{
+				ReceiveKeyIDs:        makeKeys(100),
+				AcceptOnlyListedKeys: true,
+			},
+			key:   "anykey",
+			keyID: "key-000099",
+		},
+		{
+			name: "ReceiveKeyIDs_100_no_match",
+			config: AccessKeyConfig{
+				ReceiveKeyIDs:        makeKeys(100),
+				AcceptOnlyListedKeys: true,
+			},
+			key:   "anykey",
+			keyID: "unknown-kid",
+		},
+		{
+			name: "both_100_match_by_keyID",
+			config: AccessKeyConfig{
+				ReceiveKeys:          makeKeys(100),
+				ReceiveKeyIDs:        makeKeys(100),
+				AcceptOnlyListedKeys: true,
+			},
+			key:   "unknown-key",
+			keyID: "key-000050",
+		},
+	}
+
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_ = bm.config.IsAccepted(bm.key, bm.keyID)
+			}
 		})
 	}
 }

--- a/config/file_config_test.go
+++ b/config/file_config_test.go
@@ -57,6 +57,7 @@ func Test_GetQueueSizesPerWorker(t *testing.T) {
 func TestAccessKeyConfig_GetReplaceKey(t *testing.T) {
 	type fields struct {
 		ReceiveKeys          []string
+		ReceiveKeyIDs        []string
 		SendKey              string
 		SendKeyMode          string
 		AcceptOnlyListedKeys bool
@@ -72,6 +73,12 @@ func TestAccessKeyConfig_GetReplaceKey(t *testing.T) {
 		SendKey:     "sendkey",
 		SendKeyMode: "listedonly",
 	}
+	fListedWithKeyIDs := fields{
+		ReceiveKeys:   []string{"key1", "key2"},
+		ReceiveKeyIDs: []string{"kid1", "kid2"},
+		SendKey:       "sendkey",
+		SendKeyMode:   "listedonly",
+	}
 	fMissing := fields{
 		ReceiveKeys: []string{"key1", "key2"},
 		SendKey:     "sendkey",
@@ -82,36 +89,50 @@ func TestAccessKeyConfig_GetReplaceKey(t *testing.T) {
 		SendKey:     "sendkey",
 		SendKeyMode: "unlisted",
 	}
+	fUnlistedWithKeyIDs := fields{
+		ReceiveKeys:   []string{"key1", "key2"},
+		ReceiveKeyIDs: []string{"kid1", "kid2"},
+		SendKey:       "sendkey",
+		SendKeyMode:   "unlisted",
+	}
 
 	tests := []struct {
 		name    string
 		fields  fields
 		apiKey  string
+		keyID   string
 		want    string
 		wantErr bool
 	}{
-		{"send all known", fSendAll, "key1", "sendkey", false},
-		{"send all unknown", fSendAll, "userkey", "sendkey", false},
-		{"send all missing", fSendAll, "", "sendkey", false},
-		{"listed known", fListed, "key1", "sendkey", false},
-		{"listed unknown", fListed, "userkey", "userkey", false},
-		{"listed missing", fListed, "", "", true},
-		{"missing known", fMissing, "key1", "key1", false},
-		{"missing unknown", fMissing, "userkey", "userkey", false},
-		{"missing missing", fMissing, "", "sendkey", false},
-		{"unlisted known", fUnlisted, "key1", "key1", false},
-		{"unlisted unknown", fUnlisted, "userkey", "sendkey", false},
-		{"unlisted missing", fUnlisted, "", "", true},
+		{"send all known", fSendAll, "key1", "", "sendkey", false},
+		{"send all unknown", fSendAll, "userkey", "", "sendkey", false},
+		{"send all missing", fSendAll, "", "", "sendkey", false},
+		{"listed known", fListed, "key1", "", "sendkey", false},
+		{"listed unknown", fListed, "userkey", "", "userkey", false},
+		{"listed missing", fListed, "", "", "", true},
+		{"listed by keyID known", fListedWithKeyIDs, "unknownkey", "kid1", "sendkey", false},
+		{"listed by keyID unknown", fListedWithKeyIDs, "unknownkey", "unknownkid", "unknownkey", false},
+		{"listed by keyID empty", fListedWithKeyIDs, "unknownkey", "", "unknownkey", false},
+		{"missing known", fMissing, "key1", "", "key1", false},
+		{"missing unknown", fMissing, "userkey", "", "userkey", false},
+		{"missing missing", fMissing, "", "", "sendkey", false},
+		{"unlisted known", fUnlisted, "key1", "", "key1", false},
+		{"unlisted unknown", fUnlisted, "userkey", "", "sendkey", false},
+		{"unlisted missing", fUnlisted, "", "", "", true},
+		{"unlisted by keyID known", fUnlistedWithKeyIDs, "unknownkey", "kid1", "unknownkey", false},
+		{"unlisted by keyID unknown", fUnlistedWithKeyIDs, "unknownkey", "unknownkid", "sendkey", false},
+		{"unlisted by keyID empty", fUnlistedWithKeyIDs, "unknownkey", "", "sendkey", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			a := &AccessKeyConfig{
 				ReceiveKeys:          tt.fields.ReceiveKeys,
+				ReceiveKeyIDs:        tt.fields.ReceiveKeyIDs,
 				SendKey:              tt.fields.SendKey,
 				SendKeyMode:          tt.fields.SendKeyMode,
 				AcceptOnlyListedKeys: tt.fields.AcceptOnlyListedKeys,
 			}
-			got, err := a.GetReplaceKey(tt.apiKey)
+			got, err := a.GetReplaceKey(tt.apiKey, tt.keyID)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("AccessKeyConfig.GetReplaceKey() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -223,20 +223,36 @@ groups:
           will be proxied through to the upstream API directly without modifying
           keys.
 
+      - name: ReceiveKeyIDs
+        type: stringarray
+        valuetype: stringarray
+        example: "your-key-id-goes-here"
+        reload: false
+        validations:
+          - type: elementType
+            arg: string
+        summary: is a set of Honeycomb Ingest Key IDs that the proxy will treat specially.
+        description: >
+          When `AcceptOnlyListedKeys` is `true`, traffic using an API key whose
+          Honeycomb ingest key ID matches an entry in this list will be accepted.
+          The key ID is the `id` field returned by the Honeycomb `/1/auth`
+          endpoint; it is distinct from the full API key value.
+
+          This allows authorization based on key IDs rather than full key values,
+          which avoids storing secret key material in the configuration file.
+          Both `ReceiveKeys` and `ReceiveKeyIDs` may be used simultaneously.
+
       - name: AcceptOnlyListedKeys
         type: bool
         valuetype: conditional
         extra: nostar APIKeys
         default: false
         reload: true
-        validation:
-          - type: requiredWith
-            arg: ReceiveKeys
         summary: is a boolean flag that causes events arriving with API keys not in the `ReceiveKeys` list to be rejected.
         description: >
-          If `true`, then only traffic using the keys listed in `ReceiveKeys` is
-          accepted. Events arriving with API keys not in the `ReceiveKeys` list
-          will be rejected with an HTTP `401` error.
+          If `true`, then only traffic using the keys listed in `ReceiveKeys` or
+          whose key ID is listed in `ReceiveKeyIDs` is accepted. Events arriving
+          with API keys not in either list will be rejected with an HTTP `401` error.
 
           If `false`, then all traffic is accepted and `ReceiveKeys` is ignored.
 

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -213,7 +213,7 @@ groups:
         valuetype: stringarray
         v1name: APIKeys
         example: "your-key-goes-here"
-        reload: false
+        reload: true
         validations:
           - type: elementType
             arg: string
@@ -227,7 +227,7 @@ groups:
         type: stringarray
         valuetype: stringarray
         example: "your-key-id-goes-here"
-        reload: false
+        reload: true
         validations:
           - type: elementType
             arg: string

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -242,12 +242,20 @@ groups:
           which avoids storing secret key material in the configuration file.
           Both `ReceiveKeys` and `ReceiveKeyIDs` may be used simultaneously.
 
+          Note: This feature does not support legacy API keys. Only Honeycomb
+          Ingest Keys (which have a key ID) are compatible with this setting.
+
       - name: AcceptOnlyListedKeys
         type: bool
         valuetype: conditional
         extra: nostar APIKeys
         default: false
         reload: true
+        validations:
+          - type: requiredWith
+            arg: ReceiveKeys
+          - type: requiredWith
+            arg: ReceiveKeyIDs
         summary: is a boolean flag that causes events arriving with API keys not in the `ReceiveKeys` list to be rejected.
         description: >
           If `true`, then only traffic using the keys listed in `ReceiveKeys` or

--- a/config/metadata/configMeta.yaml
+++ b/config/metadata/configMeta.yaml
@@ -227,6 +227,7 @@ groups:
         type: stringarray
         valuetype: stringarray
         example: "your-key-id-goes-here"
+        firstversion: v3.2
         reload: true
         validations:
           - type: elementType

--- a/config_complete.yaml
+++ b/config_complete.yaml
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created on 2026-04-07 at 20:01:26 UTC from ../../config.yaml using a template generated on 2026-04-07 at 20:01:09 UTC
+# created on 2026-04-08 at 18:28:49 UTC from ../../config.yaml using a template generated on 2026-04-08 at 18:28:45 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of
@@ -181,6 +181,8 @@ AccessKeys:
     ## values, which avoids storing secret key material in the configuration
     ## file. Both `ReceiveKeys` and `ReceiveKeyIDs` may be used
     ## simultaneously.
+    ## Note: This feature does not support legacy API keys. Only Honeycomb
+    ## Ingest Keys (which have a key ID) are compatible with this setting.
     ##
     ## Eligible for live reload.
     # ReceiveKeyIDs:
@@ -575,8 +577,8 @@ HoneycombLogger:
     ##
     ## Not eligible for live reload.
     # AdditionalAttributes:
-      #  rollout.id: '67890'
       #  pipeline.id: '12345'
+      #  rollout.id: '67890'
 
 ###################
 ## Stdout Logger ##

--- a/config_complete.yaml
+++ b/config_complete.yaml
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created on 2026-04-08 at 18:28:49 UTC from ../../config.yaml using a template generated on 2026-04-08 at 18:28:45 UTC
+# created on 2026-04-08 at 21:59:37 UTC from ../../config.yaml using a template generated on 2026-04-08 at 21:59:33 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of

--- a/config_complete.yaml
+++ b/config_complete.yaml
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created on 2026-02-25 at 20:49:27 UTC from ../../config.yaml using a template generated on 2026-02-25 at 20:49:24 UTC
+# created on 2026-04-07 at 20:01:26 UTC from ../../config.yaml using a template generated on 2026-04-07 at 20:01:09 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of
@@ -166,16 +166,33 @@ AccessKeys:
     ## will be proxied through to the upstream API directly without modifying
     ## keys.
     ##
-    ## Not eligible for live reload.
+    ## Eligible for live reload.
     # ReceiveKeys:
       # - your-key-goes-here
+
+    ## ReceiveKeyIDs is a set of Honeycomb Ingest Key IDs that the proxy will
+    ## treat specially.
+    ##
+    ## When `AcceptOnlyListedKeys` is `true`, traffic using an API key whose
+    ## Honeycomb ingest key ID matches an entry in this list will be
+    ## accepted. The key ID is the `id` field returned by the Honeycomb
+    ## `/1/auth` endpoint; it is distinct from the full API key value.
+    ## This allows authorization based on key IDs rather than full key
+    ## values, which avoids storing secret key material in the configuration
+    ## file. Both `ReceiveKeys` and `ReceiveKeyIDs` may be used
+    ## simultaneously.
+    ##
+    ## Eligible for live reload.
+    # ReceiveKeyIDs:
+      # - your-key-id-goes-here
 
     ## AcceptOnlyListedKeys is a boolean flag that causes events arriving
     ## with API keys not in the `ReceiveKeys` list to be rejected.
     ##
-    ## If `true`, then only traffic using the keys listed in `ReceiveKeys` is
-    ## accepted. Events arriving with API keys not in the `ReceiveKeys` list
-    ## will be rejected with an HTTP `401` error.
+    ## If `true`, then only traffic using the keys listed in `ReceiveKeys` or
+    ## whose key ID is listed in `ReceiveKeyIDs` is accepted. Events arriving
+    ## with API keys not in either list will be rejected with an HTTP `401`
+    ## error.
     ## If `false`, then all traffic is accepted and `ReceiveKeys` is ignored.
     ## This setting is applied **before** the `SendKey` and `SendKeyMode`
     ## settings.
@@ -558,8 +575,8 @@ HoneycombLogger:
     ##
     ## Not eligible for live reload.
     # AdditionalAttributes:
-      #  pipeline.id: '12345'
       #  rollout.id: '67890'
+      #  pipeline.id: '12345'
 
 ###################
 ## Stdout Logger ##

--- a/metrics.md
+++ b/metrics.md
@@ -3,7 +3,7 @@
 # Honeycomb Refinery Metrics Documentation
 
 This document contains the description of various metrics used in Refinery.
-It was automatically generated on 2026-04-08 at 18:28:49 UTC.
+It was automatically generated on 2026-04-08 at 21:59:37 UTC.
 
 Note: This document does not include metrics defined in the dynsampler-go dependency, as those metrics are generated dynamically at runtime. As a result, certain metrics may be missing or incomplete in this document, but they will still be available during execution with their full names.
 

--- a/metrics.md
+++ b/metrics.md
@@ -3,7 +3,7 @@
 # Honeycomb Refinery Metrics Documentation
 
 This document contains the description of various metrics used in Refinery.
-It was automatically generated on 2026-04-07 at 20:01:26 UTC.
+It was automatically generated on 2026-04-08 at 18:28:49 UTC.
 
 Note: This document does not include metrics defined in the dynsampler-go dependency, as those metrics are generated dynamically at runtime. As a result, certain metrics may be missing or incomplete in this document, but they will still be available during execution with their full names.
 

--- a/metrics.md
+++ b/metrics.md
@@ -3,7 +3,7 @@
 # Honeycomb Refinery Metrics Documentation
 
 This document contains the description of various metrics used in Refinery.
-It was automatically generated on 2026-02-25 at 20:49:27 UTC.
+It was automatically generated on 2026-04-07 at 20:01:26 UTC.
 
 Note: This document does not include metrics defined in the dynsampler-go dependency, as those metrics are generated dynamically at runtime. As a result, certain metrics may be missing or incomplete in this document, but they will still be available during execution with their full names.
 

--- a/refinery_config.md
+++ b/refinery_config.md
@@ -170,6 +170,8 @@ When `AcceptOnlyListedKeys` is `true`, traffic using an API key whose Honeycomb 
 The key ID is the `id` field returned by the Honeycomb `/1/auth` endpoint; it is distinct from the full API key value.
 This allows authorization based on key IDs rather than full key values, which avoids storing secret key material in the configuration file.
 Both `ReceiveKeys` and `ReceiveKeyIDs` may be used simultaneously.
+Note: This feature does not support legacy API keys.
+Only Honeycomb Ingest Keys (which have a key ID) are compatible with this setting.
 
 - Eligible for live reload.
 - Type: `stringarray`

--- a/refinery_config.md
+++ b/refinery_config.md
@@ -158,16 +158,29 @@ Not intended or supported for customer use.
 
 This list only applies to span traffic - other Honeycomb API actions will be proxied through to the upstream API directly without modifying keys.
 
-- Not eligible for live reload.
+- Eligible for live reload.
 - Type: `stringarray`
 - Example: `your-key-goes-here`
+
+### `ReceiveKeyIDs`
+
+`ReceiveKeyIDs` is a set of Honeycomb Ingest Key IDs that the proxy will treat specially.
+
+When `AcceptOnlyListedKeys` is `true`, traffic using an API key whose Honeycomb ingest key ID matches an entry in this list will be accepted.
+The key ID is the `id` field returned by the Honeycomb `/1/auth` endpoint; it is distinct from the full API key value.
+This allows authorization based on key IDs rather than full key values, which avoids storing secret key material in the configuration file.
+Both `ReceiveKeys` and `ReceiveKeyIDs` may be used simultaneously.
+
+- Eligible for live reload.
+- Type: `stringarray`
+- Example: `your-key-id-goes-here`
 
 ### `AcceptOnlyListedKeys`
 
 `AcceptOnlyListedKeys` is a boolean flag that causes events arriving with API keys not in the `ReceiveKeys` list to be rejected.
 
-If `true`, then only traffic using the keys listed in `ReceiveKeys` is accepted.
-Events arriving with API keys not in the `ReceiveKeys` list will be rejected with an HTTP `401` error.
+If `true`, then only traffic using the keys listed in `ReceiveKeys` or whose key ID is listed in `ReceiveKeyIDs` is accepted.
+Events arriving with API keys not in either list will be rejected with an HTTP `401` error.
 If `false`, then all traffic is accepted and `ReceiveKeys` is ignored.
 This setting is applied **before** the `SendKey` and `SendKeyMode` settings.
 

--- a/route/middleware.go
+++ b/route/middleware.go
@@ -45,7 +45,11 @@ func (r *Router) apiKeyProcessor(next http.Handler) http.Handler {
 		}
 
 		keycfg := r.Config.GetAccessKeyConfig()
-		if err := keycfg.IsAccepted(apiKey); err != nil {
+		keyID := ""
+		if keycfg.HasKeyIDs() {
+			keyID = r.getKeyID(apiKey)
+		}
+		if err := keycfg.IsAccepted(apiKey, keyID); err != nil {
 			r.handlerReturnWithError(w, ErrAuthInvalid, err)
 			return
 		}

--- a/route/middleware.go
+++ b/route/middleware.go
@@ -54,7 +54,7 @@ func (r *Router) apiKeyProcessor(next http.Handler) http.Handler {
 			return
 		}
 
-		replacement, err := keycfg.GetReplaceKey(apiKey)
+		replacement, err := keycfg.GetReplaceKey(apiKey, keyID)
 		if err != nil {
 			r.handlerReturnWithError(w, ErrAuthInvalid, err)
 			return

--- a/route/otlp_logs.go
+++ b/route/otlp_logs.go
@@ -26,7 +26,7 @@ func (r *Router) postOTLPLogs(w http.ResponseWriter, req *http.Request) {
 		r.handleOTLPFailureResponse(w, req, huskyotlp.OTLPError{Message: err.Error(), HTTPStatusCode: http.StatusUnauthorized})
 		return
 	}
-	keyToUse, _ := apicfg.GetReplaceKey(ri.ApiKey)
+	keyToUse, _ := apicfg.GetReplaceKey(ri.ApiKey, keyID)
 
 	if err := ri.ValidateLogsHeaders(); err != nil {
 		switch err {
@@ -90,7 +90,7 @@ func (l *LogsServer) Export(ctx context.Context, req *collectorlogs.ExportLogsSe
 	if err := apicfg.IsAccepted(ri.ApiKey, keyID); err != nil {
 		return nil, status.Error(codes.Unauthenticated, err.Error())
 	}
-	keyToUse, _ := apicfg.GetReplaceKey(ri.ApiKey)
+	keyToUse, _ := apicfg.GetReplaceKey(ri.ApiKey, keyID)
 
 	if err := ri.ValidateLogsHeaders(); err != nil && err != huskyotlp.ErrMissingAPIKeyHeader {
 		return nil, huskyotlp.AsGRPCError(err)

--- a/route/otlp_logs_test.go
+++ b/route/otlp_logs_test.go
@@ -603,8 +603,8 @@ func TestLogsOTLPHandler(t *testing.T) {
 			},
 		} {
 			t.Run(fmt.Sprintf("ApiKey %s SendKeyMode %s SendKey %s", tt.apiKey, tt.mode, tt.sendKey), func(t *testing.T) {
-				router.environmentCache.addItem(tt.apiKey, "local", time.Minute)
-				router.environmentCache.addItem(tt.sendKey, "local", time.Minute)
+				router.environmentCache.addItem(tt.apiKey, authData{environment: "local"}, time.Minute)
+				router.environmentCache.addItem(tt.sendKey, authData{environment: "local"}, time.Minute)
 
 				// HTTP
 				request, _ := http.NewRequest("POST", "/v1/logs", bytes.NewReader(body))

--- a/route/otlp_trace.go
+++ b/route/otlp_trace.go
@@ -26,7 +26,11 @@ func (r *Router) postOTLPTrace(w http.ResponseWriter, req *http.Request) {
 
 	ri := huskyotlp.GetRequestInfoFromHttpHeaders(req.Header)
 	apicfg := r.Config.GetAccessKeyConfig()
-	if err := apicfg.IsAccepted(ri.ApiKey); err != nil {
+	keyID := ""
+	if apicfg.HasKeyIDs() {
+		keyID = r.getKeyID(ri.ApiKey)
+	}
+	if err := apicfg.IsAccepted(ri.ApiKey, keyID); err != nil {
 		r.handleOTLPFailureResponse(w, req, huskyotlp.OTLPError{Message: err.Error(), HTTPStatusCode: http.StatusUnauthorized})
 		return
 	}
@@ -137,7 +141,11 @@ func (t *TraceServer) ExportTraceData(
 
 	// Perform final authentication check (key processing already done in handler)
 	apicfg := t.router.Config.GetAccessKeyConfig()
-	if err := apicfg.IsAccepted(ri.ApiKey); err != nil {
+	keyID := ""
+	if apicfg.HasKeyIDs() {
+		keyID = t.router.getKeyID(ri.ApiKey)
+	}
+	if err := apicfg.IsAccepted(ri.ApiKey, keyID); err != nil {
 		return nil, status.Error(codes.Unauthenticated, err.Error())
 	}
 

--- a/route/otlp_trace.go
+++ b/route/otlp_trace.go
@@ -34,7 +34,7 @@ func (r *Router) postOTLPTrace(w http.ResponseWriter, req *http.Request) {
 		r.handleOTLPFailureResponse(w, req, huskyotlp.OTLPError{Message: err.Error(), HTTPStatusCode: http.StatusUnauthorized})
 		return
 	}
-	keyToUse, _ := apicfg.GetReplaceKey(ri.ApiKey)
+	keyToUse, _ := apicfg.GetReplaceKey(ri.ApiKey, keyID)
 
 	if err := ri.ValidateTracesHeaders(); err != nil {
 		switch err {
@@ -213,7 +213,11 @@ func customTraceExportHandler(
 
 	// Handle SendKeyMode logic before validation, similar to HTTP handler
 	apicfg := traceServer.router.Config.GetAccessKeyConfig()
-	keyToUse, err := apicfg.GetReplaceKey(ri.ApiKey)
+	keyID := ""
+	if apicfg.HasKeyIDs() {
+		keyID = traceServer.router.getKeyID(ri.ApiKey)
+	}
+	keyToUse, err := apicfg.GetReplaceKey(ri.ApiKey, keyID)
 	if err != nil {
 		return nil, status.Error(codes.Unauthenticated, err.Error())
 	}

--- a/route/otlp_trace_test.go
+++ b/route/otlp_trace_test.go
@@ -505,7 +505,7 @@ func TestOTLPHandler(t *testing.T) {
 		apiKey := "my-api-key"
 
 		// add cached environment lookup
-		router.environmentCache.addItem(apiKey, "local", time.Minute)
+		router.environmentCache.addItem(apiKey, authData{environment: "local"}, time.Minute)
 
 		req := &collectortrace.ExportTraceServiceRequest{
 			ResourceSpans: []*trace.ResourceSpans{{
@@ -920,8 +920,8 @@ func TestOTLPHandler(t *testing.T) {
 			},
 		} {
 			t.Run(fmt.Sprintf("ApiKey %s SendKeyMode %s SendKey %s", tt.apiKey, tt.mode, tt.sendKey), func(t *testing.T) {
-				router.environmentCache.addItem(tt.apiKey, "local", time.Minute)
-				router.environmentCache.addItem(tt.sendKey, "local", time.Minute)
+				router.environmentCache.addItem(tt.apiKey, authData{environment: "local"}, time.Minute)
+				router.environmentCache.addItem(tt.sendKey, authData{environment: "local"}, time.Minute)
 
 				// HTTP
 				request, _ := http.NewRequest("POST", "/v1/traces", bytes.NewReader(body))

--- a/rules.md
+++ b/rules.md
@@ -3,7 +3,7 @@
 # Honeycomb Refinery Rules Documentation
 
 This is the documentation for the rules configuration for Honeycomb's Refinery.
-It was automatically generated on 2026-04-08 at 18:28:50 UTC.
+It was automatically generated on 2026-04-08 at 21:59:38 UTC.
 
 ## The Rules file
 

--- a/rules.md
+++ b/rules.md
@@ -3,7 +3,7 @@
 # Honeycomb Refinery Rules Documentation
 
 This is the documentation for the rules configuration for Honeycomb's Refinery.
-It was automatically generated on 2026-04-07 at 20:01:27 UTC.
+It was automatically generated on 2026-04-08 at 18:28:50 UTC.
 
 ## The Rules file
 

--- a/rules.md
+++ b/rules.md
@@ -3,7 +3,7 @@
 # Honeycomb Refinery Rules Documentation
 
 This is the documentation for the rules configuration for Honeycomb's Refinery.
-It was automatically generated on 2026-02-25 at 20:49:27 UTC.
+It was automatically generated on 2026-04-07 at 20:01:27 UTC.
 
 ## The Rules file
 

--- a/tools/convert/configDataNames.txt
+++ b/tools/convert/configDataNames.txt
@@ -1,5 +1,5 @@
 # Names of groups and fields in the new config file format.
-# Automatically generated on 2026-04-08 at 18:28:46 UTC.
+# Automatically generated on 2026-04-08 at 21:59:34 UTC.
 
 General:
   - ConfigurationVersion

--- a/tools/convert/configDataNames.txt
+++ b/tools/convert/configDataNames.txt
@@ -1,5 +1,5 @@
 # Names of groups and fields in the new config file format.
-# Automatically generated on 2026-02-25 at 20:49:25 UTC.
+# Automatically generated on 2026-04-07 at 20:01:11 UTC.
 
 General:
   - ConfigurationVersion
@@ -33,6 +33,8 @@ OpAMP:
 
 AccessKeys:
   - ReceiveKeys (originally APIKeys)
+
+  - ReceiveKeyIDs
 
   - AcceptOnlyListedKeys
 

--- a/tools/convert/configDataNames.txt
+++ b/tools/convert/configDataNames.txt
@@ -1,5 +1,5 @@
 # Names of groups and fields in the new config file format.
-# Automatically generated on 2026-04-07 at 20:01:11 UTC.
+# Automatically generated on 2026-04-08 at 18:28:46 UTC.
 
 General:
   - ConfigurationVersion

--- a/tools/convert/minimal_config.yaml
+++ b/tools/convert/minimal_config.yaml
@@ -1,5 +1,5 @@
 # sample uncommented config file containing all possible fields
-# automatically generated on 2026-02-25 at 20:49:25 UTC
+# automatically generated on 2026-04-07 at 20:01:11 UTC
 General:
   ConfigurationVersion: 2
   MinRefineryVersion: "v2.0"
@@ -17,6 +17,9 @@ OpAMP:
 AccessKeys:
   ReceiveKeys: 
     - "your-key-goes-here"
+
+  ReceiveKeyIDs: 
+    - "your-key-id-goes-here"
 
   AcceptOnlyListedKeys: false
   SendKey: SetThisToAHoneycombKey

--- a/tools/convert/minimal_config.yaml
+++ b/tools/convert/minimal_config.yaml
@@ -1,5 +1,5 @@
 # sample uncommented config file containing all possible fields
-# automatically generated on 2026-04-08 at 18:28:47 UTC
+# automatically generated on 2026-04-08 at 21:59:35 UTC
 General:
   ConfigurationVersion: 2
   MinRefineryVersion: "v2.0"

--- a/tools/convert/minimal_config.yaml
+++ b/tools/convert/minimal_config.yaml
@@ -1,5 +1,5 @@
 # sample uncommented config file containing all possible fields
-# automatically generated on 2026-04-07 at 20:01:11 UTC
+# automatically generated on 2026-04-08 at 18:28:47 UTC
 General:
   ConfigurationVersion: 2
   MinRefineryVersion: "v2.0"

--- a/tools/convert/templates/configV2.tmpl
+++ b/tools/convert/templates/configV2.tmpl
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created {{ now }} from {{ .Input }} using a template generated on 2026-02-25 at 20:49:24 UTC
+# created {{ now }} from {{ .Input }} using a template generated on 2026-04-07 at 20:01:09 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of
@@ -165,15 +165,31 @@ AccessKeys:
     ## will be proxied through to the upstream API directly without modifying
     ## keys.
     ##
-    ## Not eligible for live reload.
+    ## Eligible for live reload.
     {{ renderStringarray .Data "ReceiveKeys" "APIKeys" "your-key-goes-here" }}
+
+    ## ReceiveKeyIDs is a set of Honeycomb Ingest Key IDs that the proxy will
+    ## treat specially.
+    ##
+    ## When `AcceptOnlyListedKeys` is `true`, traffic using an API key whose
+    ## Honeycomb ingest key ID matches an entry in this list will be
+    ## accepted. The key ID is the `id` field returned by the Honeycomb
+    ## `/1/auth` endpoint; it is distinct from the full API key value.
+    ## This allows authorization based on key IDs rather than full key
+    ## values, which avoids storing secret key material in the configuration
+    ## file. Both `ReceiveKeys` and `ReceiveKeyIDs` may be used
+    ## simultaneously.
+    ##
+    ## Eligible for live reload.
+    {{ renderStringarray .Data "ReceiveKeyIDs" "ReceiveKeyIDs" "your-key-id-goes-here" }}
 
     ## AcceptOnlyListedKeys is a boolean flag that causes events arriving
     ## with API keys not in the `ReceiveKeys` list to be rejected.
     ##
-    ## If `true`, then only traffic using the keys listed in `ReceiveKeys` is
-    ## accepted. Events arriving with API keys not in the `ReceiveKeys` list
-    ## will be rejected with an HTTP `401` error.
+    ## If `true`, then only traffic using the keys listed in `ReceiveKeys` or
+    ## whose key ID is listed in `ReceiveKeyIDs` is accepted. Events arriving
+    ## with API keys not in either list will be rejected with an HTTP `401`
+    ## error.
     ## If `false`, then all traffic is accepted and `ReceiveKeys` is ignored.
     ## This setting is applied **before** the `SendKey` and `SendKeyMode`
     ## settings.

--- a/tools/convert/templates/configV2.tmpl
+++ b/tools/convert/templates/configV2.tmpl
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created {{ now }} from {{ .Input }} using a template generated on 2026-04-07 at 20:01:09 UTC
+# created {{ now }} from {{ .Input }} using a template generated on 2026-04-08 at 18:28:45 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of
@@ -179,6 +179,8 @@ AccessKeys:
     ## values, which avoids storing secret key material in the configuration
     ## file. Both `ReceiveKeys` and `ReceiveKeyIDs` may be used
     ## simultaneously.
+    ## Note: This feature does not support legacy API keys. Only Honeycomb
+    ## Ingest Keys (which have a key ID) are compatible with this setting.
     ##
     ## Eligible for live reload.
     {{ renderStringarray .Data "ReceiveKeyIDs" "ReceiveKeyIDs" "your-key-id-goes-here" }}

--- a/tools/convert/templates/configV2.tmpl
+++ b/tools/convert/templates/configV2.tmpl
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created {{ now }} from {{ .Input }} using a template generated on 2026-04-08 at 18:28:45 UTC
+# created {{ now }} from {{ .Input }} using a template generated on 2026-04-08 at 21:59:33 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of


### PR DESCRIPTION
## Summary

- Adds `AccessKeys.ReceiveKeyIDs` config option allowing Refinery to authorize traffic by Honeycomb ingest key IDs (from `/1/auth` endpoint) instead of requiring full API keys
- Updates `IsAccepted()` to check both `ReceiveKeys` (full keys) and `ReceiveKeyIDs` (key IDs) simultaneously
- Enables live reload for both `ReceiveKeys` and `ReceiveKeyIDs` config fields
- Adds benchmarks for the `IsAccepted` hot path with various list sizes

This is part of the RaaS (Refinery as a Service) feature set, split from PR #1798.

Closes FRE-6

## Test plan

- [x] Unit tests pass for `IsAccepted()` with key IDs, full keys, and mixed scenarios
- [x] Benchmarks verify performance of key lookup with 10/100 keys
- [x] Config validation passes (`make validate` in `tools/convert/`)
- [x] `go vet ./...` passes
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)