### PR TITLE
fix: pin klauspost/compress to arm64 link-register fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -120,3 +120,7 @@ require (
 )
 
 tool github.com/google/go-licenses/v2
+
+// fix for arm64 zstd decoder asm overwriting the saved link register, which breaks
+// stack unwinding during GC scans and profiling: klauspost/compress#1176 (not yet merged upstream)
+replace github.com/klauspost/compress => github.com/honeycombio/compress v1.19.1-0.20260725070242-26c7cb34104b

--- a/go.sum
+++ b/go.sum
@@ -116,6 +116,8 @@ github.com/hashicorp/go-version v1.9.0 h1:CeOIz6k+LoN3qX9Z0tyQrPtiB1DFYRPfCIBtaX
 github.com/hashicorp/go-version v1.9.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
+github.com/honeycombio/compress v1.19.1-0.20260725070242-26c7cb34104b h1:/drT0TC1FUj+KKYBmOGHNtycUYsJERFRLmEK1VwhpSQ=
+github.com/honeycombio/compress v1.19.1-0.20260725070242-26c7cb34104b/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/honeycombio/dynsampler-go v0.6.4 h1:EM3FXN2Lfmso41MRMmSvRynMrz+AHiRffaWHPf4ZHDs=
 github.com/honeycombio/dynsampler-go v0.6.4/go.mod h1:M5YYNOfxRrBlEWDatTlHMYo5F7GjwVnptx5z+uXIVMo=
 github.com/honeycombio/hpsf v0.14.0 h1:LeQbDuT+aVmiJnWp9Kqb9Qqz5OZcjDk85RMzzwKtCKI=
@@ -132,8 +134,6 @@ github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbd
 github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
-github.com/klauspost/compress v1.19.1 h1:VsB4HPswih7mmZ8WleSFQ75c/Ui1M4trX5oAsJnhSlk=
-github.com/klauspost/compress v1.19.1/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/klauspost/cpuid/v2 v2.2.10 h1:tBs3QSyvjDyFTq3uoc/9xFpCuOsJQFNPiAhYdw2skhE=
 github.com/klauspost/cpuid/v2 v2.2.10/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=


### PR DESCRIPTION
## Which problem is this PR solving?

- klauspost/compress's generated arm64 zstd decoder assembly places function locals 8 bytes too low, overlapping the saved link register. This doesn't corrupt decoded data, but it breaks stack unwinding on arm64 during GC stack scans, panic handling, and CPU/heap profiling, which can crash the process. Present since compress v1.19.0. Upstream fix: [klauspost/compress#1176](https://github.com/klauspost/compress/pull/1176) (not yet merged).

## Short description of the changes

- Pin `github.com/klauspost/compress` to the fix commit via a `replace` directive pointing at the `honeycombio/compress` fork, until the upstream PR merges and cuts a release.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pah4t3q1rYVNDZJqqrzWWs)_