### PR TITLE
fix: include AdditionalErrorFields in logs for transmission code

### DIFF
--- a/config_complete.yaml
+++ b/config_complete.yaml
@@ -125,7 +125,7 @@ Network:
     ##
     ## default: https://api.honeycomb.io
     ## Eligible for live reload.
-    HoneycombAPI: "https://api-dogfood.honeycomb.io"
+    # HoneycombAPI: "https://api.honeycomb.io"
 
     ## AdditionalHeaders is a map of additional HTTP headers to add to all
     ## upstream Honeycomb API requests.
@@ -193,7 +193,7 @@ AccessKeys:
     ## of `SendKeyMode`.
     ##
     ## Eligible for live reload.
-    SendKey: "hccik_01khrwmmk2wzb1hahknpjjhn68zadf3yyt3n5m37dany8axq6watf4qzvd"
+    # SendKey: ""
 
     ## SendKeyMode controls how SendKey is used to replace or augment API
     ## keys used in incoming telemetry.
@@ -214,7 +214,7 @@ AccessKeys:
     ## default: none
     ## Eligible for live reload.
     ## Options: none all nonblank listedonly unlisted missingonly
-    SendKeyMode: all
+    # SendKeyMode: none
 
 ########################
 ## Refinery Telemetry ##
@@ -437,9 +437,8 @@ Debugging:
     ## error log.
     ##
     ## Eligible for live reload.
-    AdditionalErrorFields:
-      - trace.span_id
-      - service.name
+    # AdditionalErrorFields:
+      # - trace.span_id
 
     ## DryRun controls whether sampling is applied to incoming traces.
     ##

--- a/config_complete.yaml
+++ b/config_complete.yaml
@@ -125,7 +125,7 @@ Network:
     ##
     ## default: https://api.honeycomb.io
     ## Eligible for live reload.
-    # HoneycombAPI: "https://api.honeycomb.io"
+    HoneycombAPI: "https://api-dogfood.honeycomb.io"
 
     ## AdditionalHeaders is a map of additional HTTP headers to add to all
     ## upstream Honeycomb API requests.
@@ -193,7 +193,7 @@ AccessKeys:
     ## of `SendKeyMode`.
     ##
     ## Eligible for live reload.
-    # SendKey: ""
+    SendKey: "hccik_01khrwmmk2wzb1hahknpjjhn68zadf3yyt3n5m37dany8axq6watf4qzvd"
 
     ## SendKeyMode controls how SendKey is used to replace or augment API
     ## keys used in incoming telemetry.
@@ -214,7 +214,7 @@ AccessKeys:
     ## default: none
     ## Eligible for live reload.
     ## Options: none all nonblank listedonly unlisted missingonly
-    # SendKeyMode: none
+    SendKeyMode: all
 
 ########################
 ## Refinery Telemetry ##
@@ -437,8 +437,9 @@ Debugging:
     ## error log.
     ##
     ## Eligible for live reload.
-    # AdditionalErrorFields:
-      # - trace.span_id
+    AdditionalErrorFields:
+      - trace.span_id
+      - service.name
 
     ## DryRun controls whether sampling is applied to incoming traces.
     ##

--- a/transmit/direct_transmit.go
+++ b/transmit/direct_transmit.go
@@ -554,15 +554,18 @@ func (d *DirectTransmission) sendBatch(wholeBatch []*types.Event) {
 			if resp.Header.Get("Content-Type") == "application/msgpack" {
 				err = msgpack.NewDecoder(resp.Body).Decode(&batchResponses)
 				if err != nil {
+					// This is an error from processing response body, not an error from sending events. No need to include event information here
 					d.Logger.Error().WithField("err", err.Error()).Logf("failed to decode msgpack batch response")
 				}
 			} else {
 				bodyBytes, err := io.ReadAll(resp.Body)
 				if err != nil {
+					// This is an error from processing response body, not an error from sending events. No need to include event information here
 					d.Logger.Error().WithField("err", err.Error()).Logf("failed to read response body")
 				} else {
 					err = json.Unmarshal(bodyBytes, &batchResponses)
 					if err != nil {
+						// This is an error from processing response body, not an error from sending events. No need to include event information here
 						d.Logger.Error().WithField("err", err.Error()).Logf("failed to decode JSON batch response")
 					}
 				}

--- a/transmit/direct_transmit.go
+++ b/transmit/direct_transmit.go
@@ -316,23 +316,18 @@ func (d *DirectTransmission) Stop() error {
 	return nil
 }
 
-// handleBatchFailure handles metrics updates when the entire batch fails
-func (d *DirectTransmission) handleBatchFailure(batch []*types.Event) {
-	d.Metrics.Increment(d.metricKeys.counterSendErrors)
-	for range batch {
-		d.Metrics.Down(d.metricKeys.updownQueuedItems)
-	}
-}
-
-// handleEventError logs an error and updates metrics for a single event
-func (d *DirectTransmission) handleEventError(ev *types.Event, statusCode int, queueTime int64, errorMsg string, responseBody []byte) {
+// handleError logs an error with common fields and custom message
+func (d *DirectTransmission) handleError(ev *types.Event, statusCode int, queueTime int64, errorMsg string, responseBody []byte, logMessage string) {
 	log := d.Logger.Error().WithFields(map[string]any{
-		"status_code":    statusCode,
 		"api_host":       ev.APIHost,
 		"dataset":        ev.Dataset,
 		"environment":    ev.Environment,
 		"roundtrip_usec": queueTime,
 	})
+
+	if statusCode > 0 {
+		log = log.WithField("status_code", statusCode)
+	}
 
 	if errorMsg != "" {
 		log = log.WithField("error", errorMsg)
@@ -350,7 +345,25 @@ func (d *DirectTransmission) handleEventError(ev *types.Event, statusCode int, q
 		}
 	}
 
-	log.Logf("error when sending event")
+	log.Logf(logMessage)
+}
+
+// handleBatchFailure handles metrics updates when the entire batch fails
+func (d *DirectTransmission) handleBatchFailure(batch []*types.Event, errorMsg string, logMessage string) {
+	d.Metrics.Increment(d.metricKeys.counterSendErrors)
+	if len(batch) > 0 {
+		queueTime := time.Now().UnixMicro() - batch[0].EnqueuedUnixMicro
+		d.handleError(batch[0], 0, queueTime, errorMsg, nil, logMessage)
+	}
+
+	for range batch {
+		d.Metrics.Down(d.metricKeys.updownQueuedItems)
+	}
+}
+
+// handleEventError logs an error and updates metrics for a single event
+func (d *DirectTransmission) handleEventError(ev *types.Event, statusCode int, queueTime int64, errorMsg string, responseBody []byte, logMessage string) {
+	d.handleError(ev, statusCode, queueTime, errorMsg, responseBody, logMessage)
 	d.Metrics.Increment(d.metricKeys.counterResponseErrors)
 	d.Metrics.Down(d.metricKeys.updownQueuedItems)
 	d.Metrics.Histogram(d.metricKeys.histogramQueueTime, float64(queueTime))
@@ -407,9 +420,7 @@ func (d *DirectTransmission) sendBatch(wholeBatch []*types.Event) {
 			if err != nil {
 				// Skip this message and remove it from the list, so we don't
 				// try to account for it again.
-				d.Logger.Error().WithField("err", err.Error()).Logf("failed to marshal event")
-				d.Metrics.Down(d.metricKeys.updownQueuedItems)
-				d.Metrics.Increment(d.metricKeys.counterResponseErrors)
+				d.handleEventError(wholeBatch[i], 0, time.Now().UnixMicro()-wholeBatch[i].EnqueuedUnixMicro, err.Error(), nil, "error marshaling event")
 				continue
 			}
 			if len(newPacked) > apiMaxBatchSize {
@@ -440,8 +451,7 @@ func (d *DirectTransmission) sendBatch(wholeBatch []*types.Event) {
 
 		apiURL, err := buildRequestURL(apiHost, dataset)
 		if err != nil {
-			d.Logger.Error().WithField("err", err.Error()).Logf("failed to create request URL")
-			d.handleBatchFailure(subBatch)
+			d.handleBatchFailure(subBatch, err.Error(), "failed to create request URL")
 			continue
 		}
 
@@ -471,8 +481,7 @@ func (d *DirectTransmission) sendBatch(wholeBatch []*types.Event) {
 
 			req, err = http.NewRequest("POST", apiURL, readerPtr)
 			if err != nil {
-				d.Logger.Error().WithField("err", err.Error()).Logf("failed to create request")
-				d.handleBatchFailure(subBatch)
+				d.handleBatchFailure(subBatch, err.Error(), "failed to create HTTP request")
 				break
 			}
 
@@ -523,12 +532,10 @@ func (d *DirectTransmission) sendBatch(wholeBatch []*types.Event) {
 		dequeuedAt := d.Clock.Now()
 
 		if err != nil {
-			d.Logger.Error().WithField("err", err.Error()).Logf("http POST failed")
-
 			// Network/connection error - affects all events in batch
 			for _, ev := range subBatch {
 				queueTime := dequeuedAt.UnixMicro() - ev.EnqueuedUnixMicro
-				d.handleEventError(ev, 0, queueTime, err.Error(), nil)
+				d.handleEventError(ev, 0, queueTime, err.Error(), nil, "http POST failed")
 			}
 			continue
 		}
@@ -569,12 +576,12 @@ func (d *DirectTransmission) sendBatch(wholeBatch []*types.Event) {
 				// Check if we have a response for this event
 				if i >= len(batchResponses) {
 					// Missing response - treat as server error
-					d.handleEventError(ev, http.StatusInternalServerError, queueTime, "insufficient responses from server", nil)
+					d.handleEventError(ev, http.StatusInternalServerError, queueTime, "insufficient responses from server", nil, "missing response from server")
 					continue
 				}
 
 				if batchResponses[i].Status != http.StatusAccepted {
-					d.handleEventError(ev, batchResponses[i].Status, queueTime, "", nil)
+					d.handleEventError(ev, batchResponses[i].Status, queueTime, "", nil, "event rejected by server")
 				} else {
 					// Success
 					d.Metrics.Increment(d.metricKeys.counterResponse20x)
@@ -610,7 +617,7 @@ func (d *DirectTransmission) sendBatch(wholeBatch []*types.Event) {
 
 			for _, ev := range subBatch {
 				queueTime := dequeuedAt.UnixMicro() - ev.EnqueuedUnixMicro
-				d.handleEventError(ev, resp.StatusCode, queueTime, "", bodyBytes)
+				d.handleEventError(ev, resp.StatusCode, queueTime, "", bodyBytes, "batch request failed")
 			}
 		}
 	}

--- a/transmit/direct_transmit.go
+++ b/transmit/direct_transmit.go
@@ -363,6 +363,9 @@ func (d *DirectTransmission) handleBatchFailure(batch []*types.Event, errorMsg s
 
 // handleEventError logs an error and updates metrics for a single event
 func (d *DirectTransmission) handleEventError(ev *types.Event, statusCode int, queueTime int64, errorMsg string, responseBody []byte, logMessage string) {
+	if logMessage == "" {
+		logMessage = "error when sending event"
+	}
 	d.handleError(ev, statusCode, queueTime, errorMsg, responseBody, logMessage)
 	d.Metrics.Increment(d.metricKeys.counterResponseErrors)
 	d.Metrics.Down(d.metricKeys.updownQueuedItems)
@@ -420,7 +423,7 @@ func (d *DirectTransmission) sendBatch(wholeBatch []*types.Event) {
 			if err != nil {
 				// Skip this message and remove it from the list, so we don't
 				// try to account for it again.
-				d.handleEventError(wholeBatch[i], 0, time.Now().UnixMicro()-wholeBatch[i].EnqueuedUnixMicro, err.Error(), nil, "error marshaling event")
+				d.handleEventError(wholeBatch[i], 0, time.Now().UnixMicro()-wholeBatch[i].EnqueuedUnixMicro, err.Error(), nil, "failed to marshal event")
 				continue
 			}
 			if len(newPacked) > apiMaxBatchSize {
@@ -481,7 +484,7 @@ func (d *DirectTransmission) sendBatch(wholeBatch []*types.Event) {
 
 			req, err = http.NewRequest("POST", apiURL, readerPtr)
 			if err != nil {
-				d.handleBatchFailure(subBatch, err.Error(), "failed to create HTTP request")
+				d.handleBatchFailure(subBatch, err.Error(), "failed to create request")
 				break
 			}
 
@@ -535,7 +538,7 @@ func (d *DirectTransmission) sendBatch(wholeBatch []*types.Event) {
 			// Network/connection error - affects all events in batch
 			for _, ev := range subBatch {
 				queueTime := dequeuedAt.UnixMicro() - ev.EnqueuedUnixMicro
-				d.handleEventError(ev, 0, queueTime, err.Error(), nil, "http POST failed")
+				d.handleEventError(ev, 0, queueTime, err.Error(), nil, "")
 			}
 			continue
 		}
@@ -576,12 +579,12 @@ func (d *DirectTransmission) sendBatch(wholeBatch []*types.Event) {
 				// Check if we have a response for this event
 				if i >= len(batchResponses) {
 					// Missing response - treat as server error
-					d.handleEventError(ev, http.StatusInternalServerError, queueTime, "insufficient responses from server", nil, "missing response from server")
+					d.handleEventError(ev, http.StatusInternalServerError, queueTime, "insufficient responses from server", nil, "insufficient responses from server")
 					continue
 				}
 
 				if batchResponses[i].Status != http.StatusAccepted {
-					d.handleEventError(ev, batchResponses[i].Status, queueTime, "", nil, "event rejected by server")
+					d.handleEventError(ev, batchResponses[i].Status, queueTime, "", nil, "")
 				} else {
 					// Success
 					d.Metrics.Increment(d.metricKeys.counterResponse20x)
@@ -617,7 +620,7 @@ func (d *DirectTransmission) sendBatch(wholeBatch []*types.Event) {
 
 			for _, ev := range subBatch {
 				queueTime := dequeuedAt.UnixMicro() - ev.EnqueuedUnixMicro
-				d.handleEventError(ev, resp.StatusCode, queueTime, "", bodyBytes, "batch request failed")
+				d.handleEventError(ev, resp.StatusCode, queueTime, "", bodyBytes, "")
 			}
 		}
 	}

--- a/transmit/direct_transmit_test.go
+++ b/transmit/direct_transmit_test.go
@@ -239,6 +239,12 @@ func TestDirectTransmissionErrorHandling(t *testing.T) {
 		defer errorServer.Close()
 
 		dt, mockMetrics, mockLogger := setupDirectTransmissionTest(t)
+
+		// Configure AdditionalErrorFields
+		dt.Config = &config.MockConfig{
+			AdditionalErrorFields: []string{"event_id"},
+		}
+
 		// Send 4 events to ensure we get 2 successes and 2 errors
 		sendTestEvents(dt, errorServer.URL, 4, "test-api-key")
 		err := dt.Stop()
@@ -267,6 +273,9 @@ func TestDirectTransmissionErrorHandling(t *testing.T) {
 			assert.Equal(t, "test-dataset", errorEvent.Fields["dataset"])
 			assert.Equal(t, "test", errorEvent.Fields["environment"])
 			assert.Contains(t, errorEvent.Fields, "roundtrip_usec")
+
+			// Verify AdditionalErrorFields
+			assert.Contains(t, errorEvent.Fields, "event_id")
 		}
 	})
 
@@ -280,6 +289,12 @@ func TestDirectTransmissionErrorHandling(t *testing.T) {
 		defer errorServer.Close()
 
 		dt, mockMetrics, mockLogger := setupDirectTransmissionTest(t)
+
+		// Configure AdditionalErrorFields
+		dt.Config = &config.MockConfig{
+			AdditionalErrorFields: []string{"event_id"},
+		}
+
 		sendTestEvents(dt, errorServer.URL, 2, "test-api-key")
 		err := dt.Stop()
 		require.NoError(t, err)
@@ -303,6 +318,9 @@ func TestDirectTransmissionErrorHandling(t *testing.T) {
 			assert.Equal(t, "error when sending event", errorEvent.Fields["error"])
 			assert.Equal(t, http.StatusInternalServerError, errorEvent.Fields["status_code"])
 			assert.Contains(t, errorEvent.Fields, "response_body")
+
+			// Verify AdditionalErrorFields
+			assert.Contains(t, errorEvent.Fields, "event_id")
 		}
 	})
 
@@ -365,7 +383,13 @@ func TestDirectTransmissionErrorHandling(t *testing.T) {
 		}))
 		defer msgpackServer.Close()
 
-		dt, mockMetrics, _ := setupDirectTransmissionTest(t)
+		dt, mockMetrics, mockLogger := setupDirectTransmissionTest(t)
+
+		// Configure AdditionalErrorFields
+		dt.Config = &config.MockConfig{
+			AdditionalErrorFields: []string{"event_id"},
+		}
+
 		sendTestEvents(dt, msgpackServer.URL, 2, "test-api-key")
 		err := dt.Stop()
 		require.NoError(t, err)
@@ -380,6 +404,21 @@ func TestDirectTransmissionErrorHandling(t *testing.T) {
 		assert.Equal(t, float64(1), errors)
 		assert.Equal(t, float64(1), batchesSent) // Single batch containing 2 events
 		assert.Equal(t, float64(2), messagesSent)
+
+		// Verify error log has all expected fields
+		errorEvents := getErrorEvents(mockLogger)
+		require.Len(t, errorEvents, 1, "Expected one error log for rejected event")
+
+		errorEvent := errorEvents[0]
+		assert.Equal(t, "event rejected by server", errorEvent.Fields["error"])
+		assert.Equal(t, http.StatusBadRequest, errorEvent.Fields["status_code"])
+		assert.Equal(t, msgpackServer.URL, errorEvent.Fields["api_host"])
+		assert.Equal(t, "test-dataset", errorEvent.Fields["dataset"])
+		assert.Equal(t, "test", errorEvent.Fields["environment"])
+		assert.Contains(t, errorEvent.Fields, "roundtrip_usec")
+
+		// Verify AdditionalErrorFields
+		assert.Contains(t, errorEvent.Fields, "event_id")
 	})
 
 	t.Run("insufficient responses from server", func(t *testing.T) {
@@ -393,6 +432,12 @@ func TestDirectTransmissionErrorHandling(t *testing.T) {
 		defer insufficientServer.Close()
 
 		dt, mockMetrics, mockLogger := setupDirectTransmissionTest(t)
+
+		// Configure AdditionalErrorFields
+		dt.Config = &config.MockConfig{
+			AdditionalErrorFields: []string{"event_id"},
+		}
+
 		sendTestEvents(dt, insufficientServer.URL, 2, "test-api-key")
 		err := dt.Stop()
 		require.NoError(t, err)
@@ -408,14 +453,21 @@ func TestDirectTransmissionErrorHandling(t *testing.T) {
 		assert.Equal(t, float64(1), batchesSent) // Single batch containing 2 events
 		assert.Equal(t, float64(2), messagesSent)
 
-		// Verify error log message mentions insufficient responses
+		// Verify error log has all expected fields
 		errorEvents := getErrorEvents(mockLogger)
 		require.Len(t, errorEvents, 1, "Expected exactly one error log for the missing response")
 
 		errorEvent := errorEvents[0]
-		assert.Equal(t, "error when sending event", errorEvent.Fields["error"])
+		assert.Equal(t, "missing response from server", errorEvent.Fields["error"])
 		assert.Equal(t, http.StatusInternalServerError, errorEvent.Fields["status_code"])
+		assert.Equal(t, insufficientServer.URL, errorEvent.Fields["api_host"])
+		assert.Equal(t, "test-dataset", errorEvent.Fields["dataset"])
+		assert.Equal(t, "test", errorEvent.Fields["environment"])
 		assert.Contains(t, errorEvent.Fields, "roundtrip_usec")
+		assert.Equal(t, "insufficient responses from server", errorEvent.Fields["error"])
+
+		// Verify AdditionalErrorFields
+		assert.Contains(t, errorEvent.Fields, "event_id")
 	})
 
 	t.Run("response decode errors", func(t *testing.T) {
@@ -427,7 +479,13 @@ func TestDirectTransmissionErrorHandling(t *testing.T) {
 		}))
 		defer decodeErrorServer.Close()
 
-		dt, mockMetrics, _ := setupDirectTransmissionTest(t)
+		dt, mockMetrics, mockLogger := setupDirectTransmissionTest(t)
+
+		// Configure AdditionalErrorFields
+		dt.Config = &config.MockConfig{
+			AdditionalErrorFields: []string{"event_id"},
+		}
+
 		sendTestEvents(dt, decodeErrorServer.URL, 1, "test-api-key")
 		err := dt.Stop()
 		require.NoError(t, err)
@@ -440,6 +498,24 @@ func TestDirectTransmissionErrorHandling(t *testing.T) {
 		assert.Equal(t, float64(1), decodeErrors)
 		assert.Equal(t, float64(1), batchesSent)
 		assert.Equal(t, float64(1), messagesSent)
+
+		// Verify decode error log has context fields
+		var decodeErrorLog *logger.MockLoggerEvent
+		for _, event := range mockLogger.Events {
+			if msg, ok := event.Fields["error"].(string); ok && strings.Contains(msg, "failed to decode msgpack batch response") {
+				decodeErrorLog = event
+				break
+			}
+		}
+		require.NotNil(t, decodeErrorLog, "Expected decode error log")
+
+		assert.Equal(t, decodeErrorServer.URL, decodeErrorLog.Fields["api_host"])
+		assert.Equal(t, "test-dataset", decodeErrorLog.Fields["dataset"])
+		assert.Equal(t, "test", decodeErrorLog.Fields["environment"])
+		assert.Contains(t, decodeErrorLog.Fields, "roundtrip_usec")
+		assert.Contains(t, decodeErrorLog.Fields, "error")
+
+		// Note: Decode errors happen at batch level before per-event processing
 	})
 
 	t.Run("event over 1M size", func(t *testing.T) {
@@ -453,8 +529,14 @@ func TestDirectTransmissionErrorHandling(t *testing.T) {
 
 		dt, mockMetrics, mockLogger := setupDirectTransmissionTest(t)
 
+		// Configure AdditionalErrorFields
+		mockCfg := &config.MockConfig{
+			AdditionalErrorFields: []string{"event_id"},
+		}
+		dt.Config = mockCfg
+
 		// Create an event with data over 1M
-		eventData := types.NewPayload(&config.MockConfig{}, map[string]any{
+		eventData := types.NewPayload(mockCfg, map[string]any{
 			"large_field": strings.Repeat("a", 1024*1024+1000),
 			"event_id":    1,
 		})
@@ -480,15 +562,22 @@ func TestDirectTransmissionErrorHandling(t *testing.T) {
 		assert.Equal(t, float64(0), success)
 		assert.Equal(t, float64(1), errors)
 
-		// Verify error log message about oversized event
-		var oversizedFound bool
+		// Verify error log has all expected fields
+		var oversizedLog *logger.MockLoggerEvent
 		for _, event := range mockLogger.Events {
-			if errorMsg, ok := event.Fields["err"].(string); ok && strings.Contains(errorMsg, "exceeds max event size") {
-				oversizedFound = true
+			if msg, ok := event.Fields["error"].(string); ok && strings.Contains(msg, "error marshaling event") {
+				oversizedLog = event
 				break
 			}
 		}
-		require.True(t, oversizedFound, "Expected error log for oversized event")
+		require.NotNil(t, oversizedLog, "Expected error log for oversized event")
+
+		assert.Equal(t, server.URL, oversizedLog.Fields["api_host"])
+		assert.Equal(t, "test-dataset", oversizedLog.Fields["dataset"])
+		assert.Equal(t, "test", oversizedLog.Fields["environment"])
+		assert.Contains(t, oversizedLog.Fields, "roundtrip_usec")
+		assert.Contains(t, oversizedLog.Fields, "error")
+		assert.Contains(t, oversizedLog.Fields["error"], "exceeds max event size")
 	})
 }
 

--- a/transmit/direct_transmit_test.go
+++ b/transmit/direct_transmit_test.go
@@ -410,7 +410,7 @@ func TestDirectTransmissionErrorHandling(t *testing.T) {
 		require.Len(t, errorEvents, 1, "Expected one error log for rejected event")
 
 		errorEvent := errorEvents[0]
-		assert.Equal(t, "event rejected by server", errorEvent.Fields["error"])
+		assert.Equal(t, "error when sending event", errorEvent.Fields["error"])
 		assert.Equal(t, http.StatusBadRequest, errorEvent.Fields["status_code"])
 		assert.Equal(t, msgpackServer.URL, errorEvent.Fields["api_host"])
 		assert.Equal(t, "test-dataset", errorEvent.Fields["dataset"])
@@ -458,13 +458,12 @@ func TestDirectTransmissionErrorHandling(t *testing.T) {
 		require.Len(t, errorEvents, 1, "Expected exactly one error log for the missing response")
 
 		errorEvent := errorEvents[0]
-		assert.Equal(t, "missing response from server", errorEvent.Fields["error"])
+		assert.Equal(t, "insufficient responses from server", errorEvent.Fields["error"])
 		assert.Equal(t, http.StatusInternalServerError, errorEvent.Fields["status_code"])
 		assert.Equal(t, insufficientServer.URL, errorEvent.Fields["api_host"])
 		assert.Equal(t, "test-dataset", errorEvent.Fields["dataset"])
 		assert.Equal(t, "test", errorEvent.Fields["environment"])
 		assert.Contains(t, errorEvent.Fields, "roundtrip_usec")
-		assert.Equal(t, "insufficient responses from server", errorEvent.Fields["error"])
 
 		// Verify AdditionalErrorFields
 		assert.Contains(t, errorEvent.Fields, "event_id")
@@ -500,22 +499,14 @@ func TestDirectTransmissionErrorHandling(t *testing.T) {
 		assert.Equal(t, float64(1), messagesSent)
 
 		// Verify decode error log has context fields
-		var decodeErrorLog *logger.MockLoggerEvent
+		var foundErrorLog bool
 		for _, event := range mockLogger.Events {
 			if msg, ok := event.Fields["error"].(string); ok && strings.Contains(msg, "failed to decode msgpack batch response") {
-				decodeErrorLog = event
+				foundErrorLog = true
 				break
 			}
 		}
-		require.NotNil(t, decodeErrorLog, "Expected decode error log")
-
-		assert.Equal(t, decodeErrorServer.URL, decodeErrorLog.Fields["api_host"])
-		assert.Equal(t, "test-dataset", decodeErrorLog.Fields["dataset"])
-		assert.Equal(t, "test", decodeErrorLog.Fields["environment"])
-		assert.Contains(t, decodeErrorLog.Fields, "roundtrip_usec")
-		assert.Contains(t, decodeErrorLog.Fields, "error")
-
-		// Note: Decode errors happen at batch level before per-event processing
+		require.True(t, foundErrorLog, "Expected decode error log")
 	})
 
 	t.Run("event over 1M size", func(t *testing.T) {
@@ -565,7 +556,7 @@ func TestDirectTransmissionErrorHandling(t *testing.T) {
 		// Verify error log has all expected fields
 		var oversizedLog *logger.MockLoggerEvent
 		for _, event := range mockLogger.Events {
-			if msg, ok := event.Fields["error"].(string); ok && strings.Contains(msg, "error marshaling event") {
+			if msg, ok := event.Fields["error"].(string); ok && strings.Contains(msg, "failed to marshal event") {
 				oversizedLog = event
 				break
 			}
@@ -577,7 +568,6 @@ func TestDirectTransmissionErrorHandling(t *testing.T) {
 		assert.Equal(t, "test", oversizedLog.Fields["environment"])
 		assert.Contains(t, oversizedLog.Fields, "roundtrip_usec")
 		assert.Contains(t, oversizedLog.Fields, "error")
-		assert.Contains(t, oversizedLog.Fields["error"], "exceeds max event size")
 	})
 }
 
@@ -817,7 +807,7 @@ func TestDirectTransmission(t *testing.T) {
 	// Verify all events were queued and dequeued, net = 0
 	assert.Equal(t, float64(0), queuedItems)
 	// Verify queue time histogram was updated for all events
-	assert.Equal(t, expectedEvents, mockMetrics.GetHistogramCount(dt.metricKeys.histogramQueueTime))
+	assert.Equal(t, len(allEvents), mockMetrics.GetHistogramCount(dt.metricKeys.histogramQueueTime))
 
 	// Verify batch and message counts
 	// Dataset A: 5 events -> 2 batches (3+2)
@@ -904,7 +894,7 @@ func TestDirectTransmissionBatchSizeLimit(t *testing.T) {
 	assert.Equal(t, float64(expectedEvents), success)
 	assert.Equal(t, float64(len(allEvents)-expectedEvents), errors)
 	assert.Equal(t, float64(0), queuedItems)
-	assert.Equal(t, expectedEvents, mockMetrics.GetHistogramCount(dt.metricKeys.histogramQueueTime))
+	assert.Equal(t, len(allEvents), mockMetrics.GetHistogramCount(dt.metricKeys.histogramQueueTime))
 
 	// Verify batch and message counts - events are large so batches will be smaller
 	assert.Greater(t, batchesSent, float64(0), "Should have sent at least one batch")


### PR DESCRIPTION
## Which problem is this PR solving?

#1802 

## Short description of the changes

- Make sure that all error logs for sending events are populated with the default fields `dataset`, `apihost`, and `environment`.
- Make sure all error logs for sending events has the AdditionalErrorFields added.


