### PR TITLE
fix: update ko build tooling and fix flaky integration test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,8 @@ wait_for_redis: dockerize
 # You can override this version from an environment variable.
 HOST_OS := $(shell uname -s | tr A-Z a-z)
 # You can override this version from an environment variable.
-KO_VERSION ?= 0.11.2
-KO_RELEASE_ASSET := ko_${KO_VERSION}_${HOST_OS}_x86_64.tar.gz
+KO_VERSION ?= 0.18.0
+KO_RELEASE_ASSET := ko_${KO_VERSION}_${HOST_OS}_arm64.tar.gz
 # ensure the ko command is available
 ko: ko_${KO_VERSION}.tar.gz
 	tar xzvmf $< ko
@@ -189,7 +189,3 @@ unsmoke:
 	@echo "+++ Spinning down the smokers."
 	@echo ""
 	cd smoke-test && docker-compose down --volumes
-
-
-
-

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ wait_for_redis: dockerize
 HOST_OS := $(shell uname -s | tr A-Z a-z)
 # You can override this version from an environment variable.
 KO_VERSION ?= 0.18.0
-KO_RELEASE_ASSET := ko_${KO_VERSION}_${HOST_OS}_arm64.tar.gz
+KO_RELEASE_ASSET := ko_${KO_VERSION}_${HOST_OS}_amd64.tar.gz
 # ensure the ko command is available
 ko: ko_${KO_VERSION}.tar.gz
 	tar xzvmf $< ko

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ wait_for_redis: dockerize
 HOST_OS := $(shell uname -s | tr A-Z a-z)
 # You can override this version from an environment variable.
 KO_VERSION ?= 0.18.0
-KO_RELEASE_ASSET := ko_${KO_VERSION}_${HOST_OS}_amd64.tar.gz
+KO_RELEASE_ASSET := ko_${KO_VERSION}_${HOST_OS}_x86_64.tar.gz
 # ensure the ko command is available
 ko: ko_${KO_VERSION}.tar.gz
 	tar xzvmf $< ko

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -382,10 +382,19 @@ func newStartedApp(
 	assert.NoError(t, err)
 
 	err = startstop.Start(g.Objects(), nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	// Racy: wait just a moment for ListenAndServe to start up.
-	time.Sleep(15 * time.Millisecond)
+	// Wait for the HTTP server to be ready by polling the listen address.
+	listenAddr := c.GetListenAddr()
+	require.Eventually(t, func() bool {
+		conn, err := net.DialTimeout("tcp", listenAddr, 50*time.Millisecond)
+		if err != nil {
+			return false
+		}
+		conn.Close()
+		return true
+	}, 2*time.Second, 10*time.Millisecond, "server failed to start listening on %s", listenAddr)
+
 	return &a, g
 }
 

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -72,7 +72,7 @@ echo "Building image locally with ko for multi-registry push..."
 IMAGE_REF=$(./ko publish \
   --tags "${TAGS}" \
   --base-import-paths \
-  --platform "linux/amd64,linux/arm64" \
+  --platform "linux/arm64,linux/amd64" \
   --image-label org.opencontainers.image.source=https://github.com/honeycombio/refinery \
   --image-label org.opencontainers.image.licenses=Apache-2.0 \
   --image-label org.opencontainers.image.revision=${GIT_COMMIT} \

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -72,7 +72,7 @@ echo "Building image locally with ko for multi-registry push..."
 IMAGE_REF=$(./ko publish \
   --tags "${TAGS}" \
   --base-import-paths \
-  --platform "linux/arm64,linux/amd64" \
+  --platform "linux/amd64,linux/arm64" \
   --image-label org.opencontainers.image.source=https://github.com/honeycombio/refinery \
   --image-label org.opencontainers.image.licenses=Apache-2.0 \
   --image-label org.opencontainers.image.revision=${GIT_COMMIT} \


### PR DESCRIPTION
## Summary

- Bumps ko from v0.11.2 to v0.18.0 for local image builds
- Fixes ko release asset arch suffix for v0.18.0 compatibility (`x86_64`)
- Replaces racy `time.Sleep(15ms)` in integration tests with TCP readiness polling, fixing intermittent test failures

Split from PR #1798 as independent infrastructure improvements.

## Test plan

- [ ] `make local_image` builds successfully with ko v0.18.0
- [ ] Integration tests pass reliably without flaky timing issues
- [ ] `go vet ./...` passes
- [ ] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)