### PR TITLE
fix: overcounting dynsampler event_count and request_count

### DIFF
--- a/collect/multi_loop_test.go
+++ b/collect/multi_loop_test.go
@@ -534,7 +534,7 @@ func TestCoordinatedReload(t *testing.T) {
 			PeerQueueSize:     3000,
 			WorkerCount:       4,
 		},
-		GetSamplerTypeVal:  &config.DeterministicSamplerConfig{SampleRate: 1},
+		GetSamplerTypeVal:  &config.DynamicSamplerConfig{SampleRate: 1, FieldList: []string{"test"}},
 		ParentIdFieldNames: []string{"trace.parent_id", "parentId"},
 		TraceIdFieldNames:  []string{"trace.trace_id", "traceId"},
 		SampleCache: config.SampleCacheConfig{
@@ -546,92 +546,71 @@ func TestCoordinatedReload(t *testing.T) {
 
 	collector := newTestCollector(t, conf)
 
-	// Send some test spans to create dataset samplers
-	processedInitial := int32(0)
-	for i := 0; i < 10; i++ {
-		span := &types.Span{
-			Event: &types.Event{
-				APIHost:    "http://api.honeycomb.io",
-				APIKey:     legacyAPIKey,
-				Dataset:    fmt.Sprintf("dataset-%d", i%3),
-				SampleRate: 1,
-				Timestamp:  time.Now(),
-				Data:       types.Payload{},
-			},
-			TraceID:     fmt.Sprintf("reload-trace-%d", i),
-			IsRoot:      true,
-			ArrivalTime: time.Now(),
-		}
-		if err := collector.AddSpan(span); err == nil {
-			atomic.AddInt32(&processedInitial, 1)
+	// waitForSamplersCreated waits until at least one worker has a sampler,
+	// proving traces were actually processed and makeDecision was called.
+	waitForSamplersCreated := func(msg string) {
+		t.Helper()
+		assert.Eventually(t, func() bool {
+			total := 0
+			for _, worker := range collector.workers {
+				ch := make(chan struct{})
+				worker.pause <- ch
+				total += len(worker.datasetSamplers)
+				close(ch)
+			}
+			return total > 0
+		}, 2*time.Second, 10*time.Millisecond, msg)
+	}
+
+	// waitForSamplersCleared waits until all workers have empty datasetSamplers.
+	waitForSamplersCleared := func(msg string) {
+		t.Helper()
+		assert.Eventually(t, func() bool {
+			for _, worker := range collector.workers {
+				ch := make(chan struct{})
+				worker.pause <- ch
+				n := len(worker.datasetSamplers)
+				close(ch)
+				if n > 0 {
+					return false
+				}
+			}
+			return true
+		}, 2*time.Second, 10*time.Millisecond, msg)
+	}
+
+	sendSpans := func(n int, dataset, traceIDPrefix string) {
+		for i := 0; i < n; i++ {
+			span := &types.Span{
+				Event: &types.Event{
+					APIHost:    "http://api.honeycomb.io",
+					APIKey:     legacyAPIKey,
+					Dataset:    fmt.Sprintf("%s", dataset),
+					SampleRate: 1,
+					Timestamp:  time.Now(),
+					Data:       types.Payload{},
+				},
+				TraceID:     fmt.Sprintf("%s-%d", traceIDPrefix, i),
+				IsRoot:      true,
+				ArrivalTime: time.Now(),
+			}
+			collector.AddSpan(span) //nolint:errcheck
 		}
 	}
 
-	// Wait for initial spans to be processed
-	assert.Eventually(t, func() bool {
-		return atomic.LoadInt32(&processedInitial) >= 8
-	}, 2*time.Second, 10*time.Millisecond, "Initial spans should be processed")
+	// Send spans and wait for workers to process them and create samplers.
+	sendSpans(20, "dataset", "reload-trace")
+	waitForSamplersCreated("samplers should be created before first reload")
 
-	// Trigger a reload - this should cause workers to recreate their samplers
-	collector.sendReloadSignal("hash1", "hash2")
+	// Reload and verify all workers clear their samplers.
+	collector.sendReloadSignal("dataset", "hash2")
+	waitForSamplersCleared("samplers should be cleared after first reload")
 
-	// Give a moment for the reload signal to be processed (reload is async)
-	// We'll verify the reload worked by checking that spans still get processed
-	time.Sleep(50 * time.Millisecond)
+	// Send spans again; samplers must be recreated, proving the system still works.
+	sendSpans(20, "dataset", "after-reload")
+	waitForSamplersCreated("samplers should be recreated after first reload")
 
-	// Check that samplers were recreated by sending more spans
-	processedAfterReload := int32(0)
-	for i := 0; i < 20; i++ {
-		span := &types.Span{
-			Event: &types.Event{
-				APIHost:    "http://api.honeycomb.io",
-				APIKey:     legacyAPIKey,
-				Dataset:    "test.reload",
-				SampleRate: 1,
-				Timestamp:  time.Now(),
-				Data:       types.Payload{},
-			},
-			TraceID:     fmt.Sprintf("after-reload-%d", i),
-			IsRoot:      true,
-			ArrivalTime: time.Now(),
-		}
-		if err := collector.AddSpan(span); err == nil {
-			atomic.AddInt32(&processedAfterReload, 1)
-		}
-	}
-
-	// Verify spans were processed after reload
-	assert.Eventually(t, func() bool {
-		return atomic.LoadInt32(&processedAfterReload) >= 15
-	}, 2*time.Second, 100*time.Millisecond, "Spans should be processed after reload")
-
-	// Trigger another reload to verify multiple reloads work
-	collector.sendReloadSignal("hash2", "hash3")
-	time.Sleep(50 * time.Millisecond)
-
-	// Send more spans to verify system still works
-	processedAfterSecondReload := int32(0)
-	for i := 0; i < 20; i++ {
-		span := &types.Span{
-			Event: &types.Event{
-				APIHost:    "http://api.honeycomb.io",
-				APIKey:     legacyAPIKey,
-				Dataset:    "test.reload2",
-				SampleRate: 1,
-				Timestamp:  time.Now(),
-				Data:       types.Payload{},
-			},
-			TraceID:     fmt.Sprintf("after-second-reload-%d", i),
-			IsRoot:      true,
-			ArrivalTime: time.Now(),
-		}
-		if err := collector.AddSpan(span); err == nil {
-			atomic.AddInt32(&processedAfterSecondReload, 1)
-		}
-	}
-
-	// Verify spans were processed after second reload
-	assert.Eventually(t, func() bool {
-		return atomic.LoadInt32(&processedAfterSecondReload) >= 15
-	}, 2*time.Second, 100*time.Millisecond, "Spans should be processed after second reload")
+	// Second reload cycle.
+	collector.sendReloadSignal("dataset", "hash3")
+	waitForSamplersCleared("samplers should be cleared after second reload")
 }

--- a/sample/dynamic.go
+++ b/sample/dynamic.go
@@ -41,7 +41,7 @@ type DynamicSampler struct {
 	keyFields, nonRootFields []string
 
 	dynsampler      dynsampler.Sampler
-	metricsRecorder dynsamplerMetricsRecorder
+	metricsRecorder *dynsamplerMetricsRecorder
 }
 
 func (d *DynamicSampler) Start() error {
@@ -56,12 +56,13 @@ func (d *DynamicSampler) Start() error {
 	d.key = newTraceKey(d.Config.FieldList, d.Config.UseTraceLength)
 	d.keyFields, d.nonRootFields = config.GetKeyFields(d.Config.GetSamplingFields())
 
-	// Register statistics from the dynsampler-go package
-	d.metricsRecorder = dynsamplerMetricsRecorder{
-		met:    d.Metrics,
-		prefix: "dynamic",
+	if d.metricsRecorder == nil {
+		d.metricsRecorder = &dynsamplerMetricsRecorder{
+			met:    d.Metrics,
+			prefix: "dynamic",
+		}
+		d.metricsRecorder.RegisterMetrics(d.dynsampler)
 	}
-	d.metricsRecorder.RegisterMetrics(d.dynsampler)
 
 	return nil
 }

--- a/sample/dynamic_ema.go
+++ b/sample/dynamic_ema.go
@@ -56,12 +56,13 @@ func (d *EMADynamicSampler) Start() error {
 	d.keyFields, d.nonRootFields = config.GetKeyFields(d.Config.GetSamplingFields())
 	d.key = newTraceKey(d.Config.FieldList, d.Config.UseTraceLength)
 
-	// Register statistics this package will produce
-	d.metricsRecorder = &dynsamplerMetricsRecorder{
-		prefix: "emadynamic",
-		met:    d.Metrics,
+	if d.metricsRecorder == nil {
+		d.metricsRecorder = &dynsamplerMetricsRecorder{
+			prefix: "emadynamic",
+			met:    d.Metrics,
+		}
+		d.metricsRecorder.RegisterMetrics(d.dynsampler)
 	}
-	d.metricsRecorder.RegisterMetrics(d.dynsampler)
 	return nil
 }
 

--- a/sample/ema_throughput.go
+++ b/sample/ema_throughput.go
@@ -58,12 +58,13 @@ func (d *EMAThroughputSampler) Start() error {
 	d.key = newTraceKey(d.Config.FieldList, d.Config.UseTraceLength)
 	d.keyFields, d.nonRootFields = config.GetKeyFields(d.Config.GetSamplingFields())
 
-	// Register statistics this package will produce
-	d.metricsRecorder = &dynsamplerMetricsRecorder{
-		prefix: "emathroughput",
-		met:    d.Metrics,
+	if d.metricsRecorder == nil {
+		d.metricsRecorder = &dynsamplerMetricsRecorder{
+			prefix: "emathroughput",
+			met:    d.Metrics,
+		}
+		d.metricsRecorder.RegisterMetrics(d.dynsampler)
 	}
-	d.metricsRecorder.RegisterMetrics(d.dynsampler)
 
 	return nil
 }

--- a/sample/sample.go
+++ b/sample/sample.go
@@ -25,6 +25,11 @@ type CanSetGoalThroughputPerSec interface {
 	SetGoalThroughputPerSec(int)
 }
 
+type sharedDynsamplerEntry struct {
+	dynsampler any
+	recorder   *dynsamplerMetricsRecorder
+}
+
 var samplerFactoryMetrics = []metrics.Metadata{
 	{Name: "unique_dynsampler_count", Type: metrics.Gauge, Unit: metrics.Dimensionless, Description: "Number of unique dynsampler-go samplers created"},
 }
@@ -38,10 +43,8 @@ type SamplerFactory struct {
 	peerCount int
 	mutex     sync.Mutex
 
-	// Shared dynsampler instances to maintain global throughput tracking
-	sharedDynsamplers map[string]any
-	// Shared metrics recorders; one per shared dynsampler to avoid N×overcounting
-	sharedMetricsRecorders map[string]*dynsamplerMetricsRecorder
+	// Shared dynsampler instances and their metrics recorders, keyed identically to avoid N×overcounting
+	sharedDynsamplers map[string]sharedDynsamplerEntry
 
 	// Store original GoalThroughputPerSec values for cluster size calculations.
 	// We need this to recalculate goal throughput values when the cluster size
@@ -62,8 +65,8 @@ func (s *SamplerFactory) updatePeerCounts() {
 	}
 
 	// Update goal throughput for all throughput-based dynsamplers
-	for dynsamplerKey, dynsamplerInstance := range s.sharedDynsamplers {
-		if hasThroughput, ok := dynsamplerInstance.(CanSetGoalThroughputPerSec); ok {
+	for dynsamplerKey, entry := range s.sharedDynsamplers {
+		if hasThroughput, ok := entry.dynsampler.(CanSetGoalThroughputPerSec); ok {
 			if cfg, ok := s.goalThroughputConfigs[dynsamplerKey]; ok {
 				// Calculate new throughput based on cluster size
 				newThroughput := max(cfg/s.peerCount, 1)
@@ -75,8 +78,7 @@ func (s *SamplerFactory) updatePeerCounts() {
 
 func (s *SamplerFactory) Start() error {
 	s.peerCount = 1
-	s.sharedDynsamplers = make(map[string]any)
-	s.sharedMetricsRecorders = make(map[string]*dynsamplerMetricsRecorder)
+	s.sharedDynsamplers = make(map[string]sharedDynsamplerEntry)
 	s.goalThroughputConfigs = make(map[string]int)
 	if s.Peers != nil {
 		s.Peers.RegisterUpdatedPeersCallback(s.updatePeerCounts)
@@ -87,35 +89,26 @@ func (s *SamplerFactory) Start() error {
 	return nil
 }
 
-func getSharedDynsampler[ST any, CT any](
+func getSharedDynsamplerAndRecorder[ST dynsampler.Sampler, CT any](
 	s *SamplerFactory,
 	dynsamplerKey string,
+	prefix string,
 	config CT,
 	create func(config CT) ST,
-) (ST, bool) {
+) (ST, *dynsamplerMetricsRecorder) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
-	var ok bool
-	var dynsamplerInstance ST
-	if dynsamplerInstance, ok = s.sharedDynsamplers[dynsamplerKey].(ST); !ok {
-		dynsamplerInstance = create(config)
-		s.sharedDynsamplers[dynsamplerKey] = dynsamplerInstance
+	if entry, ok := s.sharedDynsamplers[dynsamplerKey]; ok {
+		if existing, ok := entry.dynsampler.(ST); ok {
+			return existing, entry.recorder
+		}
 	}
-	return dynsamplerInstance, !ok
-}
-
-func getSharedMetricsRecorder(s *SamplerFactory, dynsamplerKey, prefix string, sampler dynsampler.Sampler) *dynsamplerMetricsRecorder {
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
-
-	if r, ok := s.sharedMetricsRecorders[dynsamplerKey]; ok {
-		return r
-	}
+	dynsamplerInstance := create(config)
 	r := &dynsamplerMetricsRecorder{prefix: prefix, met: s.Metrics}
-	r.RegisterMetrics(sampler)
-	s.sharedMetricsRecorders[dynsamplerKey] = r
-	return r
+	r.RegisterMetrics(dynsamplerInstance)
+	s.sharedDynsamplers[dynsamplerKey] = sharedDynsamplerEntry{dynsampler: dynsamplerInstance, recorder: r}
+	return dynsamplerInstance, r
 }
 
 // makeDynsamplerKey builds a dynsampler map key with a sorted copy of fieldList so that
@@ -141,48 +134,43 @@ func (s *SamplerFactory) createSampler(c any, keyPrefix string) Sampler {
 		sampler = &DeterministicSampler{Config: c, Logger: s.Logger, Metrics: s.Metrics}
 	case *config.DynamicSamplerConfig:
 		dynsamplerKey := makeDynsamplerKey(keyPrefix, "dynamic", c.SampleRate, c.FieldList)
-		dynsamplerInstance, _ := getSharedDynsampler(s, dynsamplerKey, c, createDynForDynamicSampler)
-		recorder := getSharedMetricsRecorder(s, dynsamplerKey, "dynamic", dynsamplerInstance)
+		dynsamplerInstance, recorder := getSharedDynsamplerAndRecorder(s, dynsamplerKey, "dynamic", c, createDynForDynamicSampler)
 		sampler = &DynamicSampler{Config: c, Logger: s.Logger, Metrics: s.Metrics, dynsampler: dynsamplerInstance, metricsRecorder: recorder}
 	case *config.EMADynamicSamplerConfig:
 		dynsamplerKey := makeDynsamplerKey(keyPrefix, "emadynamic", int64(c.GoalSampleRate), c.FieldList)
-		dynsamplerInstance, _ := getSharedDynsampler(s, dynsamplerKey, c, createDynForEMADynamicSampler)
-		recorder := getSharedMetricsRecorder(s, dynsamplerKey, "emadynamic", dynsamplerInstance)
+		dynsamplerInstance, recorder := getSharedDynsamplerAndRecorder(s, dynsamplerKey, "emadynamic", c, createDynForEMADynamicSampler)
 		sampler = &EMADynamicSampler{Config: c, Logger: s.Logger, Metrics: s.Metrics, dynsampler: dynsamplerInstance, metricsRecorder: recorder}
 	case *config.RulesBasedSamplerConfig:
 		sampler = &RulesBasedSampler{Config: c, Logger: s.Logger, Metrics: s.Metrics, SamplerFactory: s, samplerPrefix: keyPrefix}
 	case *config.TotalThroughputSamplerConfig:
 		dynsamplerKey := makeDynsamplerKey(keyPrefix, "totalthroughput", int64(c.GoalThroughputPerSec), c.FieldList)
-		dynsamplerInstance, _ := getSharedDynsampler(s, dynsamplerKey, c, createDynForTotalThroughputSampler)
+		dynsamplerInstance, recorder := getSharedDynsamplerAndRecorder(s, dynsamplerKey, "totalthroughput", c, createDynForTotalThroughputSampler)
 		// only track goal throughput config if we need to recalculate it later based on cluster size
 		if c.UseClusterSize {
 			s.mutex.Lock()
 			s.goalThroughputConfigs[dynsamplerKey] = c.GoalThroughputPerSec
 			s.mutex.Unlock()
 		}
-		recorder := getSharedMetricsRecorder(s, dynsamplerKey, "totalthroughput", dynsamplerInstance)
 		sampler = &TotalThroughputSampler{Config: c, Logger: s.Logger, Metrics: s.Metrics, dynsampler: dynsamplerInstance, metricsRecorder: recorder}
 	case *config.EMAThroughputSamplerConfig:
 		dynsamplerKey := makeDynsamplerKey(keyPrefix, "emathroughput", int64(c.GoalThroughputPerSec), c.FieldList)
-		dynsamplerInstance, _ := getSharedDynsampler(s, dynsamplerKey, c, createDynForEMAThroughputSampler)
+		dynsamplerInstance, recorder := getSharedDynsamplerAndRecorder(s, dynsamplerKey, "emathroughput", c, createDynForEMAThroughputSampler)
 		// only track goal throughput config if we need to recalculate it later based on cluster size
 		if c.UseClusterSize {
 			s.mutex.Lock()
 			s.goalThroughputConfigs[dynsamplerKey] = c.GoalThroughputPerSec
 			s.mutex.Unlock()
 		}
-		recorder := getSharedMetricsRecorder(s, dynsamplerKey, "emathroughput", dynsamplerInstance)
 		sampler = &EMAThroughputSampler{Config: c, Logger: s.Logger, Metrics: s.Metrics, dynsampler: dynsamplerInstance, metricsRecorder: recorder}
 	case *config.WindowedThroughputSamplerConfig:
 		dynsamplerKey := makeDynsamplerKey(keyPrefix, "windowedthroughput", int64(c.GoalThroughputPerSec), c.FieldList)
-		dynsamplerInstance, _ := getSharedDynsampler(s, dynsamplerKey, c, createDynForWindowedThroughputSampler)
+		dynsamplerInstance, recorder := getSharedDynsamplerAndRecorder(s, dynsamplerKey, "windowedthroughput", c, createDynForWindowedThroughputSampler)
 		// only track goal throughput config if we need to recalculate it later based on cluster size
 		if c.UseClusterSize {
 			s.mutex.Lock()
 			s.goalThroughputConfigs[dynsamplerKey] = c.GoalThroughputPerSec
 			s.mutex.Unlock()
 		}
-		recorder := getSharedMetricsRecorder(s, dynsamplerKey, "windowedthroughput", dynsamplerInstance)
 		sampler = &WindowedThroughputSampler{Config: c, Logger: s.Logger, Metrics: s.Metrics, dynsampler: dynsamplerInstance, metricsRecorder: recorder}
 	default:
 		s.Logger.Error().Logf("unknown sampler type %T. Exiting.", c)
@@ -250,15 +238,14 @@ func (s *SamplerFactory) ClearDynsamplers() {
 	defer s.mutex.Unlock()
 
 	// Stop all shared dynsamplers
-	for _, dynSampler := range s.sharedDynsamplers {
-		if stopper, ok := dynSampler.(interface{ Stop() }); ok {
+	for _, entry := range s.sharedDynsamplers {
+		if stopper, ok := entry.dynsampler.(interface{ Stop() }); ok {
 			stopper.Stop()
 		}
 	}
 
 	clear(s.sharedDynsamplers)
 	clear(s.goalThroughputConfigs)
-	clear(s.sharedMetricsRecorders)
 }
 
 // Stop cleans up all shared dynsamplers
@@ -299,8 +286,8 @@ type dynsamplerMetricsRecorder struct {
 // RegisterMetrics registers the metrics that will be recorded by this package.
 // It initializes the necessary metrics and prepares them for recording.
 // It MUST be called before any calls to RecordMetrics.
+// This function is not concurrency safe.
 func (d *dynsamplerMetricsRecorder) RegisterMetrics(sampler dynsampler.Sampler) {
-	// Register statistics this package will produce
 	d.dynPrefix = d.prefix + "_"
 	d.lastMetrics = make(map[string]internalDysamplerMetric)
 	dynInternalMetrics := sampler.GetMetrics(d.dynPrefix)

--- a/sample/sample.go
+++ b/sample/sample.go
@@ -40,6 +40,8 @@ type SamplerFactory struct {
 
 	// Shared dynsampler instances to maintain global throughput tracking
 	sharedDynsamplers map[string]any
+	// Shared metrics recorders; one per shared dynsampler to avoid N×overcounting
+	sharedMetricsRecorders map[string]*dynsamplerMetricsRecorder
 
 	// Store original GoalThroughputPerSec values for cluster size calculations.
 	// We need this to recalculate goal throughput values when the cluster size
@@ -74,6 +76,7 @@ func (s *SamplerFactory) updatePeerCounts() {
 func (s *SamplerFactory) Start() error {
 	s.peerCount = 1
 	s.sharedDynsamplers = make(map[string]any)
+	s.sharedMetricsRecorders = make(map[string]*dynsamplerMetricsRecorder)
 	s.goalThroughputConfigs = make(map[string]int)
 	if s.Peers != nil {
 		s.Peers.RegisterUpdatedPeersCallback(s.updatePeerCounts)
@@ -89,7 +92,7 @@ func getSharedDynsampler[ST any, CT any](
 	dynsamplerKey string,
 	config CT,
 	create func(config CT) ST,
-) ST {
+) (ST, bool) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
@@ -99,7 +102,20 @@ func getSharedDynsampler[ST any, CT any](
 		dynsamplerInstance = create(config)
 		s.sharedDynsamplers[dynsamplerKey] = dynsamplerInstance
 	}
-	return dynsamplerInstance
+	return dynsamplerInstance, !ok
+}
+
+func getSharedMetricsRecorder(s *SamplerFactory, dynsamplerKey, prefix string, sampler dynsampler.Sampler) *dynsamplerMetricsRecorder {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	if r, ok := s.sharedMetricsRecorders[dynsamplerKey]; ok {
+		return r
+	}
+	r := &dynsamplerMetricsRecorder{prefix: prefix, met: s.Metrics}
+	r.RegisterMetrics(sampler)
+	s.sharedMetricsRecorders[dynsamplerKey] = r
+	return r
 }
 
 // makeDynsamplerKey builds a dynsampler map key with a sorted copy of fieldList so that
@@ -125,44 +141,49 @@ func (s *SamplerFactory) createSampler(c any, keyPrefix string) Sampler {
 		sampler = &DeterministicSampler{Config: c, Logger: s.Logger, Metrics: s.Metrics}
 	case *config.DynamicSamplerConfig:
 		dynsamplerKey := makeDynsamplerKey(keyPrefix, "dynamic", c.SampleRate, c.FieldList)
-		dynsamplerInstance := getSharedDynsampler(s, dynsamplerKey, c, createDynForDynamicSampler)
-		sampler = &DynamicSampler{Config: c, Logger: s.Logger, Metrics: s.Metrics, dynsampler: dynsamplerInstance}
+		dynsamplerInstance, _ := getSharedDynsampler(s, dynsamplerKey, c, createDynForDynamicSampler)
+		recorder := getSharedMetricsRecorder(s, dynsamplerKey, "dynamic", dynsamplerInstance)
+		sampler = &DynamicSampler{Config: c, Logger: s.Logger, Metrics: s.Metrics, dynsampler: dynsamplerInstance, metricsRecorder: recorder}
 	case *config.EMADynamicSamplerConfig:
 		dynsamplerKey := makeDynsamplerKey(keyPrefix, "emadynamic", int64(c.GoalSampleRate), c.FieldList)
-		dynsamplerInstance := getSharedDynsampler(s, dynsamplerKey, c, createDynForEMADynamicSampler)
-		sampler = &EMADynamicSampler{Config: c, Logger: s.Logger, Metrics: s.Metrics, dynsampler: dynsamplerInstance}
+		dynsamplerInstance, _ := getSharedDynsampler(s, dynsamplerKey, c, createDynForEMADynamicSampler)
+		recorder := getSharedMetricsRecorder(s, dynsamplerKey, "emadynamic", dynsamplerInstance)
+		sampler = &EMADynamicSampler{Config: c, Logger: s.Logger, Metrics: s.Metrics, dynsampler: dynsamplerInstance, metricsRecorder: recorder}
 	case *config.RulesBasedSamplerConfig:
 		sampler = &RulesBasedSampler{Config: c, Logger: s.Logger, Metrics: s.Metrics, SamplerFactory: s, samplerPrefix: keyPrefix}
 	case *config.TotalThroughputSamplerConfig:
 		dynsamplerKey := makeDynsamplerKey(keyPrefix, "totalthroughput", int64(c.GoalThroughputPerSec), c.FieldList)
-		dynsamplerInstance := getSharedDynsampler(s, dynsamplerKey, c, createDynForTotalThroughputSampler)
+		dynsamplerInstance, _ := getSharedDynsampler(s, dynsamplerKey, c, createDynForTotalThroughputSampler)
 		// only track goal throughput config if we need to recalculate it later based on cluster size
 		if c.UseClusterSize {
 			s.mutex.Lock()
 			s.goalThroughputConfigs[dynsamplerKey] = c.GoalThroughputPerSec
 			s.mutex.Unlock()
 		}
-		sampler = &TotalThroughputSampler{Config: c, Logger: s.Logger, Metrics: s.Metrics, dynsampler: dynsamplerInstance}
+		recorder := getSharedMetricsRecorder(s, dynsamplerKey, "totalthroughput", dynsamplerInstance)
+		sampler = &TotalThroughputSampler{Config: c, Logger: s.Logger, Metrics: s.Metrics, dynsampler: dynsamplerInstance, metricsRecorder: recorder}
 	case *config.EMAThroughputSamplerConfig:
 		dynsamplerKey := makeDynsamplerKey(keyPrefix, "emathroughput", int64(c.GoalThroughputPerSec), c.FieldList)
-		dynsamplerInstance := getSharedDynsampler(s, dynsamplerKey, c, createDynForEMAThroughputSampler)
+		dynsamplerInstance, _ := getSharedDynsampler(s, dynsamplerKey, c, createDynForEMAThroughputSampler)
 		// only track goal throughput config if we need to recalculate it later based on cluster size
 		if c.UseClusterSize {
 			s.mutex.Lock()
 			s.goalThroughputConfigs[dynsamplerKey] = c.GoalThroughputPerSec
 			s.mutex.Unlock()
 		}
-		sampler = &EMAThroughputSampler{Config: c, Logger: s.Logger, Metrics: s.Metrics, dynsampler: dynsamplerInstance}
+		recorder := getSharedMetricsRecorder(s, dynsamplerKey, "emathroughput", dynsamplerInstance)
+		sampler = &EMAThroughputSampler{Config: c, Logger: s.Logger, Metrics: s.Metrics, dynsampler: dynsamplerInstance, metricsRecorder: recorder}
 	case *config.WindowedThroughputSamplerConfig:
 		dynsamplerKey := makeDynsamplerKey(keyPrefix, "windowedthroughput", int64(c.GoalThroughputPerSec), c.FieldList)
-		dynsamplerInstance := getSharedDynsampler(s, dynsamplerKey, c, createDynForWindowedThroughputSampler)
+		dynsamplerInstance, _ := getSharedDynsampler(s, dynsamplerKey, c, createDynForWindowedThroughputSampler)
 		// only track goal throughput config if we need to recalculate it later based on cluster size
 		if c.UseClusterSize {
 			s.mutex.Lock()
 			s.goalThroughputConfigs[dynsamplerKey] = c.GoalThroughputPerSec
 			s.mutex.Unlock()
 		}
-		sampler = &WindowedThroughputSampler{Config: c, Logger: s.Logger, Metrics: s.Metrics, dynsampler: dynsamplerInstance}
+		recorder := getSharedMetricsRecorder(s, dynsamplerKey, "windowedthroughput", dynsamplerInstance)
+		sampler = &WindowedThroughputSampler{Config: c, Logger: s.Logger, Metrics: s.Metrics, dynsampler: dynsamplerInstance, metricsRecorder: recorder}
 	default:
 		s.Logger.Error().Logf("unknown sampler type %T. Exiting.", c)
 		os.Exit(1)
@@ -237,6 +258,7 @@ func (s *SamplerFactory) ClearDynsamplers() {
 
 	clear(s.sharedDynsamplers)
 	clear(s.goalThroughputConfigs)
+	clear(s.sharedMetricsRecorders)
 }
 
 // Stop cleans up all shared dynsamplers
@@ -265,6 +287,7 @@ type internalDysamplerMetric struct {
 }
 
 type dynsamplerMetricsRecorder struct {
+	mu        sync.Mutex
 	prefix    string
 	dynPrefix string // Used for accessing metrics from dynsampler-go
 	// Stores the last recorded internal metrics produced by dynsampler-go
@@ -292,6 +315,7 @@ func (d *dynsamplerMetricsRecorder) RegisterMetrics(sampler dynsampler.Sampler) 
 }
 
 func (d *dynsamplerMetricsRecorder) RecordMetrics(sampler dynsampler.Sampler, kept bool, rate uint, numTraceKey int) {
+	d.mu.Lock()
 	for name, val := range sampler.GetMetrics(d.dynPrefix) {
 		m := d.lastMetrics[name]
 		switch m.metricType {
@@ -304,6 +328,7 @@ func (d *dynsamplerMetricsRecorder) RecordMetrics(sampler dynsampler.Sampler, ke
 			d.met.Gauge(name, float64(val))
 		}
 	}
+	d.mu.Unlock()
 
 	if kept {
 		d.met.Increment(d.metricNames.numKept)

--- a/sample/totalthroughput.go
+++ b/sample/totalthroughput.go
@@ -57,12 +57,13 @@ func (d *TotalThroughputSampler) Start() error {
 	d.key = newTraceKey(d.Config.FieldList, d.Config.UseTraceLength)
 	d.keyFields, d.nonRootFields = config.GetKeyFields(d.Config.GetSamplingFields())
 
-	// Register statistics this package will produce
-	d.metricsRecorder = &dynsamplerMetricsRecorder{
-		prefix: "totalthroughput",
-		met:    d.Metrics,
+	if d.metricsRecorder == nil {
+		d.metricsRecorder = &dynsamplerMetricsRecorder{
+			prefix: "totalthroughput",
+			met:    d.Metrics,
+		}
+		d.metricsRecorder.RegisterMetrics(d.dynsampler)
 	}
-	d.metricsRecorder.RegisterMetrics(d.dynsampler)
 	return nil
 }
 

--- a/sample/windowed_throughput.go
+++ b/sample/windowed_throughput.go
@@ -54,12 +54,13 @@ func (d *WindowedThroughputSampler) Start() error {
 	d.key = newTraceKey(d.Config.FieldList, d.Config.UseTraceLength)
 	d.keyFields, d.nonRootFields = config.GetKeyFields(d.Config.GetSamplingFields())
 
-	// Register statistics this package will produce
-	d.metricsRecorder = &dynsamplerMetricsRecorder{
-		prefix: "windowedthroughput",
-		met:    d.Metrics,
+	if d.metricsRecorder == nil {
+		d.metricsRecorder = &dynsamplerMetricsRecorder{
+			prefix: "windowedthroughput",
+			met:    d.Metrics,
+		}
+		d.metricsRecorder.RegisterMetrics(d.dynsampler)
 	}
-	d.metricsRecorder.RegisterMetrics(d.dynsampler)
 	return nil
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?

When multiple sampler configurations share a dynsampler instance (same type + same config), dynsampler metrics like `event_count` and `request_count` were inflated by the number of collector workers — making them N× higher than actual throughput. This made these metrics unreliable for diagnosing sampling behavior.

## Short description of the changes

- have `SamplerFactory` be responsible for creating `metricsRecorder` instance. This is the same pattern as with the shared dynsampler instance so they are created and shared atomically