### PR TITLE
fix: copy fields slice before sorting in newTraceKey

### DIFF
--- a/sample/trace_key.go
+++ b/sample/trace_key.go
@@ -28,10 +28,13 @@ type traceKey struct {
 
 func newTraceKey(fields []string, useTraceLength bool) *traceKey {
 	// always put the field list in sorted order for easier comparison
-	sort.Strings(fields)
-	rootOnlyFields := make([]string, 0, len(fields)/2)
-	nonRootFields := make([]string, 0, len(fields)/2)
-	for _, field := range fields {
+	copiedFields := make([]string, len(fields))
+	copy(copiedFields, fields)
+	sort.Strings(copiedFields)
+
+	rootOnlyFields := make([]string, 0, len(copiedFields)/2)
+	nonRootFields := make([]string, 0, len(copiedFields)/2)
+	for _, field := range copiedFields {
 		if strings.HasPrefix(field, config.RootPrefix) {
 			rootOnlyFields = append(rootOnlyFields, field[len(config.RootPrefix):])
 			continue


### PR DESCRIPTION
## Which problem is this PR solving?

- `newTraceKey` called `sort.Strings(fields)` directly on the caller's slice, mutating it in place and causing unintended side effects for callers that expected their slice to be unchanged

## Short description of the changes

- Copy the `fields` slice before sorting so the caller's original slice is not mutated