### PR TITLE
maint: add OSS maintainers to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @honeycombio/llm-observability @honeycombio/ai-observability
+* @honeycombio/oss-maintainers @honeycombio/llm-observability @honeycombio/ai-observability 


### PR DESCRIPTION
## Which problem is this PR solving?

- OSS Maintainers are still maintaining this project. Their reviews should be recognized as from owners.

## Short description of the changes

- add OSS maintainers to CODEOWNERS

