### PR TITLE
rel: prepare v3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Refinery Changelog
 
+## 3.3.0 2026-08-10
+
+In addition to zstd support for gRPC connections and performance improvements, this release includes updates to address CVEs in several dependencies.
+
+### 💡 Enhancements
+
+- feat: support zstd on gRPC by @mterhar in https://github.com/honeycombio/refinery/pull/1833
+- maint: upgrade to go1.26 (bonus: better CPU performance) by @lizthegrey in https://github.com/honeycombio/refinery/pull/1836
+
+### 🛠 Maintenance
+
+- maint(deps): bump the minor-patch group with 19 updates by @dependabot in https://github.com/honeycombio/refinery/pull/1829
+- maint: bump klauspost/compress to v1.19.1 by @lizthegrey in https://github.com/honeycombio/refinery/pull/1834
+- fix: stop flaky duplicate-event failures in TestAppIntegrationSendKey by @lizthegrey in https://github.com/honeycombio/refinery/pull/1837
+- maint(deps): bump google.golang.org/grpc from 1.81.1 to 1.82.1 by @dependabot in https://github.com/honeycombio/refinery/pull/1839
+- maint: bump klauspost/compress to v1.19.2 by @lizthegrey in https://github.com/honeycombio/refinery/pull/1843
+- maint: align Go version declarations in dev and CI by @robbkidd in https://github.com/honeycombio/refinery/pull/1846
+- maint(deps): bump the minor-patch group across 1 directory with 20 updates by @dependabot in https://github.com/honeycombio/refinery/pull/1847
+
 ## 3.2.2 2026-05-26
 
 ### 🐛 Fixes

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,19 @@
 
 While [CHANGELOG.md](./CHANGELOG.md) contains detailed documentation and links to all the source code changes in a given release, this document is intended to be aimed at a more comprehensible version of the contents of the release from the point of view of users of Refinery.
 
+## Version 3.3.0
+
+This release adds zstd compression support for OTLP over gRPC, upgrades the Go toolchain for better CPU performance, and updates dependencies to address CVEs.
+
+### Features
+
+* **zstd on gRPC**: Refinery's gRPC server now accepts OTLP requests sent with `grpc-encoding: zstd`. Clients already sending gzip are unaffected. The compressor streams rather than buffering whole messages.
+
+### Maintenance
+
+* Built with Go 1.26, which improves CPU performance.
+* Updated dependencies to address security vulnerabilities.
+
 ## Version 3.2.2
 
 This release fixes dynamic sampling correctness and metrics accuracy when multiple collector workers are enabled.

--- a/config.md
+++ b/config.md
@@ -3,7 +3,7 @@
 # Honeycomb Refinery Configuration Documentation
 
 This is the documentation for the configuration file for Honeycomb's Refinery.
-It was automatically generated on 2026-04-09 at 22:21:32 UTC.
+It was automatically generated on 2026-08-10 at 18:45:39 UTC.
 
 ## The Config file
 

--- a/config_complete.yaml
+++ b/config_complete.yaml
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created on 2026-04-09 at 22:21:32 UTC from ../../config.yaml using a template generated on 2026-04-09 at 22:21:28 UTC
+# created on 2026-08-10 at 18:45:39 UTC from ../../config.yaml using a template generated on 2026-08-10 at 18:45:36 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of

--- a/metrics.md
+++ b/metrics.md
@@ -3,7 +3,7 @@
 # Honeycomb Refinery Metrics Documentation
 
 This document contains the description of various metrics used in Refinery.
-It was automatically generated on 2026-04-09 at 22:21:31 UTC.
+It was automatically generated on 2026-08-10 at 18:45:39 UTC.
 
 Note: This document does not include metrics defined in the dynsampler-go dependency, as those metrics are generated dynamically at runtime. As a result, certain metrics may be missing or incomplete in this document, but they will still be available during execution with their full names.
 
@@ -81,6 +81,7 @@ Metrics in this table don't contain their expected prefixes. This is because the
 
 | Name | Type | Unit | Description |
 |------|------|------|-------------|
+| unique_dynsampler_count | Gauge | Dimensionless | Number of unique dynsampler-go samplers created |
 | _num_dropped | Counter | Dimensionless | Number of traces dropped by configured sampler |
 | _num_kept | Counter | Dimensionless | Number of traces kept by configured sampler |
 | _sample_rate | Histogram | Dimensionless | Sample rate for traces |

--- a/rules.md
+++ b/rules.md
@@ -3,7 +3,7 @@
 # Honeycomb Refinery Rules Documentation
 
 This is the documentation for the rules configuration for Honeycomb's Refinery.
-It was automatically generated on 2026-04-09 at 22:21:32 UTC.
+It was automatically generated on 2026-08-10 at 18:45:40 UTC.
 
 ## The Rules file
 

--- a/tools/convert/configDataNames.txt
+++ b/tools/convert/configDataNames.txt
@@ -1,5 +1,5 @@
 # Names of groups and fields in the new config file format.
-# Automatically generated on 2026-04-09 at 22:21:29 UTC.
+# Automatically generated on 2026-08-10 at 18:45:38 UTC.
 
 General:
   - ConfigurationVersion

--- a/tools/convert/metricsMeta.yaml
+++ b/tools/convert/metricsMeta.yaml
@@ -244,6 +244,10 @@ complete:
       unit: Dimensionless
       description: The hash of the current rules configuration
 hasprefix:
+    - name: unique_dynsampler_count
+      type: Gauge
+      unit: Dimensionless
+      description: Number of unique dynsampler-go samplers created
     - name: _num_dropped
       type: Counter
       unit: Dimensionless

--- a/tools/convert/minimal_config.yaml
+++ b/tools/convert/minimal_config.yaml
@@ -1,5 +1,5 @@
 # sample uncommented config file containing all possible fields
-# automatically generated on 2026-04-09 at 22:21:30 UTC
+# automatically generated on 2026-08-10 at 18:45:38 UTC
 General:
   ConfigurationVersion: 2
   MinRefineryVersion: "v2.0"

--- a/tools/convert/templates/configV2.tmpl
+++ b/tools/convert/templates/configV2.tmpl
@@ -2,7 +2,7 @@
 ## Honeycomb Refinery Configuration ##
 ######################################
 #
-# created {{ now }} from {{ .Input }} using a template generated on 2026-04-09 at 22:21:28 UTC
+# created {{ now }} from {{ .Input }} using a template generated on 2026-08-10 at 18:45:36 UTC
 
 # This file contains a configuration for the Honeycomb Refinery. It is in YAML
 # format, organized into named groups, each of which contains a set of


### PR DESCRIPTION
## Which problem is this PR solving?

Prepare for the v3.3.0 release.

## Short description of the changes

- Update `CHANGELOG.md` and `RELEASE_NOTES.md` for v3.3.0
- Regenerate documentation and sample configs
- No docs update PR needed; `refinery_config.md` and `refinery_rules.md` are unchanged beyond timestamps.
