### PR TITLE
fix: stop flaky duplicate-event failures in TestAppIntegrationSendKey

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -98,7 +98,7 @@ func newTestAPIServer(t testing.TB) *testAPIServer {
 		io.Copy(io.Discard, resp.Body)
 
 		return resp.StatusCode == http.StatusOK
-	}, 100*time.Millisecond, 10*time.Millisecond, "Test server failed to become ready")
+	}, 2*time.Second, 10*time.Millisecond, "Test server failed to become ready")
 
 	// Clear the health check events from the events array
 	server.mutex.Lock()
@@ -344,7 +344,7 @@ func newStartedApp(
 	if mockTransmission != nil {
 		upstreamTransmission = mockTransmission
 	} else {
-		upstreamTransmission = transmit.NewDirectTransmission(types.TransmitTypeUpstream, http.DefaultTransport.(*http.Transport), 500, 100*time.Millisecond, 100*time.Millisecond, true, nil)
+		upstreamTransmission = transmit.NewDirectTransmission(types.TransmitTypeUpstream, http.DefaultTransport.(*http.Transport), 500, 100*time.Millisecond, 2*time.Second, true, nil)
 	}
 
 	// Always create real peer transmission using DirectTransmission
@@ -354,7 +354,7 @@ func newStartedApp(
 			Timeout: 3 * time.Second,
 		}).Dial,
 	}
-	peerTransmissionWrapper := transmit.NewDirectTransmission(types.TransmitTypePeer, peerTransport, int(cfg.GetTracesConfigVal.MaxBatchSize), 100*time.Millisecond, 100*time.Millisecond, false, nil)
+	peerTransmissionWrapper := transmit.NewDirectTransmission(types.TransmitTypePeer, peerTransport, int(cfg.GetTracesConfigVal.MaxBatchSize), 100*time.Millisecond, 2*time.Second, false, nil)
 
 	var g inject.Graph
 	err = g.Provide(


### PR DESCRIPTION
## Which problem is this PR solving?

- `TestAppIntegrationSendKey` has been intermittently flaky in CI (previously flaked 2026-05-22, again on the go1.26 upgrade PR #1836), failing with "should have 1 item(s), but has 2" from the OTLP endpoint subtest.

## Short description of the changes

- Root cause: `app_test.go` configured `DirectTransmission`'s `batchSendTimeout` (which becomes `http.Client.Timeout`, covering the full round-trip) at 100ms. Under CI CPU contention, the mock server can legitimately take >100ms to respond even after successfully recording the event, so the client-side timeout fires and `direct_transmit.go`'s retry-on-timeout path resends the identical batch — duplicating the event with no dedup on the test's mock upstream.
- Bump `batchSendTimeout` to 2s in both `NewDirectTransmission` calls in `app_test.go`, matching the 10s used at all other `direct_transmit_test.go` call sites and this test's own 2s `EventuallyWithT` polling window.