### PR TITLE
chore: remove llm-o11y and ai-o11y from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @honeycombio/oss-maintainers @honeycombio/llm-observability @honeycombio/ai-observability 
+* @honeycombio/oss-maintainers


### PR DESCRIPTION
## Which problem is this PR solving?

update codeowners file to remoce llm-o11y and ai-o11y groups
