### PR TITLE
maint: upgrade to go1.26 (bonus: better CPU performance)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ commands:
 jobs:
   test:
     docker:
-      - image: cimg/go:1.25
+      - image: cimg/go:1.26
       - image: redis:6.2
     resource_class: xlarge
     steps:
@@ -94,7 +94,7 @@ jobs:
 
   build_binaries:
     docker:
-      - image: cimg/go:1.25
+      - image: cimg/go:1.26
     steps:
       - checkout
       - go-build:
@@ -185,7 +185,7 @@ jobs:
 
   build_docker:
     docker:
-      - image: cimg/go:1.25
+      - image: cimg/go:1.26
     steps:
       - checkout
       - setup_googleko
@@ -214,7 +214,7 @@ jobs:
 
   publish_docker_to_private_ecr:
     docker:
-      - image: cimg/go:1.25
+      - image: cimg/go:1.26
     steps:
       - checkout
       - setup_remote_docker
@@ -237,7 +237,7 @@ jobs:
 
   publish_docker_to_ecr_sippycup:
     docker:
-      - image: cimg/go:1.25
+      - image: cimg/go:1.26
     steps:
       - checkout
       - setup_remote_docker
@@ -261,7 +261,7 @@ jobs:
 
   publish_docker_to_all_public_registries:
     docker:
-      - image: cimg/go:1.25
+      - image: cimg/go:1.26
     steps:
       - checkout
       - setup_remote_docker

--- a/app/app.go
+++ b/app/app.go
@@ -41,7 +41,7 @@ func (a *App) Start() error {
 			a.Logger.Warn().WithFields(map[string]interface{}{
 				"configHash": cfgHash,
 				"rulesHash":  rulesHash,
-			}).Logf(msg)
+			}).Logf("%s", msg)
 		}
 		cfgMetric := config.ConfigHashMetrics(cfgHash)
 		ruleMetric := config.ConfigHashMetrics(rulesHash)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/honeycombio/refinery
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/agnivade/levenshtein v1.2.1

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -142,7 +142,7 @@ func (h *Health) Register(subsystem string, timeout time.Duration) {
 		"source":  subsystem,
 		"timeout": timeout,
 	}
-	h.Logger.Info().WithFields(fields).Logf("Registered Health ticker", subsystem, timeout)
+	h.Logger.Info().WithFields(fields).Logf("Registered Health ticker")
 	if timeout < TickerTime {
 		h.Logger.Error().WithFields(fields).Logf("Registering a timeout less than the ticker time")
 	}

--- a/route/errors.go
+++ b/route/errors.go
@@ -77,11 +77,11 @@ func (r *Router) handlerReturnWithError(w http.ResponseWriter, he handlerError, 
 }
 
 func (r *Router) handleOTLPFailureResponse(w http.ResponseWriter, req *http.Request, otlpErr husky.OTLPError) {
-	r.Logger.Error().Logf(otlpErr.Error())
+	r.Logger.Error().Logf("%s", otlpErr.Error())
 	if err := husky.WriteOtlpHttpFailureResponse(w, req, otlpErr); err != nil {
 		// If we made it here we had a problem writing an OTLP HTTP response
 		resp := fmt.Sprintf("failed to write otlp http response, %v", err.Error())
-		r.Logger.Error().Logf(resp)
+		r.Logger.Error().Logf("%s", resp)
 		w.Header().Set("Content-Type", "text/plain")
 		w.WriteHeader(http.StatusInternalServerError)
 		_, _ = io.WriteString(w, resp)

--- a/route/route.go
+++ b/route/route.go
@@ -293,7 +293,7 @@ func (r *Router) LnS() {
 	if r.Config.GetGRPCEnabled() && len(grpcAddr) > 0 {
 		l, err := net.Listen("tcp", grpcAddr)
 		if err != nil {
-			r.iopLogger.Error().Logf("failed to listen to grpc addr: " + grpcAddr)
+			r.iopLogger.Error().Logf("failed to listen to grpc addr: %s", grpcAddr)
 		}
 
 		r.iopLogger.Info().Logf("gRPC listening on %s", grpcAddr)
@@ -639,7 +639,7 @@ func (router *Router) processOTLPRequest(
 			}
 			addIncomingUserAgent(event, incomingUserAgent)
 			if err := router.processEvent(event, requestID); err != nil {
-				router.Logger.Error().Logf("Error processing event: " + err.Error())
+				router.Logger.Error().Logf("Error processing event: %s", err.Error())
 			}
 		}
 	}
@@ -684,7 +684,7 @@ func (router *Router) processOTLPRequestBatchMsgp(
 			// TODO: Apply this optimization to all incoming data instead of relying on OTLP-specific behavior.
 			err := coreFieldsUnmarshaler.UnmarshalMsgpEventMetadataOnly(ev.Attributes, &payload)
 			if err != nil {
-				router.Logger.Error().Logf("Error unmarshaling payload: " + err.Error())
+				router.Logger.Error().Logf("Error unmarshaling payload: %s", err.Error())
 				continue
 			}
 
@@ -700,7 +700,7 @@ func (router *Router) processOTLPRequestBatchMsgp(
 			}
 			addIncomingUserAgent(event, incomingUserAgent)
 			if err := router.processEvent(event, requestID); err != nil {
-				router.Logger.Error().Logf("Error processing event: " + err.Error())
+				router.Logger.Error().Logf("Error processing event: %s", err.Error())
 			}
 		}
 	}

--- a/transmit/direct_transmit.go
+++ b/transmit/direct_transmit.go
@@ -345,7 +345,7 @@ func (d *DirectTransmission) handleError(ev *types.Event, statusCode int, queueT
 		}
 	}
 
-	log.Logf(logMessage)
+	log.Logf("%s", logMessage)
 }
 
 // handleBatchFailure handles metrics updates when the entire batch fails


### PR DESCRIPTION
## Which problem is this PR solving?

- Refinery was still pinned to go1.25; go1.26 brings performance improvements we want to pick up.

## Short description of the changes

- Bump `go.mod` to go1.26.0
- Bump CircleCI `cimg/go` build images from 1.25 to 1.26