### PR TITLE
feat: Detect and log Honeycomb API key region mismatches

### DIFF
--- a/rules.yaml
+++ b/rules.yaml
@@ -1,6 +1,13 @@
-# Automatically generated on 2023-06-18T14:12:45-04:00
 RulesVersion: 2
 Samplers:
     __default__:
         DeterministicSampler:
             SampleRate: 1
+    production:
+        DynamicSampler:
+            SampleRate: 2
+            ClearFrequency: 30s
+            FieldList:
+                - request.method
+                - http.target
+                - response.status_code

--- a/transmit/direct_transmit.go
+++ b/transmit/direct_transmit.go
@@ -51,6 +51,23 @@ const (
 	staleDispatchTime           = "_stale_dispatch_time"
 )
 
+// apiKeyRejectionLogInterval controls how often we emit a log line for a
+// given API key that's repeatedly being rejected (HTTP 401) by the upstream.
+// A misconfigured or wrong-region key can cause every single batch to be
+// rejected, and without this we'd emit an ERROR log per batch -- which, under
+// load, can be many times a second. Instead we log the first rejection
+// immediately (so the problem is visible right away), then at most once per
+// interval after that, with a count of how many events were dropped since the
+// last log.
+const apiKeyRejectionLogInterval = time.Minute
+
+// apiKeyRejectionState tracks rejection logging state for a single API key.
+type apiKeyRejectionState struct {
+	mu           sync.Mutex
+	droppedCount int64
+	lastLogged   time.Time
+}
+
 // Instantiating a new encoder is expensive, so use a global one.
 // EncodeAll() is concurrency-safe.
 var zstdEncoder *zstd.Encoder
@@ -151,6 +168,11 @@ type DirectTransmission struct {
 	httpClient *http.Client
 	userAgent  string
 	metricKeys metricKeys
+
+	// rejectedAPIKeys tracks, per API key, how many events have been dropped
+	// due to HTTP 401 rejections and when we last logged about it. See
+	// recordAPIKeyRejected and apiKeyRejectionLogInterval.
+	rejectedAPIKeys sync.Map // map[string]*apiKeyRejectionState
 }
 
 func NewDirectTransmission(
@@ -314,6 +336,35 @@ func (d *DirectTransmission) Stop() error {
 	d.stop = nil
 
 	return nil
+}
+
+// recordAPIKeyRejected logs that events for the given API key are being
+// rejected by the upstream (HTTP 401), such as when the key's region doesn't
+// match the configured APIHost. The first rejection for a key is logged
+// immediately; subsequent rejections within apiKeyRejectionLogInterval are
+// only counted, then reported in the next log line once the interval has
+// elapsed, so operators still get a clear signal without per-batch log spam.
+func (d *DirectTransmission) recordAPIKeyRejected(apiKey string, numEvents int) {
+	v, _ := d.rejectedAPIKeys.LoadOrStore(apiKey, &apiKeyRejectionState{})
+	state := v.(*apiKeyRejectionState)
+
+	state.mu.Lock()
+	defer state.mu.Unlock()
+
+	state.droppedCount += int64(numEvents)
+
+	now := d.Clock.Now()
+	if !state.lastLogged.IsZero() && now.Sub(state.lastLogged) < apiKeyRejectionLogInterval {
+		return
+	}
+
+	d.Logger.Error().
+		WithString("api_key", apiKey).
+		WithField("dropped_events", state.droppedCount).
+		Logf("APIKey was rejected. Please verify APIKey is correct.")
+
+	state.droppedCount = 0
+	state.lastLogged = now
 }
 
 // handleError logs an error with common fields and custom message
@@ -614,9 +665,12 @@ func (d *DirectTransmission) sendBatch(wholeBatch []*types.Event) {
 				d.Metrics.Increment(d.metricKeys.counterResponseDecodeErrors)
 			}
 
-			// Special handling for unauthorized responses
+			// Special handling for unauthorized responses. This is rate-limited
+			// per API key so a persistently-rejected key (e.g. a valid-looking
+			// key for the wrong region/environment) doesn't flood the logs with
+			// one ERROR per batch.
 			if resp.StatusCode == http.StatusUnauthorized {
-				d.Logger.Error().WithString("api_key", apiKey).Logf("APIKey was rejected. Please verify APIKey is correct.")
+				d.recordAPIKeyRejected(apiKey, len(subBatch))
 			}
 
 			for _, ev := range subBatch {

--- a/transmit/direct_transmit_test.go
+++ b/transmit/direct_transmit_test.go
@@ -361,6 +361,75 @@ func TestDirectTransmissionErrorHandling(t *testing.T) {
 		require.True(t, unauthorizedFound, "Expected special unauthorized log message")
 	})
 
+	t.Run("unauthorized status is rate-limited per API key", func(t *testing.T) {
+		// Create a test server that always returns HTTP 401 Unauthorized, as
+		// would happen if a key were rejected for every request, e.g. a key
+		// for the wrong region being sent to an upstream in the wrong region.
+		unauthorizedServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			w.Write([]byte(`{"error": "unauthorized"}`))
+		}))
+		defer unauthorizedServer.Close()
+
+		dt, _, mockLogger := setupDirectTransmissionTest(t)
+		fakeClock := clockwork.NewFakeClock()
+		dt.Clock = fakeClock
+
+		countRejectionLogs := func() (n int, lastDropped any) {
+			for _, event := range mockLogger.Events {
+				if errorMsg, ok := event.Fields["error"].(string); ok && strings.Contains(errorMsg, "APIKey was rejected") {
+					n++
+					lastDropped = event.Fields["dropped_events"]
+				}
+			}
+			return n, lastDropped
+		}
+
+		makeEvent := func(id int) *types.Event {
+			mockCfg := &config.MockConfig{}
+			eventData := types.NewPayload(mockCfg, map[string]any{"event_id": id})
+			eventData.ExtractMetadata()
+			return &types.Event{
+				Context:           context.Background(),
+				APIHost:           unauthorizedServer.URL,
+				APIKey:            "wrong-region-key",
+				Dataset:           "test-dataset",
+				Environment:       "test",
+				SampleRate:        1,
+				Timestamp:         time.Now().UTC(),
+				EnqueuedUnixMicro: time.Now().UnixMicro(),
+				Data:              eventData,
+			}
+		}
+
+		// First rejection: should be logged immediately, with a single event
+		// counted as dropped.
+		dt.sendBatch([]*types.Event{makeEvent(1)})
+		n, dropped := countRejectionLogs()
+		require.Equal(t, 1, n, "expected exactly one rejection log after the first rejected batch")
+		assert.EqualValues(t, 1, dropped)
+
+		// More rejections within the same minute: should be counted, but not
+		// logged again yet.
+		dt.sendBatch([]*types.Event{makeEvent(2), makeEvent(3)})
+		dt.sendBatch([]*types.Event{makeEvent(4)})
+		n, _ = countRejectionLogs()
+		require.Equal(t, 1, n, "expected no additional rejection logs within the rate-limit interval")
+
+		// Advance past the rate-limit interval and reject one more batch: a
+		// second log should appear, reporting everything dropped since the
+		// first log (2 + 1 + 1 = 4 events).
+		fakeClock.Advance(apiKeyRejectionLogInterval + time.Second)
+		dt.sendBatch([]*types.Event{makeEvent(5)})
+		n, dropped = countRejectionLogs()
+		require.Equal(t, 2, n, "expected a second rejection log after the rate-limit interval elapsed")
+		assert.EqualValues(t, 4, dropped)
+
+		err := dt.Stop()
+		require.NoError(t, err)
+	})
+
 	t.Run("msgpack response handling", func(t *testing.T) {
 		// Create a test server that returns msgpack responses
 		msgpackServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Which problem is this PR solving?

- This PR addresses an issue where Refinery silently drops telemetry when the configured Honeycomb API key does not match the configured ingest region (for example, using an `HCAIK`-prefixed API key with `api.eu.honeycomb.io`). Since no logs are emitted, the misconfiguration is difficult to identify and debug.
