### PR TITLE
fix: increment send_errors for network errors from request

### DIFF
--- a/transmit/direct_transmit.go
+++ b/transmit/direct_transmit.go
@@ -351,12 +351,14 @@ func (d *DirectTransmission) handleError(ev *types.Event, statusCode int, queueT
 // handleBatchFailure handles metrics updates when the entire batch fails
 func (d *DirectTransmission) handleBatchFailure(batch []*types.Event, errorMsg string, logMessage string) {
 	d.Metrics.Increment(d.metricKeys.counterSendErrors)
+	now := time.Now().UnixMicro()
 	if len(batch) > 0 {
-		queueTime := time.Now().UnixMicro() - batch[0].EnqueuedUnixMicro
+		queueTime := now - batch[0].EnqueuedUnixMicro
 		d.handleError(batch[0], 0, queueTime, errorMsg, nil, logMessage)
 	}
 
-	for range batch {
+	for _, ev := range batch {
+		d.Metrics.Histogram(d.metricKeys.histogramQueueTime, float64(now-ev.EnqueuedUnixMicro))
 		d.Metrics.Down(d.metricKeys.updownQueuedItems)
 	}
 }
@@ -535,11 +537,7 @@ func (d *DirectTransmission) sendBatch(wholeBatch []*types.Event) {
 		dequeuedAt := d.Clock.Now()
 
 		if err != nil {
-			// Network/connection error - affects all events in batch
-			for _, ev := range subBatch {
-				queueTime := dequeuedAt.UnixMicro() - ev.EnqueuedUnixMicro
-				d.handleEventError(ev, 0, queueTime, err.Error(), nil, "")
-			}
+			d.handleBatchFailure(subBatch, err.Error(), "")
 			continue
 		}
 

--- a/transmit/direct_transmit_test.go
+++ b/transmit/direct_transmit_test.go
@@ -1208,6 +1208,9 @@ func TestDirectTransmissionRetryLogic(t *testing.T) {
 
 			if tt.expectSuccess {
 				assert.Contains(t, mockMetrics.CounterIncrements, "libhoney_upstream_response_20x")
+			} else if tt.statusCode == 0 {
+				// Network/timeout error: whole batch failed before any response
+				assert.Contains(t, mockMetrics.CounterIncrements, "libhoney_upstream_send_errors")
 			} else {
 				assert.Contains(t, mockMetrics.CounterIncrements, "libhoney_upstream_response_errors")
 			}


### PR DESCRIPTION
## Which problem is this PR solving?

The `send_errors` metric was never incremented for network errors.

## Short description of the changes

- Replaced the per-event error loop at the `httpClient.Do` failure site with a single `handleBatchFailure` call, so network errors now increment `counterSendErrors` once and log once (for the first event)
- Updated test