### PR TITLE
maint: update to husky v0.44.0, adopt new header validators

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/honeycombio/dynsampler-go v0.6.4
 	github.com/honeycombio/hpsf v0.14.0
-	github.com/honeycombio/husky v0.43.1
+	github.com/honeycombio/husky v0.44.0
 	github.com/honeycombio/libhoney-go v1.27.1
 	github.com/jessevdk/go-flags v1.6.1
 	github.com/jonboulle/clockwork v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -121,8 +121,8 @@ github.com/honeycombio/dynsampler-go v0.6.4 h1:EM3FXN2Lfmso41MRMmSvRynMrz+AHiRff
 github.com/honeycombio/dynsampler-go v0.6.4/go.mod h1:M5YYNOfxRrBlEWDatTlHMYo5F7GjwVnptx5z+uXIVMo=
 github.com/honeycombio/hpsf v0.14.0 h1:LeQbDuT+aVmiJnWp9Kqb9Qqz5OZcjDk85RMzzwKtCKI=
 github.com/honeycombio/hpsf v0.14.0/go.mod h1:VyPjyn1GViOiCrpBbPZCkEJnuDuSTUpU8LV5CWVTQm4=
-github.com/honeycombio/husky v0.43.1 h1:HRaSO59KujOsYNQO1Qkn8YFboizheTJcKlBvVhClDe8=
-github.com/honeycombio/husky v0.43.1/go.mod h1:lQ1VzGZxeYPCr4zxmak1lVe29HJFqJ6bQXWCl0ZqlNg=
+github.com/honeycombio/husky v0.44.0 h1:VJhJOEs5FQ5BFECFfi4g2rG5cMH8Ven4wqHbuk/zr40=
+github.com/honeycombio/husky v0.44.0/go.mod h1:lQ1VzGZxeYPCr4zxmak1lVe29HJFqJ6bQXWCl0ZqlNg=
 github.com/honeycombio/libhoney-go v1.27.1 h1:79FR19fVpaeDMqTDfpXtMxd90vzsxhZnIOSysMrUSQQ=
 github.com/honeycombio/libhoney-go v1.27.1/go.mod h1:qLZO8Q3ep/hISEoVC7m8N9ZOvn2eqaGdoJg9XXXasqM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=

--- a/route/otlp_logs.go
+++ b/route/otlp_logs.go
@@ -28,7 +28,7 @@ func (r *Router) postOTLPLogs(w http.ResponseWriter, req *http.Request) {
 	}
 	keyToUse, _ := apicfg.GetReplaceKey(ri.ApiKey, keyID)
 
-	if err := ri.ValidateLogsHeaders(); err != nil {
+	if err := ri.ValidateHeaders(); err != nil {
 		switch err {
 		case huskyotlp.ErrInvalidContentType:
 			r.handleOTLPFailureResponse(w, req, huskyotlp.ErrInvalidContentType)
@@ -92,7 +92,7 @@ func (l *LogsServer) Export(ctx context.Context, req *collectorlogs.ExportLogsSe
 	}
 	keyToUse, _ := apicfg.GetReplaceKey(ri.ApiKey, keyID)
 
-	if err := ri.ValidateLogsHeaders(); err != nil && err != huskyotlp.ErrMissingAPIKeyHeader {
+	if err := ri.ValidateHeaders(); err != nil && err != huskyotlp.ErrMissingAPIKeyHeader {
 		return nil, huskyotlp.AsGRPCError(err)
 	}
 

--- a/route/otlp_trace.go
+++ b/route/otlp_trace.go
@@ -232,6 +232,13 @@ func customTraceExportHandler(
 	// Update the RequestInfo with the processed key for the unmarshal step
 	ri.ApiKey = keyToUse
 
+	if err := ri.ValidateHeaders(); err != nil {
+		return nil, huskyotlp.AsGRPCError(err)
+	}
+	if err := ri.ValidateDatasetHeader(); err != nil {
+		return nil, huskyotlp.AsGRPCError(err)
+	}
+
 	in := &translatedTraceServiceRequest{
 		requestInfo: ri,
 		ctx:         ctx,

--- a/route/otlp_trace.go
+++ b/route/otlp_trace.go
@@ -36,17 +36,24 @@ func (r *Router) postOTLPTrace(w http.ResponseWriter, req *http.Request) {
 	}
 	keyToUse, _ := apicfg.GetReplaceKey(ri.ApiKey, keyID)
 
-	if err := ri.ValidateTracesHeaders(); err != nil {
+	if err := ri.ValidateHeaders(); err != nil {
 		switch err {
 		case huskyotlp.ErrInvalidContentType:
 			r.handleOTLPFailureResponse(w, req, huskyotlp.ErrInvalidContentType)
 			return
-		case huskyotlp.ErrMissingAPIKeyHeader, huskyotlp.ErrMissingDatasetHeader:
+		case huskyotlp.ErrMissingAPIKeyHeader:
 			if len(keyToUse) == 0 {
 				r.handleOTLPFailureResponse(w, req, huskyotlp.OTLPError{Message: err.Error(), HTTPStatusCode: http.StatusUnauthorized})
 				return
 			}
 		default:
+			r.handleOTLPFailureResponse(w, req, huskyotlp.OTLPError{Message: err.Error(), HTTPStatusCode: http.StatusUnauthorized})
+			return
+		}
+	}
+
+	if err := ri.ValidateDatasetHeader(); err != nil {
+		if len(keyToUse) == 0 {
 			r.handleOTLPFailureResponse(w, req, huskyotlp.OTLPError{Message: err.Error(), HTTPStatusCode: http.StatusUnauthorized})
 			return
 		}

--- a/route/otlp_trace_test.go
+++ b/route/otlp_trace_test.go
@@ -642,7 +642,7 @@ func TestOTLPHandler(t *testing.T) {
 		})
 		_, err := grpcClient.Export(ctx, req)
 		require.Error(t, err)
-		assert.Equal(t, codes.Unauthenticated, status.Code(err))
+		assert.Equal(t, codes.Unauthenticated.String(), status.Code(err).String())
 
 		events := mockTransmission.GetBlock(0)
 		assert.Equal(t, 0, len(events))

--- a/route/otlp_trace_test.go
+++ b/route/otlp_trace_test.go
@@ -629,6 +629,25 @@ func TestOTLPHandler(t *testing.T) {
 		assert.Equal(t, 0, len(events))
 	})
 
+	t.Run("rejects missing dataset header - gRPC", func(t *testing.T) {
+		req := &collectortrace.ExportTraceServiceRequest{
+			ResourceSpans: []*trace.ResourceSpans{{
+				ScopeSpans: []*trace.ScopeSpans{{
+					Spans: helperOTLPRequestSpansWithStatus(),
+				}},
+			}},
+		}
+		ctx := createGRPCContext(map[string]string{
+			"x-honeycomb-team": legacyAPIKey,
+		})
+		_, err := grpcClient.Export(ctx, req)
+		require.Error(t, err)
+		assert.Equal(t, codes.Unauthenticated, status.Code(err))
+
+		events := mockTransmission.GetBlock(0)
+		assert.Equal(t, 0, len(events))
+	})
+
 	t.Run("spans record incoming user agent - gRPC", func(t *testing.T) {
 		req := &collectortrace.ExportTraceServiceRequest{
 			ResourceSpans: []*trace.ResourceSpans{{


### PR DESCRIPTION
## Which problem is this PR solving?

- Update husky in Refinery so we can use the new header validator functions, including on the gRPC traces path.

## Short description of the changes

- Bump `husky` to v0.44.0.
- Swap `ValidateTracesHeaders`/`ValidateLogsHeaders` for the new `ValidateHeaders` + `ValidateDatasetHeader` preserving current behavior.
- Validate headers on the gRPC traces path before translation, fixing a wrong `codes.Internal` status on a missing dataset header.
