### PR TITLE
feat: override dataset name with service.name

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.25.3
+golang 1.26.1

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -2154,9 +2154,9 @@ func TestRulesBasedSamplerWithDownstreamAndClusterChanges(t *testing.T) {
 
 	// Verify that events contain expected fields for rules-based sampling
 	for _, event := range finalEvents {
-		assert.Equal(t, "dataset", event.Dataset)
 
 		serviceName := event.Data.Get("service.name")
+		assert.Equal(t, serviceName, event.Dataset)
 		statusCode := event.Data.Get("http.status_code")
 
 		// Most events should be from test-service (deterministic rules), but some may be from other-service (fallback rule)

--- a/route/route.go
+++ b/route/route.go
@@ -531,10 +531,11 @@ func (r *Router) batch(w http.ResponseWriter, req *http.Request) {
 	}
 	defer recycleHTTPBodyBuffer(bodyBuffer)
 
-	dataset, err := getDatasetFromRequest(req)
+	datasetFromRequest, err := getDatasetFromRequest(req)
 	if err != nil {
 		r.handlerReturnWithError(w, ErrReqToEvent, err)
 	}
+	dataset := ""
 
 	apiKey := req.Header.Get(types.APIKeyHeader)
 	if apiKey == "" {
@@ -566,6 +567,11 @@ func (r *Router) batch(w http.ResponseWriter, req *http.Request) {
 	userAgent := getUserAgentFromRequest(req)
 	batchedResponses := make([]*BatchResponse, 0, len(batchedEvents.events))
 	for _, bev := range batchedEvents.events {
+		datasetAny := bev.Data.Get("service.name")
+		dataset, ok := datasetAny.(string)
+		if !ok {
+			dataset = datasetFromRequest
+		}
 		if !bev.Data.IsEmpty() {
 			ev := &types.Event{
 				Context:     ctx,

--- a/route/route.go
+++ b/route/route.go
@@ -569,7 +569,7 @@ func (r *Router) batch(w http.ResponseWriter, req *http.Request) {
 	for _, bev := range batchedEvents.events {
 		datasetAny := bev.Data.Get("service.name")
 		dataset, ok := datasetAny.(string)
-		if !ok {
+		if !ok || dataset == "" {
 			dataset = datasetFromRequest
 		}
 		if !bev.Data.IsEmpty() {


### PR DESCRIPTION
To cause the same behavior we have for OTLP traffic to be applied to Honeycomb protocol traffic, override the dataset name found in the URL with the value found in the event's `service.name` field (if one exists). Only use the URL's dataset name if no field exists within the event.